### PR TITLE
[Agent Council] 메인 헤드라인 아래에 오늘 전략과 금지 행동을 바로 노출합니다.

### DIFF
--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T12:08:08.359Z
+- Generated At: 2026-04-20T13:49:43.698Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T23:07:25.179Z
-- Status: ready
+- Generated At: 2026-04-21T02:52:30.245Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T12:01:20.165Z
+- Generated At: 2026-04-20T12:04:53.281Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T19:11:38.167Z
-- Status: ready
+- Generated At: 2026-04-20T23:07:03.353Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T14:02:26.470Z
-- Status: ready
+- Generated At: 2026-04-20T14:02:44.366Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:16:55.861Z
-- Status: ready
+- Generated At: 2026-04-21T13:18:02.724Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T23:03:40.586Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-25T02:44:05.950Z
-- Status: ready
+- Generated At: 2026-04-25T02:44:26.882Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T02:51:46.653Z
-- Status: ready
+- Generated At: 2026-04-22T07:54:26.015Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-25T02:44:26.882Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T18:58:28.618Z
-- Status: ready
+- Generated At: 2026-04-24T18:59:22.363Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T23:03:50.774Z
-- Status: ready
+- Generated At: 2026-04-24T23:04:12.822Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:18:28.040Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T12:04:53.281Z
+- Generated At: 2026-04-20T12:07:44.342Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T14:02:51.180Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:49:33.507Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:18:02.724Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T19:16:36.319Z
-- Status: ready
+- Generated At: 2026-04-23T19:17:46.866Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T23:04:12.822Z
-- Status: ready
+- Generated At: 2026-04-25T02:44:05.950Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:19:18.051Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T23:07:25.179Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T02:55:15.875Z
-- Status: ready
+- Generated At: 2026-04-24T08:09:45.588Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T19:17:46.866Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T11:59:34.527Z
+- Generated At: 2026-04-20T12:00:38.222Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T02:55:15.875Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T13:43:02.571Z
-- Status: ready
+- Generated At: 2026-04-24T13:43:27.673Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:18:48.484Z
-- Status: ready
+- Generated At: 2026-04-21T13:19:18.051Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T07:58:04.771Z
-- Status: ready
+- Generated At: 2026-04-21T07:58:26.526Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-25T02:44:05.950Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T02:51:25.931Z
-- Status: ready
+- Generated At: 2026-04-22T02:51:46.653Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:13:02.545Z
-- Status: ready
+- Generated At: 2026-04-21T13:16:55.861Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T23:07:03.353Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,10 +4,23 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T13:50:05.262Z
+- Generated At: 2026-04-20T13:59:19.454Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.
+
+## Implementation Focus
+뉴스 탭 첫 화면에서 행동 제안이 바로 읽히도록 콘텐츠 위계를 다시 묶습니다.
+
+## Target Files
+- apps/web/components/research/ResearchWorkspace.tsx
+- apps/web/app/globals.css
+- packages/shared/src/research.ts
+
+## Verification
+- npm run typecheck
+- npm run build:web
 
 ## References
 - news-editor

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T23:11:09.486Z
-- Status: ready
+- Generated At: 2026-04-23T23:11:33.158Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T23:11:33.158Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T19:16:36.319Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T14:01:07.142Z
-- Status: ready
+- Generated At: 2026-04-20T14:02:26.470Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T08:00:59.926Z
-- Status: ready
+- Generated At: 2026-04-23T08:01:26.950Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T19:20:05.705Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T18:59:22.363Z
-- Status: ready
+- Generated At: 2026-04-24T23:03:50.774Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T08:00:59.926Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T02:52:30.245Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T13:52:36.979Z
-- Status: ready
+- Generated At: 2026-04-23T13:53:01.144Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T19:17:46.866Z
-- Status: ready
+- Generated At: 2026-04-23T23:11:09.486Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T14:02:44.366Z
-- Status: ready
+- Generated At: 2026-04-20T14:02:51.180Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:49:56.753Z
-- Status: ready
+- Generated At: 2026-04-21T19:17:57.607Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T02:54:50.846Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T23:10:45.758Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T23:10:45.758Z
-- Status: ready
+- Generated At: 2026-04-23T02:54:07.915Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T13:50:49.290Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -1,0 +1,19 @@
+# Agent Council Work Plan
+
+- Item: 메인 헤드라인 아래에 오늘 전략과 금지 행동을 바로 노출합니다.
+- Owner: PM
+- Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
+- Branch: codex/agent-council/headline-to-action-flow
+- Generated At: 2026-04-20T11:57:52.537Z
+
+## Detail
+메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.
+
+## References
+- news-editor
+- execution-trader
+
+## Acceptance
+- [ ] 작업 범위를 제품 변경으로 구체화한다.
+- [ ] 구현 또는 측정 지표를 연결한다.
+- [ ] 완료 후 에이전트 회의 탭과 snapshot에 반영한다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T13:50:22.886Z
-- Status: ready
+- Generated At: 2026-04-22T13:50:49.290Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T18:58:28.618Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T12:07:44.342Z
+- Generated At: 2026-04-20T12:08:08.359Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:19:18.051Z
-- Status: ready
+- Generated At: 2026-04-21T13:26:13.140Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:10:03.413Z
-- Status: ready
+- Generated At: 2026-04-21T13:13:02.545Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T23:04:12.822Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T07:58:26.526Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T13:53:01.144Z
-- Status: ready
+- Generated At: 2026-04-23T19:16:36.319Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T14:02:44.366Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T23:11:33.158Z
-- Status: ready
+- Generated At: 2026-04-24T02:54:50.846Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T23:07:03.353Z
-- Status: ready
+- Generated At: 2026-04-20T23:07:25.179Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T23:11:09.486Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:18:23.059Z
-- Status: ready
+- Generated At: 2026-04-21T13:18:28.040Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T13:50:49.290Z
-- Status: ready
+- Generated At: 2026-04-22T19:18:58.048Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T08:09:45.588Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T14:01:07.142Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T02:52:30.245Z
-- Status: ready
+- Generated At: 2026-04-21T02:52:54.430Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T23:03:20.688Z
-- Status: ready
+- Generated At: 2026-04-21T23:03:40.586Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T08:01:26.950Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:10:03.413Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T13:59:19.454Z
-- Status: ready
+- Generated At: 2026-04-20T14:01:07.142Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T23:03:40.586Z
-- Status: ready
+- Generated At: 2026-04-22T02:51:25.931Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:18:48.484Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T13:43:27.673Z
-- Status: ready
+- Generated At: 2026-04-24T18:58:28.618Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T19:11:38.167Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T13:49:43.698Z
+- Generated At: 2026-04-20T13:50:05.262Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T19:17:57.607Z
-- Status: ready
+- Generated At: 2026-04-21T19:18:19.078Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:26:48.203Z
-- Status: ready
+- Generated At: 2026-04-21T13:49:33.507Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T02:54:50.846Z
-- Status: ready
+- Generated At: 2026-04-24T02:55:15.875Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T14:03:09.234Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T23:10:25.234Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T19:17:57.607Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T02:54:28.027Z
-- Status: ready
+- Generated At: 2026-04-23T08:00:59.926Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T08:09:45.588Z
-- Status: ready
+- Generated At: 2026-04-24T08:10:12.069Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T02:54:28.027Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T07:58:04.771Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T07:54:26.015Z
-- Status: ready
+- Generated At: 2026-04-22T07:54:51.532Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T11:57:52.537Z
+- Generated At: 2026-04-20T11:59:34.527Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:16:55.861Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T19:10:48.335Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T23:03:50.774Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:26:13.140Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T07:54:26.015Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T19:18:58.048Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T13:52:36.979Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T08:01:26.950Z
-- Status: ready
+- Generated At: 2026-04-23T13:52:36.979Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T19:18:58.048Z
-- Status: ready
+- Generated At: 2026-04-22T19:20:05.705Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T13:43:02.571Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T19:18:19.078Z
-- Status: ready
+- Generated At: 2026-04-21T23:03:20.688Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T19:10:48.335Z
-- Status: ready
+- Generated At: 2026-04-20T19:11:38.167Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-24T08:10:12.069Z
-- Status: ready
+- Generated At: 2026-04-24T13:43:02.571Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,7 +4,7 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T12:00:38.222Z
+- Generated At: 2026-04-20T12:01:20.165Z
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T13:53:01.144Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:13:02.545Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T19:18:19.078Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:18:28.040Z
-- Status: ready
+- Generated At: 2026-04-21T13:18:48.484Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-23T02:54:07.915Z
-- Status: ready
+- Generated At: 2026-04-23T02:54:28.027Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T13:59:19.454Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T14:02:51.180Z
-- Status: ready
+- Generated At: 2026-04-20T14:03:09.234Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:18:23.059Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T23:03:20.688Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T18:59:22.363Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T02:52:54.430Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:26:48.203Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:49:33.507Z
-- Status: ready
+- Generated At: 2026-04-21T13:49:56.753Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T07:54:51.532Z
-- Status: ready
+- Generated At: 2026-04-22T13:50:22.886Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T02:51:25.931Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-21T13:49:56.753Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T02:51:46.653Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:18:02.724Z
-- Status: ready
+- Generated At: 2026-04-21T13:18:23.059Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-20T14:02:26.470Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T19:20:05.705Z
-- Status: ready
+- Generated At: 2026-04-22T23:10:25.234Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-20T14:03:09.234Z
-- Status: ready
+- Generated At: 2026-04-20T19:10:48.335Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T07:54:51.532Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-22T23:10:25.234Z
-- Status: ready
+- Generated At: 2026-04-22T23:10:45.758Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T08:10:12.069Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-24T13:43:27.673Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-22T13:50:22.886Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T13:26:13.140Z
-- Status: ready
+- Generated At: 2026-04-21T13:26:48.203Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T07:58:26.526Z
-- Status: ready
+- Generated At: 2026-04-21T13:10:03.413Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
 - Generated At: 2026-04-23T02:54:07.915Z
