### PR TITLE
fix(daily-council): stagger 증가 + CEO Brief 누락 방지 + 수동 트리거 스크립트

### DIFF
--- a/.claude/scripts/trigger-council.sh
+++ b/.claude/scripts/trigger-council.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Daily Agent Council 수동 트리거 스크립트
-# Claude Code 세션에서 Claude가 직접 호출 가능
+# Claude Code 세션 (또는 로컬 터미널)에서 직접 호출 가능
+#
+# 사전 요건:
+#   환경변수 GITHUB_TOKEN 또는 GH_TOKEN 필요
+#   로컬에서: export GITHUB_TOKEN=$(gh auth token)
 #
 # 사용법:
-#   bash .claude/scripts/trigger-council.sh            # 전체 실행 (all)
-#   bash .claude/scripts/trigger-council.sh cto        # 특정 에이전트만
+#   bash .claude/scripts/trigger-council.sh              # 전체 실행 (all)
+#   bash .claude/scripts/trigger-council.sh cto          # CTO 에이전트만
 #   bash .claude/scripts/trigger-council.sh cto marketer prompt_engineer
 #
 # 에이전트 이름:
@@ -15,23 +19,41 @@ set -euo pipefail
 REPO="mlender-ai/taro-stock-app"
 WORKFLOW="idea-proposal.yml"
 BRANCH="main"
-
 AGENTS=("${@:-all}")
+
+# 토큰 우선순위: GITHUB_TOKEN → GH_TOKEN
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [[ -z "$TOKEN" ]]; then
+  echo "❌ GITHUB_TOKEN (또는 GH_TOKEN) 환경변수가 없습니다."
+  echo ""
+  echo "로컬에서 실행 시:"
+  echo "  export GITHUB_TOKEN=\$(gh auth token)"
+  echo "  bash .claude/scripts/trigger-council.sh all"
+  echo ""
+  echo "또는 GitHub Actions UI에서 직접 실행:"
+  echo "  https://github.com/${REPO}/actions/workflows/${WORKFLOW}"
+  exit 1
+fi
 
 for AGENT in "${AGENTS[@]}"; do
   echo "▶ Triggering agent: $AGENT"
-  gh api \
-    --method POST \
-    "repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
-    -f ref="${BRANCH}" \
-    -f "inputs[agent]=${AGENT}" \
-    && echo "  ✅ Dispatched: $AGENT" \
-    || echo "  ❌ Failed: $AGENT"
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
+    -d "{\"ref\":\"${BRANCH}\",\"inputs\":{\"agent\":\"${AGENT}\"}}")
 
-  # CEO Brief는 agent=all 로만 실행되므로 개별 에이전트 후 별도 실행 불필요
-  # 여러 에이전트를 연속 트리거할 때 concurrency 충돌 방지
+  if [[ "$HTTP_STATUS" == "204" ]]; then
+    echo "  ✅ Dispatched: $AGENT"
+  else
+    echo "  ❌ Failed (HTTP $HTTP_STATUS): $AGENT"
+  fi
+
+  # 여러 에이전트 연속 트리거 시 concurrency 충돌 방지
   if [[ "${#AGENTS[@]}" -gt 1 && "$AGENT" != "${AGENTS[-1]}" ]]; then
-    echo "  ⏳ 대기 10s (concurrency 충돌 방지)..."
+    echo "  ⏳ 대기 10s..."
     sleep 10
   fi
 done

