### PR TITLE
feat: 종목 상세 뉴스 섹션 개선 (#254 파싱 하드닝 · #252 정합성 테스트 · #251 SWR 캐시)

### DIFF
--- a/apps/tarot-mobile/components/ticker/NewsList.tsx
+++ b/apps/tarot-mobile/components/ticker/NewsList.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { View, TouchableOpacity, StyleSheet } from "react-native";
 import { Text } from "../ui/Text";
 import { Colors, Spacing, Radius } from "../../constants/theme";
-import { apiFetch } from "../../lib/api";
+import { useCachedFetch } from "../../lib/useCachedFetch";
 import { NewsDetailModal } from "./NewsDetailModal";
 
 interface NewsItem {
@@ -30,17 +30,13 @@ function timeAgo(dateStr: string): string {
 }
 
 export function NewsList({ symbol }: Props) {
-  const [news, setNews] = useState<NewsItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  // SWR 캐시: 동일 종목 뉴스는 10분 내 재요청 없이 캐시 재사용 (탭 전환/재진입 시 호출 절감)
+  const { data, loading } = useCachedFetch<{ items: NewsItem[] }>(
+    `/api/tarot/news?symbol=${encodeURIComponent(symbol)}&limit=8`,
+    10 * 60 * 1000
+  );
+  const news = data?.items ?? [];
   const [selected, setSelected] = useState<NewsItem | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    apiFetch<{ items: NewsItem[] }>(`/api/tarot/news?symbol=${encodeURIComponent(symbol)}&limit=8`)
-      .then((data) => setNews(data.items))
-      .catch(() => setNews([]))
-      .finally(() => setLoading(false));
-  }, [symbol]);
 
   if (loading) return null;
   if (news.length === 0) return null;
@@ -54,7 +50,7 @@ export function NewsList({ symbol }: Props) {
       <View style={styles.card}>
         {news.map((item, i) => (
           <TouchableOpacity
-            key={i}
+            key={item.link || i}
             style={[styles.newsItem, i < news.length - 1 && styles.newsItemBorder]}
             onPress={() => setSelected(item)}
             activeOpacity={0.7}

--- a/apps/web/__tests__/api/tarot/news.test.ts
+++ b/apps/web/__tests__/api/tarot/news.test.ts
@@ -170,3 +170,63 @@ describe("/api/tarot/news (메타데이터 확장)", () => {
     expect(body.items).toEqual([]);
   });
 });
+
+// QA 제안 #252 — 뉴스 섹션 데이터 정합성 (결측치 / 잘못된 형식 / 중복)
+describe("/api/tarot/news (데이터 정합성)", () => {
+  it("시나리오 1: title 결측 항목 → 제외 (화면 깨짐 없음)", async () => {
+    const xml = buildRss([
+      "<item><link>https://example.com/no-title</link><description><![CDATA[본문]]></description></item>",
+      rssItem({ title: "정상 기사", link: "https://example.com/ok", description: "정상" }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=INTEG_NOTITLE"));
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].title).toBe("정상 기사");
+  });
+
+  it("시나리오 1-b: link 결측 항목 → 제외", async () => {
+    const xml = buildRss([
+      "<item><title><![CDATA[링크 없는 기사]]></title><description><![CDATA[본문]]></description></item>",
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=INTEG_NOLINK"));
+    const body = await res.json();
+    expect(body.items).toEqual([]);
+  });
+
+  it("시나리오 2: 잘못된 형식의 pubDate → 크래시 없이 유효한 ISO 시각으로 폴백", async () => {
+    const xml = buildRss([
+      rssItem({
+        title: "날짜 깨진 기사",
+        link: "https://example.com/bad-date",
+        description: "본문",
+        pubDate: "완전-잘못된-날짜",
+      }),
+    ]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=INTEG_BADDATE"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(Number.isNaN(new Date(body.items[0].publishedAt).getTime())).toBe(false);
+  });
+
+  it("시나리오 3: 동일 link 중복 기사 → 한 번만 표시", async () => {
+    const dup = rssItem({
+      title: "중복 기사",
+      link: "https://example.com/dup",
+      description: "본문",
+    });
+    const xml = buildRss([dup, dup, dup]);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, text: async () => xml });
+
+    const res = await GET(makeRequest("http://localhost/api/tarot/news?symbol=INTEG_DUP"));
+    const body = await res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].link).toBe("https://example.com/dup");
+  });
+});

--- a/apps/web/app/api/tarot/news/route.ts
+++ b/apps/web/app/api/tarot/news/route.ts
@@ -36,8 +36,16 @@ function inferCategory(title: string, description: string, rawCategory: string):
   return "시장";
 }
 
+// pubDate가 비정상 포맷이면 Invalid Date → toISOString() 예외. 안전하게 변환.
+function safePublishedAt(pubDate: string): string {
+  if (!pubDate) return new Date().toISOString();
+  const d = new Date(pubDate);
+  return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
+}
+
 function parseYahooRss(xml: string): NewsItem[] {
   const items: NewsItem[] = [];
+  const seen = new Set<string>(); // link 기준 중복 기사 제거
   const itemRegex = /<item>([\s\S]*?)<\/item>/g;
   let match;
   while ((match = itemRegex.exec(xml)) !== null) {
@@ -57,19 +65,24 @@ function parseYahooRss(xml: string): NewsItem[] {
       ?? block.match(/<category>(.*?)<\/category>/)?.[1]
       ?? "";
 
-    if (title && link) {
-      const cleanTitle = title.trim();
-      const cleanDescription = description.replace(/<[^>]*>/g, "").trim().slice(0, 200);
-      items.push({
-        title: cleanTitle,
-        description: cleanDescription,
-        summary: cleanDescription,
-        link: link.trim(),
-        publishedAt: pubDate ? new Date(pubDate).toISOString() : new Date().toISOString(),
-        source: source.trim() || "Yahoo Finance",
-        category: inferCategory(cleanTitle, cleanDescription, rawCategory.trim()),
-      });
-    }
+    const cleanTitle = title.trim();
+    const cleanLink = link.trim();
+    // 필수 필드(title/link) 결측 항목 제외 — 깨진 카드가 사용자에게 노출되지 않도록
+    if (!cleanTitle || !cleanLink) continue;
+    // 동일 link 중복 기사 제거
+    if (seen.has(cleanLink)) continue;
+    seen.add(cleanLink);
+
+    const cleanDescription = description.replace(/<[^>]*>/g, "").trim().slice(0, 200);
+    items.push({
+      title: cleanTitle,
+      description: cleanDescription,
+      summary: cleanDescription,
+      link: cleanLink,
+      publishedAt: safePublishedAt(pubDate),
+      source: source.trim() || "Yahoo Finance",
+      category: inferCategory(cleanTitle, cleanDescription, rawCategory.trim()),
+    });
   }
   return items;
 }


### PR DESCRIPTION
## 직군별 에이전트 제안 구현 (2026-05-30)

CEO 브리핑(#257, 오늘자=중복) 무시, PM(#250)·Prompt Engineer(#256) 제외(품질/제품원칙 위배 — CEO 피드백 반영), Security(#253) 보고만(개발 없음). 나머지 직군 차례대로 구현.

### 🛠 Backend / CTO — #254 종목 데이터 API 응답 파싱 하드닝
`apps/web/app/api/tarot/news/route.ts`
- `link` 기준 **중복 기사 제거**
- 필수 필드(`title`/`link`) 결측 항목 제외 로직 명확화
- `safePublishedAt`: 비정상 `pubDate`(Invalid Date)로 인한 `toISOString` 예외 방어 → graceful fallback
- 데이터 품질 문제는 백엔드에서 조용히 흡수, 사용자에겐 정합된 데이터만 노출

### 🧪 QA — #252 뉴스 섹션 데이터 정합성 테스트
`apps/web/__tests__/api/tarot/news.test.ts` (8 → 12 케이스)
- 결측: `title`/`link` 누락 항목 제외
- 잘못된 형식: 비정상 `pubDate` → 크래시 없이 유효 ISO 폴백
- 중복: 동일 `link` 기사 1회만 표시

### 📱 Frontend — #251 로컬 캐시 개선으로 API 호출 최적화
`apps/tarot-mobile/components/ticker/NewsList.tsx`
- raw `apiFetch` + `useEffect` → 기존 `useCachedFetch`(SWR) 훅 전환
- 동일 종목 뉴스 10분 내 캐시 재사용 → 탭 전환/재진입 시 호출 절감
- list key `index` → `item.link` 안정 키

### 🚀 (포함) Vercel Git 네이티브 연동 전환
- 디버깅 불가하던 GitHub Actions 배포 워크플로우 제거, `vercel.json` 모노레포 빌드 명시, `docs/vercel-setup.md` 가이드

## 검증
- `npm run lint` ✅ / `npm run typecheck` ✅ / `npm run build:web` ✅
- `npm run test` ✅ 101 passed (11 files)
- `typecheck:mobile` ✅ / `verify-bundle.sh` ✅ (iOS 번들링 통과)

> ⚠️ 모바일 런타임 시뮬레이터 QA는 컨테이너 제약으로 미실행. NewsList 변경은 검증된 기존 훅으로의 단순 치환 + 빌드/타입체크 통과.

https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN

---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_