### PR TITLE
feat(stock-store): per-symbol 캐시 + stale-while-revalidate [우선순위 #2]

### DIFF
--- a/apps/tarot-mobile/app/ticker/[symbol].tsx
+++ b/apps/tarot-mobile/app/ticker/[symbol].tsx
@@ -45,7 +45,7 @@ export default function TickerDetailScreen() {
   const {
     quote, chartBars, chartRange, quoteLoading, chartLoading,
     profile, quarterlyEarnings, annualFinancials, financialsLoading,
-    fetchQuote, fetchChart, fetchFinancials, reset,
+    fetchQuote, fetchChart, fetchFinancials, clearActive,
   } = useStockStore();
   const { isFavorite, addFavorite, removeFavorite } = useFavoritesStore();
   const { setTicker } = useDrawStore();
@@ -59,13 +59,17 @@ export default function TickerDetailScreen() {
     fetchQuote(symbol);
     fetchChart(symbol);
     fetchFinancials(symbol);
-    return () => reset();
+    return () => clearActive();
   }, [symbol]);
 
   const handleRefresh = useCallback(async () => {
     if (!symbol) return;
     setRefreshing(true);
-    await Promise.all([fetchQuote(symbol), fetchChart(symbol), fetchFinancials(symbol)]);
+    await Promise.all([
+      fetchQuote(symbol, { force: true }),
+      fetchChart(symbol, undefined, { force: true }),
+      fetchFinancials(symbol, { force: true }),
+    ]);
     setRefreshing(false);
   }, [symbol, fetchQuote, fetchChart, fetchFinancials]);
 

--- a/apps/tarot-mobile/lib/stockStore.ts
+++ b/apps/tarot-mobile/lib/stockStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { apiFetch } from "./api";
+import { classifyFreshness } from "@trading/shared/src/staleness";
 import type { StockQuote, StockChartBar, StockChartResponse } from "@trading/shared/src/stockTypes";
 
 export type ChartRange = "1d" | "5d" | "1mo" | "3mo" | "1y";
@@ -31,7 +32,25 @@ interface FinancialsResponse {
   annualFinancials: AnnualFinancial[];
 }
 
+interface FinancialsBundle {
+  profile: CompanyProfile;
+  quarterlyEarnings: QuarterlyEarning[];
+  annualFinancials: AnnualFinancial[];
+  cachedAt: number; // for staleness
+}
+
+interface ChartBundle {
+  bars: StockChartBar[];
+  range: ChartRange;
+  cachedAt: number;
+}
+
+// Stale-while-revalidate: data 60초 이내 → fresh (fetch 스킵), 5분 이내 → stale (즉시 표시 + 백그라운드 fetch), 그 외 → expired (정상 fetch)
+const FRESH_TTL_MS = 60 * 1000;
+const STALE_TTL_MS = 5 * 60 * 1000;
+
 interface StockState {
+  // 현재 화면 표시용 (셀렉터)
   quote: StockQuote | null;
   chartBars: StockChartBar[];
   chartRange: ChartRange;
@@ -39,17 +58,23 @@ interface StockState {
   chartLoading: boolean;
   error: string | null;
 
-  // Financials
+  // Financials (현재 표시)
   profile: CompanyProfile | null;
   quarterlyEarnings: QuarterlyEarning[];
   annualFinancials: AnnualFinancial[];
   financialsLoading: boolean;
 
-  fetchQuote: (symbol: string) => Promise<void>;
-  fetchChart: (symbol: string, range?: ChartRange) => Promise<void>;
-  fetchFinancials: (symbol: string) => Promise<void>;
+  // per-symbol 캐시 (stale-while-revalidate 지원)
+  quoteCache: Record<string, StockQuote>;
+  chartCache: Record<string, ChartBundle>;
+  financialsCache: Record<string, FinancialsBundle>;
+
+  fetchQuote: (symbol: string, opts?: { force?: boolean }) => Promise<void>;
+  fetchChart: (symbol: string, range?: ChartRange, opts?: { force?: boolean }) => Promise<void>;
+  fetchFinancials: (symbol: string, opts?: { force?: boolean }) => Promise<void>;
   setChartRange: (range: ChartRange) => void;
-  reset: () => void;
+  /** 현재 표시 상태만 비움 — 캐시는 유지 (다른 종목 진입 시 호출). */
+  clearActive: () => void;
 }
 
 export const useStockStore = create<StockState>((set, get) => ({
@@ -63,47 +88,127 @@ export const useStockStore = create<StockState>((set, get) => ({
   quarterlyEarnings: [],
   annualFinancials: [],
   financialsLoading: false,
+  quoteCache: {},
+  chartCache: {},
+  financialsCache: {},
 
-  fetchQuote: async (symbol) => {
-    set({ quoteLoading: true, error: null });
+  fetchQuote: async (symbol, opts) => {
+    const force = opts?.force === true;
+    const cached = get().quoteCache[symbol];
+    const now = Date.now();
+    const freshness = cached
+      ? classifyFreshness(cached.dataAt, now, FRESH_TTL_MS, STALE_TTL_MS)
+      : "expired";
+
+    // 캐시 hit: 즉시 표시 (fresh든 stale이든)
+    if (cached) {
+      set({ quote: cached, quoteLoading: false, error: null });
+    } else {
+      set({ quote: null, quoteLoading: true, error: null });
+    }
+
+    // fresh + !force → fetch 스킵
+    if (freshness === "fresh" && !force) {
+      return;
+    }
+
+    // stale 또는 expired 또는 force → fetch (백그라운드)
     try {
       const data = await apiFetch<StockQuote>(
         `/api/tarot/quote?symbol=${encodeURIComponent(symbol)}`
       );
-      set({ quote: data, quoteLoading: false });
+      set((s) => ({
+        quote: get().quote?.symbol === symbol || !get().quote ? data : s.quote,
+        quoteLoading: false,
+        quoteCache: { ...s.quoteCache, [symbol]: data },
+      }));
     } catch (err) {
+      // 캐시 hit이었으면 에러 무시하고 stale 데이터 유지 (백그라운드 재검증 실패)
+      const hadCache = !!cached;
       set({
         quoteLoading: false,
-        error: err instanceof Error ? err.message : "시세 조회 실패",
+        error: hadCache ? null : err instanceof Error ? err.message : "시세 조회 실패",
       });
     }
   },
 
-  fetchChart: async (symbol, range) => {
+  fetchChart: async (symbol, range, opts) => {
+    const force = opts?.force === true;
     const r = range ?? get().chartRange;
-    set({ chartLoading: true, chartRange: r });
+    const cacheKey = `${symbol}:${r}`;
+    const cached = get().chartCache[cacheKey];
+    const now = Date.now();
+    const cachedAtIso = cached ? new Date(cached.cachedAt).toISOString() : null;
+    const freshness = cachedAtIso
+      ? classifyFreshness(cachedAtIso, now, FRESH_TTL_MS, STALE_TTL_MS)
+      : "expired";
+
+    if (cached) {
+      set({ chartBars: cached.bars, chartRange: r, chartLoading: false });
+    } else {
+      set({ chartBars: [], chartRange: r, chartLoading: true });
+    }
+
+    if (freshness === "fresh" && !force) return;
+
     try {
       const data = await apiFetch<StockChartResponse>(
         `/api/tarot/chart?symbol=${encodeURIComponent(symbol)}&range=${r}`
       );
-      set({ chartBars: data.bars, chartLoading: false });
+      set((s) => ({
+        chartBars: get().chartRange === r ? data.bars : s.chartBars,
+        chartLoading: false,
+        chartCache: {
+          ...s.chartCache,
+          [cacheKey]: { bars: data.bars, range: r, cachedAt: Date.now() },
+        },
+      }));
     } catch {
-      set({ chartLoading: false, chartBars: [] });
+      set({ chartLoading: false });
     }
   },
 
-  fetchFinancials: async (symbol) => {
-    set({ financialsLoading: true });
+  fetchFinancials: async (symbol, opts) => {
+    const force = opts?.force === true;
+    const cached = get().financialsCache[symbol];
+    const now = Date.now();
+    const cachedAtIso = cached ? new Date(cached.cachedAt).toISOString() : null;
+    const freshness = cachedAtIso
+      ? classifyFreshness(cachedAtIso, now, FRESH_TTL_MS, STALE_TTL_MS)
+      : "expired";
+
+    if (cached) {
+      set({
+        profile: cached.profile,
+        quarterlyEarnings: cached.quarterlyEarnings,
+        annualFinancials: cached.annualFinancials,
+        financialsLoading: false,
+      });
+    } else {
+      set({ financialsLoading: true });
+    }
+
+    if (freshness === "fresh" && !force) return;
+
     try {
       const data = await apiFetch<FinancialsResponse>(
         `/api/tarot/financials?symbol=${encodeURIComponent(symbol)}`
       );
-      set({
+      set((s) => ({
         profile: data.profile,
         quarterlyEarnings: data.quarterlyEarnings,
         annualFinancials: data.annualFinancials,
         financialsLoading: false,
-      });
+        financialsCache: {
+          ...s.financialsCache,
+          [symbol]: {
+            profile: data.profile,
+            quarterlyEarnings: data.quarterlyEarnings,
+            annualFinancials: data.annualFinancials,
+            cachedAt: Date.now(),
+          },
+        },
+      }));
     } catch {
       set({ financialsLoading: false });
     }
@@ -111,7 +216,7 @@ export const useStockStore = create<StockState>((set, get) => ({
 
   setChartRange: (range) => set({ chartRange: range }),
 
-  reset: () =>
+  clearActive: () =>
     set({
       quote: null,
       chartBars: [],

--- a/packages/shared/__tests__/staleness.test.ts
+++ b/packages/shared/__tests__/staleness.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { classifyFreshness, isFresh } from "../src/staleness";
+
+describe("staleness", () => {
+  const now = Date.parse("2026-05-27T12:00:00.000Z");
+  const freshTtl = 60_000; // 1 min
+  const staleTtl = 5 * 60_000; // 5 min
+
+  it("dataAt 없으면 expired", () => {
+    expect(classifyFreshness(null, now, freshTtl, staleTtl)).toBe("expired");
+    expect(classifyFreshness(undefined, now, freshTtl, staleTtl)).toBe("expired");
+  });
+
+  it("dataAt 가 잘못된 형식이면 expired", () => {
+    expect(classifyFreshness("not-a-date", now, freshTtl, staleTtl)).toBe("expired");
+  });
+
+  it("freshTtl 이내면 fresh", () => {
+    const t = new Date(now - 30_000).toISOString(); // 30초 전
+    expect(classifyFreshness(t, now, freshTtl, staleTtl)).toBe("fresh");
+    expect(isFresh(t, now, freshTtl)).toBe(true);
+  });
+
+  it("freshTtl 초과 + staleTtl 이내면 stale", () => {
+    const t = new Date(now - 120_000).toISOString(); // 2분 전
+    expect(classifyFreshness(t, now, freshTtl, staleTtl)).toBe("stale");
+    expect(isFresh(t, now, freshTtl)).toBe(false);
+  });
+
+  it("staleTtl 초과면 expired", () => {
+    const t = new Date(now - 6 * 60_000).toISOString(); // 6분 전
+    expect(classifyFreshness(t, now, freshTtl, staleTtl)).toBe("expired");
+  });
+
+  it("미래 시간(서버 시계 앞섬) 은 fresh로 간주", () => {
+    const t = new Date(now + 10_000).toISOString(); // 10초 후
+    expect(classifyFreshness(t, now, freshTtl, staleTtl)).toBe("fresh");
+  });
+
+  it("freshTtl 경계값 정확 매치", () => {
+    const t = new Date(now - freshTtl).toISOString(); // 정확히 60초 전
+    expect(classifyFreshness(t, now, freshTtl, staleTtl)).toBe("fresh");
+  });
+
+  it("staleTtl 경계값 정확 매치", () => {
+    const t = new Date(now - staleTtl).toISOString(); // 정확히 5분 전
+    expect(classifyFreshness(t, now, freshTtl, staleTtl)).toBe("stale");
+  });
+});

--- a/packages/shared/src/staleness.ts
+++ b/packages/shared/src/staleness.ts
@@ -1,0 +1,27 @@
+// Cache freshness utilities.
+// dataAt: ISO 8601 timestamp from server response (StockQuote.dataAt).
+// freshTtlMs: data considered fresh within this window — fetch can be skipped.
+// staleTtlMs: data older than this is considered too stale to display — must fetch.
+// Between fresh and stale: display cached data immediately and revalidate in background.
+
+export type Freshness = "fresh" | "stale" | "expired";
+
+export function classifyFreshness(
+  dataAt: string | null | undefined,
+  now: number,
+  freshTtlMs: number,
+  staleTtlMs: number
+): Freshness {
+  if (!dataAt) return "expired";
+  const t = Date.parse(dataAt);
+  if (!Number.isFinite(t)) return "expired";
+  const age = now - t;
+  if (age < 0) return "fresh"; // server clock ahead of client — treat as fresh
+  if (age <= freshTtlMs) return "fresh";
+  if (age <= staleTtlMs) return "stale";
+  return "expired";
+}
+
+export function isFresh(dataAt: string | null | undefined, now: number, freshTtlMs: number): boolean {
+  return classifyFreshness(dataAt, now, freshTtlMs, freshTtlMs) === "fresh";
+}


### PR DESCRIPTION
## 우선순위 #2 — stale-while-revalidate + per-symbol 캐시

CEO Brief #212 오늘 처리 우선순위 2번. 원본 이슈: #207.

## 가설 재정의 (CEO 컨펌 후 진행)

원본 #207 가설("PriceStats/RangeBar/MetricsGrid가 각자 fetch")이 코드와 안 맞음 — 이미 zustand store에서 단일 호출 + 컴포넌트는 prop 패턴. CEO 컨펌으로 진짜 가치 있는 작업으로 재정의:

**종목 상세 재진입 시 즉시 paint (stale-while-revalidate)** — #213 에서 추가한 `dataAt` 필드를 활용해 per-symbol 캐시 + freshness 분류 + 백그라운드 재검증.

## 변경 요약

### `packages/shared/src/staleness.ts` (신규)
순수 헬퍼:
- `classifyFreshness(dataAt, now, freshTtl, staleTtl)` → `"fresh" | "stale" | "expired"`
- `isFresh(dataAt, now, freshTtl)` 단축형

엣지 케이스: null/undefined/잘못된 ISO → `"expired"`. 미래 시간(서버 시계 앞섬) → `"fresh"` 안전 처리.

### `packages/shared/__tests__/staleness.test.ts` (신규)
vitest 8 케이스 — null, 잘못된 형식, fresh, stale, expired, 미래 시간, 두 경계값.

### `apps/tarot-mobile/lib/stockStore.ts` (재설계)
- **per-symbol 캐시 맵**: `quoteCache`, `chartCache` (range별 키), `financialsCache`
- **3-단계 freshness 분류**:
  - `fresh` (60초 이내) + `!force` → 캐시 즉시 표시, **fetch 스킵**
  - `stale` (5분 이내) → 캐시 즉시 표시 + **백그라운드 재검증** (실패해도 stale 유지)
  - `expired` 또는 캐시 없음 → loading=true, 정상 fetch
- **`force: true` 옵션** — RefreshControl 등 명시적 새로고침 시 사용
- `reset()` → `clearActive()` 로 의미 명확화 (캐시는 유지)

### `apps/tarot-mobile/app/ticker/[symbol].tsx`
- `reset` → `clearActive` 호출 변경
- RefreshControl 핸들러 → `force: true` 옵션으로 캐시 우회

## 효과

| 시나리오 | 기존 | 변경 후 |
|---|---|---|
| 종목 A → B → A 재진입 | 매번 quote/chart/financials 3회 fetch | A 캐시 hit, fresh면 fetch 스킵 / stale이면 즉시 paint + 백그라운드 |
| 첫 진입 후 60초 내 새로고침 | 3회 fetch | (`force: true` 명시 시에만) 3회 fetch |
| 종목 상세 첫 paint (cache hit) | 로딩 스피너 + 네트워크 RTT | 즉시 표시 (백그라운드 재검증) |
| 네트워크 실패 (stale 보유 시) | 화면 빈 상태 | stale 데이터 유지, 에러 노출 X |

## 검증

- [x] `npm run lint` 전 워크스페이스 통과
- [x] `npm run test` **128/128** 통과 (staleness 신규 8케이스 포함)
- [x] `npm run build:web` 통과

## North Star 정렬

4축 중 **① UX 개선**(재진입 시 첫 paint 단축) + **③ 백엔드 인프라**(불필요 호출 절감) 직결.

## 다음 우선순위 의존성

- **우선순위 #3** (#210 — Prompt Engineer 종목 데이터 주입): 독립 진행 가능. `StockQuote` 스키마(#213) 활용.
- **우선순위 #4-#8**: 독립 진행 가능.


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_