### PR TITLE
feat(quote): 결측치 명시 + dataAt + 캐싱 TTL 분기 + 데이터 완전성 헤더 [우선순위 #1]

### DIFF
--- a/apps/tarot-mobile/components/ticker/MetricsGrid.tsx
+++ b/apps/tarot-mobile/components/ticker/MetricsGrid.tsx
@@ -32,8 +32,8 @@ export function MetricsGrid({ quote }: Props) {
   const metrics: MetricCard[] = [
     {
       label: "시가총액",
-      value: formatLargeNumber(quote.marketCap, currency),
-      show: quote.marketCap > 0,
+      value: quote.marketCap != null ? formatLargeNumber(quote.marketCap, currency) : "-",
+      show: quote.marketCap != null && quote.marketCap > 0,
     },
     {
       label: "PER",

--- a/apps/tarot-mobile/components/ticker/PriceStats.tsx
+++ b/apps/tarot-mobile/components/ticker/PriceStats.tsx
@@ -28,7 +28,7 @@ export function PriceStats({ quote }: Props) {
 
       <View style={styles.card}>
         {/* Day range */}
-        {quote.dayLow > 0 && quote.dayHigh > 0 && (
+        {quote.dayLow != null && quote.dayHigh != null && quote.dayLow > 0 && quote.dayHigh > 0 && (
           <RangeBar
             label="오늘"
             min={quote.dayLow}
@@ -39,7 +39,7 @@ export function PriceStats({ quote }: Props) {
         )}
 
         {/* 52-week range */}
-        {quote.fiftyTwoWeekLow > 0 && quote.fiftyTwoWeekHigh > 0 && (
+        {quote.fiftyTwoWeekLow != null && quote.fiftyTwoWeekHigh != null && quote.fiftyTwoWeekLow > 0 && quote.fiftyTwoWeekHigh > 0 && (
           <View style={styles.rangeSpacing}>
             <RangeBar
               label="52주"

--- a/apps/web/__tests__/api/tarot/quote.test.ts
+++ b/apps/web/__tests__/api/tarot/quote.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// 검증 항목:
+//   1. 정상 응답 — 모든 필드 채워짐, dataAt 존재, X-Data-Completeness=full
+//   2. 결측치 — 외부 API에서 일부 필드 누락 → null 명시 + X-Data-Completeness 헤더에 누락 필드 콤마 명시
+//   3. symbol 누락 → 400
+//   4. 외부 API 502 → 502 패스스루
+//   5. 외부 API result 없음 → 404
+//   6. 캐시 — 같은 symbol 두 번째 호출은 외부 fetch 없이 캐시 응답
+//   7. 결측치 발생 시 구조화 로그 (metric: quote_field_missing)
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { GET } from "@/app/api/tarot/quote/route";
+import { NextRequest } from "next/server";
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+function fullYahooPayload() {
+  return {
+    quoteSummary: {
+      result: [
+        {
+          price: {
+            shortName: "Apple Inc.",
+            longName: "Apple Inc.",
+            currency: "USD",
+            exchangeName: "NMS",
+            regularMarketPrice: { raw: 200.5 },
+            regularMarketPreviousClose: { raw: 198.0 },
+            regularMarketChange: { raw: 2.5 },
+            regularMarketChangePercent: { raw: 1.26 },
+            marketCap: { raw: 3_000_000_000_000 },
+          },
+          summaryDetail: {
+            dayLow: { raw: 199.0 },
+            dayHigh: { raw: 201.5 },
+            fiftyTwoWeekLow: { raw: 150.0 },
+            fiftyTwoWeekHigh: { raw: 220.0 },
+            trailingPE: { raw: 28.5 },
+            volume: { raw: 50_000_000 },
+            averageVolume: { raw: 45_000_000 },
+            dividendYield: { raw: 0.005 },
+          },
+          defaultKeyStatistics: {
+            forwardPE: { raw: 25.0 },
+            priceToBook: { raw: 40.0 },
+          },
+          financialData: {
+            returnOnEquity: { raw: 1.5 },
+            grossMargins: { raw: 0.45 },
+            operatingMargins: { raw: 0.3 },
+            totalRevenue: { raw: 400_000_000_000 },
+            revenueGrowth: { raw: 0.05 },
+            debtToEquity: { raw: 150 },
+          },
+        },
+      ],
+    },
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("/api/tarot/quote", () => {
+  it("symbol 누락 → 400", async () => {
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote"));
+    expect(res.status).toBe(400);
+  });
+
+  it("정상 응답 — 모든 필드 채워짐 + dataAt + X-Data-Completeness=full", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => fullYahooPayload(),
+    });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=FULL1"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.symbol).toBe("FULL1");
+    expect(body.currentPrice).toBe(200.5);
+    expect(body.dayLow).toBe(199.0);
+    expect(body.dayHigh).toBe(201.5);
+    expect(body.fiftyTwoWeekLow).toBe(150.0);
+    expect(body.fiftyTwoWeekHigh).toBe(220.0);
+    expect(body.marketCap).toBe(3_000_000_000_000);
+    expect(typeof body.dataAt).toBe("string");
+    expect(() => new Date(body.dataAt)).not.toThrow();
+    expect(Number.isNaN(new Date(body.dataAt).getTime())).toBe(false);
+
+    expect(res.headers.get("X-Data-Completeness")).toBe("full");
+  });
+
+  it("결측치 — dayLow / dayHigh / 52주 / marketCap 누락 시 null + X-Data-Completeness 헤더에 명시", async () => {
+    const payload = fullYahooPayload();
+    const r = payload.quoteSummary.result[0]!;
+    // 의도적 누락
+    delete (r.summaryDetail as { dayLow?: unknown }).dayLow;
+    delete (r.summaryDetail as { dayHigh?: unknown }).dayHigh;
+    delete (r.summaryDetail as { fiftyTwoWeekLow?: unknown }).fiftyTwoWeekLow;
+    delete (r.summaryDetail as { fiftyTwoWeekHigh?: unknown }).fiftyTwoWeekHigh;
+    delete (r.price as { marketCap?: unknown }).marketCap;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=MISS1"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.dayLow).toBeNull();
+    expect(body.dayHigh).toBeNull();
+    expect(body.fiftyTwoWeekLow).toBeNull();
+    expect(body.fiftyTwoWeekHigh).toBeNull();
+    expect(body.marketCap).toBeNull();
+
+    const completeness = res.headers.get("X-Data-Completeness") ?? "";
+    expect(completeness).toContain("dayLow");
+    expect(completeness).toContain("dayHigh");
+    expect(completeness).toContain("fiftyTwoWeekLow");
+    expect(completeness).toContain("fiftyTwoWeekHigh");
+    expect(completeness).toContain("marketCap");
+  });
+
+  it("결측치 발생 시 구조화 로그 출력 (metric: quote_field_missing)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const payload = fullYahooPayload();
+    delete (payload.quoteSummary.result[0]!.price as { marketCap?: unknown }).marketCap;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+
+    await GET(makeRequest("http://localhost/api/tarot/quote?symbol=LOG1"));
+
+    const calls = warnSpy.mock.calls.map((c) => String(c[0]));
+    const found = calls.find((c) => c.includes("quote_field_missing") && c.includes("marketCap") && c.includes("LOG1"));
+    expect(found).toBeTruthy();
+  });
+
+  it("외부 API 502 → 502 패스스루", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=ERR1"));
+    expect(res.status).toBe(502);
+  });
+
+  it("외부 API result 없음 → 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ quoteSummary: { result: [] } }),
+    });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=EMPTY1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("캐시 — 같은 symbol 두 번째 호출은 외부 fetch 없이 캐시 응답", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => fullYahooPayload(),
+    });
+
+    const r1 = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=CACHE1"));
+    expect(r1.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const r2 = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=CACHE1"));
+    expect(r2.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const body = await r2.json();
+    expect(body.symbol).toBe("CACHE1");
+    expect(typeof body.dataAt).toBe("string");
+  });
+});

--- a/apps/web/app/api/tarot/quote/route.ts
+++ b/apps/web/app/api/tarot/quote/route.ts
@@ -4,9 +4,13 @@ import type { StockQuote } from "@trading/shared/src/stockTypes";
 const YAHOO_QUOTE_URL = "https://query2.finance.yahoo.com/v10/finance/quoteSummary";
 const USER_AGENT = "Mozilla/5.0 (compatible; TarotStockBot/1.0)";
 
-// 5분 in-memory 캐시
-const CACHE_TTL_MS = 5 * 60 * 1000;
-const cache = new Map<string, { data: StockQuote; expiresAt: number }>();
+// 캐시 TTL: 장중 30초 / 장외 5분 (Yahoo marketState 기준)
+const CACHE_TTL_REGULAR_MS = 30 * 1000;
+const CACHE_TTL_OFF_HOURS_MS = 5 * 60 * 1000;
+const cache = new Map<string, { data: StockQuote; completeness: string; expiresAt: number }>();
+
+// 결측 가능 필드 — 외부 데이터 소스에서 누락 시 null. 0과 결측을 구분.
+const NULLABLE_FIELDS = ["dayLow", "dayHigh", "fiftyTwoWeekLow", "fiftyTwoWeekHigh", "marketCap"] as const;
 
 function extractNum(obj: unknown): number | null {
   if (obj && typeof obj === "object" && "raw" in obj) {
@@ -15,6 +19,17 @@ function extractNum(obj: unknown): number | null {
   }
   if (typeof obj === "number" && Number.isFinite(obj)) return obj;
   return null;
+}
+
+function logMissing(symbol: string, fields: readonly string[]): void {
+  if (fields.length === 0) return;
+  for (const field of fields) {
+    console.warn(JSON.stringify({ metric: "quote_field_missing", symbol, field }));
+  }
+}
+
+function pickCacheTtl(marketState: string | null): number {
+  return marketState === "REGULAR" ? CACHE_TTL_REGULAR_MS : CACHE_TTL_OFF_HOURS_MS;
 }
 
 export async function GET(req: NextRequest) {
@@ -26,7 +41,9 @@ export async function GET(req: NextRequest) {
   const now = Date.now();
   const hit = cache.get(symbol);
   if (hit && hit.expiresAt > now) {
-    return NextResponse.json(hit.data);
+    return NextResponse.json(hit.data, {
+      headers: { "X-Data-Completeness": hit.completeness, "X-Cache": "HIT" },
+    });
   }
 
   try {
@@ -71,6 +88,12 @@ export async function GET(req: NextRequest) {
     const changePercent = extractNum(price.regularMarketChangePercent) ??
       (previousClose ? ((currentPrice - previousClose) / previousClose) * 100 : 0);
 
+    const dayLow = extractNum(summary.dayLow);
+    const dayHigh = extractNum(summary.dayHigh);
+    const fiftyTwoWeekLow = extractNum(summary.fiftyTwoWeekLow);
+    const fiftyTwoWeekHigh = extractNum(summary.fiftyTwoWeekHigh);
+    const marketCap = extractNum(price.marketCap);
+
     const quote: StockQuote = {
       symbol,
       shortName: (price.shortName as string) ?? symbol,
@@ -81,28 +104,39 @@ export async function GET(req: NextRequest) {
       previousClose,
       change,
       changePercent,
-      dayLow: extractNum(summary.dayLow) ?? 0,
-      dayHigh: extractNum(summary.dayHigh) ?? 0,
-      fiftyTwoWeekLow: extractNum(summary.fiftyTwoWeekLow) ?? 0,
-      fiftyTwoWeekHigh: extractNum(summary.fiftyTwoWeekHigh) ?? 0,
-      marketCap: extractNum(price.marketCap) ?? 0,
+      dayLow,
+      dayHigh,
+      fiftyTwoWeekLow,
+      fiftyTwoWeekHigh,
+      marketCap,
       trailingPE: extractNum(summary.trailingPE),
       forwardPE: extractNum(keyStats.forwardPE) ?? extractNum(summary.forwardPE),
       priceToBook: extractNum(keyStats.priceToBook),
       dividendYield: extractNum(summary.dividendYield),
       volume: extractNum(summary.volume) ?? 0,
       averageVolume: extractNum(summary.averageVolume) ?? 0,
-      // Phase 2 extended fields
       returnOnEquity: extractNum(financialData.returnOnEquity),
       grossMargins: extractNum(financialData.grossMargins),
       operatingMargins: extractNum(financialData.operatingMargins),
       totalRevenue: extractNum(financialData.totalRevenue),
       revenueGrowth: extractNum(financialData.revenueGrowth),
       debtToEquity: extractNum(financialData.debtToEquity),
+      dataAt: new Date(now).toISOString(),
     };
 
-    cache.set(symbol, { data: quote, expiresAt: now + CACHE_TTL_MS });
-    return NextResponse.json(quote);
+    // 결측치 추적: null인 필드 목록
+    const missing = NULLABLE_FIELDS.filter((f) => quote[f] === null);
+    logMissing(symbol, missing);
+
+    const completeness = missing.length === 0 ? "full" : missing.join(",");
+    const marketState = (price.marketState as string | undefined) ?? null;
+    const ttl = pickCacheTtl(marketState);
+
+    cache.set(symbol, { data: quote, completeness, expiresAt: now + ttl });
+
+    return NextResponse.json(quote, {
+      headers: { "X-Data-Completeness": completeness, "X-Cache": "MISS" },
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/packages/shared/src/stockTypes.ts
+++ b/packages/shared/src/stockTypes.ts
@@ -11,11 +11,12 @@ export interface StockQuote {
   previousClose: number;
   change: number;
   changePercent: number;
-  dayLow: number;
-  dayHigh: number;
-  fiftyTwoWeekLow: number;
-  fiftyTwoWeekHigh: number;
-  marketCap: number;
+  // 결측 가능 — 외부 데이터 소스에서 누락 시 null. 0과 결측을 구분하기 위함.
+  dayLow: number | null;
+  dayHigh: number | null;
+  fiftyTwoWeekLow: number | null;
+  fiftyTwoWeekHigh: number | null;
+  marketCap: number | null;
   trailingPE: number | null;
   forwardPE: number | null;
   priceToBook: number | null;
@@ -29,6 +30,8 @@ export interface StockQuote {
   totalRevenue?: number | null;
   revenueGrowth?: number | null;
   debtToEquity?: number | null;
+  // 응답 생성 시각 (ISO 8601). 캐시 신선도 추적용.
+  dataAt: string;
 }
 
 export interface StockChartBar {


### PR DESCRIPTION
## 우선순위 #1 — `/api/tarot/quote` 응답 스키마 확장 + 캐싱 일관화

CEO Brief #212 의 오늘 처리 우선순위 1번 항목. 원본 이슈: #204.

## 변경 요약

### `packages/shared/src/stockTypes.ts`
- `dayLow`, `dayHigh`, `fiftyTwoWeekLow`, `fiftyTwoWeekHigh`, `marketCap` → **nullable** (`number | null`). 0과 결측을 구분하기 위함.
- **`dataAt: string`** (ISO 8601) 신규 — 응답 생성 시각, 캐시 신선도 추적.

### `apps/web/app/api/tarot/quote/route.ts`
- 결측 시 `null` 명시 (기존 `?? 0` 제거)
- **`X-Data-Completeness`** 응답 헤더: 전부 채워지면 `full`, 누락 시 필드 콤마 명시
- **`X-Cache`** 응답 헤더: `HIT` / `MISS`
- **캐시 TTL 분기**: Yahoo `marketState === "REGULAR"` 면 30초, 그 외 5분
- **결측치 구조화 로그**: `{metric: "quote_field_missing", symbol, field}` — 결측치율 측정 인프라 첫 단계
- `dataAt` 응답 필드 포함

### 클라이언트 호환성 패치
- `apps/tarot-mobile/components/ticker/PriceStats.tsx` — `quote.dayLow > 0` → `quote.dayLow != null && quote.dayLow > 0`
- `apps/tarot-mobile/components/ticker/MetricsGrid.tsx` — `marketCap` null 처리 + "-" placeholder

## 테스트 (TDD — RED → GREEN)

`apps/web/__tests__/api/tarot/quote.test.ts` 신규 — vitest 7케이스:
1. ✅ symbol 누락 → 400
2. ✅ 정상 응답 — 모든 필드 채워짐 + dataAt + `X-Data-Completeness=full`
3. ✅ 결측치 (dayLow/dayHigh/52주/marketCap) → null + 헤더에 누락 필드 명시
4. ✅ 결측치 발생 시 구조화 로그 출력 (`quote_field_missing`)
5. ✅ 외부 API 502 → 502 패스스루
6. ✅ 외부 API result 없음 → 404
7. ✅ 캐시 동작 — 같은 symbol 두 번째 호출은 fetch 없이 캐시 응답

## 검증

- [x] `npm run lint` (전 워크스페이스 typecheck) 통과
- [x] `npm run test` 120/120 통과
- [x] `npm run build:web` 통과

## North Star 정렬

4축 중 **③ 백엔드 인프라**(API 정합성·캐싱·외부 데이터)와 **④ 토스증권 멘탈모델**(단일 호출로 시세·등락·52주·시가총액 1차 정보 완비)에 직결.

## 다음 우선순위 의존성

- **우선순위 #2** (#207 — 종목 상세 N+1 호출 제거): 이 PR이 선행. 확장된 스키마를 클라이언트 셀렉터에서 단일 호출로 통합.
- **우선순위 #3** (#210 — 해석 프롬프트 종목 데이터 주입): 이 PR이 선행. 확장된 응답을 LLM 입력으로 사용.
- **우선순위 #8** (#206 — 정합성 회귀 테스트): 이 PR의 테스트가 시작점. QA 확장 가능.


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_