### PR TITLE
feat(ticker): sticky 헤더 + 탭별 스크롤 보존 + 압축 헤더 토글 [우선순위 #5]

### DIFF
--- a/apps/tarot-mobile/app/ticker/[symbol].tsx
+++ b/apps/tarot-mobile/app/ticker/[symbol].tsx
@@ -1,7 +1,8 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import {
   SafeAreaView, View, ScrollView, TouchableOpacity,
   StyleSheet, Dimensions, ActivityIndicator, RefreshControl,
+  NativeSyntheticEvent, NativeScrollEvent,
 } from "react-native";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { Text } from "../../components/ui/Text";
@@ -16,6 +17,8 @@ import { CompanyInfo } from "../../components/ticker/CompanyInfo";
 import { FinancialChart } from "../../components/ticker/FinancialChart";
 import { NewsList } from "../../components/ticker/NewsList";
 import { TickerCardHistory } from "../../components/ticker/TickerCardHistory";
+import { CompactHeader } from "../../components/ticker/CompactHeader";
+import { planTabSwitch, shouldShowCompactHeader } from "@trading/shared/src/tabScrollPositions";
 import { useStockStore, type ChartRange } from "../../lib/stockStore";
 import { useFavoritesStore } from "../../lib/favoritesStore";
 import { useDrawStore } from "../../lib/drawStore";
@@ -23,6 +26,8 @@ import { useUserStore } from "../../lib/store";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const CHART_WIDTH = SCREEN_WIDTH - Spacing.s24 * 2;
+// 큰 헤더(현재가 영역)가 화면 위로 사라지는 임계값. 토스 패턴: 큰 가격 영역이 sticky 영역 위로 올라가면 압축 헤더 활성화.
+const COMPACT_THRESHOLD = 140;
 
 const RANGE_OPTIONS: { key: ChartRange; label: string }[] = [
   { key: "1d", label: "1일" },
@@ -52,6 +57,12 @@ export default function TickerDetailScreen() {
   const { setTicker } = useDrawStore();
   const [activeTab, setActiveTab] = useState<TickerTab>("chart");
   const [refreshing, setRefreshing] = useState(false);
+  const [showCompact, setShowCompact] = useState(false);
+
+  // 탭별 스크롤 위치 보존 — 탭 전환 시 이전 위치로 복원
+  const scrollViewRef = useRef<ScrollView | null>(null);
+  const scrollPositions = useRef<Record<TickerTab, number>>({ chart: 0, info: 0 });
+  const currentScrollY = useRef(0);
 
   const isFav = symbol ? isFavorite(symbol) : false;
 
@@ -98,6 +109,22 @@ export default function TickerDetailScreen() {
     router.push("/(tabs)/draw");
   }, [symbol, quote, setTicker, router]);
 
+  const handleTabChange = useCallback((tab: TickerTab) => {
+    const plan = planTabSwitch(activeTab, tab, scrollPositions.current, currentScrollY.current);
+    scrollPositions.current = plan.positionsAfter;
+    setActiveTab(tab);
+    requestAnimationFrame(() => {
+      scrollViewRef.current?.scrollTo({ y: plan.targetY, animated: false });
+    });
+  }, [activeTab]);
+
+  const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const y = e.nativeEvent.contentOffset.y;
+    currentScrollY.current = y;
+    const shouldShow = shouldShowCompactHeader(y, COMPACT_THRESHOLD);
+    setShowCompact((prev) => (prev === shouldShow ? prev : shouldShow));
+  }, []);
+
   if (!symbol) {
     router.back();
     return null;
@@ -110,9 +137,13 @@ export default function TickerDetailScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView
+        ref={scrollViewRef}
         style={styles.scrollView}
         contentContainerStyle={styles.scroll}
         showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        stickyHeaderIndices={[2]}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -121,8 +152,8 @@ export default function TickerDetailScreen() {
           />
         }
       >
-        {/* Header */}
-        <View style={styles.header}>
+        {/* [0] Navigation Header — 일반 스크롤 */}
+        <View style={styles.navHeader}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
             <Text variant="body-sm" color={Colors.midGrayText}>← 뒤로</Text>
           </TouchableOpacity>
@@ -135,8 +166,8 @@ export default function TickerDetailScreen() {
           )}
         </View>
 
-        {/* Ticker Info */}
-        <View style={styles.tickerInfo}>
+        {/* [1] 큰 헤더 — 스크롤되면 사라지는 종목 이름 + 큰 가격 */}
+        <View style={styles.largeHeader}>
           <View style={styles.tickerRow}>
             <TickerLogo ticker={symbol} size={48} />
             <View style={styles.tickerMeta}>
