### PR TITLE
feat: CEO Brief #93 — IAP 서버 검증 강화 + 결과 화면 로드 최적화

### DIFF
--- a/apps/web/__tests__/iap-purchase.test.ts
+++ b/apps/web/__tests__/iap-purchase.test.ts
@@ -7,8 +7,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 //   2. 영수증 거래 없음 → 402 RECEIPT_INVALID
 //   3. 프로덕션 sandbox 구매 → 402 SANDBOX_NOT_ALLOWED
 //   4. idempotencyKey 중복 → 200 duplicate:true (크레딧 미지급)
-//   5. RevenueCat API 장애 → 502 RECEIPT_ERROR
-//   6. 필수 파라미터 누락 → 400
+//   5. purchaseToken 재사용 (다른 idempotencyKey) → 409 TOKEN_ALREADY_USED
+//   6. RevenueCat API 장애 → 502 RECEIPT_ERROR
+//   7. 필수 파라미터 누락 → 400
 
 // Prisma mock
 const mockFindFirst = vi.fn();
@@ -20,6 +21,9 @@ vi.mock("@/lib/tarot/prisma", () => ({
       findFirst: () => mockFindFirst(),
       create: () => mockCreate(),
       aggregate: () => mockAggregate(),
+    },
+    adminAuditLog: {
+      create: vi.fn().mockResolvedValue({}),
     },
   },
 }));
