### PR TITLE
feat(prompt-v2.1): 종목 정체성(이름·섹터·시가총액·52주 위치) 심리 신호로 통합 [우선순위 #3]

### DIFF
--- a/apps/web/lib/tarot/market.ts
+++ b/apps/web/lib/tarot/market.ts
@@ -149,6 +149,17 @@ export async function fetchMarketSnapshot(
   const support20 = recentLows.length > 0 ? Math.min(...recentLows) : undefined;
   const resistance20 = recentHighs.length > 0 ? Math.max(...recentHighs) : undefined;
 
+  // 52주 위치 — 1년 데이터의 high/low 범위 내 현재 가격 위치 (0~1)
+  let fiftyTwoWeekPosition: number | undefined;
+  if (highs.length > 0 && lows.length > 0) {
+    const high52 = Math.max(...highs);
+    const low52 = Math.min(...lows);
+    const range = high52 - low52;
+    if (range > 0) {
+      fiftyTwoWeekPosition = Math.min(1, Math.max(0, (price - low52) / range));
+    }
+  }
+
   const condition = inferCondition(
     changePercent, rsi, macd.histogram, price, sma20, bb?.upper ?? null, bb?.lower ?? null
   );
@@ -186,6 +197,10 @@ export async function fetchMarketSnapshot(
   }
   if (support20 !== undefined) snapshot.support20 = support20;
   if (resistance20 !== undefined) snapshot.resistance20 = resistance20;
+
+  // 종목 정체성 — chart meta로부터 즉시 채울 수 있는 것만. sector/industry/marketCap은 별도 API 통합 후 추가 예정.
+  if (meta?.shortName) snapshot.name = meta.shortName;
+  if (fiftyTwoWeekPosition !== undefined) snapshot.fiftyTwoWeekPosition = fiftyTwoWeekPosition;
 
   marketCache.set(cacheKey, { snapshot, expiresAt: now + MARKET_CACHE_TTL_MS });
   return snapshot;

--- a/packages/tarot-core/src/__tests__/prompt-v2.1-identity.test.ts
+++ b/packages/tarot-core/src/__tests__/prompt-v2.1-identity.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { buildInterpretationPromptV2_1 } from "../prompts/interpret-v2.1.0.js";
+import type { MarketSnapshot, DrawnCard } from "../types.js";
+
+function baseMarket(): MarketSnapshot {
+  return {
+    ticker: "AAPL",
+    market: "US",
+    price: 200,
+    changePercent: 0.5,
+    volume: 1_000_000,
+    condition: "neutral",
+    summary: "AAPL 200 (+0.50%) — 중립",
+  };
+}
+
+function sampleCard(): DrawnCard {
+  return {
+    card: {
+      id: "the-tower",
+      name: "The Tower",
+      nameKo: "탑",
+      arcana: "major",
+      number: 16,
+      keywords: ["upheaval", "change"],
+      keywordsKo: ["격변", "변화"],
+      meaningUpright: "기존 구조의 흔들림",
+      meaningReversed: "두려워하던 폭락은 오지 않음",
+      imageUrl: "/cards/the-tower.jpg",
+      toneGuide: "차분하지만 단호한",
+      isActive: true,
+    },
+    orientation: "upright",
+  };
+}
+
+describe("interpret-v2.1.0 — 종목 정체성 통합", () => {
+  it("회사 이름(name) 이 풍경 컨텍스트에 포함", () => {
+    const market = baseMarket();
+    market.name = "Apple Inc.";
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    expect(prompt).toContain("Apple Inc.");
+  });
+
+  it("섹터(sector) 가 풍경 컨텍스트에 포함", () => {
+    const market = baseMarket();
+    market.sector = "Technology";
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    expect(prompt).toContain("Technology");
+  });
+
+  it("시가총액 — 대형주(>= $10B)면 심리 표현 추가", () => {
+    const market = baseMarket();
+    market.marketCap = 3_000_000_000_000; // $3T
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    // 대형주 심리 신호 — "대중이 안다고 믿는" / "유명한" 류 표현
+    expect(prompt).toMatch(/대중이 안다고 믿는|많은 사람이 알고 있는|유명한/);
+  });
+
+  it("시가총액 — 소형주(< $1B)면 다른 심리 표현", () => {
+    const market = baseMarket();
+    market.marketCap = 500_000_000; // $500M
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    expect(prompt).toMatch(/소수만 아는|덜 알려진|관심받지 못한/);
+  });
+
+  it("52주 위치 — 고점 부근(>= 0.85) 심리 표현", () => {
+    const market = baseMarket();
+    market.fiftyTwoWeekPosition = 0.92;
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    expect(prompt).toMatch(/1년 동안 가장 사랑받았던|일 년 동안 가장 사랑받았던|일 년 중 가장 높은/);
+  });
+
+  it("52주 위치 — 저점 부근(<= 0.15) 심리 표현", () => {
+    const market = baseMarket();
+    market.fiftyTwoWeekPosition = 0.08;
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    expect(prompt).toMatch(/1년 동안 가장 외면받았던|일 년 동안 가장 외면받았던|일 년 중 가장 낮은/);
+  });
+
+  it("종목 정체성 필드 모두 없어도 프롬프트는 정상 생성 (하위 호환)", () => {
+    const market = baseMarket(); // 추가 필드 없음
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    expect(prompt).toContain("AAPL");
+    expect(prompt).toContain("탑");
+    expect(prompt.length).toBeGreaterThan(500);
+  });
+
+  it("종목명/섹터/시가총액/52주 위치 절대 노출 금지 — 숫자 그대로는 나오면 안 됨", () => {
+    const market = baseMarket();
+    market.name = "Apple Inc.";
+    market.sector = "Technology";
+    market.marketCap = 3_000_000_000_000;
+    market.fiftyTwoWeekPosition = 0.92;
+
+    const prompt = buildInterpretationPromptV2_1(market, [sampleCard()]);
+    // marketCap 숫자 자체는 노출 금지 (3000000000000, $3T 등)
+    expect(prompt).not.toContain("3000000000000");
+    expect(prompt).not.toContain("$3T");
+    // 52주 위치 비율 자체도 노출 금지
+    expect(prompt).not.toContain("0.92");
+    expect(prompt).not.toContain("92%");
+  });
+});

--- a/packages/tarot-core/src/prompts/interpret-v2.1.0.ts
+++ b/packages/tarot-core/src/prompts/interpret-v2.1.0.ts
@@ -118,6 +118,38 @@ function translateSentiment(market: MarketSnapshot): string | null {
   return "뉴스 온도가 미지근함 — 결정적인 소식이 없는 시점";
 }
 
+// 시가총액 → 군중 인식 심리 (숫자 노출 금지)
+function translateMarketCap(market: MarketSnapshot): string | null {
+  if (market.marketCap === undefined) return null;
+  const cap = market.marketCap;
+  // KRW 표시는 amount가 100배~1000배 큰데, 일단 USD/KRW 통일 임계값으로 운영. 추후 currency-aware로 확장.
+  if (cap >= 100_000_000_000) return "대중이 안다고 믿는 거대한 이름 — 모두가 한 번쯤 들어본 종목";
+  if (cap >= 10_000_000_000) return "많은 사람이 알고 있는 익숙한 이름 — 시장의 단골 주제";
+  if (cap >= 1_000_000_000) return "관심 있는 사람들 사이에서 회자되는 중간 규모의 이름";
+  return "소수만 아는 종목 — 군중의 눈 밖에 있어 외로운 자리";
+}
+
+// 52주 위치 → 1년 군중 기억 심리 (비율·퍼센트 노출 금지)
+function translateRangePosition(market: MarketSnapshot): string | null {
+  if (market.fiftyTwoWeekPosition === undefined) return null;
+  const pos = market.fiftyTwoWeekPosition;
+  if (pos >= 0.85) return "1년 동안 가장 사랑받았던 자리 근처 — 모두의 시선이 모인 정점";
+  if (pos >= 0.6) return "지난 1년 흐름에서 상위권에 자리잡은 — 기대가 누적된 위치";
+  if (pos >= 0.4) return "1년 범위 중간 — 어디로든 갈 수 있는 무게중심";
+  if (pos > 0.15) return "지난 1년 흐름에서 하위권 — 외면받기 시작한 위치";
+  return "1년 동안 가장 외면받았던 자리 근처 — 군중이 잊고 있는 바닥 부근";
+}
+
+// 종목 정체성 (이름·섹터·산업) — 카드 해석에 컨텍스트 제공. 절대 숫자 미노출.
+function translateIdentity(market: MarketSnapshot): string | null {
+  const parts: string[] = [];
+  if (market.name) parts.push(market.name);
+  if (market.sector) parts.push(`${market.sector} 섹터`);
+  if (market.industry && market.industry !== market.sector) parts.push(market.industry);
+  if (parts.length === 0) return null;
+  return parts.join(" · ");
+}
+
 function conditionToEmotion(condition: string): string {
   const map: Record<string, string> = {
     bullish: "기대와 흥분이 뒤섞인 상승장",
@@ -132,6 +164,13 @@ function conditionToEmotion(condition: string): string {
 function buildPsychologyContext(market: MarketSnapshot): string {
   const lines: string[] = [];
 
+  // 종목 정체성 — 첫 줄에 등장하여 카드 해석에 컨텍스트 제공
+  const identitySignal = translateIdentity(market);
+  if (identitySignal) lines.push(`이 종목의 정체: ${identitySignal}`);
+
+  const capSignal = translateMarketCap(market);
+  if (capSignal) lines.push(`군중 인지도: ${capSignal}`);
+
   lines.push(`오늘의 에너지: ${translateMomentum(market)}`);
 
   const rsiSignal = translateRsi(market);
@@ -139,6 +178,9 @@ function buildPsychologyContext(market: MarketSnapshot): string {
 
   const macdSignal = translateMacd(market);
   if (macdSignal) lines.push(`모멘텀 흐름: ${macdSignal}`);
+
+  const rangePosSignal = translateRangePosition(market);
+  if (rangePosSignal) lines.push(`1년 군중 기억: ${rangePosSignal}`);
 
   const trendSignal = translateTrendPosition(market);
   if (trendSignal) lines.push(`추세 맥락: ${trendSignal}`);

--- a/packages/tarot-core/src/types.ts
+++ b/packages/tarot-core/src/types.ts
@@ -57,6 +57,12 @@ export interface MarketSnapshot {
   support20?: number;
   resistance20?: number;
   sentimentScore?: number;
+  // 종목 정체성 — 카드 해석 풍경에 활용. 숫자 자체는 프롬프트에 노출되지 않고 심리 표현으로 번역됨.
+  name?: string;            // 회사 이름 (예: "Apple Inc.")
+  sector?: string;          // 섹터 (예: "Technology")
+  industry?: string;        // 산업 (예: "Consumer Electronics")
+  marketCap?: number;       // 시가총액 (대형/중형/소형 심리 차이)
+  fiftyTwoWeekPosition?: number; // 0~1, 52주 범위 내 현재 위치
   condition: MarketCondition;
   summary: string;
 }


### PR DESCRIPTION
## 우선순위 #3 — 해석 프롬프트에 종목 정체성 통합

CEO Brief #212 오늘 처리 우선순위 3번. 원본 이슈: #210.

## 가설 재정의 (CEO 컨펌 후 진행)

원본 #210은 v1.1.0 기준이라 outdated. 운영 중인 v2.1.0은 이미 RSI/MACD/볼린저/지지저항/뉴스 sentiment를 풍부한 심리 언어로 활용. 진짜 누락은 **"종목 정체성"** — 회사 이름·섹터·시가총액·52주 위치. CEO 컨펌 후 v2.1.0 안에서 정체성 번역 추가로 진행.

## 변경 요약

### `packages/tarot-core/src/types.ts`
`MarketSnapshot` 에 옵션 필드 5개 추가:
- `name?: string` — 회사 이름
- `sector?: string` — 섹터
- `industry?: string` — 산업
- `marketCap?: number` — 시가총액
- `fiftyTwoWeekPosition?: number` — 0~1, 52주 범위 내 위치

모두 optional이라 **하위 호환 보장**.

### `packages/tarot-core/src/prompts/interpret-v2.1.0.ts`
세 개 번역 함수 신규:
- **`translateIdentity`**: name + sector + industry → "Apple Inc. · Technology 섹터 · Consumer Electronics"
- **`translateMarketCap`**: 시가총액 → 군중 인지도 심리 (4단계)
  - $100B+ → "대중이 안다고 믿는 거대한 이름"
  - $10B+ → "많은 사람이 알고 있는 익숙한 이름"
  - $1B+ → "관심 있는 사람들 사이에서 회자되는 중간 규모"
  - $1B 미만 → "소수만 아는 종목 — 군중의 눈 밖에 있어 외로운 자리"
- **`translateRangePosition`**: 52주 위치 → 1년 군중 기억 심리 (5단계)
  - 0.85+ → "1년 동안 가장 사랑받았던 자리 근처 — 모두의 시선이 모인 정점"
  - 0.15 미만 → "1년 동안 가장 외면받았던 자리 근처 — 군중이 잊고 있는 바닥 부근"

`buildPsychologyContext` 첫 줄에 정체성 + 인지도 등장, 추세 맥락 앞에 1년 군중 기억 삽입.

**절대 규칙 유지**: 숫자·비율·금액 자체는 프롬프트 미노출. 심리 언어로만 번역. 테스트로 검증.

### `apps/web/lib/tarot/market.ts`
Chart API 응답으로 즉시 채울 수 있는 필드 통합:
- `meta.shortName` → `name`
- 1년 closes 데이터 min/max로 **52주 위치 계산**

`sector`/`industry`/`marketCap` 은 별도 API 통합 후 추가 예정 (다음 PR).

### `packages/tarot-core/src/__tests__/prompt-v2.1-identity.test.ts` (신규)
vitest 8 케이스:
1. 회사 이름이 프롬프트에 포함
2. 섹터가 포함
3. 시가총액 — 대형주($3T) 심리 표현
4. 시가총액 — 소형주($500M) 다른 표현
5. 52주 위치 — 고점 부근(0.92) 표현
6. 52주 위치 — 저점 부근(0.08) 표현
7. **하위 호환** — 새 필드 없어도 프롬프트 정상 생성
8. **숫자 미노출** — marketCap 원본 숫자/`$3T`/`92%`/`0.92` 절대 안 나옴

## 검증

- [x] `npm run lint` 전 워크스페이스 통과
- [x] `npm run test` **136/136** 통과 (신규 8 포함)
- [x] `npm run build:web` 통과

## 효과

- LLM 입력에 종목별 맥락 추가 — "AAPL의 탑 카드" vs "외면받는 소형주의 탑 카드" 처럼 카드 해석이 종목 정체성과 자연스럽게 연결됨
- 사용자가 토스증권에서 본 종목 컨텍스트(이름·섹터·52주 위치)가 우리 해석 풍경에 그대로 이어짐 — **토스 멘탈모델 정합**
- 토큰 증가는 최소 (정체성 라인 1-2줄 추가)

## North Star 정렬

4축 중 **② 콘텐츠 강화**(해석 깊이) + **④ 토스증권 멘탈모델**(종목 정체성 인식 패턴) 직결.

## 다음 우선순위 의존성

- 우선순위 #4-#8 — 모두 독립 진행 가능
- 별도 후속 PR — sector/industry/marketCap 필드를 financials API 응답에서 snapshot으로 통합


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_