### PR TITLE
fix: 에이전트 카운슬 + 이메일 브리핑 워크플로우 main 반영

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -19,16 +19,8 @@ permissions:
   issues: write
   models: read
 
-# ─────────────────────────────────────────────────────────────
-# 공통 컨텍스트 (모든 에이전트 공유)
-# 앱: 주식 시장 지표를 AI가 분석 → 타로 카드 형식으로 해석 제공 (네이티브 앱)
-# 스택: React Native + Expo SDK 54, Next.js 14, PostgreSQL + Prisma, Claude/OpenAI AI
-# 현재: 카드 뽑기(1장/3장), Apple/Google 로그인, 크레딧(IAP+광고), 히스토리/분석, 즐겨찾기, 어드민
-# ─────────────────────────────────────────────────────────────
-
 jobs:
 
-  # ── 1. PM — 제품 전략 / 사용자 니즈 ──────────────────────────
   pm:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'pm' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -45,26 +37,16 @@ jobs:
             당신은 타로 증권 앱의 Product Manager입니다.
             사용자 페르소나: MZ세대 개인 투자자, 타로에 관심 있는 주식 입문자.
             KPI: DAU, 크레딧 소비량, 앱스토어 평점, D7/D30 리텐션.
-            당신의 시각: 사용자 문제 → 측정 가능한 임팩트 순으로 사고한다.
+            현재 구현: 카드 뽑기(1장/3장), Apple/Google 로그인, 크레딧(IAP+광고), 히스토리/분석, 즐겨찾기, 어드민.
           prompt: |
             오늘의 제품 개선 우선순위를 분석하고 가장 임팩트 높은 아이디어 1개를 제안하세요.
 
             ## 🎯 PM 제안
-
             ## 사용자 문제
-            (구체적인 페인 포인트 또는 놓치고 있는 기회)
-
             ## 기능 아이디어
-            (솔루션 설명 — 사용자 관점에서)
-
             ## 성공 지표
-            (측정 가능한 KPI, 목표 수치 포함)
-
             ## 우선순위 근거
-            (왜 지금 이것이 중요한가)
-
-            ## 난이도 및 예상 소요
-            (S=1일 / M=1주 / L=2주+)
+            ## 난이도 (S/M/L)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -75,7 +57,6 @@ jobs:
             --label "idea,agent-council,pm" \
             --repo "${{ github.repository }}"
 
-  # ── 2. Frontend — React Native / Expo / 모바일 UX ────────────
   frontend:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'frontend' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -97,21 +78,11 @@ jobs:
             모바일 프런트엔드 관점에서 개선할 아이디어 1개를 제안하세요.
 
             ## 📱 Frontend 제안
-
             ## 현재 문제
-            (UX 마찰, 성능 병목, 코드 중복, 접근성 미비 등)
-
             ## 개선 방안
-            (구체적 구현: 컴포넌트명, 파일 경로, 라이브러리)
-
             ## 영향받는 화면/파일
-            (수정 대상 목록)
-
             ## 예상 효과
-            (성능 지표, 사용자 경험, 번들 크기 등)
-
-            ## 구현 복잡도
-            (S/M/L + 이유)
+            ## 구현 복잡도 (S/M/L)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -122,7 +93,6 @@ jobs:
             --label "idea,agent-council,frontend,mobile" \
             --repo "${{ github.repository }}"
 
-  # ── 3. Backend — API / DB / 인프라 ───────────────────────────
   backend:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'backend' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -137,28 +107,18 @@ jobs:
           model: openai/gpt-4o
           system: |
             당신은 타로 증권 앱의 백엔드 개발자입니다.