-- Status: queued
+- Status: ready
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

--- a/.github/agent-council/headline-to-action-flow.md
+++ b/.github/agent-council/headline-to-action-flow.md
@@ -4,8 +4,8 @@
 - Owner: PM
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/2
 - Branch: codex/agent-council/headline-to-action-flow
-- Generated At: 2026-04-21T02:52:54.430Z
-- Status: ready
+- Generated At: 2026-04-21T07:58:04.771Z
+- Status: queued
 
 ## Detail
 메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.


### PR DESCRIPTION
<!-- research-action-pr:headline-to-action-flow -->

Related to #2

## Action Item
메인 헤드라인 아래에 오늘 전략과 하지 말아야 할 행동을 붙여 사용자가 뉴스만 읽고 멈추지 않고 곧바로 실행 판단으로 넘어가게 만듭니다.

## Ownership
- Owner: PM
- Branch: codex/agent-council/headline-to-action-flow
- Plan: .github/agent-council/headline-to-action-flow.md

## Implementation Focus
뉴스 탭 첫 화면에서 행동 제안이 바로 읽히도록 콘텐츠 위계를 다시 묶습니다.

## Target Files
- apps/web/components/research/ResearchWorkspace.tsx
- apps/web/app/globals.css
- packages/shared/src/research.ts

## Verification
- npm run typecheck
- npm run build:web

## Notes
- This draft PR is automatically created so implementation can start from a live branch immediately.
- Update the branch with real code changes and move the checklist to implementation detail as work progresses.