@@ -54,7 +58,8 @@ vi.mock("@/lib/tarot/credits", () => ({
 
 describe("POST /api/tarot/credits/purchase — IAP 검증", () => {
   beforeEach(() => {
-    mockFindFirst.mockResolvedValue(null); // 중복 없음 (기본값)
+    // 기본값: 두 번의 findFirst 모두 null (중복 없음)
+    mockFindFirst.mockResolvedValue(null);
     mockCreate.mockResolvedValue({});
     mockAggregate.mockResolvedValue({ _sum: { amount: 10 } });
   });
@@ -128,7 +133,8 @@ describe("POST /api/tarot/credits/purchase — IAP 검증", () => {
   });
 
   it("동일 idempotencyKey 중복 요청 → 200 duplicate:true (크레딧 미지급)", async () => {
-    mockFindFirst.mockResolvedValueOnce({ id: "existing-ledger" }); // 이미 지급됨
+    // 1차 체크(idempotencyKey)에서 기존 항목 발견
+    mockFindFirst.mockResolvedValueOnce({ id: "existing-ledger" });
 
     const { POST } = await import("../app/api/tarot/credits/purchase/route");
     const res = await POST(makeRequest({ productId: "tarot_credits_5", purchaseToken: "tx-abc123", idempotencyKey: "iap_tx-abc123", platform: "ios" }));
@@ -136,7 +142,23 @@ describe("POST /api/tarot/credits/purchase — IAP 검증", () => {
 
     expect(res.status).toBe(200);
     expect(body.duplicate).toBe(true);
-    // fetch(RevenueCat)는 호출되지 않아야 함
+    // RevenueCat은 호출되지 않아야 함
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("동일 purchaseToken 다른 idempotencyKey → 409 TOKEN_ALREADY_USED", async () => {
+    // 1차 체크(idempotencyKey) → null, 2차 체크(purchaseToken) → 기존 항목 발견
+    mockFindFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "existing-token-ledger" });
+
+    const { POST } = await import("../app/api/tarot/credits/purchase/route");
+    const res = await POST(makeRequest({ productId: "tarot_credits_5", purchaseToken: "tx-abc123", idempotencyKey: "iap_tx-abc123-retry", platform: "ios" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.code).toBe("TOKEN_ALREADY_USED");
+    // RevenueCat은 호출되지 않아야 함
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/tarot/credits/purchase/route.ts
+++ b/apps/web/app/api/tarot/credits/purchase/route.ts
@@ -100,19 +100,46 @@ export async function POST(req: NextRequest) {
   const creditAmount = PRODUCT_CREDIT_MAP[productId];
   if (!creditAmount) return errorJson("Unknown product", "INVALID_PRODUCT", 400);
 
-  // 멱등성 1: 동일 idempotencyKey로 이미 크레딧 지급됐으면 현재 잔액만 반환 (빠른 경로)
-  const existing = await prisma.tarotCreditLedger.findFirst({
+  // 1차 중복 방지: idempotencyKey 기반 클라이언트 재시도 (빠른 경로)
+  const existingByKey = await prisma.tarotCreditLedger.findFirst({
     where: { userId, referenceId: idempotencyKey, reason: "PURCHASE" },
   });
-  if (existing) {
+  if (existingByKey) {
     const credits = await getCreditBalance(userId);
     return NextResponse.json({ credits, duplicate: true });
   }
 
+  // 2차 중복 방지: purchaseToken 글로벌 재사용 차단 — RevenueCat 호출 전에 처리해 API 비용 절감
+  const existingByToken = await prisma.tarotCreditLedger.findFirst({
+    where: { referenceId: purchaseToken, reason: "PURCHASE" },
+  });
+  if (existingByToken) {
+    console.warn(`[iap/purchase] token reuse attempt: userId=${userId} token=${purchaseToken} idempotencyKey=${idempotencyKey}`);
+    void prisma.adminAuditLog.create({
+      data: {
+        action: "iap.token_reuse",
+        targetId: userId,
+        targetType: "User",
+        after: { purchaseToken, productId, idempotencyKey, platform },
+      },
+    });
+    return errorJson("이미 사용된 구매 토큰입니다", "TOKEN_ALREADY_USED", 409);
+  }
+
   // RevenueCat Subscriber API로 실제 거래 검증
+  let isSandboxPurchase = false;
   try {
     const { valid, isSandbox } = await verifyRevenueCat(userId, purchaseToken, productId, platform);
+    isSandboxPurchase = isSandbox;
     if (!valid) {
+      void prisma.adminAuditLog.create({
+        data: {
+          action: isSandbox ? "iap.sandbox_rejected" : "iap.receipt_invalid",
+          targetId: userId,
+          targetType: "User",
+          after: { purchaseToken, productId, platform, idempotencyKey },
+        },
+      });
       if (isSandbox) return errorJson("테스트 결제는 프로덕션에서 사용할 수 없습니다", "SANDBOX_NOT_ALLOWED", 402);
       return errorJson("영수증 검증 실패: 해당 거래를 찾을 수 없습니다", "RECEIPT_INVALID", 402);
     }
@@ -121,16 +148,17 @@ export async function POST(req: NextRequest) {
     return errorJson("영수증 검증 서버 오류", "RECEIPT_ERROR", 502);
   }
 
-  // 멱등성 2: purchaseToken 글로벌 중복 사용 방지 (다른 userId 또는 다른 idempotencyKey로 재사용 차단)
-  const tokenUsed = await prisma.tarotCreditLedger.findFirst({
-    where: { referenceId: purchaseToken, reason: "PURCHASE" },
-  });
-  if (tokenUsed) {
-    console.warn(`[iap/purchase] duplicate purchaseToken detected: ${purchaseToken} userId=${userId}`);
-    return errorJson("이미 사용된 영수증입니다", "TOKEN_ALREADY_USED", 409);
-  }
-
-  // referenceId를 purchaseToken으로 저장해 글로벌 유일성 보장
+  // referenceId를 purchaseToken으로 저장 — 글로벌 유일성 보장 (2차 중복 방지와 일관성)
   const credits = await addCredit(userId, creditAmount, "PURCHASE", purchaseToken);
+
+  void prisma.adminAuditLog.create({
+    data: {
+      action: "iap.purchase_success",
+      targetId: userId,
+      targetType: "User",
+      after: { purchaseToken, productId, creditAmount, platform, isSandbox: isSandboxPurchase, idempotencyKey },
+    },
+  });
+
   return NextResponse.json({ credits, purchased: creditAmount });
 }

--- a/apps/web/app/api/tarot/credits/route.ts
+++ b/apps/web/app/api/tarot/credits/route.ts
@@ -9,5 +9,8 @@ export async function GET(req: NextRequest) {
   if (auth instanceof NextResponse) return auth;
 
   const credits = await getCreditBalance(auth.userId);
-  return NextResponse.json({ userId: auth.userId, credits });
+  return NextResponse.json(
+    { userId: auth.userId, credits },
+    { headers: { "Cache-Control": "private, max-age=5" } }
+  );
 }

--- a/apps/web/app/api/tarot/history/[id]/route.ts
+++ b/apps/web/app/api/tarot/history/[id]/route.ts
@@ -32,7 +32,9 @@ export async function GET(
       );
     }
 
-    return NextResponse.json(draw);
+    return NextResponse.json(draw, {
+      headers: { "Cache-Control": "private, max-age=300, stale-while-revalidate=60" },
+    });
   } catch (error) {
     return NextResponse.json(
       {

--- a/apps/web/app/api/tarot/history/route.ts
+++ b/apps/web/app/api/tarot/history/route.ts
@@ -63,15 +63,18 @@ export async function GET(request: Request) {
       prisma.tarotDrawHistory.count({ where }),
     ]);
 
-    return NextResponse.json({
-      items,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
+    return NextResponse.json(
+      {
+        items,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
       },
-    });
+      { headers: { "Cache-Control": "private, max-age=30" } }
+    );
   } catch (error) {
     return NextResponse.json(
       {

--- a/apps/web/lib/tarot/credits.ts
+++ b/apps/web/lib/tarot/credits.ts
@@ -3,12 +3,28 @@ import type { TarotCreditReason } from "@prisma/client";
 
 const SIGNUP_BONUS = 3;
 
+// Short-lived in-memory cache to deduplicate concurrent aggregate queries.
+// Invalidated on every write, so balance staleness is bounded to BALANCE_CACHE_TTL_MS
+// only in the window between a write and the next read.
+const BALANCE_CACHE_TTL_MS = 5_000;
+const balanceCache = new Map<string, { balance: number; expiresAt: number }>();
+
+function invalidateBalanceCache(userId: string) {
+  balanceCache.delete(userId);
+}
+
 export async function getCreditBalance(userId: string): Promise<number> {
+  const now = Date.now();
+  const cached = balanceCache.get(userId);
+  if (cached && cached.expiresAt > now) return cached.balance;
+
   const result = await prisma.tarotCreditLedger.aggregate({
     where: { userId },
     _sum: { amount: true },
   });
-  return result._sum.amount ?? 0;
+  const balance = result._sum.amount ?? 0;
+  balanceCache.set(userId, { balance, expiresAt: now + BALANCE_CACHE_TTL_MS });
+  return balance;
 }
 
 export async function addCredit(
@@ -20,6 +36,7 @@ export async function addCredit(
   const data: { userId: string; amount: number; reason: TarotCreditReason; referenceId?: string | null } = { userId, amount, reason };
   if (referenceId !== undefined) data.referenceId = referenceId;
   await prisma.tarotCreditLedger.create({ data });
+  invalidateBalanceCache(userId);
   return getCreditBalance(userId);
 }
 
@@ -35,6 +52,7 @@ export async function deductCredit(
   const data: { userId: string; amount: number; reason: TarotCreditReason; referenceId?: string | null } = { userId, amount: -amount, reason };
   if (referenceId !== undefined) data.referenceId = referenceId;
   await prisma.tarotCreditLedger.create({ data });
+  invalidateBalanceCache(userId);
   return { ok: true, balance: balance - amount };
 }
 


### PR DESCRIPTION
## 구현 항목

### 1️⃣ IAP 서버 검증 프로세스 강화 (Security / O3-KR2)

**`apps/web/app/api/tarot/credits/purchase/route.ts`**
- **1차 중복 방지**: idempotencyKey 기반 클라이언트 재시도 감지 (빠른 경로)
- **2차 중복 방지**: purchaseToken 글로벌 재사용 차단 — RevenueCat 호출 *전*에 처리하여 불필요한 API 비용 절감. 동일 purchaseToken을 다른 idempotencyKey로 재제출하는 영수증 위변조 패턴 차단 (409 TOKEN_ALREADY_USED)
- **감사 로그**: 구매 성공 / sandbox 거부 / 영수증 무효 / 토큰 재사용 시도를 `AdminAuditLog`에 기록
- referenceId에 purchaseToken 저장 (글로벌 유일성 보장)

**`apps/web/lib/tarot/credits.ts`**
- `getCreditBalance`에 5초 TTL in-memory 캐시 추가 — 연속 draw/purchase 요청 시 DB aggregate 중복 쿼리 제거
- write(addCredit/deductCredit) 시 캐시 즉시 무효화

**`apps/web/__tests__/iap-purchase.test.ts`**
- `TOKEN_ALREADY_USED` (409) 케이스 추가
- `adminAuditLog` mock 추가
- 테스트 총 수: 8개 (기존 7개 → +1)

### 2️⃣ 결과 화면 로드 최적화 — API 응답 캐싱 (Backend / O2-KR4)

Redis 없이 HTTP 캐시 헤더로 클라이언트-레벨 캐싱 도입:

| 엔드포인트 | Cache-Control | 효과 |
|---|---|---|
| `GET /api/tarot/history` | `private, max-age=30` | 히스토리 목록 30초 캐시 |
| `GET /api/tarot/history/[id]` | `private, max-age=300, stale-while-revalidate=60` | 개별 뽑기 결과 5분 캐시 |
| `GET /api/tarot/credits` | `private, max-age=5` | 잔액 조회 5초 캐시 |

결과 화면 진입 시 반복 API 호출을 클라이언트 캐시로 차단 → 네트워크 왕복 없이 즉시 응답.

## 킬리스트 (미구현)

- **Frontend 로딩 애니메이션 최적화**: CEO 판단에 따라 로드 시간 단축 후 재검토
- **Redis 도입**: 현재 트래픽 규모에서 과잉 인프라. DAU 1,000 이상 시 재검토
- **심리 프로파일 기반 맞춤형 해석**: 토큰 비용 및 프롬프트 복잡성 고려하여 O2-KR2 달성 후 재검토
- **"오늘의 투자 운세" 푸시 알림**: 앱 출시 후 1개월 리텐션 데이터 분석 후 결정

## 스키마 메모 (Prisma migration 미생성)

성능 향상을 위해 다음 인덱스 추가를 권장:
```prisma
// TarotCreditLedger — purchaseToken 중복 체크 속도 향상
@@index([userId, referenceId])

// TarotDrawHistory — DB 캐시 조회 속도 향상  
@@index([cacheKey])
```
migration은 별도 PR로 처리 필요.

## 검증

- [x] lint 통과
- [x] typecheck 통과
- [x] build:web 통과
- [x] test 통과 (114/114)

## 참조

이슈: #93

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcC1KY2hVmxFCo2sSq6YD7)_