-            스택: Next.js 14 API Routes, PostgreSQL + Prisma ORM, Railway/Supabase 배포.
+            스택: Next.js 14 API Routes, PostgreSQL + Prisma ORM.
             핵심 API: /api/tarot/draw, /api/tarot/analytics, /api/tarot/credits, /api/admin/*.
             당신의 시각: API 성능, DB 쿼리 최적화, 캐싱, 확장성, 데이터 정합성.
           prompt: |
             백엔드/인프라 관점에서 개선할 아이디어 1개를 제안하세요.
 
             ## ⚙️ Backend 제안
-
             ## 현재 문제
-            (성능 병목, 쿼리 비효율, 캐싱 부재, 확장성 리스크 등)
-
             ## 개선 방안
-            (API 설계, DB 인덱스, 캐싱 전략, 인프라 변경 등)
-
             ## 영향받는 파일/API
-            (경로 포함)
-
             ## 예상 효과
-            (레이턴시 감소, 비용 절감, 처리량 증가 등 수치 포함)
-
             ## 마이그레이션 위험도
-            (없음 / 낮음 / 중간 / 높음)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -169,7 +129,6 @@ jobs:
             --label "idea,agent-council,backend" \
             --repo "${{ github.repository }}"
 
-  # ── 4. Designer — UX / UI / 비주얼 ──────────────────────────
   designer:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'designer' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -184,28 +143,17 @@ jobs:
           model: openai/gpt-4o
           system: |
             당신은 타로 증권 앱의 UI/UX 디자이너입니다.
-            현재 디자인 시스템: 다크 테마(#121212), 타로 에센스 컬러(#3ecf8e), 그래핏 베이스(#242424).
-            현재 화면: 스플래시, 온보딩, 로그인, 홈, 카드 뽑기, 결과, 히스토리, 마이페이지.
+            디자인 시스템: 다크 테마(#121212), 타로 에센스(#3ecf8e), 그래핏 베이스(#242424).
             당신의 시각: 감성적 몰입감, 시각적 계층구조, 마이크로인터랙션, 접근성, 일관된 디자인 언어.
           prompt: |
             UX/UI 디자인 관점에서 개선할 아이디어 1개를 제안하세요.
 
             ## 🎨 Designer 제안
-
             ## 현재 디자인 문제
-            (시각적 불일치, UX 마찰, 감성 연결 부족, 접근성 미비 등)
-
             ## 디자인 개선 방향
-            (레이아웃, 컬러, 타이포그래피, 애니메이션, 마이크로인터랙션)
-
             ## 영향받는 화면
-            (화면명 목록)
-
             ## 레퍼런스 패턴
-            (벤치마크할 앱이나 디자인 패턴)
-
             ## 구현 복잡도
-            (디자이너 관점: 낮음/중간/높음 + 개발자 관점)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -216,7 +164,6 @@ jobs:
             --label "idea,agent-council,design" \
             --repo "${{ github.repository }}"
 
-  # ── 5. QA — 품질 / 테스트 / 버그 예방 ───────────────────────
   qa:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'qa' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -231,29 +178,17 @@ jobs:
           model: openai/gpt-4o
           system: |
             당신은 타로 증권 앱의 QA 엔지니어입니다.
-            현재 테스트: packages/tarot-core vitest 31개 (forbidden/draw/cache). E2E 없음.
+            현재 테스트: packages/tarot-core vitest 31개. E2E 없음.
             당신의 시각: 회귀 버그 예방, 엣지 케이스 발굴, 자동화 가능한 테스트 시나리오.
           prompt: |
             품질 보증 관점에서 개선할 아이디어 1개를 제안하세요.
 
             ## 🧪 QA 제안
-
             ## 현재 품질 리스크
-            (버그 가능성이 높은 영역, 테스트 공백 지점)
-
             ## 개선 방안
-            (테스트 케이스, 자동화 시나리오, 수동 체크리스트)
-
             ## 구체적 테스트 시나리오 3개
-            1. (Given/When/Then 형식)
-            2.
-            3.
-
             ## 영향 범위
-            (어떤 기능/흐름이 커버되는가)
-
-            ## 구현 방법
-            (vitest / Detox E2E / Playwright / 수동 QA)
+            ## 구현 방법 (vitest / Detox / Playwright / 수동)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -264,7 +199,6 @@ jobs:
             --label "idea,agent-council,qa" \
             --repo "${{ github.repository }}"
 
-  # ── 6. CTO — 기술 부채 / 아키텍처 / 확장성 ──────────────────
   cto:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'cto' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -285,21 +219,11 @@ jobs:
             기술 부채 또는 아키텍처 관점에서 개선할 아이디어 1개를 제안하세요.
 
             ## 🏗️ CTO 제안
-
             ## 기술 부채 항목
-            (구체적인 코드/아키텍처 문제)
-
             ## 방치 시 리스크
-            (확장성 저하, 보안 취약, 개발 속도 저하 등)
-
             ## 개선 방향
-            (리팩토링 전략, 마이그레이션 경로, 새 패턴 도입)
-
             ## 영향받는 파일/패키지
-            (모노레포 기준 경로)
-
             ## 예상 ROI
-            (투자 대비 효과 — 개발 속도, 비용, 안정성)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -310,7 +234,6 @@ jobs:
             --label "idea,agent-council,cto,tech-debt" \
             --repo "${{ github.repository }}"
 
-  # ── 7. Marketer — 성장 / 바이럴 / 리텐션 ────────────────────
   marketer:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'marketer' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -325,28 +248,18 @@ jobs:
           model: openai/gpt-4o
           system: |
             당신은 타로 증권 앱의 그로스 마케터입니다.
-            채널: App Store(앱스토어 ASO), 소셜(인스타/틱톡), 바이럴 루프.
-            현재 수익화: 크레딧 IAP(유료) + AdMob 리워드 광고(무료).
+            채널: App Store ASO, 소셜(인스타/틱톡), 바이럴 루프.
+            수익화: 크레딧 IAP + AdMob 리워드 광고.
             당신의 시각: 신규 유입, 바이럴 계수(K-factor), 크레딧 소비 증대, D7/D30 리텐션.
           prompt: |
             성장/마케팅 관점에서 개선할 아이디어 1개를 제안하세요.
 
             ## 📣 Marketer 제안
-
             ## 성장 기회
-            (신규 유입, 리텐션, 바이럴 중 어디를 공략하는가)
-
             ## 전략 아이디어
-            (구체적 기능 또는 캠페인)
-
             ## 실행 방법
-            (앱 내 기능, ASO, 소셜 콘텐츠, 이벤트 등)
-
             ## 예상 지표 개선
-            (설치 수, DAU, 크레딧 매출, 바이럴 계수 등 수치로)
-
             ## 비용/리소스
-            (개발 工數, 마케팅 예산 필요 여부)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -357,7 +270,6 @@ jobs:
             --label "idea,agent-council,marketing" \
             --repo "${{ github.repository }}"
 
-  # ── 8. Security — 보안 / 규제 준수 ──────────────────────────
   security:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'security' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -372,27 +284,17 @@ jobs:
           model: openai/gpt-4o
           system: |
             당신은 타로 증권 앱의 보안 및 규정 준수 담당자입니다.
-            앱: 금융 AI 해석 서비스. Apple/Google 로그인, IAP, 크레딧 시스템, 시장 데이터 포함.
-            주요 위험: JWT 관리, IAP 영수증 서버 검증, 개인정보 처리, 금융광고 규제(자본시장법).
+            앱: 금융 AI 해석 서비스. Apple/Google 로그인, IAP, 크레딧 시스템.
+            위험: JWT 관리, IAP 영수증 서버 검증, 개인정보 처리, 금융광고 규제(자본시장법).
           prompt: |
-            현재 앱에서 점검하거나 강화해야 할 보안/컴플라이언스 항목 1개를 제안하세요.
+            보안/컴플라이언스 항목 1개를 제안하세요.
 
             ## 🔒 Security 제안
-
             ## 위험 항목
-            (구체적 취약점 또는 규제 미준수 사항)
-
             ## 현재 상태
-            (어떤 코드/설정에서 이슈가 발생하는가)
-
             ## 개선 방안
-            (코드/설정/프로세스 레벨 구체적 수정 방법)
-
-            ## 우선순위
-            (Critical/High/Medium/Low + 이유)
-
+            ## 우선순위 (Critical/High/Medium/Low)
             ## 관련 규제/기준
-            (OWASP, 자본시장법, Apple/Google 정책 등)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -403,7 +305,6 @@ jobs:
             --label "idea,agent-council,security" \
             --repo "${{ github.repository }}"
 
-  # ── 9. Prompt Engineer — AI 해석 품질 ───────────────────────
   prompt_engineer:
     if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'prompt_engineer' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -418,29 +319,17 @@ jobs:
           model: openai/gpt-4o
           system: |
             당신은 타로 증권 앱의 AI 해석 품질 담당 프롬프트 엔지니어입니다.
-            현재: packages/tarot-core/src/prompts/interpret-v1.1.0.ts (한국어 최적화, SINGLE/THREE_CARD 분기).
-            구조: 3단 폴백(LLM→캐시→프리빌트). 출력: {headline, summary, detail}.
-            금칙어: 매수/매도/수익보장 등 금융 권유 표현 차단.
+            현재: interpret-v1.1.0.ts (한국어 최적화, SINGLE/THREE_CARD 분기).
+            3단 폴백(LLM→캐시→프리빌트). 출력: {headline, summary, detail}.
           prompt: |
-            현재 타로 카드 해석 프롬프트를 개선하거나 새 기능을 추가할 아이디어를 제안하세요.
+            AI 해석 품질 개선 아이디어를 제안하세요.
 
             ## ✨ Prompt Engineer 제안
-
             ## 현재 문제 또는 기회
-            (해석 품질, 사용자 반응, 폴백률, 안전 필터 충돌 등)
-
             ## 개선 방향
-            (구체적 프롬프트 전략, 파라미터, 새 출력 필드)
-
-            ## 샘플 비교
-            개선 전: (짧게)
-            개선 후: (짧게)
-
+            ## 샘플 비교 (개선 전 / 개선 후)
             ## 검증 방법
-            (A/B 테스트, 폴백률 측정, 사용자 별점 비교)
-
             ## 토큰 비용 영향
-            (증가 / 감소 / 동일)
       - name: Create Issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -451,14 +340,15 @@ jobs:
             --label "idea,agent-council,prompt" \
             --repo "${{ github.repository }}"
 
-  # ── 10. CEO Brief — 모든 에이전트 종합 + 교차 검증 ──────────
   ceo_brief:
     needs: [pm, frontend, backend, designer, qa, cto, marketer, security, prompt_engineer]
     if: always() && (github.event.inputs.agent == 'all' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
+    outputs:
+      brief: ${{ steps.brief.outputs.response }}
     steps:
       - uses: actions/checkout@v4
-      - name: "[CEO] 에이전트 브리핑 종합 + 아이디어 교차 검증"
+      - name: "[CEO] 에이전트 브리핑 종합 + 교차 검증"
         uses: actions/ai-inference@v1
         id: brief
         with:
@@ -466,79 +356,68 @@ jobs:
           system: |
             당신은 타로 증권 앱 CEO의 수석 비서 AI입니다.
             매일 아침 9개 팀 에이전트의 제안을 읽고 CEO가 5분 안에 판단할 수 있는 브리핑을 작성합니다.
-            CEO 관심사: 사용자 성장, 수익화, 스토어 평점, 기술 부채, 팀 정렬.
-            당신의 역할: 에이전트 간 시너지 발굴, 충돌 지점 명확화, 실행 우선순위 정렬.
           prompt: |
-            아래 9개 에이전트의 오늘 제안을 읽고 CEO 일일 브리핑을 작성하세요.
+            아래 9개 에이전트 제안을 읽고 CEO 일일 브리핑을 작성하세요.
 
-            ---
-            **PM 제안:**
-            ${{ needs.pm.outputs.proposal }}
-
-            ---
-            **Frontend 제안:**
-            ${{ needs.frontend.outputs.proposal }}
-
-            ---
-            **Backend 제안:**
-            ${{ needs.backend.outputs.proposal }}
-
-            ---
-            **Designer 제안:**
-            ${{ needs.designer.outputs.proposal }}
-
-            ---
-            **QA 제안:**
-            ${{ needs.qa.outputs.proposal }}
-
-            ---
-            **CTO 제안:**
-            ${{ needs.cto.outputs.proposal }}
-
-            ---
-            **Marketer 제안:**
-            ${{ needs.marketer.outputs.proposal }}
-
-            ---
-            **Security 제안:**
-            ${{ needs.security.outputs.proposal }}
-
-            ---
-            **Prompt Engineer 제안:**
-            ${{ needs.prompt_engineer.outputs.proposal }}
-
-            ---
-
-            위 9개 제안을 분석하여 다음 형식으로 CEO 브리핑을 작성하세요:
+            **PM:** ${{ needs.pm.outputs.proposal }}
+            **Frontend:** ${{ needs.frontend.outputs.proposal }}
+            **Backend:** ${{ needs.backend.outputs.proposal }}
+            **Designer:** ${{ needs.designer.outputs.proposal }}
+            **QA:** ${{ needs.qa.outputs.proposal }}
+            **CTO:** ${{ needs.cto.outputs.proposal }}
+            **Marketer:** ${{ needs.marketer.outputs.proposal }}
+            **Security:** ${{ needs.security.outputs.proposal }}
+            **Prompt Engineer:** ${{ needs.prompt_engineer.outputs.proposal }}
 
             ## 📋 CEO Daily Brief
-
             ## 오늘의 핵심 3가지
-            (가장 중요한 것 3개 — 한 줄씩, 담당 에이전트 명시)
-            1.
-            2.
-            3.
-
             ## 에이전트 공통 의견 (시너지)
-            (여러 에이전트가 같은 방향을 가리키는 것 — 강하게 실행해야 하는 시그널)
-
             ## 에이전트 간 충돌/논쟁 포인트
-            (의견이 갈리는 것 — CEO 결정이 필요한 트레이드오프)
-
             ## 즉시 실행 가능 (이번 주, 개발 없이)
-            (설정 변경, 문서 업데이트, ASO 개선 등)
-
             ## 다음 스프린트 1순위
-            (개발이 필요한 것 중 ROI가 가장 높은 것 1개 — 이유 포함)
-
             ## 무시해도 되는 것
-            (지금 시점에서 우선순위가 낮은 제안 — 이유 포함)
       - name: Create CEO Brief Issue
+        id: create_issue
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue create \
+          URL=$(gh issue create \
             --title "📋 [CEO Brief] $(date '+%Y-%m-%d') 일일 에이전트 브리핑" \
             --body "${{ steps.brief.outputs.response }}" \
             --label "ceo-brief,agent-council,daily" \
-            --repo "${{ github.repository }}"
+            --repo "${{ github.repository }}")
+          echo "issue_url=$URL" >> $GITHUB_OUTPUT
+
+  send_email:
+    needs: [ceo_brief]
+    if: always() && needs.ceo_brief.result == 'success' && (github.event.inputs.agent == 'all' || github.event_name == 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Format and Send Email
+        uses: actions/ai-inference@v1
+        id: email_html
+        with:
+          model: openai/gpt-4o
+          system: |
+            당신은 CEO 비서 AI입니다. 브리핑을 모바일 최적화 HTML 이메일로 변환합니다.
+          prompt: |
+            아래 CEO Brief를 HTML 이메일 body로 변환하세요.
+            스타일: 배경 #0f0f0f, 카드 #1e1e1e, 강조색 #3ecf8e, 충돌은 #e07b3e.
+            핵심 3가지는 굵게 초록 강조. 섹션마다 border-left:3px solid #3ecf8e 카드 스타일.
+            최하단에 GitHub 이슈 링크 포함.
+            HTML body 내용만 반환 (body 태그 제외).
+
+            ${{ needs.ceo_brief.outputs.brief }}
+      - name: Send Email via Gmail
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "☀️ [CEO Brief] $(date '+%Y-%m-%d') 일일 에이전트 브리핑"
+          to: ${{ secrets.REPORT_EMAIL }}
+          from: "Trading Taro 에이전트 카운슬 <${{ secrets.SMTP_USERNAME }}>"
+          html_body: ${{ steps.email_html.outputs.response }}


### PR DESCRIPTION
## 문제
PR #46 squash 머지 시 rebase 충돌 해결 과정에서 워크플로우 파일이 이전 버전으로 덮어써짐.

## 수정 내용
`idea-proposal.yml`을 완전한 에이전트 카운슬 버전으로 교체:
- 9개 에이전트 병렬 실행 (PM / Frontend / Backend / Designer / QA / CTO / Marketer / Security / Prompt Engineer)
- `ceo_brief` job: 전체 종합 + 교차 검증 → GitHub 이슈 생성
- `send_email` job: CEO Brief → HTML 이메일 → Gmail 발송 (Secrets: SMTP_USERNAME / SMTP_PASSWORD / REPORT_EMAIL)
- 스케줄: 매일 07:00 KST (`cron: "0 22 * * *"`)
- `daily-report.yml` 별도 파일 불필요 → `send_email` job으로 통합

https://claude.ai/code/session_01DRieRVRKkYGJASgnRHdPXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRieRVRKkYGJASgnRHdPXV)_