### PR TITLE
test(quote+swr): API 회귀 6개 + SWR 정책 결정 로직 10개 [우선순위 #8 — 마지막]

### DIFF
--- a/apps/tarot-mobile/lib/stockStore.ts
+++ b/apps/tarot-mobile/lib/stockStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { apiFetch } from "./api";
-import { classifyFreshness } from "@trading/shared/src/staleness";
+import { decideSwrAction } from "@trading/shared/src/swrPolicy";
 import type { StockQuote, StockChartBar, StockChartResponse } from "@trading/shared/src/stockTypes";
 
 export type ChartRange = "1d" | "5d" | "1mo" | "3mo" | "1y";
@@ -96,9 +96,13 @@ export const useStockStore = create<StockState>((set, get) => ({
     const force = opts?.force === true;
     const cached = get().quoteCache[symbol];
     const now = Date.now();
-    const freshness = cached
-      ? classifyFreshness(cached.dataAt, now, FRESH_TTL_MS, STALE_TTL_MS)
-      : "expired";
+    const action = decideSwrAction({
+      cachedDataAt: cached?.dataAt,
+      force,
+      now,
+      freshTtlMs: FRESH_TTL_MS,
+      staleTtlMs: STALE_TTL_MS,
+    });
 
     // 캐시 hit: 즉시 표시 (fresh든 stale이든)
     if (cached) {
@@ -107,12 +111,9 @@ export const useStockStore = create<StockState>((set, get) => ({
       set({ quote: null, quoteLoading: true, error: null });
     }
 
-    // fresh + !force → fetch 스킵
-    if (freshness === "fresh" && !force) {
-      return;
-    }
+    if (action === "skip") return;
 
-    // stale 또는 expired 또는 force → fetch (백그라운드)
+    // background-revalidate 또는 fetch-blocking → 동일 fetch 코드 (UX 차이는 위에서 set로 처리됨)
     try {
       const data = await apiFetch<StockQuote>(
         `/api/tarot/quote?symbol=${encodeURIComponent(symbol)}`
@@ -139,9 +140,13 @@ export const useStockStore = create<StockState>((set, get) => ({
     const cached = get().chartCache[cacheKey];
     const now = Date.now();
     const cachedAtIso = cached ? new Date(cached.cachedAt).toISOString() : null;
-    const freshness = cachedAtIso
-      ? classifyFreshness(cachedAtIso, now, FRESH_TTL_MS, STALE_TTL_MS)
-      : "expired";
+    const action = decideSwrAction({
+      cachedDataAt: cachedAtIso,
+      force,
+      now,
+      freshTtlMs: FRESH_TTL_MS,
+      staleTtlMs: STALE_TTL_MS,
+    });
 
     if (cached) {
       set({ chartBars: cached.bars, chartRange: r, chartLoading: false });
@@ -149,7 +154,7 @@ export const useStockStore = create<StockState>((set, get) => ({
       set({ chartBars: [], chartRange: r, chartLoading: true });
     }
 
-    if (freshness === "fresh" && !force) return;
+    if (action === "skip") return;
 
     try {
       const data = await apiFetch<StockChartResponse>(
@@ -173,9 +178,13 @@ export const useStockStore = create<StockState>((set, get) => ({
     const cached = get().financialsCache[symbol];
     const now = Date.now();
     const cachedAtIso = cached ? new Date(cached.cachedAt).toISOString() : null;
-    const freshness = cachedAtIso
-      ? classifyFreshness(cachedAtIso, now, FRESH_TTL_MS, STALE_TTL_MS)
-      : "expired";
+    const action = decideSwrAction({
+      cachedDataAt: cachedAtIso,
+      force,
+      now,
+      freshTtlMs: FRESH_TTL_MS,
+      staleTtlMs: STALE_TTL_MS,
+    });
 
     if (cached) {
       set({
@@ -188,7 +197,7 @@ export const useStockStore = create<StockState>((set, get) => ({
       set({ financialsLoading: true });
     }
 
-    if (freshness === "fresh" && !force) return;
+    if (action === "skip") return;
 
     try {
       const data = await apiFetch<FinancialsResponse>(

--- a/apps/web/__tests__/api/tarot/quote.test.ts
+++ b/apps/web/__tests__/api/tarot/quote.test.ts
@@ -196,4 +196,88 @@ describe("/api/tarot/quote", () => {
     expect(body.symbol).toBe("CACHE1");
     expect(typeof body.dataAt).toBe("string");
   });
+
+  // ─── 추가 회귀 (QA 우선순위 #8) ──────────────────────────────────────────────
+
+  it("부분 결측 — marketCap만 누락 → completeness=\"marketCap\"", async () => {
+    const payload = fullYahooPayload();
+    delete (payload.quoteSummary.result[0]!.price as { marketCap?: unknown }).marketCap;
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => payload });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=PART1"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.marketCap).toBeNull();
+    expect(body.dayLow).toBe(199.0); // 다른 필드는 보존
+    expect(res.headers.get("X-Data-Completeness")).toBe("marketCap");
+  });
+
+  it("부분 결측 — 52주 두 필드만 누락 → completeness=\"fiftyTwoWeekLow,fiftyTwoWeekHigh\"", async () => {
+    const payload = fullYahooPayload();
+    const r = payload.quoteSummary.result[0]!;
+    delete (r.summaryDetail as { fiftyTwoWeekLow?: unknown }).fiftyTwoWeekLow;
+    delete (r.summaryDetail as { fiftyTwoWeekHigh?: unknown }).fiftyTwoWeekHigh;
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => payload });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=PART2"));
+    const body = await res.json();
+    expect(body.fiftyTwoWeekLow).toBeNull();
+    expect(body.fiftyTwoWeekHigh).toBeNull();
+    expect(body.marketCap).toBe(3_000_000_000_000);
+    expect(res.headers.get("X-Data-Completeness")).toBe("fiftyTwoWeekLow,fiftyTwoWeekHigh");
+  });
+
+  it("X-Cache 헤더 — 첫 호출 MISS, 두 번째 HIT", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => fullYahooPayload() });
+
+    const r1 = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=CACHE2"));
+    expect(r1.headers.get("X-Cache")).toBe("MISS");
+
+    const r2 = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=CACHE2"));
+    expect(r2.headers.get("X-Cache")).toBe("HIT");
+  });
+
+  it("X-Cache 헤더는 캐시 응답에서도 completeness 보존", async () => {
+    const payload = fullYahooPayload();
+    delete (payload.quoteSummary.result[0]!.price as { marketCap?: unknown }).marketCap;
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => payload });
+
+    const r1 = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=CACHE3"));
+    expect(r1.headers.get("X-Data-Completeness")).toBe("marketCap");
+
+    // 두 번째 호출 — 캐시 hit이지만 completeness 동일 유지
+    const r2 = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=CACHE3"));
+    expect(r2.headers.get("X-Cache")).toBe("HIT");
+    expect(r2.headers.get("X-Data-Completeness")).toBe("marketCap");
+  });
+
+  it("외부 fetch 예외(timeout) → 500 + 메시지 전달", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("AbortError: signal timed out"));
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=TIMEOUT1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("AbortError");
+  });
+
+  it("응답 본문에 알려지지 않은 추가 필드 없음 — 스키마 안정성", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => fullYahooPayload() });
+    const res = await GET(makeRequest("http://localhost/api/tarot/quote?symbol=SCHEMA1"));
+    const body = await res.json();
+    const expectedKeys = [
+      "symbol", "shortName", "longName", "currency", "exchange",
+      "currentPrice", "previousClose", "change", "changePercent",
+      "dayLow", "dayHigh", "fiftyTwoWeekLow", "fiftyTwoWeekHigh", "marketCap",
+      "trailingPE", "forwardPE", "priceToBook", "dividendYield",
+      "volume", "averageVolume",
+      "returnOnEquity", "grossMargins", "operatingMargins", "totalRevenue", "revenueGrowth", "debtToEquity",
+      "dataAt",
+    ];
+    const actualKeys = Object.keys(body).sort();
+    const unexpected = actualKeys.filter((k) => !expectedKeys.includes(k));
+    expect(unexpected).toEqual([]);
+  });
 });

--- a/packages/shared/__tests__/swrPolicy.test.ts
+++ b/packages/shared/__tests__/swrPolicy.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { decideSwrAction } from "../src/swrPolicy";
+
+const now = Date.parse("2026-05-27T12:00:00.000Z");
+const FRESH = 60_000;
+const STALE = 5 * 60_000;
+
+describe("decideSwrAction", () => {
+  it("캐시 없음 → fetch-blocking", () => {
+    expect(decideSwrAction({
+      cachedDataAt: null, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("fetch-blocking");
+  });
+
+  it("캐시 있음 + fresh + !force → skip (fetch 전혀 안 함)", () => {
+    const dataAt = new Date(now - 30_000).toISOString(); // 30초 전
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("skip");
+  });
+
+  it("캐시 있음 + fresh + force=true → fetch-blocking (사용자 명시적 새로고침)", () => {
+    const dataAt = new Date(now - 30_000).toISOString();
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: true, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("fetch-blocking");
+  });
+
+  it("캐시 있음 + stale → background-revalidate (즉시 표시 + 백그라운드)", () => {
+    const dataAt = new Date(now - 120_000).toISOString(); // 2분 전 (fresh 초과, stale 이내)
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("background-revalidate");
+  });
+
+  it("캐시 있음 + stale + force=true → fetch-blocking (사용자 우선)", () => {
+    const dataAt = new Date(now - 120_000).toISOString();
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: true, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("fetch-blocking");
+  });
+
+  it("캐시 있음 + expired → fetch-blocking", () => {
+    const dataAt = new Date(now - 10 * 60_000).toISOString(); // 10분 전
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("fetch-blocking");
+  });
+
+  it("캐시 있음 + 잘못된 dataAt 형식 → fetch-blocking (안전 폴백)", () => {
+    expect(decideSwrAction({
+      cachedDataAt: "not-a-date", force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("fetch-blocking");
+  });
+
+  it("undefined dataAt → fetch-blocking", () => {
+    expect(decideSwrAction({
+      cachedDataAt: undefined, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("fetch-blocking");
+  });
+
+  it("fresh 경계값 정확 매치 → skip", () => {
+    const dataAt = new Date(now - FRESH).toISOString();
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("skip");
+  });
+
+  it("stale 경계값 정확 매치 → background-revalidate", () => {
+    const dataAt = new Date(now - STALE).toISOString();
+    expect(decideSwrAction({
+      cachedDataAt: dataAt, force: false, now, freshTtlMs: FRESH, staleTtlMs: STALE,
+    })).toBe("background-revalidate");
+  });
+});

--- a/packages/shared/src/swrPolicy.ts
+++ b/packages/shared/src/swrPolicy.ts
@@ -1,0 +1,33 @@
+// stale-while-revalidate 결정 로직 — 컴포넌트와 분리해 회귀 봉쇄.
+// dataAt(ISO 8601) 기준 freshness를 평가해 fetch 동작을 결정.
+
+import { classifyFreshness } from "./staleness.js";
+
+export type FetchAction =
+  | "skip"                  // 캐시 fresh이고 force=false → fetch 전혀 안 함
+  | "background-revalidate" // 캐시 stale → 캐시 즉시 표시 + 백그라운드 fetch
+  | "fetch-blocking";       // 캐시 expired/없음 → loading=true 후 fetch
+
+export interface SwrInput {
+  cachedDataAt: string | null | undefined; // 캐시된 응답의 dataAt
+  force: boolean;                          // RefreshControl 등 명시적 새로고침
+  now: number;
+  freshTtlMs: number;
+  staleTtlMs: number;
+}
+
+export function decideSwrAction(input: SwrInput): FetchAction {
+  if (input.force) return "fetch-blocking";
+  if (!input.cachedDataAt) return "fetch-blocking";
+
+  const freshness = classifyFreshness(
+    input.cachedDataAt,
+    input.now,
+    input.freshTtlMs,
+    input.staleTtlMs
+  );
+
+  if (freshness === "fresh") return "skip";
+  if (freshness === "stale") return "background-revalidate";
+  return "fetch-blocking";
+}


### PR DESCRIPTION
## 우선순위 #8 — quote API 회귀 테스트 + SWR 정책 결정 로직 검증

CEO Brief #212 오늘 처리 우선순위 8번 (마지막). 원본 이슈: #206.

## 배경

원본 QA 제안 핵심은 quote API 정합성 회귀 + 결측치 안전 렌더. #213에서 이미 7개 케이스 도입됐고, #214에서 stale-while-revalidate 패턴 도입됨. 이번 PR은 그 위에 **부분 결측 / 캐시 헤더 / 예외 / 스키마 안정성 회귀**를 보강하고, **stockStore 안에 묻혀있던 SWR 결정 로직을 순수 함수로 분리**해 회귀 테스트로 봉쇄함.

## 변경 요약

### `packages/shared/src/swrPolicy.ts` (신규)
순수 함수 `decideSwrAction(input)` — `cached / force / now / freshTtl / staleTtl` 입력 → 세 가지 액션 결정:
- `skip` — 캐시 fresh + !force (fetch 전혀 안 함)
- `background-revalidate` — 캐시 stale (즉시 표시 + 백그라운드 fetch)
- `fetch-blocking` — 캐시 expired / 없음 / force / 잘못된 dataAt 형식 (안전 폴백)

### `packages/shared/__tests__/swrPolicy.test.ts` (신규)
vitest **10 케이스** — 캐시 없음, fresh+skip, force 우선(fresh도 fetch), stale→background, expired, 잘못된 형식 폴백, undefined, fresh/stale 두 경계값.

### `apps/tarot-mobile/lib/stockStore.ts` (리팩토링)
`fetchQuote` / `fetchChart` / `fetchFinancials` 모두 `decideSwrAction` 사용. 세 함수의 분기 로직이 통일되고, 회귀 테스트로 정책 검증됨. `classifyFreshness` 직접 호출 제거.

### `apps/web/__tests__/api/tarot/quote.test.ts` (6 케이스 추가)
1. **부분 결측 — marketCap만** → `completeness="marketCap"` (다른 필드 보존)
2. **부분 결측 — 52주 두 필드** → `completeness="fiftyTwoWeekLow,fiftyTwoWeekHigh"`
3. **X-Cache 헤더** — 첫 호출 `MISS`, 두 번째 `HIT`
4. **캐시 응답에서도 X-Data-Completeness 보존** — 두 번째 호출도 결측 헤더 유지
5. **fetch timeout 예외** → 500 + 메시지에 `AbortError` 포함
6. **응답 스키마 안정성** — 알려지지 않은 추가 필드 절대 없음 (스키마 흐름 검증)

## 검증

- [x] `npm run lint` 전 워크스페이스 통과
- [x] `npm run test` **172/172** 통과 (이전 156 → +16 신규)
- [x] `npm run build:web` 통과

## 효과

- quote API의 **부분 결측 / 캐시 / 예외 / 스키마 변화** 회귀 봉쇄. 외부 데이터 소스가 흔들려도 클라이언트는 명확한 정보 받음.
- stockStore SWR 정책이 **회귀 테스트로 검증됨** — 향후 freshness 임계값 조정 / 새 force 시나리오 추가 시 안전.
- stockStore 가독성 ↑ — 세 fetch 함수의 분기가 동일한 `decideSwrAction` 호출로 정렬됨.

## North Star 정렬

4축 중 **③ 백엔드 인프라**(API 정합성·결측치 추적·회귀 봉쇄) 직결. 측정 지표 "결측치율 < 1%" 추적 인프라의 기반.

## 오늘 처리 우선순위 완료

CEO Brief #212 의 오늘 처리 우선순위 8개 항목 모두 완료:
1. ✅ #204 — quote 스키마 확장 + 캐싱 (#213)
2. ✅ #207 → SWR 도입 (#214)
3. ✅ #210 → 종목 정체성 통합 (#215)
4. ✅ #202 — 종목 카드 히스토리 (#216)
5. ✅ #203 — sticky 헤더 (#217)
6. ⛔ #208 — Marketer 푸시 (사용자 deny, 가이드 갱신 main 직접 push)
7. ✅ #205 — 헤더 타이포 위계 (#218)
8. ✅ #206 — quote API 회귀 + SWR 검증 (본 PR)
9. ✅ #209 — Security 보고 (별도 PR 없음)


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_