### PR TITLE
feat(mobile): #263 뉴스 컨텍스트 기반 타로 카드 뽑기 CTA

### DIFF
--- a/apps/tarot-mobile/components/ticker/NewsList.tsx
+++ b/apps/tarot-mobile/components/ticker/NewsList.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { View, TouchableOpacity, StyleSheet } from "react-native";
 import { Text } from "../ui/Text";
 import { Colors, Spacing, Radius } from "../../constants/theme";
 import { useCachedFetch } from "../../lib/useCachedFetch";
 import { NewsDetailModal } from "./NewsDetailModal";
+import { NewsTarotCta } from "./NewsTarotCta";
 
 interface NewsItem {
   title: string;
@@ -38,6 +39,20 @@ export function NewsList({ symbol }: Props) {
   const news = data?.items ?? [];
   const [selected, setSelected] = useState<NewsItem | null>(null);
 
+  // 가장 빈도 높은 카테고리 — CTA 카피 개인화 (PM #263).
+  const topCategory = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const n of news) {
+      if (n.category) counts.set(n.category, (counts.get(n.category) ?? 0) + 1);
+    }
+    let best: string | undefined;
+    let bestN = 0;
+    for (const [cat, n] of counts) {
+      if (n > bestN) { best = cat; bestN = n; }
+    }
+    return best;
+  }, [news]);
+
   if (loading) return null;
   if (news.length === 0) return null;
 
@@ -51,7 +66,7 @@ export function NewsList({ symbol }: Props) {
         {news.map((item, i) => (
           <TouchableOpacity
             key={item.link || i}
-            style={[styles.newsItem, i < news.length - 1 && styles.newsItemBorder]}
+            style={[styles.newsItem, styles.newsItemBorder]}
             onPress={() => setSelected(item)}
             activeOpacity={0.7}
           >
@@ -73,6 +88,8 @@ export function NewsList({ symbol }: Props) {
             </View>
           </TouchableOpacity>
         ))}
+        {/* PM #263: 뉴스 컨텍스트에서 이 종목 타로 뽑기 유도 */}
+        <NewsTarotCta symbol={symbol} topCategory={topCategory} />
       </View>
 
       <NewsDetailModal

--- a/apps/tarot-mobile/components/ticker/NewsTarotCta.tsx
+++ b/apps/tarot-mobile/components/ticker/NewsTarotCta.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { TouchableOpacity, StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+import { Text } from "../ui/Text";
+import { Colors, Spacing, Radius } from "../../constants/theme";
+import { useDrawStore } from "../../lib/drawStore";
+import { useStockStore } from "../../lib/stockStore";
+
+interface Props {
+  symbol: string;
+  /** 가장 빈도 높은 뉴스 카테고리 — 카피 개인화 (선택). */
+  topCategory?: string;
+}
+
+// 카테고리별 카피 — 뉴스 맥락을 카드 뽑기 동기로 이어주기 위함 (PM #263).
+// 단정형/투자조언 금칙어 회피.
+const CATEGORY_HOOKS: Record<string, string> = {
+  "실적": "실적 발표 직후의 흐름, 타로로 읽어볼까요?",
+  "M&A": "큰 변화의 신호, 타로가 어떻게 보는지 궁금하지 않으세요?",
+  "애널리스트": "전문가 시선 너머의 흐름, 타로로 들여다보기",
+  "주주환원": "주주환원 발표 흐름, 타로 카드로 해석해 보세요",
+  "경영진": "리더십 변화의 의미, 타로의 상징으로 풀어보기",
+  "규제/소송": "외부 변수 속 흐름, 타로가 어떤 신호를 보일지",
+  "기술": "기술 혁신의 흐름, 카드로 해석해 보세요",
+  "거시경제": "거시 흐름 속 이 종목, 타로의 시선으로",
+  "시장": "오늘의 흐름, 타로로 들여다보기",
+};
+const DEFAULT_HOOK = "이 종목의 흐름, 타로로 풀어볼까요?";
+
+export function NewsTarotCta({ symbol, topCategory }: Props) {
+  const router = useRouter();
+  const { setTicker } = useDrawStore();
+  const { quote } = useStockStore();
+
+  const hook = (topCategory && CATEGORY_HOOKS[topCategory]) || DEFAULT_HOOK;
+
+  const handlePress = () => {
+    setTicker(symbol, quote?.shortName ?? symbol);
+    router.push("/(tabs)/draw");
+  };
+
+  return (
+    <TouchableOpacity style={styles.row} onPress={handlePress} activeOpacity={0.7}>
+      <View style={styles.left}>
+        <Text style={styles.icon}>🔮</Text>
+        <View style={styles.textCol}>
+          <Text variant="body-sm" color={Colors.whiteout} style={styles.title}>
+            {hook}
+          </Text>
+          <Text variant="caption" color={Colors.midGrayText}>
+            {symbol} · 1장 또는 3장 스프레드
+          </Text>
+        </View>
+      </View>
+      <Text variant="body-sm" color={Colors.taroEssence} style={styles.arrow}>
+        ›
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: 16,
+    gap: 12,
+    backgroundColor: Colors.voidGreen,
+    borderTopWidth: 1,
+    borderTopColor: Colors.carbonBorder,
+  },
+  left: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    flex: 1,
+  },
+  icon: {
+    fontSize: 22,
+  },
+  textCol: {
+    flex: 1,
+    gap: 2,
+  },
+  title: {
+    fontWeight: "600",
+  },
+  arrow: {
+    fontSize: 24,
+    marginLeft: Spacing.s8,
+  },
+});
+
+// 사용처에서 사용 — 라디우스 일치를 위해 호출 부에서 카드 안에 배치 권장.
+NewsTarotCta.displayName = "NewsTarotCta";
+export const NEWS_CTA_BORDER_RADIUS = Radius.cards;


### PR DESCRIPTION
closes #263

## Summary
뉴스를 본 사용자가 바로 그 자리에서 타로로 종목 흐름을 해석할 수 있도록 NewsList 마지막 row에 카드 뽑기 CTA 추가.

- `NewsTarotCta`: 종목 + 카테고리 기반 카피 + 카드 뽑기 라우팅
- 뉴스 카테고리 빈도 계산해 가장 많은 카테고리에 맞춰 카피 개인화 (실적/M&A/애널리스트/주주환원/경영진/규제소송/기술/거시경제/시장)
- NewsList 마지막 뉴스의 border 제거 → 모든 row가 border-bottom으로 통일되어 CTA row와 시각적 연속성
- 투자조언/매수매도 금칙어 회피한 문구

## Test plan
- [x] typecheck 통과
- [x] iOS 번들 export 성공

https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN

---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_