@@ -148,38 +179,48 @@ export default function TickerDetailScreen() {
               </Text>
             </View>
           </View>
-        </View>
 
-        {/* Price */}
-        {quoteLoading ? (
-          <View style={styles.priceSection}>
-            <ActivityIndicator size="small" color={Colors.taroEssence} />
-          </View>
-        ) : quote ? (
-          <View style={styles.priceSection}>
-            <Text style={[styles.currentPrice, { color: Colors.whiteout }]}>
-              {formatPrice(quote.currentPrice, currency)}
-            </Text>
-            <View style={styles.changeRow}>
-              <Text style={[styles.changeText, { color: priceColor }]}>
-                {isPositive ? "+" : ""}{formatPrice(Math.abs(quote.change), currency)}
-              </Text>
-              <Text style={[styles.changePercent, { color: priceColor }]}>
-                ({isPositive ? "+" : ""}{quote.changePercent.toFixed(2)}%)
-              </Text>
+          {quoteLoading ? (
+            <View style={styles.priceSection}>
+              <ActivityIndicator size="small" color={Colors.taroEssence} />
             </View>
-          </View>
-        ) : null}
-
-        {/* Tab Bar */}
-        <View style={styles.tabSection}>
-          <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
+          ) : quote ? (
+            <View style={styles.priceSection}>
+              <Text style={[styles.currentPrice, { color: Colors.whiteout }]}>
+                {formatPrice(quote.currentPrice, currency)}
+              </Text>
+              <View style={styles.changeRow}>
+                <Text style={[styles.changeText, { color: priceColor }]}>
+                  {isPositive ? "+" : ""}{formatPrice(Math.abs(quote.change), currency)}
+                </Text>
+                <Text style={[styles.changePercent, { color: priceColor }]}>
+                  ({isPositive ? "+" : ""}{quote.changePercent.toFixed(2)}%)
+                </Text>
+              </View>
+            </View>
+          ) : null}
         </View>
 
-        {/* Tab Content */}
-        {activeTab === "chart" ? (
-          <>
-            {/* Chart */}
+        {/* [2] STICKY — 압축 헤더(opacity 토글) + TabBar */}
+        <View style={styles.stickyArea}>
+          {showCompact && quote && (
+            <CompactHeader
+              symbol={symbol}
+              shortName={quote.shortName ?? symbol}
+              currentPrice={quote.currentPrice}
+              change={quote.change}
+              changePercent={quote.changePercent}
+              currency={currency}
+            />
+          )}
+          <View style={styles.tabBarWrapper}>
+            <TabBar activeTab={activeTab} onTabChange={handleTabChange} />
+          </View>
+        </View>
+
+        {/* [3] Tab Content */}
+        <View style={styles.tabContent}>
+          {activeTab === "chart" ? (
             <View style={styles.chartSection}>
               <PriceChart
                 bars={chartBars}
@@ -208,40 +249,39 @@ export default function TickerDetailScreen() {
                 ))}
               </View>
             </View>
-          </>
-        ) : (
-          <>
-            {/* Info Tab: PriceStats + MetricsGrid + CompanyInfo + Financials */}
-            {quote && (
-              <>
-                <PriceStats quote={quote} />
-                <MetricsGrid quote={quote} />
-              </>
-            )}
-            {profile && (
-              <CompanyInfo
-                symbol={symbol}
-                name={quote?.longName ?? quote?.shortName ?? symbol}
-                exchange={quote?.exchange ?? ""}
-                profile={profile}
-              />
-            )}
-            {(quarterlyEarnings.length > 0 || annualFinancials.length > 0) && (
-              <FinancialChart
-                quarterlyEarnings={quarterlyEarnings}
-                annualFinancials={annualFinancials}
-                width={SCREEN_WIDTH}
-                currency={currency}
-              />
-            )}
-            {isLoggedIn && userId && (
-              <TickerCardHistory symbol={symbol} userId={userId} />
-            )}
-            <NewsList symbol={symbol} />
-          </>
-        )}
+          ) : (
+            <>
+              {quote && (
+                <>
+                  <PriceStats quote={quote} />
+                  <MetricsGrid quote={quote} />
+                </>
+              )}
+              {profile && (
+                <CompanyInfo
+                  symbol={symbol}
+                  name={quote?.longName ?? quote?.shortName ?? symbol}
+                  exchange={quote?.exchange ?? ""}
+                  profile={profile}
+                />
+              )}
+              {(quarterlyEarnings.length > 0 || annualFinancials.length > 0) && (
+                <FinancialChart
+                  quarterlyEarnings={quarterlyEarnings}
+                  annualFinancials={annualFinancials}
+                  width={SCREEN_WIDTH}
+                  currency={currency}
+                />
+              )}
+              {isLoggedIn && userId && (
+                <TickerCardHistory symbol={symbol} userId={userId} />
+              )}
+              <NewsList symbol={symbol} />
+            </>
+          )}
+        </View>
 
