### PR TITLE
fix(daily-council): ai-inference partial failure 안정성 강화 — 9개 에이전트 continue-on-error + response empty 체크

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -155,6 +155,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -267,7 +268,7 @@ jobs:
 
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -313,6 +314,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -393,7 +395,7 @@ jobs:
             ### 위험/대안
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -439,6 +441,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -513,7 +516,7 @@ jobs:
             (없음 / 낮음 / 중간 / 높음 — `db push` 기준)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -559,6 +562,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -635,7 +639,7 @@ jobs:
             (자기 직전 이력에서 다룬 차원과 다른가? — 사운드 / 햅틱 / 타이포 / 컬러 / 여백 / 정보 위계 / 트랜지션 중 어느 것?)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -681,6 +685,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -755,7 +760,7 @@ jobs:
             ### 자동화 가능 여부
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -801,6 +806,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -874,7 +880,7 @@ jobs:
             ### 마이그레이션 전략 (`db push` 가정)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -920,6 +926,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -994,7 +1001,7 @@ jobs:
             ### 비용/리소스
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -1040,6 +1047,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -1093,7 +1101,7 @@ jobs:
             ### North Star 정렬 (1문장)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -1139,6 +1147,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -1209,7 +1218,7 @@ jobs:
             ### 토큰 비용 영향
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1335,6 +1335,23 @@ jobs:
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | contains(\"$TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+      - name: Fetch today's new agent issues (실제 번호)
+        id: today_issues
+        if: steps.dedup.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TODAY: ${{ needs.prepare.outputs.today }}
+        run: |
+          LIST=$(gh issue list --label "agent-council" --state open --limit 30 \
+            --json number,title,labels --repo "${{ github.repository }}" | \
+            jq -r --arg today "$TODAY" '.[] | select(.title | contains($today)) | "#\(.number) \(.title) [labels: \(.labels | map(.name) | join(\",\"))]"')
+          echo "list<<__EOF__" >> $GITHUB_OUTPUT
+          if [ -z "$LIST" ]; then
+            echo "(오늘 신규 이슈 없음)"
+          else
+            echo "$LIST"
+          fi
+          echo "__EOF__" >> $GITHUB_OUTPUT
       - name: "[CEO Brief]"
         if: steps.dedup.outputs.exists == 'false'
         uses: actions/ai-inference@v1
@@ -1366,12 +1383,17 @@ jobs:
             11. 우선순위 정렬 기준 (위에서 아래로): ① 즉시 대응(Critical 보안·스토어 차단) → ② 정렬도 5점 + 다른 에이전트와 묶음 가능(의존성) → ③ 정렬도 5점 단독 → ④ 정렬도 4점 → ⑤ 정렬도 3점 이하 (그래도 처리는 함, 우선순위만 낮음).
             12. 사용자가 5분 안에 GO/NO-GO 판단 가능한 분량.
             13. **자동 점수 시스템 결과 활용** (2026-05-27 도입): 각 제안 본문 끝의 `Score: U=X F=Y N=Z A=W` 합계가 함께 전달됨. 14+(`score-strong`)은 우선순위 상단, 11-13(`score-conditional`)은 중단. 10 이하는 score_and_filter job이 이미 close했으므로 이 브리핑에는 도착하지 않음. **자동 점수와 North Star 정렬도가 충돌하면 North Star가 우선** (점수는 LLM 자기 평가라 편향 가능).
+            14. **이슈 번호 인용 규칙 (2026-05-28 추가 — 절대 규칙)**: 우선순위 항목의 "이슈: #N" 인용은 반드시 아래 prompt 의 **"📌 오늘 사이클 신규 이슈 (정확한 번호)"** 목록의 번호만 사용한다. 어제/그저께 닫힌 이슈 번호를 인용하지 마라. 이전 사이클 이슈 번호 인용은 사고이며, 사용자가 새 브리핑을 어제 거 재탕으로 오해하게 만든다. 만약 오늘 신규 이슈 목록이 비어있으면 "이슈: (오늘 사이클 신규 이슈 없음)" 으로 표시.
           prompt: |
             ## 🌟 North Star (이번 주 테마)
             ${{ needs.prepare.outputs.north_star }}
 
             ---
-            ## 📅 어제 CEO Brief (채택 항목 진척 추적용)
+            ## 📌 오늘 사이클 신규 이슈 (정확한 번호 — 우선순위 인용은 이 번호만 사용)
+            ${{ steps.today_issues.outputs.list }}
+
+            ---
+            ## 📅 어제 CEO Brief (채택 항목 진척 추적용 — 이슈 번호 재인용 금지)
             ${{ needs.prepare.outputs.yesterday_brief }}
 
             ---


### PR DESCRIPTION
## 진단

**2026-05-28 사이클에서 QA·CTO·Marketer 3개 에이전트 이슈가 누락됨.**

| 에이전트 | sleep | 결과 |
|---|---|---|
| PM | 15 | ✅ #220 |
| Frontend | 30 | ✅ #221 |
| Backend | 45 | ✅ #222 |
| Designer | 60 | ✅ #223 |
| **QA** | **75** | **❌ 미생성** |
| **CTO** | **90** | **❌ 미생성** |
| **Marketer** | **105** | **❌ 미생성** |
| Security | 120 | ✅ #224 |
| Prompt Engineer | 135 | ✅ #225 |
| CEO Brief | — | ✅ #226 |

### 원인 추정
정확한 root cause는 workflow run logs 직접 접근 불가로 100% 단정 어려움. 가장 합리적 추정:
- **GitHub Models gpt-4o API의 일시적 partial failure** (transient outage 또는 token/rate limit)
- ai-inference step이 실패하면 **job 전체가 실패** → Create Issue step 건너뜀 → 그 에이전트 이슈 누락
- 어제(5/27) 같은 stagger로 9개 모두 통과했고 오늘만 3개 빠진 패턴 → 외부 API 일시 문제 가능성

### 워크플로우 취약점
- job-level 멱등성(`Check duplicate`)은 있지만 **step-level 실패에 취약**
- ai-inference 실패 = 전체 job 실패 = 이슈 누락

## 수정

9개 에이전트 ai-inference step에 `continue-on-error: true` + Create Issue 조건에 응답 존재 체크 추가.

```diff
   - name: "[PM] 제품 제안"
     if: steps.ctx.outputs.exists == 'false'
     uses: actions/ai-inference@v1
     id: proposal
+    continue-on-error: true
     with:
       model: openai/gpt-4o
       ...

   - name: Create Issue
-    if: steps.ctx.outputs.exists == 'false'
+    if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
```

### 효과
- 일부 에이전트 ai-inference 실패해도 **job은 success로 종료**
- 성공한 에이전트는 정상 진행 — partial 사이클 보존
- `score_and_filter` / `ceo_brief` 는 이미 `if: always()` 라 partial 입력에도 실행됨
- ceo_brief의 ai-inference (id: `brief`)는 다른 식별자 — 패치 영향 없음

## 적용 범위

| 에이전트 | line (continue-on-error) | line (Create Issue if) |
|---|---|---|
| PM | 158 | 271 |
| Frontend | 317 | 398 |
| Backend | 444 | 519 |
| Designer | 565 | 642 |
| QA | 688 | 763 |
| CTO | 809 | 883 |
| Marketer | 929 | 1004 |
| Security | 1050 | 1104 |
| Prompt Engineer | 1150 | 1221 |

## 오늘 한정 복구 (이 PR 머지 무관, 즉시 가능)

GitHub Actions UI에서 수동 트리거:
1. https://github.com/mlender-ai/taro-stock-app/actions/workflows/idea-proposal.yml
2. **Run workflow** 클릭 → `agent: all` (default) → **Run**
3. ~4분 대기 → 멱등성으로 이미 있는 6개는 skip되고 **빠진 QA·CTO·Marketer 3개만 자동 생성**
4. 자동으로 새 score_and_filter 점수 매김 (기존 #226 CEO Brief는 dedup 통과)

## 추가 강화 후보 (v2 — 별도 PR)

- ai-inference 실패 시 GitHub Actions `::warning::` 메시지 출력
- 자동 retry (max 2회)
- prepare context 크기 모니터링 (token 한도 안전 마진)
- ceo_brief system-prompt에 "일부 에이전트 입력이 비어있을 수 있음" 안내 추가

## North Star 정렬

거버넌스 메타 — 일일 회의 안정성은 모든 4축(UX·콘텐츠·백엔드·토스 멘탈모델) 작업의 기반. 사고 0건 목표.


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_