### PR TITLE
fix(agent-council): CEO Brief LLM 호출 실패 차단 — feedback_brief 분리

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       feedback: ${{ steps.fetch.outputs.feedback }}
+      feedback_brief: ${{ steps.fetch.outputs.feedback_brief }}
       merged_prs: ${{ steps.fetch.outputs.merged_prs }}
       open_issues: ${{ steps.fetch.outputs.open_issues }}
       closed_issues: ${{ steps.fetch.outputs.closed_issues }}
@@ -109,6 +110,12 @@ jobs:
           if [ -z "$FEEDBACK" ]; then
             FEEDBACK="피드백 이력 없음 — 첫 번째 사이클입니다."
           fi
+          # CEO Brief용 짧은 버전 (REPO_MAP 제외, 5KB 제한) — agent prompt와 분리해
+          # CEO Brief의 LLM 입력 토큰 부담을 줄이고 호출 실패를 차단.
+          FEEDBACK_BRIEF=$(printf '%s' "$FEEDBACK" | head -c 5000)
+          echo "feedback_brief<<__EOF__" >> "$GITHUB_OUTPUT"
+          echo "$FEEDBACK_BRIEF" >> "$GITHUB_OUTPUT"
+          echo "__EOF__" >> "$GITHUB_OUTPUT"
 
           # 실제 레포 파일 구조 주입 — 에이전트가 존재하지 않는 경로를 환각 인용하는 사고 방지
           # (2026-05-31 사용자 피드백: "선행으로 파일 리소스/경로를 먼저 파악하고 이슈 생성하라")
@@ -1534,7 +1541,7 @@ jobs:
 
             ---
             ## 💬 피드백 이력
-            ${{ needs.prepare.outputs.feedback }}
+            ${{ needs.prepare.outputs.feedback_brief }}
 
             ---
             ## 🗂️ 최근 닫힌 이슈 (이미 처리된 영역)

--- a/apps/web/app/api/slack/test-gemini/route.ts
+++ b/apps/web/app/api/slack/test-gemini/route.ts
@@ -32,12 +32,12 @@ export async function GET(req: NextRequest) {
   try {
     const res = await fetch(url, { method: "POST", headers, body });
 
-    const body = await res.text();
+    const responseBody = await res.text();
     if (!res.ok) {
-      return NextResponse.json({ ok: false, status: res.status, body }, { status: 200 });
+      return NextResponse.json({ ok: false, status: res.status, body: responseBody }, { status: 200 });
     }
 
-    const data = JSON.parse(body);
+    const data = JSON.parse(responseBody);
     const reply = useOpenAI
       ? (data.choices?.[0]?.message?.content ?? "(empty)")
       : (data.candidates?.[0]?.content?.parts?.[0]?.text ?? "(empty)");


### PR DESCRIPTION
## 원인

6/1자 CEO Brief가 자동 생성되지 않은 이유 진단:
- 어제(5/31) `idea-proposal.yml`의 `prepare` 단계에 **실제 레포 파일 트리(REPO_MAP, 400줄 ~15KB)를 `feedback` 출력에 결합**해 모든 agent prompt에 주입함 (환각 경로 차단 목적).
- `ceo_brief` job의 prompt에도 동일한 `feedback`을 그대로 사용 → 9개 에이전트 제안 + 어제 brief + 형식 instruction + 새 REPO_MAP feedback이 합쳐져 LLM 입력 토큰이 한계에 근접.
- `brief` step은 `continue-on-error: true`라 LLM 실패 시 빈 response 반환 → `Create CEO Brief Issue` step의 `steps.brief.outputs.response != ''` 조건 false → CEO Brief 이슈 생성 skip.

증거: 6/1자 9개 agent 이슈(#273-#279)는 모두 정상 생성됨 → cron + agent jobs 정상. CEO Brief만 누락.

## 변경

- `prepare` step에 `feedback_brief` 출력 신설: 기존 `FEEDBACK`(REPO_MAP 제외)을 `head -c 5000`으로 잘라 짧게.
- `ceo_brief` prompt의 "💬 피드백 이력" 섹션이 `feedback_brief`를 사용하도록 전환.
- agent jobs(PM/Frontend/Backend/...)는 그대로 `feedback`(REPO_MAP 포함) 사용 — 환각 경로 차단 효과 유지.

## 즉시 조치

6/1자 CEO Brief는 이슈 #282로 수동 작성/게시. 본 PR 머지 후 6/2자부터 자동 복구.

https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN

---
_Generated by [Claude Code](https://claude.ai/code/session_018VFCMioUN87dRVA2oPN6EN)_