### PR TITLE
feat(ticker): 종목 상세에 "이 종목 카드 히스토리" 섹션 추가 [우선순위 #4]

### DIFF
--- a/apps/tarot-mobile/app/ticker/[symbol].tsx
+++ b/apps/tarot-mobile/app/ticker/[symbol].tsx
@@ -15,6 +15,7 @@ import { MetricsGrid } from "../../components/ticker/MetricsGrid";
 import { CompanyInfo } from "../../components/ticker/CompanyInfo";
 import { FinancialChart } from "../../components/ticker/FinancialChart";
 import { NewsList } from "../../components/ticker/NewsList";
+import { TickerCardHistory } from "../../components/ticker/TickerCardHistory";
 import { useStockStore, type ChartRange } from "../../lib/stockStore";
 import { useFavoritesStore } from "../../lib/favoritesStore";
 import { useDrawStore } from "../../lib/drawStore";
@@ -41,7 +42,7 @@ function formatPrice(price: number, currency: string): string {
 export default function TickerDetailScreen() {
   const router = useRouter();
   const { symbol } = useLocalSearchParams<{ symbol: string }>();
-  const { isLoggedIn } = useUserStore();
+  const { isLoggedIn, userId } = useUserStore();
   const {
     quote, chartBars, chartRange, quoteLoading, chartLoading,
     profile, quarterlyEarnings, annualFinancials, financialsLoading,
@@ -232,6 +233,9 @@ export default function TickerDetailScreen() {
                 width={SCREEN_WIDTH}
                 currency={currency}
               />
+            )}
+            {isLoggedIn && userId && (
+              <TickerCardHistory symbol={symbol} userId={userId} />
             )}
             <NewsList symbol={symbol} />
           </>

--- a/apps/tarot-mobile/components/ticker/TickerCardHistory.tsx
+++ b/apps/tarot-mobile/components/ticker/TickerCardHistory.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from "react";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
+import { Text } from "../ui/Text";
+import { Colors, Spacing, Radius } from "../../constants/theme";
+import { apiFetch } from "../../lib/api";
+import { formatTimeAgo, formatCardLabel } from "@trading/shared/src/historyFormatting";
+
+interface HistoryItemCard {
+  cardId: string;
+  orientation: string;
+  slot: string | null;
+  position: number;
+  card: { nameKo: string; name: string; number: number };
+}
+
+interface HistoryItem {
+  id: string;
+  ticker: string;
+  market: string;
+  spread: string;
+  headline: string;
+  source: string;
+  creditCost: number;
+  createdAt: string;
+  cards: HistoryItemCard[];
+}
+
+interface Props {
+  symbol: string;
+  userId: string;
+  limit?: number;
+}
+
+export function TickerCardHistory({ symbol, userId, limit = 5 }: Props) {
+  const router = useRouter();
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!symbol || !userId) return;
+    setLoading(true);
+    setError(false);
+    const params = new URLSearchParams({ userId, ticker: symbol, limit: String(limit) });
+    apiFetch<{ items: HistoryItem[] }>(`/api/tarot/history?${params}`)
+      .then((data) => setItems(data.items))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, [symbol, userId, limit]);
+
+  // 로딩 중에는 렌더링하지 않음 (다른 섹션이 먼저 채워지므로 깜빡임 방지)
+  if (loading) return null;
+  // 에러는 콘솔로만 — 사용자에게 노출하지 않음 (이 섹션은 부가 기능)
+  if (error) return null;
+  // 히스토리 없음 — 섹션 자체를 숨김 (빈 상태 강조보다 깔끔한 화면 우선)
+  if (items.length === 0) return null;
+
+  return (
+    <View style={styles.container}>
+      <Text variant="caption" color={Colors.midGrayText} style={styles.sectionLabel}>
+        이 종목 카드 히스토리
+      </Text>
+
+      <View style={styles.card}>
+        {items.map((item, i) => {
+          const cards = formatCardLabel(item.cards);
+          return (
+            <TouchableOpacity
+              key={item.id}
+              style={[styles.item, i < items.length - 1 && styles.itemBorder]}
+              onPress={() => router.push(`/history/${item.id}`)}
+              activeOpacity={0.75}
+            >
+              <View style={styles.itemHeader}>
+                <Text variant="caption" color={Colors.midGrayText}>
+                  {cards}
+                </Text>
+                <Text variant="caption" color={Colors.ironOutline}>
+                  {formatTimeAgo(item.createdAt, Date.now())}
+                </Text>
+              </View>
+              <Text variant="body-sm" color={Colors.whiteout} numberOfLines={2} style={styles.headline}>
+                {item.headline}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: Spacing.s24,
+  },
+  sectionLabel: {
+    marginBottom: Spacing.s8,
+    letterSpacing: 0.5,
+  },
+  card: {
+    backgroundColor: Colors.graphiteBase,
+    borderRadius: Radius.cards,
+    borderWidth: 1,
+    borderColor: Colors.carbonBorder,
+    overflow: "hidden",
+  },
+  item: {
+    padding: 16,
+    gap: 6,
+  },
+  itemBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.carbonBorder,
+  },
+  itemHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  headline: {
+    lineHeight: 20,
+    fontWeight: "500",
+  },
+});

--- a/packages/shared/__tests__/historyFormatting.test.ts
+++ b/packages/shared/__tests__/historyFormatting.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { formatTimeAgo, formatCardLabel } from "../src/historyFormatting";
+
+describe("formatTimeAgo", () => {
+  const now = Date.parse("2026-05-27T12:00:00.000Z");
+
+  it("잘못된 ISO → 빈 문자열", () => {
+    expect(formatTimeAgo("not-a-date", now)).toBe("");
+  });
+
+  it("1분 미만 → '방금'", () => {
+    expect(formatTimeAgo(new Date(now - 30_000).toISOString(), now)).toBe("방금");
+  });
+
+  it("분 단위", () => {
+    expect(formatTimeAgo(new Date(now - 5 * 60_000).toISOString(), now)).toBe("5분 전");
+  });
+
+  it("시간 단위", () => {
+    expect(formatTimeAgo(new Date(now - 3 * 3600_000).toISOString(), now)).toBe("3시간 전");
+  });
+
+  it("일 단위", () => {
+    expect(formatTimeAgo(new Date(now - 2 * 86400_000).toISOString(), now)).toBe("2일 전");
+  });
+
+  it("달 단위 — 30일 이상", () => {
+    expect(formatTimeAgo(new Date(now - 60 * 86400_000).toISOString(), now)).toBe("2달 전");
+  });
+
+  it("정확히 60초 — '1분 전'", () => {
+    expect(formatTimeAgo(new Date(now - 60_000).toISOString(), now)).toBe("1분 전");
+  });
+});
+
+describe("formatCardLabel", () => {
+  it("빈 배열 → 빈 문자열", () => {
+    expect(formatCardLabel([])).toBe("");
+  });
+
+  it("1장 → 카드 이름만", () => {
+    expect(formatCardLabel([{ position: 1, card: { nameKo: "탑" } }])).toBe("탑");
+  });
+
+  it("3장 — position 순서대로 정렬", () => {
+    const cards = [
+      { position: 3, card: { nameKo: "별" } },
+      { position: 1, card: { nameKo: "탑" } },
+      { position: 2, card: { nameKo: "죽음" } },
+    ];
+    expect(formatCardLabel(cards)).toBe("탑 · 죽음 · 별");
+  });
+
+  it("빈 카드 이름은 제외", () => {
+    const cards = [
+      { position: 1, card: { nameKo: "탑" } },
+      { position: 2, card: { nameKo: "" } },
+      { position: 3, card: { nameKo: "별" } },
+    ];
+    expect(formatCardLabel(cards)).toBe("탑 · 별");
+  });
+});

--- a/packages/shared/src/historyFormatting.ts
+++ b/packages/shared/src/historyFormatting.ts
@@ -1,0 +1,31 @@
+// 종목 카드 히스토리 표시용 순수 포매터.
+// 컴포넌트 분리되어 vitest로 회귀 봉쇄.
+
+export interface HistoryItemCardLite {
+  position: number;
+  card: { nameKo: string };
+}
+
+export function formatTimeAgo(iso: string, now: number): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "";
+  const diff = now - t;
+  if (diff < 60_000) return "방금";
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 60) return `${mins}분 전`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}일 전`;
+  const months = Math.floor(days / 30);
+  return `${months}달 전`;
+}
+
+export function formatCardLabel(cards: HistoryItemCardLite[]): string {
+  const names = [...cards]
+    .sort((a, b) => a.position - b.position)
+    .map((c) => c.card.nameKo)
+    .filter((n) => n.length > 0);
+  if (names.length === 0) return "";
+  return names.join(" · ");
+}


### PR DESCRIPTION
## 우선순위 #4 — 종목 상세에 "이 종목 카드 히스토리" 섹션

CEO Brief #212 오늘 처리 우선순위 4번. 원본 이슈: #202.

## 스코프 축소 (가설 검증 결과)

원본 PM 제안은 "Backend 스키마에 `symbol` 인덱스 추가 필요" 라고 봤으나, 검토 결과:
- `TarotDrawHistory` 모델에 이미 `ticker` 필드 + `@@index([ticker, createdAt])` 인덱스 존재
- `/api/tarot/history` 도 `ticker` 필터 파라미터 지원

→ **Backend 변경 일체 불필요**. Frontend 컴포넌트 + 통합만 작업.

## 변경 요약

### `packages/shared/src/historyFormatting.ts` (신규)
순수 포매터를 컴포넌트와 분리:
- `formatTimeAgo(iso, now)` — 방금/N분 전/N시간 전/N일 전/N달 전
- `formatCardLabel(cards)` — position 순 정렬 후 ` · ` 구분

### `packages/shared/__tests__/historyFormatting.test.ts` (신규)
vitest 11 케이스 — 잘못된 ISO, 시간 단위 경계, position 정렬, 빈 이름 제외 등.

### `apps/tarot-mobile/components/ticker/TickerCardHistory.tsx` (신규)
- props: `symbol`, `userId`, `limit` (기본 5)
- `/api/tarot/history?userId=X&ticker=Y&limit=5` 호출
- **빈 상태/에러/로딩 시 섹션 자체 숨김** — 사용자 시선 분산 최소화
- 각 항목 탭 시 `/history/[id]` 딥링크
- 카드 이름 · 시간 + 헤드라인 (2줄까지)

### `apps/tarot-mobile/app/ticker/[symbol].tsx`
Info 탭에 통합. 위치: `FinancialChart` 아래, `NewsList` 위. `isLoggedIn && userId` 일 때만 렌더.

## 검증

- [x] `npm run lint` 전 워크스페이스 통과
- [x] `npm run test` **147/147** 통과 (historyFormatting 11 신규 포함)
- [x] `npm run build:web` 통과

## 효과

- 사용자가 같은 종목에 대해 과거에 뽑은 카드를 **종목 상세 화면에서 바로 확인** 가능. 종목 → 카드 역참조 플로우 신설
- 종목 페이지가 **토스증권의 "내 종목 메모" 정신 모델**처럼 사용자의 기억 저장소 역할
- 히스토리 없는 사용자에게는 섹션이 보이지 않아 깔끔한 화면 유지

## North Star 정렬

4축 중 **① UX 개선**(종목 페이지가 기억 저장소가 되도록 플로우 보완) + **② 콘텐츠 강화**(카드 히스토리도 콘텐츠다)에 직결.

## 다음 우선순위 의존성

- 우선순위 #5-#8 모두 독립 진행 가능


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_