--- a/.claude/scripts/trigger-council.sh
+++ b/.claude/scripts/trigger-council.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Daily Agent Council 수동 트리거 스크립트
+# Claude Code 세션에서 Claude가 직접 호출 가능
+#
+# 사용법:
+#   bash .claude/scripts/trigger-council.sh            # 전체 실행 (all)
+#   bash .claude/scripts/trigger-council.sh cto        # 특정 에이전트만
+#   bash .claude/scripts/trigger-council.sh cto marketer prompt_engineer
+#
+# 에이전트 이름:
+#   all / pm / frontend / backend / designer / qa / cto / marketer / security / prompt_engineer
+
+set -euo pipefail
+
+REPO="mlender-ai/taro-stock-app"
+WORKFLOW="idea-proposal.yml"
+BRANCH="main"
+
+AGENTS=("${@:-all}")
+
+for AGENT in "${AGENTS[@]}"; do
+  echo "▶ Triggering agent: $AGENT"
+  gh api \
+    --method POST \
+    "repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches" \
+    -f ref="${BRANCH}" \
+    -f "inputs[agent]=${AGENT}" \
+    && echo "  ✅ Dispatched: $AGENT" \
+    || echo "  ❌ Failed: $AGENT"
+
+  # CEO Brief는 agent=all 로만 실행되므로 개별 에이전트 후 별도 실행 불필요
+  # 여러 에이전트를 연속 트리거할 때 concurrency 충돌 방지
+  if [[ "${#AGENTS[@]}" -gt 1 && "$AGENT" != "${AGENTS[-1]}" ]]; then
+    echo "  ⏳ 대기 10s (concurrency 충돌 방지)..."
+    sleep 10
+  fi
+done
+
+echo ""
+echo "🔗 실행 확인: https://github.com/${REPO}/actions/workflows/${WORKFLOW}"

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -155,6 +155,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -267,7 +268,7 @@ jobs:
 
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -313,6 +314,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -393,7 +395,7 @@ jobs:
             ### 위험/대안
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -439,6 +441,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -513,7 +516,7 @@ jobs:
             (없음 / 낮음 / 중간 / 높음 — `db push` 기준)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -559,6 +562,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -635,7 +639,7 @@ jobs:
             (자기 직전 이력에서 다룬 차원과 다른가? — 사운드 / 햅틱 / 타이포 / 컬러 / 여백 / 정보 위계 / 트랜지션 중 어느 것?)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -681,6 +685,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -755,7 +760,7 @@ jobs:
             ### 자동화 가능 여부
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -801,6 +806,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -874,7 +880,7 @@ jobs:
             ### 마이그레이션 전략 (`db push` 가정)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -920,6 +926,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -994,7 +1001,7 @@ jobs:
             ### 비용/리소스
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -1040,6 +1047,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -1093,7 +1101,7 @@ jobs:
             ### North Star 정렬 (1문장)
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}
@@ -1139,6 +1147,7 @@ jobs:
         if: steps.ctx.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: proposal
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 4096
@@ -1209,7 +1218,7 @@ jobs:
             ### 토큰 비용 영향
             ${{ needs.prepare.outputs.scoring_guide }}
       - name: Create Issue
-        if: steps.ctx.outputs.exists == 'false'
+        if: steps.ctx.outputs.exists == 'false' && steps.proposal.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.proposal.outputs.response }}

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -785,7 +785,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Rate limit stagger
-        run: sleep 90
+        run: sleep 150
       - name: Check duplicate & fetch self history
         id: ctx
         env:
@@ -905,7 +905,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Rate limit stagger
-        run: sleep 105
+        run: sleep 180
       - name: Check duplicate & fetch self history
         id: ctx
         env:
@@ -1126,7 +1126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Rate limit stagger
-        run: sleep 135
+        run: sleep 210
       - name: Check duplicate & fetch self history
         id: ctx
         env:
@@ -1356,6 +1356,7 @@ jobs:
         if: steps.dedup.outputs.exists == 'false'
         uses: actions/ai-inference@v1
         id: brief
+        continue-on-error: true
         with:
           model: openai/gpt-4o
           max-tokens: 8192
@@ -1503,7 +1504,7 @@ jobs:
             ### 🧭 사용자 결정 필요 항목
             (북스타 갱신, 반복 주제 종결, 임계값 조정 등 CEO가 직접 판단할 것)
       - name: Create CEO Brief Issue
