### PR TITLE
fix(council): CEO Brief 입력 다이어트 + deterministic 폴백

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1439,16 +1439,41 @@ jobs:
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | contains(\"$TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
-      - name: Fetch today's new agent issues (실제 번호)
+      - name: Fetch today's new agent issues (실제 번호) + compact digest
         id: today_issues
         if: steps.dedup.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
         run: |
-          LIST=$(gh issue list --label "agent-council" --state open --limit 30 \
-            --json number,title,labels --repo "${{ github.repository }}" | \
-            jq -r --arg today "$TODAY" '.[] | select(.title | contains($today)) | "#" + (.number|tostring) + " " + .title + " [labels: " + (.labels | map(.name) | join(",")) + "]"')
+          # 오늘 사이클 agent-council open 이슈 원본 (번호·제목·라벨·본문)
+          gh issue list --label "agent-council" --state open --limit 30 \
+            --json number,title,labels,body --repo "${{ github.repository }}" \
+            > /tmp/today_raw.json
+
+          # ── 우선순위 인용용 number 목록 (rule #14 — 기존 list 출력 유지) ──
+          LIST=$(jq -r --arg today "$TODAY" '.[] | select(.title | contains($today)) | "#" + (.number|tostring) + " " + .title + " [labels: " + (.labels | map(.name) | join(",")) + "]"' /tmp/today_raw.json)
+
+          # ── compact digest_json (폴백 스크립트 입력) ──
+          # lane: 알려진 lane 라벨 우선, scoreLabel: score-* 라벨, rationale: ### 근거 첫 줄 또는 본문 120자
+          jq --arg today "$TODAY" '
+            def lane: ([.labels[].name] - ["idea","agent-council","mobile","tech-debt","daily","score-strong","score-conditional","score-missing"]) | (.[0] // "unknown");
+            def scorelabel: ([.labels[].name] | map(select(test("^score-(strong|conditional|missing)$"))) | (.[0] // "score-none"));
+            def rationale:
+              (.body // "") as $b
+              | ($b | split("\n")) as $lines
+              | ([range(0; ($lines|length)) | select($lines[.] | test("^#{1,4}[[:space:]]*근거"))] | (.[0] // -1)) as $idx
+              | (if $idx >= 0
+                 then ([ $lines[($idx+1):][] | select(test("\\S")) ] | (.[0] // ""))
+                 else "" end) as $found
+              | (if ($found | test("\\S")) then $found else ($b | gsub("\n";" ")) end)
+              | gsub("\n";" ") | .[0:120];
+            [ .[] | select(.title | contains($today)) | {number, lane: lane, title, scoreLabel: scorelabel, rationale: rationale} ]
+          ' /tmp/today_raw.json > /tmp/digest.json
+
+          # ── markdown_digest (LLM 브리핑 프롬프트 입력 — 사람이 읽는 형태) ──
+          MD=$(jq -r '.[] | "- #\(.number) [\(.lane)] [\(.scoreLabel)] \(.title)\n  근거: \(.rationale)"' /tmp/digest.json)
+
           if [ -z "$LIST" ]; then
             echo "has_issues=false" >> $GITHUB_OUTPUT
             echo "list<<__EOF__" >> $GITHUB_OUTPUT
@@ -1458,6 +1483,9 @@ jobs:
             echo "has_issues=true" >> $GITHUB_OUTPUT
             echo "list<<__EOF__" >> $GITHUB_OUTPUT
             echo "$LIST" >> $GITHUB_OUTPUT
+            echo "__EOF__" >> $GITHUB_OUTPUT
+            echo "markdown_digest<<__EOF__" >> $GITHUB_OUTPUT
+            echo "$MD" >> $GITHUB_OUTPUT
             echo "__EOF__" >> $GITHUB_OUTPUT
           fi
       - name: "[CEO Brief]"
@@ -1511,33 +1539,8 @@ jobs:
             ${{ needs.prepare.outputs.yesterday_brief }}
 
             ---
-            ## 9개 에이전트 오늘 제안
-
-            **PM:** ${{ needs.pm.outputs.proposal }}
-
-            ---
-            **Frontend:** ${{ needs.frontend.outputs.proposal }}
-
-            ---
-            **Backend:** ${{ needs.backend.outputs.proposal }}
-
-            ---
-            **Designer:** ${{ needs.designer.outputs.proposal }}
-
-            ---
-            **QA:** ${{ needs.qa.outputs.proposal }}
-
-            ---
-            **CTO:** ${{ needs.cto.outputs.proposal }}
-
-            ---
-            **Marketer:** ${{ needs.marketer.outputs.proposal }}
-
-            ---
-            **Security:** ${{ needs.security.outputs.proposal }}
-
-            ---
-            **Prompt Engineer:** ${{ needs.prompt_engineer.outputs.proposal }}
+            ## 📊 오늘 제안 다이제스트 (이슈번호·lane·점수라벨·근거 1줄)
+            ${{ steps.today_issues.outputs.markdown_digest }}
 
             ---
             ## 💬 피드백 이력
@@ -1616,16 +1619,41 @@ jobs:
 
             ### 🧭 사용자 결정 필요 항목
             (북스타 갱신, 반복 주제 종결, 임계값 조정 등 CEO가 직접 판단할 것)
+      - name: Setup Node (폴백용)
+        if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true' && (steps.brief.outcome == 'failure' || steps.brief.outputs.response == '')
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: CEO Brief deterministic 폴백 (LLM 실패/빈응답 시)
+        id: fallback
+        if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true' && (steps.brief.outcome == 'failure' || steps.brief.outputs.response == '')
+        env:
+          MERGED_PRS: ${{ needs.prepare.outputs.merged_prs }}
+          CLOSED_ISSUES: ${{ needs.prepare.outputs.closed_issues }}
+          TODAY: ${{ needs.prepare.outputs.today }}
+        run: |
+          printf '%s' "$MERGED_PRS" > /tmp/merged.txt
+          printf '%s' "$CLOSED_ISSUES" > /tmp/done.txt
+          npx -y tsx@4.19.2 scripts/ceo-brief-fallback.ts \
+            /tmp/digest.json /tmp/merged.txt /tmp/done.txt "$TODAY" /tmp/brief.md
+          echo "used=true" >> $GITHUB_OUTPUT
       - name: Create CEO Brief Issue
-        if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true' && steps.brief.outputs.response != ''
+        if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true' && (steps.brief.outputs.response != '' || steps.fallback.outputs.used == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ steps.brief.outputs.response }}
+          USED_FALLBACK: ${{ steps.fallback.outputs.used }}
           TODAY: ${{ needs.prepare.outputs.today }}
         run: |
-          printf '%s' "$BODY" > /tmp/body.md
+          if [ "$USED_FALLBACK" = "true" ]; then
+            # 폴백 스크립트가 /tmp/brief.md 에 작성함. 제목에 식별 접미사.
+            TITLE="📋 [CEO Brief] $TODAY 일일 에이전트 브리핑 (자동 폴백)"
+          else
+            printf '%s' "$BODY" > /tmp/brief.md
+            TITLE="📋 [CEO Brief] $TODAY 일일 에이전트 브리핑"
+          fi
           gh issue create \
-            --title "📋 [CEO Brief] $TODAY 일일 에이전트 브리핑" \
-            --body-file /tmp/body.md \
+            --title "$TITLE" \
+            --body-file /tmp/brief.md \
             --label "ceo-brief,agent-council,daily" \
             --repo "${{ github.repository }}"

--- a/scripts/__tests__/ceo-brief-fallback.test.ts
+++ b/scripts/__tests__/ceo-brief-fallback.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderFallbackBrief,
+  sortByScore,
+  detectRepeats,
+  normalizeTitleTokens,
+  type DigestEntry,
+} from "../ceo-brief-fallback";
+
+const entry = (over: Partial<DigestEntry>): DigestEntry => ({
+  number: 1,
+  lane: "pm",
+  title: "제목",
+  scoreLabel: "score-none",
+  rationale: "근거",
+  ...over,
+});
+
+describe("sortByScore", () => {
+  it("점수 내림차순, 동점은 번호 오름차순으로 정렬한다", () => {
+    const digest: DigestEntry[] = [
+      entry({ number: 10, scoreLabel: "score-conditional" }),
+      entry({ number: 5, scoreLabel: "score-strong" }),
+      entry({ number: 3, scoreLabel: "score-missing" }),
+      entry({ number: 8, scoreLabel: "score-strong" }),
+    ];
+    const sorted = sortByScore(digest);
+    expect(sorted.map((e) => e.number)).toEqual([5, 8, 10, 3]);
+  });
+});
+
+describe("normalizeTitleTokens", () => {
+  it("lane 접두사·날짜·불용어를 제거하고 토큰화한다", () => {
+    const tokens = normalizeTitleTokens("[CTO] 2026-06-01 SWR TTL 캐시 정책 개선");
+    expect(tokens).toContain("swr");
+    expect(tokens).toContain("ttl");
+    expect(tokens).toContain("캐시");
+    expect(tokens).not.toContain("cto");
+    expect(tokens).not.toContain("2026");
+    expect(tokens).not.toContain("개선"); // 불용어
+  });
+});
+
+describe("detectRepeats", () => {
+  it("머지된 PR 제목과 키워드가 겹치는 제안을 반복 의심으로 플래그한다", () => {
+    const digest: DigestEntry[] = [
+      entry({ number: 100, title: "[CTO] SWR TTL 캐시 정책 강화" }),
+      entry({ number: 101, title: "[Designer] 온보딩 카드 일러스트 추가" }),
+    ];
+    const matches = detectRepeats(
+      digest,
+      ["feat: SWR TTL 캐시 정책 도입"],
+      [],
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entry.number).toBe(100);
+    expect(matches[0].matchedSource).toContain("SWR TTL 캐시");
+  });
+
+  it("겹치는 키워드가 없으면 플래그하지 않는다", () => {
+    const digest: DigestEntry[] = [
+      entry({ number: 200, title: "[QA] 결제 플로우 회귀 테스트" }),
+    ];
+    const matches = detectRepeats(digest, ["feat: 뉴스 탭 무한 스크롤"], []);
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("renderFallbackBrief", () => {
+  it("폴백 배너를 포함한다", () => {
+    const out = renderFallbackBrief({
+      digest: [entry({})],
+      mergedPrTitles: [],
+      doneIssueTitles: [],
+      today: "2026-06-01",
+    });
+    expect(out).toContain("⚠️ 자동 폴백");
+    expect(out).toContain("(자동 폴백)");
+  });
+
+  it("digest 3건을 점수순 표로 렌더하고 반복 의심 1건을 우선순위에서 제외한다", () => {
+    const digest: DigestEntry[] = [
+      entry({ number: 1, lane: "pm", title: "[PM] 신규 위젯 기획", scoreLabel: "score-conditional" }),
+      entry({ number: 2, lane: "cto", title: "[CTO] SWR TTL 캐시 정책 강화", scoreLabel: "score-strong" }),
+      entry({ number: 3, lane: "qa", title: "[QA] 차트 회귀 테스트", scoreLabel: "score-missing" }),
+    ];
+    const out = renderFallbackBrief({
+      digest,
+      mergedPrTitles: ["feat: SWR TTL 캐시 정책 도입"],
+      doneIssueTitles: [],
+      today: "2026-06-01",
+    });
+
+    // 반복 의심 섹션에 #2 가 들어간다
+    const repeatSection = out.split("### ⚠️ 반복 의심")[1].split("### ✅")[0];
+    expect(repeatSection).toContain("#2");
+
+    // 우선순위 리스트에서 #2 는 빠지고, score-strong 이 빠졌으니 #1(conditional)이 1순위
+    const prioritySection = out.split("### ✅ 오늘 처리 우선순위")[1];
+    expect(prioritySection).not.toContain("#2");
+    expect(prioritySection).toContain("#1");
+    expect(prioritySection).toContain("#3");
+    // #1(conditional) 이 #3(missing) 보다 앞
+    expect(prioritySection.indexOf("#1")).toBeLessThan(prioritySection.indexOf("#3"));
+  });
+
+  it("digest 가 비어도 크래시 없이 렌더한다", () => {
+    const out = renderFallbackBrief({
+      digest: [],
+      mergedPrTitles: [],
+      doneIssueTitles: [],
+      today: "2026-06-01",
+    });
+    expect(out).toContain("오늘 사이클 신규 제안 없음");
+    expect(out).toContain("처리 대상 없음");
+  });
+});

--- a/scripts/ceo-brief-fallback.ts
+++ b/scripts/ceo-brief-fallback.ts
@@ -1,0 +1,290 @@
+/**
+ * CEO Brief deterministic 폴백 렌더러.
+ *
+ * idea-proposal.yml 의 ceo_brief job 에서 LLM 브리핑(actions/ai-inference)이
+ * 실패하거나 빈 응답일 때, 규칙 기반으로 브리핑을 *항상* 생성한다.
+ * (AGENT_BIBLE 규칙 9 "빈 화면 절대 금지 → 폴백" 을 파이프라인 자신에게 적용)
+ *
+ * 순수 렌더 함수(renderFallbackBrief)와 CLI 엔트리를 분리해 vitest 로 검증 가능.
+ * 외부 네트워크/LLM 호출 없음 — 결정론적.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+export interface DigestEntry {
+  number: number;
+  lane: string;
+  title: string;
+  /** score-strong | score-conditional | score-missing | score-none */
+  scoreLabel: string;
+  rationale: string;
+}
+
+export interface FallbackInput {
+  digest: DigestEntry[];
+  /** 최근 머지된 PR 제목 (반복 탐지용) */
+  mergedPrTitles: string[];
+  /** 최근 DONE/closed 이슈 제목 (반복 탐지용) */
+  doneIssueTitles: string[];
+  /** YYYY-MM-DD (KST) */
+  today: string;
+}
+
+export interface RepeatMatch {
+  entry: DigestEntry;
+  /** 겹친 것으로 판정된 소스 제목 (PR 또는 DONE 이슈) */
+  matchedSource: string;
+  sharedTokens: string[];
+}
+
+const SCORE_RANK: Record<string, number> = {
+  "score-strong": 3,
+  "score-conditional": 2,
+};
+
+function scoreRank(scoreLabel: string): number {
+  return SCORE_RANK[scoreLabel] ?? 1;
+}
+
+const SCORE_KO: Record<string, string> = {
+  "score-strong": "강함(14+)",
+  "score-conditional": "조건부(11-13)",
+  "score-missing": "점수 누락",
+  "score-none": "미채점",
+};
+
+function scoreKo(scoreLabel: string): string {
+  return SCORE_KO[scoreLabel] ?? scoreLabel;
+}
+
+/** 점수 내림차순, 동점은 이슈 번호 오름차순(결정론적 안정 정렬). */
+export function sortByScore(entries: DigestEntry[]): DigestEntry[] {
+  return [...entries].sort((a, b) => {
+    const diff = scoreRank(b.scoreLabel) - scoreRank(a.scoreLabel);
+    if (diff !== 0) return diff;
+    return a.number - b.number;
+  });
+}
+
+const LANE_PREFIX_RE = /^\s*\[[^\]]*\]\s*/;
+const DATE_RE = /\d{4}-\d{2}-\d{2}/g;
+// 의미 없는 공통 토큰 (제목 노이즈) — 겹침 판정에서 제외
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "추가",
+  "개선",
+  "수정",
+  "구현",
+  "적용",
+  "제안",
+  "기능",
+  "지원",
+  "처리",
+  "변경",
+  "도입",
+]);
+
+/** 제목을 비교 가능한 토큰 집합으로 정규화 — lane 접두사/날짜/기호 제거 후 토큰화. */
+export function normalizeTitleTokens(title: string): string[] {
+  const stripped = title.replace(LANE_PREFIX_RE, "").replace(DATE_RE, " ");
+  const tokens = stripped
+    .toLowerCase()
+    // 영문/숫자/한글만 남기고 토큰 분리
+    .split(/[^a-z0-9가-힣]+/u)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+  return Array.from(new Set(tokens));
+}
+
+/**
+ * 반복(이미 처리된 영역) 의심 탐지 — 결정론적 토큰 겹침.
+ * 하드 킬 금지: *플래그만* (의미 기반 dedup 은 Phase 3).
+ * 임계값: 공통 의미 토큰 2개 이상 AND 제안 토큰의 40% 이상 겹침.
+ */
+export function detectRepeats(
+  digest: DigestEntry[],
+  mergedPrTitles: string[],
+  doneIssueTitles: string[],
+): RepeatMatch[] {
+  const sources = [...mergedPrTitles, ...doneIssueTitles]
+    .map((title) => ({ title, tokens: new Set(normalizeTitleTokens(title)) }))
+    .filter((s) => s.tokens.size > 0);
+
+  const matches: RepeatMatch[] = [];
+  for (const entry of digest) {
+    const propTokens = normalizeTitleTokens(entry.title);
+    if (propTokens.length === 0) continue;
+
+    let best: RepeatMatch | null = null;
+    for (const source of sources) {
+      const shared = propTokens.filter((t) => source.tokens.has(t));
+      const ratio = shared.length / propTokens.length;
+      if (shared.length >= 2 && ratio >= 0.4) {
+        if (best === null || shared.length > best.sharedTokens.length) {
+          best = { entry, matchedSource: source.title, sharedTokens: shared };
+        }
+      }
+    }
+    if (best) matches.push(best);
+  }
+  return matches;
+}
+
+function escapeCell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\n/g, " ").trim();
+}
+
+function laneLabel(lane: string): string {
+  return lane && lane.length > 0 ? lane : "unknown";
+}
+
+/** 순수 렌더 함수 — 입력만으로 폴백 브리핑 마크다운 문자열을 만든다. */
+export function renderFallbackBrief(input: FallbackInput): string {
+  const { digest, mergedPrTitles, doneIssueTitles, today } = input;
+
+  const repeats = detectRepeats(digest, mergedPrTitles, doneIssueTitles);
+  const repeatNumbers = new Set(repeats.map((r) => r.entry.number));
+
+  const sorted = sortByScore(digest);
+  const prioritized = sorted.filter((e) => !repeatNumbers.has(e.number));
+
+  const lines: string[] = [];
+
+  // 1. 상단 경고 배너
+  lines.push(
+    "> ⚠️ 자동 폴백 — LLM 브리핑 생성 실패로 규칙 기반 생성됨. 점수순 정렬 + 반복 의심 표시만 제공.",
+  );
+  lines.push("");
+  lines.push(`## 📋 CEO Daily Brief (자동 폴백) — ${today}`);
+  lines.push("");
+
+  // 2. 오늘 제안 표 (점수순)
+  lines.push("### 📊 오늘 제안 (점수순)");
+  lines.push("");
+  if (sorted.length === 0) {
+    lines.push("오늘 사이클 신규 제안 없음.");
+  } else {
+    lines.push("| 에이전트 | 제안 제목 (#번호) | 점수 라벨 | 근거 |");
+    lines.push("|---|---|---|---|");
+    for (const e of sorted) {
+      lines.push(
+        `| ${escapeCell(laneLabel(e.lane))} | ${escapeCell(e.title)} (#${e.number}) | ${escapeCell(
+          scoreKo(e.scoreLabel),
+        )} | ${escapeCell(e.rationale)} |`,
+      );
+    }
+  }
+  lines.push("");
+
+  // 3. 반복 의심 섹션 (플래그만, 하드 킬 금지)
+  lines.push("### ⚠️ 반복 의심 (이미 구현/처리된 영역 — 확인 요망)");
+  lines.push("");
+  if (repeats.length === 0) {
+    lines.push("없음.");
+  } else {
+    lines.push("| 제안 (#번호) | 겹친 기존 작업 | 공통 키워드 |");
+    lines.push("|---|---|---|");
+    for (const r of repeats) {
+      lines.push(
+        `| ${escapeCell(r.entry.title)} (#${r.entry.number}) | ${escapeCell(
+          r.matchedSource,
+        )} | ${escapeCell(r.sharedTokens.join(", "))} |`,
+      );
+    }
+    lines.push("");
+    lines.push(
+      "> 결정론적 키워드 매칭이라 부정확할 수 있음 — 하드 킬 아님. 실제 중복 여부는 사람이 확인.",
+    );
+  }
+  lines.push("");
+
+  // 4. 처리 우선순위 리스트 (반복 의심 제외, 점수순)
+  lines.push("### ✅ 오늘 처리 우선순위 (반복 의심 제외 · 점수순)");
+  lines.push("");
+  if (prioritized.length === 0) {
+    lines.push("처리 대상 없음.");
+  } else {
+    prioritized.forEach((e, i) => {
+      lines.push(
+        `${i + 1}. **${e.title}** (#${e.number}) — ${laneLabel(e.lane)} · ${scoreKo(e.scoreLabel)}`,
+      );
+    });
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI 엔트리: 파일 경로를 받아 /tmp/brief.md(또는 stdout)에 출력.
+//   argv[2] = digest.json 경로 (필수)
+//   argv[3] = merged PR 제목 파일 (한 줄에 하나, 선택)
+//   argv[4] = DONE/closed 이슈 제목 파일 (한 줄에 하나, 선택)
+//   argv[5] = today (YYYY-MM-DD, 선택)
+//   argv[6] = 출력 파일 경로 (선택 — 없으면 stdout)
+// ─────────────────────────────────────────────────────────────
+
+function readLines(path: string | undefined): string[] {
+  if (!path) return [];
+  try {
+    return readFileSync(path, "utf8")
+      .split("\n")
+      .map((l) => l.trim())
+      // gh 출력의 "- #123 제목" 형태에서 접두 기호 제거
+      .map((l) => l.replace(/^-\s*(#\d+\s*)?/, ""))
+      .filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function parseDigest(path: string): DigestEntry[] {
+  const raw = readFileSync(path, "utf8").trim();
+  if (!raw) return [];
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map((item): DigestEntry => {
+    const obj = (item ?? {}) as Record<string, unknown>;
+    return {
+      number: Number(obj.number ?? 0),
+      lane: String(obj.lane ?? ""),
+      title: String(obj.title ?? ""),
+      scoreLabel: String(obj.scoreLabel ?? "score-none"),
+      rationale: String(obj.rationale ?? ""),
+    };
+  });
+}
+
+function main(): void {
+  const argv = process.argv;
+  const digestPath = argv[2];
+  if (!digestPath) {
+    console.error("usage: tsx scripts/ceo-brief-fallback.ts <digest.json> [merged.txt] [done.txt] [today] [out.md]");
+    process.exit(1);
+    return;
+  }
+
+  const input: FallbackInput = {
+    digest: parseDigest(digestPath),
+    mergedPrTitles: readLines(argv[3]),
+    doneIssueTitles: readLines(argv[4]),
+    today: argv[5] ?? new Date().toISOString().slice(0, 10),
+  };
+
+  const output = renderFallbackBrief(input);
+  const outPath = argv[6];
+  if (outPath) {
+    writeFileSync(outPath, output, "utf8");
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+// tsx/node 로 직접 실행될 때만 CLI 동작 (vitest import 시엔 실행 안 함)
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("ceo-brief-fallback")) {
+  main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,11 @@ import path from "path";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["packages/**/__tests__/**/*.test.ts", "apps/web/__tests__/**/*.test.ts"],
+    include: [
+      "packages/**/__tests__/**/*.test.ts",
+      "apps/web/__tests__/**/*.test.ts",
+      "scripts/**/__tests__/**/*.test.ts",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Phase 0 — 에이전트 파이프라인 신뢰성. CEO Brief가 LLM 호출 실패와 무관하게 매일 자동 생성되도록 만들고, 실패를 유발하던 입력 과부하를 제거.

- **Task 1 (입력 다이어트)**: `ceo_brief` 프롬프트에서 9개 제안 전문(9×4096 토큰) → compact digest 1개로 교체. `today_issues` step이 이슈번호·lane·점수라벨·근거 1줄을 `markdown_digest`(프롬프트용)와 `/tmp/digest.json`(폴백 입력)으로 생성.
- **REPO_MAP 제거**: 브리핑 입력은 `feedback_brief`(REPO_MAP 제외) 사용. 에이전트 job 프롬프트의 REPO_MAP은 그대로 유지(경로 환각 방지).
- **Task 2 (deterministic 폴백)**: `brief` step(`continue-on-error`) 실패/빈응답 시 `scripts/ceo-brief-fallback.ts`로 규칙 기반 브리핑을 항상 생성. 점수순 정렬 + 반복 의심 플래그(하드 킬 아님). 제목 `(자동 폴백)` 접미사 + 본문 경고 배너로 식별.

근본 원인: `ceo_brief`가 제안 전문 + 파일경로 400개를 한 번에 삼켜 GitHub Models 입력 한도 초과 → 브리핑 실패 (#282).

## 변경 범위 (충돌 최소화)
- `.github/workflows/idea-proposal.yml` — `ceo_brief` job + `today_issues` step만. 다른 9개 에이전트 job·제안 프롬프트 미변경.
- `scripts/ceo-brief-fallback.ts` (신규, 외부 의존성 없음 — `node:fs`만)
- `scripts/__tests__/ceo-brief-fallback.test.ts` (신규)
- `vitest.config.ts` — scripts include 1줄 추가(additive)

## Test plan
- [x] `npx vitest run` — 218 passed (폴백 7케이스 포함: 점수순 정렬, 반복 의심 제외, 폴백 배너, 빈 digest)
- [x] `npm run typecheck` — 전 워크스페이스 통과
- [x] `npm run build:web` — 성공
- [x] 폴백 스크립트 strict standalone 타입체크 통과
- [x] CLI end-to-end 샘플 실행으로 digest→폴백 렌더 검증
- [ ] (수동) `gh workflow run idea-proposal.yml` 1회 실행 → 브리핑 이슈 정상 생성 + 입력 토큰 감소 확인

Related: #282 · Out of scope: Slack 전부, 에이전트 제안 프롬프트, Phase 1 항목

🤖 Generated with [Claude Code](https://claude.com/claude-code)