### PR TITLE
feat(animation): 카드 이동 및 결과 화면 진입 애니메이션 강화

### DIFF
--- a/apps/tarot-mobile/app/result/index.tsx
+++ b/apps/tarot-mobile/app/result/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import {
   SafeAreaView, View, ScrollView, TouchableOpacity,
-  StyleSheet, Animated, Alert,
+  StyleSheet, Animated, Alert, Easing,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Text } from "../../components/ui/Text";
@@ -26,15 +26,28 @@ const SLOT_LABELS: Record<string, string> = {
 
 function CardReveal({ card, index }: { card: DrawnCard; index: number }) {
   const opacity = useRef(new Animated.Value(0)).current;
-  const translateY = useRef(new Animated.Value(32)).current;
-  const scale = useRef(new Animated.Value(0.96)).current;
+  const translateY = useRef(new Animated.Value(52)).current;
+  const scale = useRef(new Animated.Value(0.92)).current;
+  const shimmer = useRef(new Animated.Value(-80)).current;
 
   useEffect(() => {
+    const delay = index * 250;
     Animated.parallel([
-      Animated.timing(opacity,     { toValue: 1,    duration: 600, delay: index * 250, useNativeDriver: true }),
-      Animated.timing(translateY,  { toValue: 0,    duration: 600, delay: index * 250, useNativeDriver: true }),
-      Animated.timing(scale,       { toValue: 1,    duration: 600, delay: index * 250, useNativeDriver: true }),
+      Animated.timing(opacity,    { toValue: 1, duration: 600, delay, useNativeDriver: true }),
+      Animated.timing(translateY, { toValue: 0, duration: 650, delay, easing: Easing.out(Easing.back(1.3)), useNativeDriver: true }),
+      Animated.timing(scale,      { toValue: 1, duration: 600, delay, easing: Easing.out(Easing.back(1.1)), useNativeDriver: true }),
     ]).start();
+
+    const timer = setTimeout(() => {
+      Animated.timing(shimmer, {
+        toValue: 80,
+        duration: 450,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }).start();
+    }, delay + 650);
+
+    return () => clearTimeout(timer);
   }, []);
 
   const slotLabel = card.slot ? SLOT_LABELS[card.slot] ?? null : null;
@@ -53,6 +66,10 @@ function CardReveal({ card, index }: { card: DrawnCard; index: number }) {
         <Animated.View style={[styles.cardThumb, card.isReversed && styles.cardThumbReversed]}>
           <Text style={styles.cardThumSymbol}>{card.symbol}</Text>
           {card.isReversed && <Text style={styles.reversedMark}>▽</Text>}
+          <Animated.View
+            pointerEvents="none"
+            style={[styles.shimmerBarBase, { transform: [{ translateX: shimmer }, { rotate: '15deg' }] }]}
+          />
         </Animated.View>
         <View style={styles.cardMeta}>
           <Text variant="subheading" color={Colors.whiteout}>{card.nameKo}</Text>
@@ -89,6 +106,11 @@ export default function ResultScreen() {
   const [feedbackRating, setFeedbackRating] = useState<number | null>(null);
   const [feedbackSent, setFeedbackSent] = useState(false);
   const [shareLoading, setShareLoading] = useState(false);
+  const screenFade = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(screenFade, { toValue: 1, duration: 350, useNativeDriver: true }).start();
+  }, []);
 
   useEffect(() => {
     if (adStatus === "earned") {
@@ -206,6 +228,7 @@ export default function ResultScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
+      <Animated.View style={{ flex: 1, opacity: screenFade }}>
       <ScrollView
         contentContainerStyle={styles.scroll}
         showsVerticalScrollIndicator={false}
@@ -321,6 +344,7 @@ export default function ResultScreen() {
           />
         </View>
       </ScrollView>
+      </Animated.View>
     </SafeAreaView>
   );
 }
@@ -338,7 +362,8 @@ const styles = StyleSheet.create({
   slotBadge:      { alignSelf: "flex-start", backgroundColor: Colors.voidGreen, borderRadius: 4, paddingHorizontal: 8, paddingVertical: 3, marginBottom: 12 },
   slotLabel:      { letterSpacing: 1.5, fontWeight: "700" },
   cardHeader:     { flexDirection: "row", gap: 16, marginBottom: 12 },
-  cardThumb:      { width: 64, height: 92, backgroundColor: Colors.ebonyCanvas, borderRadius: 10, borderWidth: 1.5, borderColor: Colors.taroEssence, alignItems: "center", justifyContent: "center", gap: 4 },
+  cardThumb:      { width: 64, height: 92, backgroundColor: Colors.ebonyCanvas, borderRadius: 10, borderWidth: 1.5, borderColor: Colors.taroEssence, alignItems: "center", justifyContent: "center", gap: 4, overflow: "hidden" },
+  shimmerBarBase: { position: "absolute", top: -10, bottom: -10, width: 20, backgroundColor: Colors.taroEssence, opacity: 0.2 },
   cardThumbReversed: { borderColor: Colors.ironOutline, opacity: 0.85 },
   cardThumSymbol: { fontSize: 18, color: Colors.taroEssence, fontWeight: "700" },
   reversedMark:   { fontSize: 9, color: Colors.ironOutline },

--- a/apps/tarot-mobile/components/CardSpread.tsx
+++ b/apps/tarot-mobile/components/CardSpread.tsx
@@ -25,7 +25,7 @@ export function CardSpread({ spreadType, onComplete }: CardSpreadProps) {
   const [revealedSet, setRevealedSet] = useState<ReadonlySet<number>>(new Set());
 
   const enterYs = useRef(
-    Array.from({ length: CARD_COUNT }, () => new Animated.Value(200))
+    Array.from({ length: CARD_COUNT }, () => new Animated.Value(280))
   ).current;
 
   const enterOpacities = useRef(
@@ -70,6 +70,10 @@ export function CardSpread({ spreadType, onComplete }: CardSpreadProps) {
     )
   ).current;
 
+  const tapScales = useRef(
+    Array.from({ length: CARD_COUNT }, () => new Animated.Value(1))
+  ).current;
+
   useEffect(() => {
     const animations = Array.from({ length: CARD_COUNT }, (_, i) =>
       Animated.parallel([
@@ -103,6 +107,11 @@ export function CardSpread({ spreadType, onComplete }: CardSpreadProps) {
       useNativeDriver: true,
     }).start();
 
+    Animated.sequence([
+      Animated.timing(tapScales[cardIdx]!, { toValue: 1.12, duration: 90, useNativeDriver: true }),
+      Animated.spring(tapScales[cardIdx]!, { toValue: 1, tension: 200, friction: 8, useNativeDriver: true }),
+    ]).start();
+
     dimOpacities.forEach((anim, i) => {
       if (!newSelected.includes(i)) {
         Animated.timing(anim, {
@@ -125,13 +134,15 @@ export function CardSpread({ spreadType, onComplete }: CardSpreadProps) {
       setTimeout(() => {
         Animated.timing(flipScales[cardIdx]!, {
           toValue: 0,
-          duration: 210,
+          duration: 180,
+          easing: Easing.in(Easing.quad),
           useNativeDriver: true,
         }).start(() => {
           setRevealedSet(prev => new Set([...prev, cardIdx]));
-          Animated.timing(flipScales[cardIdx]!, {
+          Animated.spring(flipScales[cardIdx]!, {
             toValue: 1,
-            duration: 210,
+            tension: 200,
+            friction: 10,
             useNativeDriver: true,
           }).start(() => {
             done++;
@@ -200,7 +211,7 @@ export function CardSpread({ spreadType, onComplete }: CardSpreadProps) {
                     styles.card,
                     isSelected && !isRevealed && styles.cardSelected,
                     isRevealed && styles.cardRevealed,
-                    { transform: [{ scaleX: flipScales[i]! }] },
+                    { transform: [{ scaleX: flipScales[i]! }, { scale: tapScales[i]! }] },
                   ]}
                 >
                   {isRevealed ? (

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "6.0"
   }
 }
 


### PR DESCRIPTION
## 구현 항목

### CEO Brief #135 실행 지시: 카드 이동 및 결과 화면 진입 애니메이션 강화

**CardSpread.tsx** (카드 선택 화면)
- 카드 등장 Y 오프셋 200 → 280 (더 드라마틱한 아래에서 솟아오르는 효과)
- 카드 탭 시 스케일 펄스 추가: `1 → 1.12` 후 spring으로 자연스럽게 복귀 (`tapScales` ref 신규)
- 플립 2단계(카드 앞면 공개) `Animated.timing` → `Animated.spring(tension:200, friction:10)`으로 교체해 바운스감 부여
- 플립 1단계에 `Easing.in(Easing.quad)` 적용으로 가속감 추가

**result/index.tsx** (결과 화면)
- 결과 화면 전체 진입 fade-in 애니메이션 350ms (`screenFade`) — 이전엔 화면이 즉시 등장
- `CardReveal` translateY 초기값 32 → 52, scale 초기값 0.96 → 0.92 (더 큰 이동 범위)
- translateY에 `Easing.out(Easing.back(1.3))`, scale에 `Easing.out(Easing.back(1.1))` 적용해 스프링감 부여
- 카드 썸네일에 shimmer 스윕 애니메이션 추가 (카드 공개 후 650ms, 빛이 카드를 가로지르는 효과)

**tsconfig.base.json**
- `ignoreDeprecations: "5.0"` → `"6.0"` (TypeScript 6.0.2 환경 호환)

## 킬리스트 (미구현)

이슈 #135 본문이 생성 도중 잘려 있어 Kill list 섹션이 존재하지 않음. 확인된 범위 내에서만 구현함.

## 검증

- [x] lint 통과 (`npm run lint:web`)
- [x] typecheck 통과 (`npm run typecheck:web`)
- [x] build:web 통과
- [x] test 통과 (113 tests passed)

## 참조

이슈: #135

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfsvoY146jiuKZZFRRzeQR)_