### PR TITLE
[Agent Council] 실데이터 fetch와 fallback 상태를 운영 패널에 드러냅니다.

### DIFF
--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T18:54:20.650Z
-- Status: ready
+- Generated At: 2026-05-16T19:59:07.572Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T23:12:54.580Z
-- Status: ready
+- Generated At: 2026-05-16T23:13:24.507Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:52:49.150Z
-- Status: ready
+- Generated At: 2026-05-16T05:53:18.070Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T23:00:26.851Z
-- Status: ready
+- Generated At: 2026-05-13T23:35:09.370Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T06:01:40.660Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T15:13:28.339Z
-- Status: ready
+- Generated At: 2026-05-14T15:14:05.862Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T17:39:10.109Z
-- Status: ready
+- Generated At: 2026-05-15T17:39:54.641Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T17:44:28.760Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-17T02:26:26.827Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T19:38:50.636Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T09:40:41.172Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T04:38:33.583Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T21:52:55.726Z
-- Status: ready
+- Generated At: 2026-05-15T22:46:05.961Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T23:27:20.114Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T06:01:09.304Z
-- Status: ready
+- Generated At: 2026-05-16T06:01:40.660Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T23:35:44.049Z
-- Status: ready
+- Generated At: 2026-05-14T00:03:45.267Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T19:43:49.237Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T18:53:51.716Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T17:43:40.850Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T23:43:55.476Z
-- Status: ready
+- Generated At: 2026-05-17T02:26:26.827Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:48:34.412Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:30:55.669Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T19:59:07.572Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T17:51:42.455Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T23:14:34.168Z
-- Status: ready
+- Generated At: 2026-05-14T23:15:07.245Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T22:50:49.662Z
-- Status: ready
+- Generated At: 2026-05-14T22:51:25.750Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T10:08:15.203Z
-- Status: ready
+- Generated At: 2026-05-14T10:08:54.866Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T21:19:35.194Z
-- Status: ready
+- Generated At: 2026-05-13T21:21:22.191Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T21:21:22.191Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T02:11:46.411Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T04:38:33.583Z
-- Status: ready
+- Generated At: 2026-05-14T07:38:11.302Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:47:54.964Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T10:08:54.866Z
-- Status: ready
+- Generated At: 2026-05-14T12:22:31.119Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T23:48:00.065Z
-- Status: ready
+- Generated At: 2026-05-15T23:48:36.168Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T21:13:19.944Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T06:27:20.007Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T11:47:24.808Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T16:55:48.365Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T19:59:39.850Z
-- Status: ready
+- Generated At: 2026-05-16T20:52:35.574Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T22:38:56.164Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:47:54.964Z
-- Status: ready
+- Generated At: 2026-05-16T05:48:34.412Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T19:20:08.829Z
-- Status: ready
+- Generated At: 2026-05-15T19:20:43.835Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T23:13:24.507Z
-- Status: ready
+- Generated At: 2026-05-16T23:43:27.153Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:00:23.630Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T23:35:44.049Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T20:54:25.249Z
-- Status: ready
+- Generated At: 2026-05-15T21:52:25.334Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:13:38.471Z
-- Status: ready
+- Generated At: 2026-05-16T05:14:09.444Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T23:35:09.370Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T21:42:01.719Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:21:36.939Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T20:54:25.249Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T19:29:29.807Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T17:10:30.424Z
-- Status: ready
+- Generated At: 2026-05-13T17:11:54.466Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:49:10.055Z
-- Status: ready
+- Generated At: 2026-05-16T05:50:20.700Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T10:57:12.752Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T17:44:28.760Z
-- Status: ready
+- Generated At: 2026-05-14T19:29:29.807Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T10:08:54.866Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T13:04:09.838Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T23:43:55.476Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T15:58:54.047Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:30:55.669Z
-- Status: ready
+- Generated At: 2026-05-16T05:33:18.666Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T09:23:48.822Z
-- Status: ready
+- Generated At: 2026-05-16T09:24:18.493Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T17:11:54.466Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:50:20.700Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T21:19:35.194Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T13:04:09.838Z
-- Status: ready
+- Generated At: 2026-05-16T13:04:38.600Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T02:28:50.039Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T19:59:39.850Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T11:57:57.373Z
-- Status: ready
+- Generated At: 2026-05-13T14:29:13.012Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T19:44:25.440Z
-- Status: ready
+- Generated At: 2026-05-13T21:19:35.194Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T04:59:52.207Z
-- Status: ready
+- Generated At: 2026-05-16T05:00:23.630Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T11:49:53.185Z
-- Status: ready
+- Generated At: 2026-05-15T13:47:36.775Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:50:20.700Z
-- Status: ready
+- Generated At: 2026-05-16T05:52:49.150Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T15:51:43.074Z
-- Status: ready
+- Generated At: 2026-05-16T15:52:19.055Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T22:46:38.140Z
-- Status: ready
+- Generated At: 2026-05-15T23:26:47.219Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:21:36.939Z
-- Status: ready
+- Generated At: 2026-05-16T05:22:04.764Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T19:20:43.835Z
-- Status: ready
+- Generated At: 2026-05-15T20:53:36.085Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:13:38.471Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T11:49:21.041Z
-- Status: ready
+- Generated At: 2026-05-15T11:49:53.185Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T12:23:09.023Z
-- Status: ready
+- Generated At: 2026-05-14T15:13:28.339Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T11:49:53.185Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T21:03:56.915Z
-- Status: ready
+- Generated At: 2026-05-14T21:13:19.944Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T19:38:50.636Z
-- Status: ready
+- Generated At: 2026-05-14T21:03:56.915Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T10:56:43.442Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T23:43:27.153Z
-- Status: ready
+- Generated At: 2026-05-16T23:43:55.476Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T07:53:09.837Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T12:23:09.023Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:53:18.070Z
-- Status: ready
+- Generated At: 2026-05-16T06:01:09.304Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T04:37:56.071Z
-- Status: ready
+- Generated At: 2026-05-14T04:38:33.583Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T17:39:10.109Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T02:29:20.890Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T21:41:32.253Z
-- Status: ready
+- Generated At: 2026-05-16T21:42:01.719Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T15:14:05.862Z
-- Status: ready
+- Generated At: 2026-05-14T17:43:40.850Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:06:05.384Z
-- Status: ready
+- Generated At: 2026-05-16T05:13:38.471Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T17:43:40.850Z
-- Status: ready
+- Generated At: 2026-05-14T17:44:28.760Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-17T02:27:01.078Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T23:49:46.114Z
-- Status: ready
+- Generated At: 2026-05-15T02:28:50.039Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T06:26:45.094Z
-- Status: ready
+- Generated At: 2026-05-15T06:27:20.007Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T19:59:07.572Z
-- Status: ready
+- Generated At: 2026-05-16T19:59:39.850Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T23:43:27.153Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T20:53:36.085Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T23:49:46.114Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T20:53:04.464Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T09:41:16.205Z
-- Status: ready
+- Generated At: 2026-05-15T11:49:21.041Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T14:49:36.912Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T16:50:10.347Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T06:27:20.007Z
-- Status: ready
+- Generated At: 2026-05-15T09:40:41.172Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T10:57:12.752Z
-- Status: ready
+- Generated At: 2026-05-16T11:46:49.413Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T14:29:53.194Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T18:53:51.716Z
-- Status: ready
+- Generated At: 2026-05-16T18:54:20.650Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T23:00:26.851Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T02:11:10.116Z
-- Status: ready
+- Generated At: 2026-05-16T02:11:46.411Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T07:53:09.837Z
-- Status: ready
+- Generated At: 2026-05-16T07:53:44.886Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T00:03:45.267Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T23:13:24.507Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T17:11:54.466Z
-- Status: ready
+- Generated At: 2026-05-13T19:43:49.237Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T13:48:19.150Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T14:29:13.012Z
-- Status: ready
+- Generated At: 2026-05-13T14:29:53.194Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:00:23.630Z
-- Status: ready
+- Generated At: 2026-05-16T05:05:34.330Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T11:57:21.248Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:44:46.420Z
-- Status: ready
+- Generated At: 2026-05-16T05:47:54.964Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T11:46:49.413Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T00:04:24.712Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T07:38:11.302Z
-- Status: ready
+- Generated At: 2026-05-14T07:38:44.136Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T23:48:36.168Z
-- Status: ready
+- Generated At: 2026-05-16T02:11:10.116Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T22:38:24.311Z
-- Status: ready
+- Generated At: 2026-05-16T22:38:56.164Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T23:49:16.110Z
-- Status: ready
+- Generated At: 2026-05-14T23:49:46.114Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T04:37:56.071Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T02:11:10.116Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:14:09.444Z
-- Status: ready
+- Generated At: 2026-05-16T05:21:36.939Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:06:05.384Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T00:04:24.712Z
-- Status: ready
+- Generated At: 2026-05-14T04:37:56.071Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T10:56:43.442Z
-- Status: ready
+- Generated At: 2026-05-16T10:57:12.752Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T20:53:36.085Z
-- Status: ready
+- Generated At: 2026-05-15T20:54:25.249Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T09:37:40.154Z
-- Status: ready
+- Generated At: 2026-05-13T09:38:17.756Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T23:27:20.114Z
-- Status: ready
+- Generated At: 2026-05-15T23:48:00.065Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -2,10 +2,10 @@
 
 - Item: 실데이터 fetch와 fallback 상태를 운영 패널에 드러냅니다.
 - Owner: CTO
-- Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
+- Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T02:11:46.411Z
-- Status: ready
+- Generated At: 2026-05-16T04:59:52.207Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T15:14:05.862Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T07:38:44.136Z
-- Status: ready
+- Generated At: 2026-05-14T10:08:15.203Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T21:13:19.944Z
-- Status: ready
+- Generated At: 2026-05-14T22:50:49.662Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T02:28:50.039Z
-- Status: ready
+- Generated At: 2026-05-15T02:29:20.890Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:33:18.666Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T17:39:54.641Z
-- Status: ready
+- Generated At: 2026-05-15T19:20:08.829Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T07:38:11.302Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T17:51:42.455Z
-- Status: ready
+- Generated At: 2026-05-16T18:53:51.716Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T19:20:43.835Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T23:26:47.219Z
-- Status: ready
+- Generated At: 2026-05-15T23:27:20.114Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:05:34.330Z
-- Status: ready
+- Generated At: 2026-05-16T05:06:05.384Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T09:38:17.756Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T17:39:54.641Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T02:29:20.890Z
-- Status: ready
+- Generated At: 2026-05-15T06:26:45.094Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:48:34.412Z
-- Status: ready
+- Generated At: 2026-05-16T05:49:10.055Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T23:48:36.168Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T23:15:07.245Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:33:18.666Z
-- Status: ready
+- Generated At: 2026-05-16T05:33:48.634Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T15:59:29.069Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T23:49:16.110Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T13:04:38.600Z
-- Status: ready
+- Generated At: 2026-05-16T14:49:36.912Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T22:38:56.164Z
-- Status: ready
+- Generated At: 2026-05-16T23:12:54.580Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T09:24:18.493Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T15:58:54.047Z
-- Status: ready
+- Generated At: 2026-05-15T15:59:29.069Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T12:22:31.119Z
-- Status: ready
+- Generated At: 2026-05-14T12:23:09.023Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:14:09.444Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T20:52:35.574Z
-- Status: ready
+- Generated At: 2026-05-16T20:53:04.464Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:44:46.420Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T07:38:44.136Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:05:34.330Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T15:13:28.339Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T21:03:56.915Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T09:23:48.822Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T11:46:49.413Z
-- Status: ready
+- Generated At: 2026-05-16T11:47:24.808Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T17:50:35.419Z
-- Status: ready
+- Generated At: 2026-05-16T17:51:42.455Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T06:01:40.660Z
-- Status: ready
+- Generated At: 2026-05-16T07:53:09.837Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T09:24:18.493Z
-- Status: ready
+- Generated At: 2026-05-16T10:56:43.442Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T17:50:35.419Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T04:59:52.207Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:33:48.634Z
-- Status: ready
+- Generated At: 2026-05-16T05:38:26.832Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T11:57:57.373Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T07:53:44.886Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T16:55:48.365Z
-- Status: ready
+- Generated At: 2026-05-16T17:50:35.419Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T23:14:34.168Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T14:50:10.780Z
-- Status: ready
+- Generated At: 2026-05-16T15:51:43.074Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:33:48.634Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T22:38:24.311Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T23:12:54.580Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T21:21:22.191Z
-- Status: ready
+- Generated At: 2026-05-13T22:59:16.743Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-17T02:26:26.827Z
-- Status: ready
+- Generated At: 2026-05-17T02:27:01.078Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T21:41:32.253Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T20:53:04.464Z
-- Status: ready
+- Generated At: 2026-05-16T21:41:32.253Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:49:10.055Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:22:04.764Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T22:59:16.743Z
-- Status: ready
+- Generated At: 2026-05-13T23:00:26.851Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T20:52:35.574Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T23:48:00.065Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T11:57:21.248Z
-- Status: ready
+- Generated At: 2026-05-13T11:57:57.373Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T09:38:17.756Z
-- Status: ready
+- Generated At: 2026-05-13T11:57:21.248Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:53:18.070Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T22:59:16.743Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T22:51:25.750Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T23:15:07.245Z
-- Status: ready
+- Generated At: 2026-05-14T23:49:16.110Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T19:43:49.237Z
-- Status: ready
+- Generated At: 2026-05-13T19:44:25.440Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T07:53:44.886Z
-- Status: ready
+- Generated At: 2026-05-16T09:23:48.822Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T19:20:08.829Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:38:26.832Z
-- Status: ready
+- Generated At: 2026-05-16T05:39:01.694Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T15:52:19.055Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:39:01.694Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T22:51:25.750Z
-- Status: ready
+- Generated At: 2026-05-14T23:14:34.168Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:44:18.623Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:22:04.764Z
-- Status: ready
+- Generated At: 2026-05-16T05:30:20.259Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T23:26:47.219Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T19:44:25.440Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T11:47:24.808Z
-- Status: ready
+- Generated At: 2026-05-16T13:04:09.838Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T13:48:19.150Z
-- Status: ready
+- Generated At: 2026-05-15T15:58:54.047Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T21:42:01.719Z
-- Status: ready
+- Generated At: 2026-05-16T22:38:24.311Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:39:01.694Z
-- Status: ready
+- Generated At: 2026-05-16T05:44:18.623Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T09:40:41.172Z
-- Status: ready
+- Generated At: 2026-05-15T09:41:16.205Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T14:49:36.912Z
-- Status: ready
+- Generated At: 2026-05-16T14:50:10.780Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T15:59:29.069Z
-- Status: ready
+- Generated At: 2026-05-15T17:39:10.109Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T22:46:05.961Z
-- Status: ready
+- Generated At: 2026-05-15T22:46:38.140Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T21:52:55.726Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T14:50:10.780Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:38:26.832Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T10:08:15.203Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T16:50:10.347Z
-- Status: ready
+- Generated At: 2026-05-16T16:55:48.365Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T21:52:25.334Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T15:52:19.055Z
-- Status: ready
+- Generated At: 2026-05-16T16:50:10.347Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:52:49.150Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T06:01:09.304Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:30:20.259Z
-- Status: ready
+- Generated At: 2026-05-16T05:30:55.669Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T00:03:45.267Z
-- Status: ready
+- Generated At: 2026-05-14T00:04:24.712Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T12:22:31.119Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T14:29:13.012Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T15:51:43.074Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T13:47:36.775Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T09:41:16.205Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T13:04:38.600Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T13:47:36.775Z
-- Status: ready
+- Generated At: 2026-05-15T13:48:19.150Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T18:54:20.650Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-13T17:10:30.424Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-16T05:44:18.623Z
-- Status: ready
+- Generated At: 2026-05-16T05:44:46.420Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T23:35:09.370Z
-- Status: ready
+- Generated At: 2026-05-13T23:35:44.049Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T11:49:21.041Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/taro-stock-app/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-16T05:30:20.259Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T06:26:45.094Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-15T21:52:25.334Z
-- Status: ready
+- Generated At: 2026-05-15T21:52:55.726Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T22:46:38.140Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-14T19:29:29.807Z
-- Status: ready
+- Generated At: 2026-05-14T19:38:50.636Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-15T22:46:05.961Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -4,8 +4,8 @@
 - Owner: CTO
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
-- Generated At: 2026-05-13T14:29:53.194Z
-- Status: ready
+- Generated At: 2026-05-13T17:10:30.424Z
+- Status: queued
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