-        {/* CTA */}
+        {/* [4] CTA */}
         <View style={styles.ctaSection}>
           <Button
             variant="primary"
@@ -257,25 +297,31 @@ export default function TickerDetailScreen() {
 const styles = StyleSheet.create({
   container:    { flex: 1, backgroundColor: Colors.ebonyCanvas },
   scrollView:   { flex: 1 },
-  scroll:       { paddingHorizontal: Spacing.s24, paddingBottom: 48 },
+  scroll:       { paddingBottom: 48 },
 
-  header:       { flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingTop: Spacing.s16, marginBottom: Spacing.s16 },
+  // [0] Navigation header
+  navHeader:    { flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingHorizontal: Spacing.s24, paddingTop: Spacing.s16, marginBottom: Spacing.s16 },
   backBtn:      { padding: 4 },
   favBtn:       { padding: 4 },
   favIcon:      { fontSize: 24, color: Colors.midGrayText },
   favIconActive:{ color: "#f43f5e" },
 
-  tickerInfo:   { marginBottom: Spacing.s16 },
-  tickerRow:    { flexDirection: "row", alignItems: "center", gap: 12 },
+  // [1] 큰 헤더
+  largeHeader:  { paddingHorizontal: Spacing.s24, marginBottom: Spacing.s16 },
+  tickerRow:    { flexDirection: "row", alignItems: "center", gap: 12, marginBottom: Spacing.s16 },
   tickerMeta:   { flex: 1, gap: 2 },
-
-  priceSection: { marginBottom: Spacing.s16, minHeight: 60 },
+  priceSection: { minHeight: 60 },
   currentPrice: { fontSize: 32, fontWeight: "700" },
   changeRow:    { flexDirection: "row", gap: 8, marginTop: 4 },
   changeText:   { fontSize: 16, fontWeight: "600" },
   changePercent:{ fontSize: 16, fontWeight: "600" },
 
-  tabSection:   { marginBottom: Spacing.s24 },
+  // [2] Sticky 영역
+  stickyArea:   { backgroundColor: Colors.ebonyCanvas, zIndex: 10 },
+  tabBarWrapper:{ paddingHorizontal: Spacing.s24 },
+
+  // [3] Tab content — sticky 아래 여백 보장
+  tabContent:   { paddingHorizontal: Spacing.s24, paddingTop: Spacing.s24 },
 
   chartSection: { marginBottom: Spacing.s24 },
   rangeRow:     { flexDirection: "row", justifyContent: "space-around", marginTop: Spacing.s16 },
@@ -283,5 +329,5 @@ const styles = StyleSheet.create({
   rangeTabActive: { backgroundColor: Colors.voidGreen },
   rangeTextActive: { fontWeight: "700" },
 
-  ctaSection:   { marginTop: Spacing.s8 },
+  ctaSection:   { paddingHorizontal: Spacing.s24, marginTop: Spacing.s8 },
 });

--- a/apps/tarot-mobile/components/ticker/CompactHeader.tsx
+++ b/apps/tarot-mobile/components/ticker/CompactHeader.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Text } from "../ui/Text";
+import { Colors, Spacing } from "../../constants/theme";
+
+interface Props {
+  symbol: string;
+  shortName: string;
+  currentPrice: number;
+  change: number;
+  changePercent: number;
+  currency: string;
+}
+
+function formatPrice(price: number, currency: string): string {
+  if (currency === "KRW") {
+    return `₩${price.toLocaleString("ko-KR", { maximumFractionDigits: 0 })}`;
+  }
+  return `$${price.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+// 토스증권 패턴: 스크롤 시 상단에 sticky로 노출되는 압축 헤더 (이름 + 가격 + 등락 알약)
+export function CompactHeader({ symbol, shortName, currentPrice, change, changePercent, currency }: Props) {
+  const isPositive = change >= 0;
+  const priceColor = isPositive ? Colors.taroEssence : "#f43f5e";
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.left}>
+        <Text variant="body-sm" color={Colors.whiteout} style={styles.name} numberOfLines={1}>
+          {shortName || symbol}
+        </Text>
+      </View>
+      <View style={styles.right}>
+        <Text variant="body-sm" color={Colors.whiteout} style={styles.price}>
+          {formatPrice(currentPrice, currency)}
+        </Text>
+        <View style={[styles.changeBadge, { backgroundColor: isPositive ? "rgba(62, 207, 142, 0.15)" : "rgba(244, 63, 94, 0.15)" }]}>
+          <Text variant="caption" color={priceColor} style={styles.changeText}>
+            {isPositive ? "+" : ""}{changePercent.toFixed(2)}%
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.s24,
+    paddingVertical: 10,
+    backgroundColor: Colors.ebonyCanvas,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.carbonBorder,
+  },
+  left: {
+    flex: 1,
+    marginRight: 12,
+  },
+  name: {
+    fontWeight: "600",
+  },
+  right: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  price: {
+    fontWeight: "700",
+  },
+  changeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 9999,
+  },
+  changeText: {
+    fontWeight: "700",
+  },
+});

--- a/packages/shared/__tests__/tabScrollPositions.test.ts
+++ b/packages/shared/__tests__/tabScrollPositions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { planTabSwitch, shouldShowCompactHeader } from "../src/tabScrollPositions";
+
+describe("planTabSwitch", () => {
+  it("현재 탭의 스크롤 위치를 저장하고 새 탭의 저장된 위치로 이동", () => {
+    const positions = { chart: 0, info: 0 };
+    const plan = planTabSwitch("chart", "info", positions, 150);
+    expect(plan.positionsAfter.chart).toBe(150);
+    expect(plan.positionsAfter.info).toBe(0);
+    expect(plan.targetY).toBe(0);
+  });
+
+  it("이전에 저장된 위치가 있으면 그 위치로 복원", () => {
+    const positions = { chart: 0, info: 300 };
+    const plan = planTabSwitch("chart", "info", positions, 50);
+    expect(plan.positionsAfter.chart).toBe(50);
+    expect(plan.positionsAfter.info).toBe(300);
+    expect(plan.targetY).toBe(300);
+  });
+
+  it("같은 탭으로 전환 — 현재 위치 저장 후 동일 위치로", () => {
+    const positions = { chart: 100, info: 0 };
+    const plan = planTabSwitch("chart", "chart", positions, 200);
+    // 마지막 set이 우선이므로 결과적으로 200
+    expect(plan.positionsAfter.chart).toBe(200);
+    expect(plan.targetY).toBe(200);
+  });
+
+  it("원본 positions 객체를 변형하지 않음 (불변)", () => {
+    const positions = { chart: 0, info: 0 };
+    planTabSwitch("chart", "info", positions, 100);
+    expect(positions.chart).toBe(0);
+    expect(positions.info).toBe(0);
+  });
+
+  it("3개 탭에서 한 탭만 갱신", () => {
+    type T = "a" | "b" | "c";
+    const positions: Record<T, number> = { a: 10, b: 20, c: 30 };
+    const plan = planTabSwitch<T>("b", "c", positions, 99);
+    expect(plan.positionsAfter.a).toBe(10);
+    expect(plan.positionsAfter.b).toBe(99);
+    expect(plan.positionsAfter.c).toBe(30);
+    expect(plan.targetY).toBe(30);
+  });
+});
+
+describe("shouldShowCompactHeader", () => {
+  it("임계값 미만 → false", () => {
+    expect(shouldShowCompactHeader(50, 140)).toBe(false);
+  });
+
+  it("임계값 정확히 일치 → true", () => {
+    expect(shouldShowCompactHeader(140, 140)).toBe(true);
+  });
+
+  it("임계값 초과 → true", () => {
+    expect(shouldShowCompactHeader(200, 140)).toBe(true);
+  });
+
+  it("음수 스크롤(bounce) → false", () => {
+    expect(shouldShowCompactHeader(-20, 140)).toBe(false);
+  });
+});

--- a/packages/shared/src/tabScrollPositions.ts
+++ b/packages/shared/src/tabScrollPositions.ts
@@ -1,0 +1,29 @@
+// 탭 전환 시 스크롤 위치 보존 로직 — 컴포넌트와 분리해 회귀 봉쇄.
+
+export interface TabSwitchPlan<T extends string> {
+  positionsAfter: Record<T, number>;
+  targetY: number;
+}
+
+/**
+ * 현재 탭에서 다른 탭으로 전환할 때 어떤 스크롤 위치로 복원할지 계산.
+ * - 현재 탭의 스크롤 위치를 저장
+ * - 새 탭의 저장된 위치를 반환 (없으면 0)
+ */
+export function planTabSwitch<T extends string>(
+  prevTab: T,
+  nextTab: T,
+  positions: Record<T, number>,
+  currentScrollY: number
+): TabSwitchPlan<T> {
+  const positionsAfter = { ...positions, [prevTab]: currentScrollY };
+  const targetY = positionsAfter[nextTab] ?? 0;
+  return { positionsAfter, targetY };
+}
+
+/**
+ * 압축 헤더를 노출해야 하는지 판단. 임계값을 초과하면 true.
+ */
+export function shouldShowCompactHeader(scrollY: number, threshold: number): boolean {
+  return scrollY >= threshold;
+}


### PR DESCRIPTION
## 우선순위 #5 — 종목 상세 sticky 헤더 + 탭별 스크롤 보존

CEO Brief #212 오늘 처리 우선순위 5번. 원본 이슈: #203.

## 변경 요약

### `packages/shared/src/tabScrollPositions.ts` (신규)
순수 함수 2개:
- `planTabSwitch(prev, next, positions, currentY)` — 탭 전환 시 현재 스크롤 저장 + 새 탭의 저장 위치 반환. **불변 갱신**.
- `shouldShowCompactHeader(scrollY, threshold)` — 임계값 도달 여부.

### `packages/shared/__tests__/tabScrollPositions.test.ts` (신규)
vitest 9 케이스:
- 탭 전환 시 위치 저장 + 새 탭 위치 복원
- 같은 탭으로 전환 시 동작
- **불변성** — 원본 positions 객체 변형 X
- 3개 탭 시나리오
- 임계값 미만/일치/초과/음수(bounce)

### `apps/tarot-mobile/components/ticker/CompactHeader.tsx` (신규)
토스 스타일 압축 헤더: 이름 + 가격 + 등락 알약 배지. 스크롤 임계값 초과 시 sticky 영역 안에 등장.

### `apps/tarot-mobile/app/ticker/[symbol].tsx` (리팩토링)
ScrollView 자식 구조 재정의:
```
[0] Navigation header (← 뒤로 + 찜)
[1] 큰 헤더 (TickerLogo + 이름 + 큰 가격)        ← 스크롤되면 사라짐
[2] STICKY (압축 헤더 + 탭바)                    ← 항상 노출
[3] 탭 콘텐츠 (차트 또는 종목정보)
[4] CTA
```
`stickyHeaderIndices={[2]}` 적용.

탭별 스크롤 보존: `useRef<Record<TickerTab, number>>` + `planTabSwitch` 로 불변 갱신 + `requestAnimationFrame` 에서 `scrollTo`.

압축 헤더 토글: `onScroll throttle 16ms` + `shouldShowCompactHeader` + setState는 변화 시점에만.

레이아웃 변경: `paddingHorizontal`을 컨테이너 → 각 섹션으로 이동 (sticky가 전체 너비를 차지하도록).

## Expo Go 호환

`react-native-reanimated` **미사용**. 기본 ScrollView + stickyHeaderIndices + onScroll만 사용. Expo SDK 54 안전.

## 검증

- [x] `npm run lint` 전 워크스페이스 통과
- [x] `npm run test` **156/156** 통과 (신규 9 포함)
- [x] `npm run build:web` 통과

## 효과

- 종목 상세 어느 위치에서도 **현재가·등락이 시야에 유지됨** — 토스증권 종목 상세 패턴 직접 구현
- 탭(차트 ↔ 종목정보) 전환 시 **각 탭의 마지막 스크롤 위치가 보존**되어 탐색 맥락이 끊기지 않음
- 압축 헤더는 큰 헤더가 사라진 후에만 등장 → 정보 중복 없이 자연스러운 전환

## North Star 정렬

4축 중 **① UX 개선**(정보 탐색 맥락 보존 + 시세 상시 노출) + **④ 토스증권 멘탈모델**(sticky 헤더 + 탭별 독립 스크롤 패턴) 직결.

## 다음 우선순위 의존성

- 우선순위 #6 (Marketer #208 — 데일리 푸시 페어 카피): 독립
- 우선순위 #7 (Designer #205 — 헤더 타이포 위계): **이 PR과 동일 파일(PriceStats 영역) 변경 — 충돌 가능. 이 PR 머지 후 진행 권장**
- 우선순위 #8 (QA #206 — quote API 회귀 테스트): 독립


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_