### PR TITLE
fix(ceo-brief): jq syntax error — INVALID_CHARACTER 차단 (CEO Brief job 실패 원인)

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1344,7 +1344,7 @@ jobs:
         run: |
           LIST=$(gh issue list --label "agent-council" --state open --limit 30 \
             --json number,title,labels --repo "${{ github.repository }}" | \
-            jq -r --arg today "$TODAY" '.[] | select(.title | contains($today)) | "#\(.number) \(.title) [labels: \(.labels | map(.name) | join(\",\"))]"')
+            jq -r --arg today "$TODAY" '.[] | select(.title | contains($today)) | "#" + (.number|tostring) + " " + .title + " [labels: " + (.labels | map(.name) | join(",")) + "]"')
           echo "list<<__EOF__" >> $GITHUB_OUTPUT
           if [ -z "$LIST" ]; then
             echo "(오늘 신규 이슈 없음)"


### PR DESCRIPTION
## 문제

5/29 사이클 CEO Brief 누락 + 수동 재트리거에서도 같은 실패:
https://github.com/mlender-ai/taro-stock-app/actions/runs/26610876572/job/78416704326

```
jq: error: syntax error, unexpected INVALID_CHARACTER (Unix shell quoting issues?) at <top-level>, line 1:
.[] | select(.title | contains($today)) | "#\(.number) \(.title) [labels: \(.labels | map(.name) | join(\",\"))]"
jq: 1 compile error
Error: Process completed with exit code 3.
```

## 원인

PR #234에서 추가한 `Fetch today's new agent issues` step의 jq 표현식이 잘못됨:

```jq
"...\(.labels | map(.name) | join(\",\"))..."
```

jq 문자열 보간 `\(...)` 내부에 위치한 `join(\",\")` 의 `\"` 시퀀스를 jq 파서가 `INVALID_CHARACTER` 로 거부.

## 수정

문자열 보간 대신 `+` 연결 방식으로 교체 — 큰따옴표 escape 자체가 불필요:

```diff
- '.[] | select(.title | contains($today)) | "#\(.number) \(.title) [labels: \(.labels | map(.name) | join(\",\"))]"'
+ '.[] | select(.title | contains($today)) | "#" + (.number|tostring) + " " + .title + " [labels: " + (.labels | map(.name) | join(",")) + "]"'
```

## 복구

이 PR 머지 후 GitHub Actions UI에서 다시 수동 트리거:
1. https://github.com/mlender-ai/taro-stock-app/actions/workflows/idea-proposal.yml
2. Run workflow → agent: `all`
3. 누락된 CTO·Marketer·Prompt Engineer·CEO Brief 생성됨

---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_