### PR TITLE
fix(mobile): 스크롤 불작동·티커이미지 사라짐·인기종목 빈화면 3종 크리티컬 수정

### DIFF
--- a/apps/tarot-mobile/app/(tabs)/draw.tsx
+++ b/apps/tarot-mobile/app/(tabs)/draw.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import {
   SafeAreaView, View, TouchableOpacity, Animated,
   StyleSheet, ActivityIndicator, Alert,
 } from "react-native";
-import { useRouter } from "expo-router";
+import { useRouter, useFocusEffect } from "expo-router";
 import * as ExpoDigest from "expo-crypto";
 import { Text } from "../../components/ui/Text";
 import { Colors, Spacing, Radius } from "../../constants/theme";
@@ -65,6 +65,13 @@ export default function DrawScreen() {
   const { credits, setCredits, isLoggedIn } = useUserStore();
   const [phase, setPhase] = useState<"select" | "selecting" | "flipping" | "done">("select");
   const [loadingLabel, setLoadingLabel] = useState("해석 중...");
+
+  // 탭 포커스 시 "done" 상태면 "select"로 리셋 — 인기종목 클릭 후 빈 화면 방지
+  useFocusEffect(
+    useCallback(() => {
+      setPhase((prev) => (prev === "done" ? "select" : prev));
+    }, [])
+  );
 
   useEffect(() => {
     if (phase !== "flipping") return;

--- a/apps/tarot-mobile/app/(tabs)/index.tsx
+++ b/apps/tarot-mobile/app/(tabs)/index.tsx
@@ -97,6 +97,7 @@ export default function HomeScreen() {
     <SafeAreaView style={styles.container}>
       <StatusBar barStyle="light-content" />
       <ScrollView
+        style={styles.scrollView}
         contentContainerStyle={styles.scroll}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
@@ -268,6 +269,7 @@ export default function HomeScreen() {
 
 const styles = StyleSheet.create({
   container:    { flex: 1, backgroundColor: Colors.ebonyCanvas },
+  scrollView:   { flex: 1 },
   scroll:       { paddingHorizontal: Spacing.s24, paddingBottom: 40 },
   header:       { flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingTop: Spacing.s16, marginBottom: Spacing.s32 },
   brand:        { letterSpacing: 2 },

--- a/apps/tarot-mobile/app/result/index.tsx
+++ b/apps/tarot-mobile/app/result/index.tsx
@@ -207,6 +207,7 @@ export default function ResultScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView
+        style={styles.scrollView}
         contentContainerStyle={styles.scroll}
         showsVerticalScrollIndicator={false}
       >
@@ -327,6 +328,7 @@ export default function ResultScreen() {
 
 const styles = StyleSheet.create({
   container:      { flex: 1, backgroundColor: Colors.ebonyCanvas },
+  scrollView:     { flex: 1 },
   scroll:         { paddingHorizontal: Spacing.s24, paddingBottom: 48 },
   header:         { paddingTop: Spacing.s16, marginBottom: Spacing.s16 },
   backBtn:        { alignSelf: "flex-start", padding: 4 },

--- a/apps/tarot-mobile/components/TickerLogo.tsx
+++ b/apps/tarot-mobile/components/TickerLogo.tsx
@@ -8,31 +8,44 @@ interface Props {
 }
 
 export function TickerLogo({ ticker, size = 32 }: Props) {
-  const urls = getTickerLogoUrls(ticker, Math.max(size * 2, 128)); // 최소 128px
+  const urls = getTickerLogoUrls(ticker, Math.max(size * 2, 128));
   const [urlIndex, setUrlIndex] = useState(0);
+  const [loaded, setLoaded] = useState(false);
   const radius = size * 0.25;
 
-  // ticker 변경 시 항상 첫 URL부터 재시도
+  // ticker 변경 시 항상 첫 URL부터 재시도 + 로드 상태 초기화
   useEffect(() => {
     setUrlIndex(0);
+    setLoaded(false);
   }, [ticker]);
 
   const currentUrl = urls[urlIndex] ?? null;
 
+  // 모든 소스 실패 또는 URL 없음 → 컬러 이니셜 폴백
   if (!currentUrl) {
     return <Fallback ticker={ticker} size={size} radius={radius} />;
   }
 
   return (
-    <Image
-      source={{ uri: currentUrl }}
-      style={{ width: size, height: size, borderRadius: radius }}
-      onError={() => {
-        const next = urlIndex + 1;
-        setUrlIndex(next); // urls[next]가 없으면 null → Fallback
-      }}
-      resizeMode="contain"
-    />
+    <View style={{ width: size, height: size }}>
+      {/* 이미지 로드 완료 전 폴백 항상 표시 (blank 상태 방지) */}
+      {!loaded && <Fallback ticker={ticker} size={size} radius={radius} />}
+      <Image
+        source={{ uri: currentUrl }}
+        style={[
+          { width: size, height: size, borderRadius: radius },
+          // 로드 전: invisible로 마운트해 onLoad/onError 이벤트 수신 대기
+          !loaded && (StyleSheet.absoluteFill as object),
+          !loaded && { opacity: 0 },
+        ]}
+        onLoad={() => setLoaded(true)}
+        onError={() => {
+          setLoaded(false);
+          setUrlIndex((prev) => prev + 1);
+        }}
+        resizeMode="contain"
+      />
+    </View>
   );
 }
 

--- a/apps/tarot-mobile/lib/tickerLogo.ts
+++ b/apps/tarot-mobile/lib/tickerLogo.ts
@@ -96,8 +96,12 @@ export function getTickerLogoUrls(ticker: string, size = 48): string[] {
 
   if (!domain) return [];
 
-  // Clearbit: 고품질 PNG. 실패 시 colored-initial 폴백 (파비콘보다 훨씬 낫다)
-  return [`https://logo.clearbit.com/${domain}?size=${size}`];
+  // 1순위: Clearbit 고품질 PNG
+  // 2순위: Google Favicons (Clearbit 실패/rate-limit 시 폴백)
+  return [
+    `https://logo.clearbit.com/${domain}`,
+    `https://www.google.com/s2/favicons?sz=128&domain=${domain}`,
+  ];
 }
 
 /** Legacy single-URL helper — returns first candidate */


### PR DESCRIPTION
Bug 1 — 스크롤 불작동 (홈·결과화면)
- ScrollView에 style={{ flex: 1 }} 추가
- SafeAreaView(flex:1) 안에서 ScrollView가 콘텐츠 높이로 고정되던 문제 해결
- 파일: app/(tabs)/index.tsx, app/result/index.tsx

Bug 2 — 티커 이미지 blank 상태 (로딩 중 빈 화면)
- Image onLoad 전까지 colored-initial Fallback 표시
- invisible Image를 absoluteFill로 마운트해 이벤트 수신 대기
- Google Favicons를 Clearbit 실패 시 2순위 fallback URL로 추가
- 파일: components/TickerLogo.tsx, lib/tickerLogo.ts

Bug 3 — 인기종목 클릭 → 빈 draw 화면
- draw 탭은 tab navigation으로 언마운트 안 됨 → 이전 draw 완료 후 phase='done' 유지
- useFocusEffect로 포커스 시 'done'→'select' 리셋 추가
- 파일: app/(tabs)/draw.tsx

https://claude.ai/code/session_01DRieRVRKkYGJASgnRHdPXV

## Summary

- what changed
- why it changed

## Scope

- [ ] web
- [ ] api
- [ ] shared
- [ ] prisma
- [ ] docs / ci / ops

## Validation

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run build`
- [ ] local UI or API smoke check completed

## Deployment Notes

- environment variable changes:
- migration required: yes / no
- rollout order:

## Rollback Plan

- previous healthy commit or deployment:
- rollback trigger:
- rollback steps:

## Screenshots or Logs

- UI screenshot if the PR changes frontend behavior
- relevant terminal output if the PR changes deployment or runtime behavior
