### PR TITLE
feat(ceo-brief): 2026-05-29 — 뉴스 메타/모달 + 재무 위계 + 차트 회귀 테스트 (#235·#237·#238·#240)

### DIFF
--- a/apps/tarot-mobile/components/ticker/KeyMetricsGrid.tsx
+++ b/apps/tarot-mobile/components/ticker/KeyMetricsGrid.tsx
@@ -9,10 +9,13 @@ interface Props {
   currency?: string;
 }
 
+type Tier = "primary" | "secondary";
+
 interface MetricCard {
   label: string;
   value: string;
   show: boolean;
+  tier: Tier;
 }
 
 function formatLargeNumber(n: number, currency: string): string {
@@ -29,27 +32,12 @@ function formatLargeNumber(n: number, currency: string): string {
 
 export function KeyMetricsGrid({ metrics, currency = "USD" }: Props) {
   const cards: MetricCard[] = [
+    // primary tier: 투자 판단에 직접 영향이 큰 지표
     {
       label: "EPS",
       value: metrics.eps != null ? `${metrics.eps.toFixed(2)}` : "-",
       show: metrics.eps != null,
-    },
-    {
-      label: "PEG",
-      value: metrics.pegRatio != null ? `${metrics.pegRatio.toFixed(2)}배` : "-",
-      show: metrics.pegRatio != null,
-    },
-    {
-      label: "PSR",
-      value: metrics.priceToSalesTrailing12Months != null
-        ? `${metrics.priceToSalesTrailing12Months.toFixed(2)}배`
-        : "-",
-      show: metrics.priceToSalesTrailing12Months != null,
-    },
-    {
-      label: "BPS",
-      value: metrics.bookValue != null ? `${metrics.bookValue.toFixed(2)}` : "-",
-      show: metrics.bookValue != null,
+      tier: "primary" as const,
     },
     {
       label: "순이익률",
@@ -57,13 +45,7 @@ export function KeyMetricsGrid({ metrics, currency = "USD" }: Props) {
         ? `${(metrics.profitMargins * 100).toFixed(2)}%`
         : "-",
       show: metrics.profitMargins != null,
-    },
-    {
-      label: "매출총이익률",
-      value: metrics.grossMargins != null
-        ? `${(metrics.grossMargins * 100).toFixed(2)}%`
-        : "-",
-      show: metrics.grossMargins != null,
+      tier: "primary" as const,
     },
     {
       label: "ROA",
@@ -71,52 +53,119 @@ export function KeyMetricsGrid({ metrics, currency = "USD" }: Props) {
         ? `${(metrics.returnOnAssets * 100).toFixed(2)}%`
         : "-",
       show: metrics.returnOnAssets != null,
-    },
-    {
-      label: "유동비율",
-      value: metrics.currentRatio != null ? `${metrics.currentRatio.toFixed(2)}` : "-",
-      show: metrics.currentRatio != null,
-    },
-    {
-      label: "당좌비율",
-      value: metrics.quickRatio != null ? `${metrics.quickRatio.toFixed(2)}` : "-",
-      show: metrics.quickRatio != null,
-    },
-    {
-      label: "총현금",
-      value: metrics.totalCash != null ? formatLargeNumber(metrics.totalCash, currency) : "-",
-      show: metrics.totalCash != null,
-    },
-    {
-      label: "총부채",
-      value: metrics.totalDebt != null ? formatLargeNumber(metrics.totalDebt, currency) : "-",
-      show: metrics.totalDebt != null,
+      tier: "primary" as const,
     },
     {
       label: "잉여현금흐름",
       value: metrics.freeCashflow != null ? formatLargeNumber(metrics.freeCashflow, currency) : "-",
       show: metrics.freeCashflow != null,
+      tier: "primary" as const,
+    },
+    // secondary tier: 보조 지표
+    {
+      label: "PEG",
+      value: metrics.pegRatio != null ? `${metrics.pegRatio.toFixed(2)}배` : "-",
+      show: metrics.pegRatio != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "PSR",
+      value: metrics.priceToSalesTrailing12Months != null
+        ? `${metrics.priceToSalesTrailing12Months.toFixed(2)}배`
+        : "-",
+      show: metrics.priceToSalesTrailing12Months != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "BPS",
+      value: metrics.bookValue != null ? `${metrics.bookValue.toFixed(2)}` : "-",
+      show: metrics.bookValue != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "매출총이익률",
+      value: metrics.grossMargins != null
+        ? `${(metrics.grossMargins * 100).toFixed(2)}%`
+        : "-",
+      show: metrics.grossMargins != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "유동비율",
+      value: metrics.currentRatio != null ? `${metrics.currentRatio.toFixed(2)}` : "-",
+      show: metrics.currentRatio != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "당좌비율",
+      value: metrics.quickRatio != null ? `${metrics.quickRatio.toFixed(2)}` : "-",
+      show: metrics.quickRatio != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "총현금",
+      value: metrics.totalCash != null ? formatLargeNumber(metrics.totalCash, currency) : "-",
+      show: metrics.totalCash != null,
+      tier: "secondary" as const,
+    },
+    {
+      label: "총부채",
+      value: metrics.totalDebt != null ? formatLargeNumber(metrics.totalDebt, currency) : "-",
+      show: metrics.totalDebt != null,
+      tier: "secondary" as const,
     },
   ].filter((m) => m.show);
 
   if (cards.length === 0) return null;
 
+  const primary = cards.filter((c) => c.tier === "primary");
+  const secondary = cards.filter((c) => c.tier === "secondary");
+
   return (
     <View style={styles.container}>
-      <Text variant="caption" color={Colors.midGrayText} style={styles.sectionLabel}>
+      <Text variant="subheading" color={Colors.taroEssence} style={styles.sectionLabel}>
         재무 지표
       </Text>
 
-      <View style={styles.grid}>
-        {cards.map((m) => (
-          <View key={m.label} style={styles.card}>
-            <Text variant="caption" color={Colors.midGrayText}>{m.label}</Text>
-            <Text variant="subheading" color={Colors.whiteout} style={styles.value}>
-              {m.value}
-            </Text>
+      {primary.length > 0 && (
+        <>
+          <Text variant="caption" color={Colors.midGrayText} style={styles.tierLabel}>
+            핵심 지표
+          </Text>
+          <View style={styles.grid}>
+            {primary.map((m) => (
+              <View key={m.label} style={[styles.card, styles.primaryCard]}>
+                <Text variant="caption" color={Colors.midGrayText} style={styles.cardLabel}>
+                  {m.label}
+                </Text>
+                <Text variant="subheading" color={Colors.whiteout} style={styles.primaryValue}>
+                  {m.value}
+                </Text>
+              </View>
+            ))}
           </View>
-        ))}
-      </View>
+        </>
+      )}
+
+      {secondary.length > 0 && (
+        <>
+          <Text variant="caption" color={Colors.midGrayText} style={styles.tierLabel}>
+            보조 지표
+          </Text>
+          <View style={styles.grid}>
+            {secondary.map((m) => (
+              <View key={m.label} style={[styles.card, styles.secondaryCard]}>
+                <Text variant="caption" color={Colors.midGrayText} style={styles.cardLabel}>
+                  {m.label}
+                </Text>
+                <Text variant="body" color={Colors.whiteout} style={styles.secondaryValue}>
+                  {m.value}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </>
+      )}
     </View>
   );
 }
@@ -124,27 +173,51 @@ export function KeyMetricsGrid({ metrics, currency = "USD" }: Props) {
 const styles = StyleSheet.create({
   container: {
     marginBottom: Spacing.s24,
+    gap: 8,
   },
   sectionLabel: {
-    marginBottom: Spacing.s8,
+    marginBottom: 4,
+    fontWeight: "600",
+    letterSpacing: 0.3,
+  },
+  tierLabel: {
+    marginTop: 8,
+    marginBottom: 4,
     letterSpacing: 0.5,
+    textTransform: "uppercase",
   },
   grid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 8,
+    gap: 16,
   },
   card: {
-    width: "48%",
+    width: "47%",
     flexGrow: 1,
-    backgroundColor: Colors.graphiteBase,
     borderRadius: 12,
     padding: 16,
     borderWidth: 1,
-    borderColor: Colors.carbonBorder,
-    gap: 6,
+    gap: 8,
   },
-  value: {
+  primaryCard: {
+    backgroundColor: Colors.voidGreen,
+    borderColor: Colors.deepInsight,
+  },
+  secondaryCard: {
+    backgroundColor: Colors.graphiteBase,
+    borderColor: Colors.carbonBorder,
+  },
+  cardLabel: {
+    letterSpacing: 0.3,
+  },
+  primaryValue: {
     fontWeight: "700",
+    fontSize: 18,
+    lineHeight: 22,
+  },
+  secondaryValue: {
+    fontWeight: "500",
+    fontSize: 15,
+    lineHeight: 20,
   },
 });

--- a/apps/tarot-mobile/components/ticker/NewsDetailModal.tsx
+++ b/apps/tarot-mobile/components/ticker/NewsDetailModal.tsx
@@ -1,0 +1,289 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Modal,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Linking,
+  ActivityIndicator,
+} from "react-native";
+import { Text } from "../ui/Text";
+import { Colors, Spacing, Radius } from "../../constants/theme";
+import { apiFetch } from "../../lib/api";
+import { trackEvent } from "../../lib/tracking";
+
+interface NewsItem {
+  title: string;
+  description: string;
+  summary?: string;
+  link: string;
+  publishedAt: string;
+  source: string;
+  category?: string;
+}
+
+interface InsightResponse {
+  headline: string;
+  summary: string;
+  cardName: string;
+  orientation: "upright" | "reversed";
+}
+
+interface Props {
+  visible: boolean;
+  item: NewsItem | null;
+  symbol: string;
+  onClose: () => void;
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}분 전`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}
+
+export function NewsDetailModal({ visible, item, symbol, onClose }: Props) {
+  const [insight, setInsight] = useState<InsightResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!visible || !item) return;
+
+    const startedAt = Date.now();
+    setLoading(true);
+    trackEvent("news_modal_opened", {
+      symbol,
+      category: item.category,
+      source: item.source,
+    });
+
+    apiFetch<InsightResponse>(
+      `/api/tarot/news-insight?symbol=${encodeURIComponent(symbol)}`,
+    )
+      .then((data) => setInsight(data))
+      .catch(() => setInsight(null))
+      .finally(() => setLoading(false));
+
+    return () => {
+      const dwellMs = Date.now() - startedAt;
+      trackEvent("news_modal_closed", { symbol, dwellMs });
+    };
+  }, [visible, item, symbol]);
+
+  if (!item) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text variant="caption" color={Colors.midGrayText}>
+            관련 뉴스
+          </Text>
+          <TouchableOpacity onPress={onClose} hitSlop={12}>
+            <Text variant="body-sm" color={Colors.taroEssence}>
+              닫기
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.body}>
+          {/* 타로 투자 인사이트 (상단 우선 노출) */}
+          <View style={styles.insightCard}>
+            <Text variant="caption" color={Colors.midGrayText} style={styles.sectionLabel}>
+              타로 투자 인사이트
+            </Text>
+
+            {loading ? (
+              <View style={styles.insightLoading}>
+                <ActivityIndicator size="small" color={Colors.taroEssence} />
+              </View>
+            ) : insight ? (
+              <>
+                <View style={styles.cardBadgeRow}>
+                  <View style={styles.cardBadge}>
+                    <Text variant="caption" color={Colors.taroEssence}>
+                      {insight.cardName}
+                    </Text>
+                  </View>
+                  <View style={[styles.cardBadge, styles.orientationBadge]}>
+                    <Text variant="caption" color={Colors.midGrayText}>
+                      {insight.orientation === "upright" ? "정방향" : "역방향"}
+                    </Text>
+                  </View>
+                </View>
+
+                <Text variant="subheading" color={Colors.whiteout} style={styles.insightHeadline}>
+                  {insight.headline}
+                </Text>
+
+                <Text variant="body-sm" color={Colors.midGrayText} style={styles.insightSummary}>
+                  {insight.summary}
+                </Text>
+
+                <Text variant="caption" color={Colors.ironOutline} style={styles.disclaimer}>
+                  타로 해석은 참고용 콘텐츠이며 투자 조언이 아닙니다.
+                </Text>
+              </>
+            ) : (
+              <Text variant="body-sm" color={Colors.midGrayText}>
+                인사이트를 불러올 수 없습니다.
+              </Text>
+            )}
+          </View>
+
+          {/* 기사 본문 */}
+          <View style={styles.articleSection}>
+            <View style={styles.metaRow}>
+              {item.category ? (
+                <View style={styles.categoryBadge}>
+                  <Text variant="caption" color={Colors.taroEssence}>
+                    {item.category}
+                  </Text>
+                </View>
+              ) : null}
+              <Text variant="caption" color={Colors.midGrayText}>
+                {item.source}
+              </Text>
+              <Text variant="caption" color={Colors.ironOutline}>
+                · {timeAgo(item.publishedAt)}
+              </Text>
+            </View>
+
+            <Text variant="subheading" color={Colors.whiteout} style={styles.articleTitle}>
+              {item.title}
+            </Text>
+
+            {item.summary || item.description ? (
+              <Text variant="body-sm" color={Colors.midGrayText} style={styles.articleBody}>
+                {item.summary || item.description}
+              </Text>
+            ) : null}
+          </View>
+        </ScrollView>
+
+        <View style={styles.footer}>
+          <TouchableOpacity
+            style={styles.linkButton}
+            onPress={() => {
+              Linking.openURL(item.link).catch(() => {});
+            }}
+            activeOpacity={0.7}
+          >
+            <Text variant="body-sm" color={Colors.taroEssence}>
+              원문 보기
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.ebonyCanvas,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.s16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.carbonBorder,
+  },
+  body: {
+    padding: Spacing.s16,
+    gap: Spacing.s24,
+  },
+  sectionLabel: {
+    marginBottom: Spacing.s8,
+    letterSpacing: 0.5,
+  },
+  insightCard: {
+    backgroundColor: Colors.voidGreen,
+    borderRadius: Radius.cards,
+    padding: Spacing.s24,
+    borderWidth: 1,
+    borderColor: Colors.deepInsight,
+    gap: 12,
+  },
+  insightLoading: {
+    paddingVertical: Spacing.s24,
+    alignItems: "center",
+  },
+  cardBadgeRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  cardBadge: {
+    backgroundColor: Colors.ebonyCanvas,
+    borderRadius: 9999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderWidth: 1,
+    borderColor: Colors.deepInsight,
+  },
+  orientationBadge: {
+    borderColor: Colors.carbonBorder,
+  },
+  insightHeadline: {
+    fontWeight: "700",
+    lineHeight: 26,
+  },
+  insightSummary: {
+    lineHeight: 20,
+  },
+  disclaimer: {
+    marginTop: Spacing.s8,
+    fontStyle: "italic",
+  },
+  articleSection: {
+    gap: 12,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  categoryBadge: {
+    backgroundColor: Colors.voidGreen,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderWidth: 1,
+    borderColor: Colors.deepInsight,
+  },
+  articleTitle: {
+    fontWeight: "700",
+    lineHeight: 26,
+  },
+  articleBody: {
+    lineHeight: 20,
+  },
+  footer: {
+    padding: Spacing.s16,
+    borderTopWidth: 1,
+    borderTopColor: Colors.carbonBorder,
+  },
+  linkButton: {
+    backgroundColor: Colors.graphiteBase,
+    borderRadius: Radius.cards,
+    paddingVertical: 12,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.carbonBorder,
+  },
+});

--- a/apps/tarot-mobile/components/ticker/NewsList.tsx
+++ b/apps/tarot-mobile/components/ticker/NewsList.tsx
@@ -1,15 +1,18 @@
 import React, { useEffect, useState } from "react";
-import { View, TouchableOpacity, StyleSheet, Linking } from "react-native";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
 import { Text } from "../ui/Text";
 import { Colors, Spacing, Radius } from "../../constants/theme";
 import { apiFetch } from "../../lib/api";
+import { NewsDetailModal } from "./NewsDetailModal";
 
 interface NewsItem {
   title: string;
   description: string;
+  summary?: string;
   link: string;
   publishedAt: string;
   source: string;
+  category?: string;
 }
 
 interface Props {
@@ -29,6 +32,7 @@ function timeAgo(dateStr: string): string {
 export function NewsList({ symbol }: Props) {
   const [news, setNews] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<NewsItem | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -52,19 +56,35 @@ export function NewsList({ symbol }: Props) {
           <TouchableOpacity
             key={i}
             style={[styles.newsItem, i < news.length - 1 && styles.newsItemBorder]}
-            onPress={() => Linking.openURL(item.link).catch(() => {})}
+            onPress={() => setSelected(item)}
             activeOpacity={0.7}
           >
             <Text variant="body-sm" color={Colors.whiteout} numberOfLines={2} style={styles.newsTitle}>
               {item.title}
             </Text>
             <View style={styles.newsMeta}>
-              <Text variant="caption" color={Colors.midGrayText}>{item.source}</Text>
+              <View style={styles.metaLeft}>
+                {item.category ? (
+                  <View style={styles.categoryChip}>
+                    <Text variant="caption" color={Colors.taroEssence}>
+                      {item.category}
+                    </Text>
+                  </View>
+                ) : null}
+                <Text variant="caption" color={Colors.midGrayText}>{item.source}</Text>
+              </View>
               <Text variant="caption" color={Colors.ironOutline}>{timeAgo(item.publishedAt)}</Text>
             </View>
           </TouchableOpacity>
         ))}
       </View>
+
+      <NewsDetailModal
+        visible={selected !== null}
+        item={selected}
+        symbol={symbol}
+        onClose={() => setSelected(null)}
+      />
     </View>
   );
 }
@@ -99,5 +119,19 @@ const styles = StyleSheet.create({
   newsMeta: {
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "center",
+  },
+  metaLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  categoryChip: {
+    backgroundColor: Colors.voidGreen,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderWidth: 1,
+    borderColor: Colors.deepInsight,
   },
 });

--- a/apps/tarot-mobile/lib/tracking.ts
+++ b/apps/tarot-mobile/lib/tracking.ts
@@ -67,7 +67,9 @@ export type TarotEvent =
   | "credit_purchased"
   | "collection_viewed"
   | "analytics_viewed"
-  | "onboarding_completed";
+  | "onboarding_completed"
+  | "news_modal_opened"
+  | "news_modal_closed";
 
 let _apiBase: string | null = null;
 let _getToken: (() => string | null) | null = null;

--- a/apps/web/__tests__/api/tarot/chart.test.ts
+++ b/apps/web/__tests__/api/tarot/chart.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// 검증 항목 (QA 이슈 #240 차트 데이터 정합성 테스트):
+//   1. symbol 누락 → 400
+//   2. range 무효 → 400 + 허용 목록 안내
+//   3. 정상 응답 — bars 배열 정렬·필드 완비
+//   4. close가 null인 바는 스킵 (조용히 누락 처리)
+//   5. close가 NaN/Infinity 같은 비정상 값일 때도 스킵 (Number.isFinite 가드)
+//   6. open/high/low가 null이면 close 값으로 폴백
+//   7. 동일 timestamp 중복 입력 — 모두 가공되지만 close 무결성 유지
+//   8. timestamps 배열은 있는데 quote 데이터 자체가 비어있을 때 bars=[]
+//   9. 외부 API 502 → 502 패스스루
+//   10. 외부 API result 없음 → 404
+//   11. 캐시 — 같은 (symbol, range, interval) 두 번째 호출은 외부 fetch 없이 응답
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { GET } from "@/app/api/tarot/chart/route";
+import { NextRequest } from "next/server";
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+interface YahooBar {
+  open: number | null;
+  high: number | null;
+  low: number | null;
+  close: number | null;
+  volume: number | null;
+}
+
+function yahooChartPayload(timestamps: number[], bars: YahooBar[]) {
+  return {
+    chart: {
+      result: [
+        {
+          meta: { currency: "USD", symbol: "TEST", exchangeName: "NMS" },
+          timestamp: timestamps,
+          indicators: {
+            quote: [
+              {
+                open: bars.map((b) => b.open),
+                high: bars.map((b) => b.high),
+                low: bars.map((b) => b.low),
+                close: bars.map((b) => b.close),
+                volume: bars.map((b) => b.volume),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("/api/tarot/chart", () => {
+  it("symbol 누락 → 400", async () => {
+    const res = await GET(makeRequest("http://localhost/api/tarot/chart"));
+    expect(res.status).toBe(400);
+  });
+
+  it("range 무효 → 400 + 허용 목록 안내", async () => {
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=AAPL&range=99y"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid range");
+    expect(body.error).toContain("1d");
+  });
+
+  it("정상 응답 — bars 배열 + 필드 완비", async () => {
+    const ts = [1_700_000_000, 1_700_086_400, 1_700_172_800];
+    const bars: YahooBar[] = [
+      { open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 },
+      { open: 102, high: 108, low: 101, close: 107, volume: 1_200_000 },
+      { open: 107, high: 110, low: 106, close: 109, volume: 900_000 },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload(ts, bars),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=NORMAL1&range=1mo"),
+    );
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.bars).toHaveLength(3);
+    expect(body.bars[0]).toMatchObject({ open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 });
+    expect(typeof body.bars[0].date).toBe("string");
+    expect(() => new Date(body.bars[0].date)).not.toThrow();
+    expect(body.meta.currency).toBe("USD");
+    expect(body.meta.exchangeName).toBe("NMS");
+  });
+
+  it("close=null 인 바는 스킵 (결측치 안전 처리)", async () => {
+    const ts = [1_700_000_000, 1_700_086_400, 1_700_172_800];
+    const bars: YahooBar[] = [
+      { open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 },
+      { open: 102, high: null, low: null, close: null, volume: 0 },
+      { open: 107, high: 110, low: 106, close: 109, volume: 900_000 },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload(ts, bars),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=NULL1&range=1mo"),
+    );
+    const body = await res.json();
+    expect(body.bars).toHaveLength(2);
+    expect(body.bars[0].close).toBe(102);
+    expect(body.bars[1].close).toBe(109);
+  });
+
+  it("close=NaN / Infinity 등 비정상 값도 스킵 (Number.isFinite 가드)", async () => {
+    const ts = [1_700_000_000, 1_700_086_400, 1_700_172_800, 1_700_259_200];
+    const bars: YahooBar[] = [
+      { open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 },
+      { open: 100, high: 105, low: 99, close: Number.NaN, volume: 0 },
+      { open: 100, high: 105, low: 99, close: Number.POSITIVE_INFINITY, volume: 0 },
+      { open: 107, high: 110, low: 106, close: 109, volume: 900_000 },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload(ts, bars),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=BAD1&range=1mo"),
+    );
+    const body = await res.json();
+    expect(body.bars).toHaveLength(2);
+    expect(body.bars.map((b: { close: number }) => b.close)).toEqual([102, 109]);
+  });
+
+  it("open/high/low가 null이면 close 값으로 폴백", async () => {
+    const ts = [1_700_000_000];
+    const bars: YahooBar[] = [
+      { open: null, high: null, low: null, close: 100, volume: 0 },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload(ts, bars),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=FALLBACK1&range=1mo"),
+    );
+    const body = await res.json();
+    expect(body.bars).toHaveLength(1);
+    expect(body.bars[0]).toMatchObject({ open: 100, high: 100, low: 100, close: 100 });
+  });
+
+  it("동일 timestamp 중복 입력 — close가 유효한 모든 바를 보존 (가공 일관성)", async () => {
+    const sameTs = 1_700_000_000;
+    const ts = [sameTs, sameTs, sameTs];
+    const bars: YahooBar[] = [
+      { open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 },
+      { open: 102, high: 106, low: 101, close: 103, volume: 0 },
+      { open: 103, high: 107, low: 102, close: 104, volume: 0 },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload(ts, bars),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=DUP1&range=1mo"),
+    );
+    const body = await res.json();
+    expect(body.bars).toHaveLength(3);
+    // 같은 timestamp이지만 변환은 안전하게 동작
+    expect(body.bars.every((b: { close: number }) => Number.isFinite(b.close))).toBe(true);
+  });
+
+  it("timestamps 있지만 quote 비어있음 → bars=[] (크래시 없음)", async () => {
+    const payload = {
+      chart: {
+        result: [
+          {
+            meta: { currency: "USD", symbol: "TEST" },
+            timestamp: [1_700_000_000, 1_700_086_400],
+            indicators: { quote: [] },
+          },
+        ],
+      },
+    };
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => payload });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=EMPTY1&range=1mo"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.bars).toEqual([]);
+    expect(body.meta.currency).toBe("USD");
+  });
+
+  it("외부 API 502 → 502 패스스루", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=ERR1&range=1mo"),
+    );
+    expect(res.status).toBe(502);
+  });
+
+  it("외부 API result 없음 → 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ chart: { result: [] } }),
+    });
+
+    const res = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=NORESULT1&range=1mo"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("캐시 — 같은 (symbol, range, interval) 두 번째 호출은 외부 fetch 없이 응답", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload([1_700_000_000], [
+        { open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 },
+      ]),
+    });
+
+    const r1 = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=CACHE1&range=1mo"),
+    );
+    expect(r1.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const r2 = await GET(
+      makeRequest("http://localhost/api/tarot/chart?symbol=CACHE1&range=1mo"),
+    );
+    expect(r2.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // 캐시 hit
+
+    const body = await r2.json();
+    expect(body.bars).toHaveLength(1);
+  });
+
+  it("다른 range는 별도 캐시 — 같은 symbol 다른 range는 새 fetch", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload([1_700_000_000], [
+        { open: 100, high: 105, low: 99, close: 102, volume: 1_000_000 },
+      ]),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => yahooChartPayload([1_700_000_000], [
+        { open: 200, high: 210, low: 195, close: 205, volume: 500_000 },
+      ]),
+    });
+
+    await GET(makeRequest("http://localhost/api/tarot/chart?symbol=MULTIRANGE&range=1mo"));
+    await GET(makeRequest("http://localhost/api/tarot/chart?symbol=MULTIRANGE&range=1y"));
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/__tests__/api/tarot/news.test.ts
+++ b/apps/web/__tests__/api/tarot/news.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// 검증 항목 (Backend 이슈 #237 — 뉴스 메타데이터 확장):
+//   1. symbol 누락 → 400
+//   2. 정상 RSS 파싱 — title/link/summary/description/category/source/publishedAt 필수 필드 채워짐
+//   3. <source> 태그 부재 → "Yahoo Finance" 폴백
+//   4. <category> 태그 부재 → 키워드 기반 자동 분류 ("실적"/"M&A" 등)
+//   5. summary == description (별칭, 후방 호환)
+//   6. CDATA 래핑된 카테고리 정상 추출
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { GET } from "@/app/api/tarot/news/route";
+import { NextRequest } from "next/server";
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+function rssItem(opts: {
+  title: string;
+  link: string;
+  description: string;
+  pubDate?: string;
+  source?: string;
+  category?: string;
+  cdataCategory?: string;
+}): string {
+  const parts: string[] = ["<item>"];
+  parts.push(`<title><![CDATA[${opts.title}]]></title>`);
+  parts.push(`<link>${opts.link}</link>`);
+  parts.push(`<description><![CDATA[${opts.description}]]></description>`);
+  if (opts.pubDate) parts.push(`<pubDate>${opts.pubDate}</pubDate>`);
+  if (opts.source) parts.push(`<source url="https://example.com">${opts.source}</source>`);
+  if (opts.category) parts.push(`<category>${opts.category}</category>`);
+  if (opts.cdataCategory) parts.push(`<category><![CDATA[${opts.cdataCategory}]]></category>`);
+  parts.push("</item>");
+  return parts.join("");
+}
+
+function buildRss(items: string[]): string {
+  return `<?xml version="1.0"?><rss><channel>${items.join("")}</channel></rss>`;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("/api/tarot/news (메타데이터 확장)", () => {
+  it("symbol 누락 → 400", async () => {
+    const res = await GET(makeRequest("http://localhost/api/tarot/news"));
+    expect(res.status).toBe(400);
+  });
+
+  it("정상 응답 — title/link/summary/description/category/source/publishedAt 모두 채워짐", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "Apple beats Q4 earnings expectations",
+        link: "https://example.com/aapl-earnings",
+        description: "Apple reported strong quarterly revenue.",
+        pubDate: "Mon, 27 May 2026 12:00:00 GMT",
+        source: "Yahoo Finance",
+        category: "Finance",
+      }),
+    ]);
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=AAPL"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    const item = body.items[0];
+    expect(item.title).toBe("Apple beats Q4 earnings expectations");
+    expect(item.link).toBe("https://example.com/aapl-earnings");
+    expect(item.summary).toBe("Apple reported strong quarterly revenue.");
+    expect(item.description).toBe(item.summary); // 별칭 일치
+    expect(item.source).toBe("Yahoo Finance");
+    expect(item.category).toBe("Finance"); // RSS 카테고리 우선
+    expect(item.publishedAt).toMatch(/^2026-05-27/);
+  });
+
+  it("<source> 태그 부재 → 'Yahoo Finance' 폴백", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "Test",
+        link: "https://example.com/x",
+        description: "desc",
+      }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=NOSRC"));
+    const body = await res.json();
+    expect(body.items[0].source).toBe("Yahoo Finance");
+  });
+
+  it("<category> 부재 + 제목에 'earnings' → 자동 분류 '실적'", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "Nvidia quarterly earnings beat analyst estimates",
+        link: "https://example.com/nvda",
+        description: "Revenue jumped 20%.",
+      }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=NVDA"));
+    const body = await res.json();
+    expect(body.items[0].category).toBe("실적");
+  });
+
+  it("<category> 부재 + 제목에 'acquisition' → 자동 분류 'M&A'", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "Microsoft announces acquisition of Activision",
+        link: "https://example.com/msft",
+        description: "Deal valued at 70B USD.",
+      }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=MSFT"));
+    const body = await res.json();
+    expect(body.items[0].category).toBe("M&A");
+  });
+
+  it("<category> 부재 + 키워드 미매치 → 기본 '시장'", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "Random headline",
+        link: "https://example.com/r",
+        description: "Just a description.",
+      }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=RANDOM"));
+    const body = await res.json();
+    expect(body.items[0].category).toBe("시장");
+  });
+
+  it("CDATA 래핑된 <category> 정상 추출", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "Apple stock",
+        link: "https://example.com/a",
+        description: "desc",
+        cdataCategory: "Technology",
+      }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=CDATA"));
+    const body = await res.json();
+    expect(body.items[0].category).toBe("Technology");
+  });
+
+  it("외부 RSS 실패 → items=[] (크래시 없음)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, text: async () => "" });
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=ERR"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+  });
+});

--- a/apps/web/app/api/tarot/news/route.ts
+++ b/apps/web/app/api/tarot/news/route.ts
@@ -9,9 +9,31 @@ const cache = new Map<string, { data: NewsItem[]; expiresAt: number }>();
 interface NewsItem {
   title: string;
   description: string;
+  summary: string;
   link: string;
   publishedAt: string;
   source: string;
+  category: string;
+}
+
+const CATEGORY_KEYWORDS: Array<{ keywords: RegExp; category: string }> = [
+  { keywords: /\b(earnings|revenue|profit|guidance|eps|quarterly|results)\b/i, category: "실적" },
+  { keywords: /\b(merger|acquisition|deal|buyout|takeover|m&a)\b/i, category: "M&A" },
+  { keywords: /\b(upgrade|downgrade|rating|price target|analyst)\b/i, category: "애널리스트" },
+  { keywords: /\b(dividend|buyback|split|payout)\b/i, category: "주주환원" },
+  { keywords: /\b(ceo|cfo|executive|leadership|board)\b/i, category: "경영진" },
+  { keywords: /\b(lawsuit|sec|investigation|fine|regulation|fda|approval)\b/i, category: "규제/소송" },
+  { keywords: /\b(ai|chip|semiconductor|cloud|tech|software|app)\b/i, category: "기술" },
+  { keywords: /\b(fed|inflation|rate|economy|gdp|jobs|cpi)\b/i, category: "거시경제" },
+];
+
+function inferCategory(title: string, description: string, rawCategory: string): string {
+  if (rawCategory) return rawCategory;
+  const blob = `${title} ${description}`;
+  for (const { keywords, category } of CATEGORY_KEYWORDS) {
+    if (keywords.test(blob)) return category;
+  }
+  return "시장";
 }
 
 function parseYahooRss(xml: string): NewsItem[] {
@@ -31,14 +53,21 @@ function parseYahooRss(xml: string): NewsItem[] {
     const source = block.match(/<source[^>]*>(.*?)<\/source>/)?.[1]
       ?? block.match(/<source[^>]*url="([^"]*)".*?<\/source>/)?.[1]
       ?? "Yahoo Finance";
+    const rawCategory = block.match(/<category><!\[CDATA\[(.*?)\]\]><\/category>/)?.[1]
+      ?? block.match(/<category>(.*?)<\/category>/)?.[1]
+      ?? "";
 
     if (title && link) {
+      const cleanTitle = title.trim();
+      const cleanDescription = description.replace(/<[^>]*>/g, "").trim().slice(0, 200);
       items.push({
-        title: title.trim(),
-        description: description.replace(/<[^>]*>/g, "").trim().slice(0, 200),
+        title: cleanTitle,
+        description: cleanDescription,
+        summary: cleanDescription,
         link: link.trim(),
         publishedAt: pubDate ? new Date(pubDate).toISOString() : new Date().toISOString(),
         source: source.trim() || "Yahoo Finance",
+        category: inferCategory(cleanTitle, cleanDescription, rawCategory.trim()),
       });
     }
   }


### PR DESCRIPTION
## Summary

CEO Brief #246 (2026-05-29) 항목 중 Frontend(#236 스켈레톤 — 피그마 미반영) / Marketer(임시 직무 변경 중) 제외, 의존성 순서로 4개 일괄 처리.

### Backend #237 — `/api/tarot/news` 메타데이터 확장
- `summary` 필드 추가 (description 별칭, 후방 호환 유지)
- `category` 필드 추가: Yahoo RSS `<category>` 태그 우선 → 부재 시 키워드 기반 자동 분류(실적/M&A/애널리스트/주주환원/경영진/규제/소송/기술/거시경제/시장)

### PM #235 — 뉴스 클릭 시 타로 인사이트 모달
- `NewsDetailModal` 신규: 종목 단위 `/api/tarot/news-insight` 재사용 → 카드명·정/역방향 배지 + 헤드라인·요약 + 면책 한 줄
- `NewsList`: 외부 링크 즉시 이동 → 모달 오픈으로 전환, 리스트에 카테고리 칩 노출
- `tracking`: `news_modal_opened`/`news_modal_closed` 이벤트 + `dwellMs` 측정

### Designer #238 — 재무 지표 위계 강화
- 12개 지표를 핵심(EPS·순이익률·ROA·잉여현금흐름) / 보조 2단계로 분리
- 핵심 카드: `voidGreen` 배경 + `deepInsight` 보더 + 18pt 굵은 값
- 보조 카드: `graphiteBase` 배경 + 15pt regular
- 섹션 헤더: caption(midGrayText) → subheading(taroEssence, semi-bold)
- 그리드 간격 8 → 16, 카드 내부 라벨/값 간격 6 → 8

### QA #240 — 차트 데이터 정합성 + 뉴스 메타 회귀 테스트
- `/api/tarot/chart` 12 케이스: 무효 range/symbol, close=null/NaN/Infinity 스킵, open/high/low null → close 폴백, 동일 timestamp 중복, quote 빈 응답, 외부 502/404 패스스루, 캐시 hit/miss + range별 분리
- `/api/tarot/news` 8 케이스: source/category 필수 채움, RSS 카테고리 우선 → 키워드 자동 분류(실적/M&A/기본'시장'), CDATA 카테고리, summary 별칭, 외부 실패 시 빈 배열

## Test plan
- [x] `npm run typecheck` 전체 통과 (web/mobile/shared/core/api)
- [x] `npm run test` 201 케이스 전부 통과 (신규 20 포함)
- [ ] `verify-bundle.sh` 통과 (백그라운드 실행 중)
- [ ] iOS 시뮬레이터에서 뉴스 모달 / 재무 지표 위계 시각 확인
- [ ] 머지 후 CEO Brief #235·#237·#238·#240 close


---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_