-        if: steps.dedup.outputs.exists == 'false'
+        if: steps.dedup.outputs.exists == 'false' && steps.brief.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.brief.outputs.response }}

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1335,6 +1335,23 @@ jobs:
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | contains(\"$TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+      - name: Fetch today's new agent issues (실제 번호)
+        id: today_issues
+        if: steps.dedup.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TODAY: ${{ needs.prepare.outputs.today }}
+        run: |
+          LIST=$(gh issue list --label "agent-council" --state open --limit 30 \
+            --json number,title,labels --repo "${{ github.repository }}" | \
+            jq -r --arg today "$TODAY" '.[] | select(.title | contains($today)) | "#\(.number) \(.title) [labels: \(.labels | map(.name) | join(\",\"))]"')
+          echo "list<<__EOF__" >> $GITHUB_OUTPUT
+          if [ -z "$LIST" ]; then
+            echo "(오늘 신규 이슈 없음)"
+          else
+            echo "$LIST"
+          fi
+          echo "__EOF__" >> $GITHUB_OUTPUT
       - name: "[CEO Brief]"
         if: steps.dedup.outputs.exists == 'false'
         uses: actions/ai-inference@v1
@@ -1366,12 +1383,17 @@ jobs:
             11. 우선순위 정렬 기준 (위에서 아래로): ① 즉시 대응(Critical 보안·스토어 차단) → ② 정렬도 5점 + 다른 에이전트와 묶음 가능(의존성) → ③ 정렬도 5점 단독 → ④ 정렬도 4점 → ⑤ 정렬도 3점 이하 (그래도 처리는 함, 우선순위만 낮음).
             12. 사용자가 5분 안에 GO/NO-GO 판단 가능한 분량.
             13. **자동 점수 시스템 결과 활용** (2026-05-27 도입): 각 제안 본문 끝의 `Score: U=X F=Y N=Z A=W` 합계가 함께 전달됨. 14+(`score-strong`)은 우선순위 상단, 11-13(`score-conditional`)은 중단. 10 이하는 score_and_filter job이 이미 close했으므로 이 브리핑에는 도착하지 않음. **자동 점수와 North Star 정렬도가 충돌하면 North Star가 우선** (점수는 LLM 자기 평가라 편향 가능).
+            14. **이슈 번호 인용 규칙 (2026-05-28 추가 — 절대 규칙)**: 우선순위 항목의 "이슈: #N" 인용은 반드시 아래 prompt 의 **"📌 오늘 사이클 신규 이슈 (정확한 번호)"** 목록의 번호만 사용한다. 어제/그저께 닫힌 이슈 번호를 인용하지 마라. 이전 사이클 이슈 번호 인용은 사고이며, 사용자가 새 브리핑을 어제 거 재탕으로 오해하게 만든다. 만약 오늘 신규 이슈 목록이 비어있으면 "이슈: (오늘 사이클 신규 이슈 없음)" 으로 표시.
           prompt: |
             ## 🌟 North Star (이번 주 테마)
             ${{ needs.prepare.outputs.north_star }}
 
             ---
-            ## 📅 어제 CEO Brief (채택 항목 진척 추적용)
+            ## 📌 오늘 사이클 신규 이슈 (정확한 번호 — 우선순위 인용은 이 번호만 사용)
+            ${{ steps.today_issues.outputs.list }}
+
+            ---
+            ## 📅 어제 CEO Brief (채택 항목 진척 추적용 — 이슈 번호 재인용 금지)
             ${{ needs.prepare.outputs.yesterday_brief }}
 
             ---


### PR DESCRIPTION
## 문제

5/29 사이클에서 CTO·Marketer·Prompt Engineer·CEO Brief 4개 누락.

| 에이전트 | sleep | 5/29 결과 |
|---|---|---|
| PM~QA | 15~75s | ✅ |
| **CTO** | 90s | ❌ 누락 |
| **Marketer** | 105s | ❌ 누락 |
| Security | 120s | ✅ |
| **Prompt Engineer** | 135s | ❌ 누락 |
| **CEO Brief** | — | ❌ 누락 |

## 원인

GitHub Models `gpt-4o` API가 후반 에이전트 호출 시 빈 응답 반환. 개별 에이전트는 PR #234에서 이미 `continue-on-error: true` + 응답 가드가 적용되어 있어 빈 이슈 생성은 막혔으나 **CEO Brief는 미적용 상태였음**.

## 수정 내용

### 1. stagger 간격 확장
```diff
- CTO:            sleep 90  →  sleep 150
- Marketer:       sleep 105 →  sleep 180
- Prompt Engineer: sleep 135 →  sleep 210
```
후반 에이전트들을 충분히 분산시켜 rate limit 회피.

### 2. CEO Brief 안정성 패치
```diff
+ continue-on-error: true   (ai-inference 실패 시 job 계속)
- if: steps.dedup.outputs.exists == 'false'
+ if: steps.dedup.outputs.exists == 'false' && steps.brief.outputs.response != ''
```

### 3. `.claude/scripts/trigger-council.sh`
Claude Code 세션에서 내가 직접 수동 트리거 가능:
```bash
# 전체 재실행 (누락 에이전트 복구 — dedup으로 이미 있는 것은 skip)
bash .claude/scripts/trigger-council.sh

# 특정 에이전트만
bash .claude/scripts/trigger-council.sh cto marketer prompt_engineer
```

## 개선 후 stagger 타임라인

| 에이전트 | 대기 시간 |
|---|---|
| PM | 15s |
| Frontend | 30s |
| Backend | 45s |
| Designer | 60s |
| QA | 75s |
| CTO | **150s** |
| Marketer | **180s** |
| Security | 120s |
| Prompt Engineer | **210s** |

---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_