--- a/.github/agent-council/cto-live-data-health-check.md
+++ b/.github/agent-council/cto-live-data-health-check.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/mlender-ai/auto-trading-bot/issues/38
 - Branch: codex/agent-council/cto-live-data-health-check
 - Generated At: 2026-05-14T22:50:49.662Z
-- Status: queued
+- Status: ready
 
 ## Detail
 뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.


### PR DESCRIPTION
<!-- research-action-pr:cto-live-data-health-check -->

Related to #38

## Action Item
뉴스 RSS, 차트 API, 기사 이미지 추출이 실패해 fallback으로 내려간 경우를 회의 탭과 markdown summary에서 바로 알 수 있게 만듭니다.

## Ownership
- Owner: CTO
- Branch: codex/agent-council/cto-live-data-health-check
- Plan: .github/agent-council/cto-live-data-health-check.md

## Implementation Focus
실데이터 성공률과 fallback 사용 여부를 구조화된 운영 신호로 표면화합니다.

## Target Files
- packages/shared/src/researchLive.ts
- packages/shared/src/researchPipeline.ts
- apps/web/components/research/ResearchWorkspace.tsx

## Verification
- npm run typecheck
- npm run research:generate
- npm run build:web

## Notes
- This draft PR is automatically created so implementation can start from a live branch immediately.
- Update the branch with real code changes and move the checklist to implementation detail as work progresses.