### PR TITLE
feat(council): lane-state 원장 — 반복 제안 차단 + yesterday_brief 정밀화

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -43,8 +43,12 @@ jobs:
       yesterday_brief: ${{ steps.fetch.outputs.yesterday_brief }}
       today: ${{ steps.fetch.outputs.today }}
       scoring_guide: ${{ steps.fetch.outputs.scoring_guide }}
+      lane_state_json: ${{ steps.lane_state.outputs.lane_state_json }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Fetch Context, Feedback, North Star
         id: fetch
@@ -65,15 +69,22 @@ jobs:
           echo "$NS" >> "$GITHUB_OUTPUT"
           echo "__EOF__" >> "$GITHUB_OUTPUT"
 
-          # 어제 CEO Brief — 채택 항목 진척 추적용
-          # 이슈 번호(#NNN)를 마스킹하여 오늘 브리핑에서 어제 번호를 재인용하는 사고 방지
-          YB=$(gh issue list --label "ceo-brief" --state all --limit 5 \
+          # 어제 CEO Brief — 채택 항목 진척 추적 + 킬리스트/반복경고 보존 (Phase 1)
+          # (구) head -c 2000 + 번호 마스킹 → 킬리스트(하단)가 잘리고 #번호가 죽어
+          # 반복 탐지 신호가 소실됐다. 이제 마스킹 제거 + 하단 섹션 우선 보존.
+          # 어제 번호 오인용 방지는 ceo_brief 프롬프트 규칙(신규 번호는 today list만)으로 대체.
+          YB_FULL=$(gh issue list --label "ceo-brief" --state all --limit 5 \
             --json title,body \
             --repo "${{ github.repository }}" | \
-            jq -r ".[] | select(.title | contains(\"$YESTERDAY\")) | .body" 2>/dev/null | head -c 2000 | \
-            sed -E 's/#([0-9]+)/[이전이슈]/g')
-          if [ -z "$YB" ]; then
+            jq -r ".[] | select(.title | contains(\"$YESTERDAY\")) | .body" 2>/dev/null)
+          if [ -z "$YB_FULL" ]; then
             YB="어제 CEO Brief 없음 — 진척 추적 불가, 새 사이클로 시작."
+          elif [ ${#YB_FULL} -gt 6000 ]; then
+            # 길면 '오늘 처리 우선순위'~끝(반복경고·킬리스트 포함)을 우선 보존
+            YB=$(printf '%s' "$YB_FULL" | awk '/오늘 처리 우선순위/{f=1} f' | head -c 6000)
+            [ -z "$YB" ] && YB=$(printf '%s' "$YB_FULL" | tail -c 6000)
+          else
+            YB="$YB_FULL"
           fi
           echo "yesterday_brief<<__EOF__" >> "$GITHUB_OUTPUT"
           echo "$YB" >> "$GITHUB_OUTPUT"
@@ -151,6 +162,68 @@ jobs:
           echo "$SCORING_GUIDE" >> "$GITHUB_OUTPUT"
           echo "__EOF__" >> "$GITHUB_OUTPUT"
 
+      # ── Lane-State 원장 (Phase 1) — lane별 DONE/KILLED/IN-PROGRESS 파생 ──
+      # 각 에이전트가 자기 lane 슬라이스를 받아 이미 끝난/거부된 영역 재제안 차단(#282).
+      - name: Build lane-state ledger
+        id: lane_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          DEGRADED=0
+          # lane/scoreLabel 파생 jq (Phase 0 digest 와 동일한 규칙)
+          LANEJQ='def lane: ([.labels[].name] - ["idea","agent-council","mobile","tech-debt","daily","score-strong","score-conditional","score-missing"]) | (.[0] // "unknown"); def scorelabel: ([.labels[].name] | map(select(test("^score-(strong|conditional|missing)$"))) | (.[0] // "score-none"));'
+
+          # 1) 머지 PR (번호+제목+본문 — 연결 이슈 #NNN 추출용)
+          if ! gh pr list --state merged --limit 30 \
+                --json number,title,body --repo "${{ github.repository }}" > /tmp/ls_merged.json 2>/dev/null; then
+            echo "[]" > /tmp/ls_merged.json; DEGRADED=1
+          fi
+          # 2) 닫힌 agent-council 이슈 (lane/score 파생)
+          if gh issue list --label "agent-council" --state closed --limit 40 \
+                --json number,title,labels --repo "${{ github.repository }}" > /tmp/ls_closed_raw.json 2>/dev/null; then
+            jq "$LANEJQ"' [ .[] | {number, title, lane: lane, scoreLabel: scorelabel} ]' /tmp/ls_closed_raw.json > /tmp/ls_closed.json
+          else
+            echo "[]" > /tmp/ls_closed.json; DEGRADED=1
+          fi
+          # 3) 열린 agent-council 이슈 (lane/score 파생)
+          if gh issue list --label "agent-council" --state open --limit 50 \
+                --json number,title,labels --repo "${{ github.repository }}" > /tmp/ls_open_raw.json 2>/dev/null; then
+            jq "$LANEJQ"' [ .[] | {number, title, lane: lane, scoreLabel: scorelabel} ]' /tmp/ls_open_raw.json > /tmp/ls_open.json
+          else
+            echo "[]" > /tmp/ls_open.json; DEGRADED=1
+          fi
+
+          if [ "$DEGRADED" = "1" ]; then
+            LS_JSON='{"__degraded__":true}'
+          else
+            LS_JSON=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts build \
+              /tmp/ls_merged.json /tmp/ls_closed.json /tmp/ls_open.json 2>/dev/null || echo '{"__degraded__":true}')
+            [ -z "$LS_JSON" ] && LS_JSON='{"__degraded__":true}'
+          fi
+
+          # JSON 한 줄 — 멀티라인 가드용 heredoc output
+          echo "lane_state_json<<__LSEOF__" >> "$GITHUB_OUTPUT"
+          echo "$LS_JSON" >> "$GITHUB_OUTPUT"
+          echo "__LSEOF__" >> "$GITHUB_OUTPUT"
+
+          # 옵저버빌리티(9.1): 원장을 job summary + 아티팩트로 덤프
+          {
+            echo "### 🧾 Lane-State 원장 (이번 사이클)"
+            echo '```json'
+            printf '%s\n' "$LS_JSON" | jq . 2>/dev/null || printf '%s\n' "$LS_JSON"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf '%s' "$LS_JSON" > /tmp/lane-state.json
+      - name: Upload lane-state artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lane-state-${{ steps.fetch.outputs.today }}
+          path: /tmp/lane-state.json
+          if-no-files-found: ignore
+          retention-days: 14
+
   # ─────────────────────────────────────────────────────────────
   # 1. PM
   # ─────────────────────────────────────────────────────────────
@@ -169,15 +242,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[PM\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
 
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "pm" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["pm"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["pm"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "pm" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -243,6 +332,12 @@ jobs:
           prompt: |
             ## 🌟 North Star (이번 주 단일 진실)
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 PM 에이전트 자기 직전 5개 제안 (같은 영역 재제안 금지)
@@ -334,14 +429,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[Frontend\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "frontend" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["frontend"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["frontend"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "frontend" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -404,6 +515,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 Frontend 자기 직전 5개 제안 (같은 영역 재제안 금지)
@@ -489,14 +606,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[Backend\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "backend" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["backend"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["backend"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "backend" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -540,6 +673,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 Backend 자기 직전 5개 제안
@@ -610,14 +749,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[Designer\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "design" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["design"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["design"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "design" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -662,6 +817,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 Designer 자기 직전 5개 제안 (같은 화면/효과 절대 재제안 금지)
@@ -733,14 +894,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[QA\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "qa" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["qa"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["qa"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "qa" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -784,6 +961,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 QA 자기 직전 5개 제안
@@ -854,14 +1037,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[CTO\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "cto" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["cto"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["cto"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "cto" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -905,6 +1104,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 CTO 자기 직전 5개 제안
@@ -974,14 +1179,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[Marketer\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "marketing" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["marketing"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["marketing"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "marketing" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -1041,6 +1262,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 Marketer 자기 직전 5개 제안
@@ -1131,14 +1358,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[Security\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "security" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["security"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["security"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "security" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -1169,6 +1412,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 Security 자기 직전 5개 제안
@@ -1231,14 +1480,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
             jq "[.[] | select(.title | test(\"\\\\[Prompt Engineer\\\\] $TODAY\"))] | length")
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          # Lane-State 슬라이스 (Phase 1) — 자기 직군 DONE/KILLED/IN-PROGRESS
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          LANE_SLICE=$(npx -y tsx@4.19.2 scripts/build-lane-state.ts slice "prompt" /tmp/lane-state.json 2>/dev/null || echo "이력 없음 — 새 영역 제안 가능.")
+          echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
+          echo "$LANE_SLICE" >> $GITHUB_OUTPUT
+          echo "__EOF__" >> $GITHUB_OUTPUT
+
+          DONE_NUMS=$(jq -r '(.["prompt"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
+          KILLED_NUMS=$(jq -r '(.["prompt"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           HIST=$(gh issue list --label "prompt" --state all --limit 5 \
-            --json title,body,state --repo "${{ github.repository }}" | \
-            jq -r '.[] | "### [\(.state)] \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"' 2>/dev/null || echo "이력 없음")
+            --json number,title,body,state --repo "${{ github.repository }}" | \
+            jq -r --arg done "$DONE_NUMS" --arg killed "$KILLED_NUMS" '
+              ($done | split(" ") | map(select(length>0) | tonumber)) as $d
+              | ($killed | split(" ") | map(select(length>0) | tonumber)) as $k
+              | .[] | (.number) as $n
+              | (if ($d | index($n)) then "DONE" elif ($k | index($n)) then "KILLED" else .state end) as $v
+              | "### [\($v)] #\($n) \(.title)\n\(.body | .[0:700] | gsub("\n";" "))\n"
+            ' 2>/dev/null || echo "이력 없음")
           echo "history<<__EOF__" >> $GITHUB_OUTPUT
           echo "$HIST" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
@@ -1282,6 +1547,12 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
+            ${{ steps.ctx.outputs.lane_slice }}
+            > ⚠️ 위 DONE/KILLED 목록의 주제는 절대 재제안 금지. 재제안 시 CEO Brief에서 자동 킬리스트 처리되어 사이클이 낭비된다.
+            > 개선하려면 반드시 "기존 #NNN 위에 무엇을 *추가*하는가"를 명시하라.
 
             ---
             ## 📜 Prompt Engineer 자기 직전 5개 제안
@@ -1535,7 +1806,10 @@ jobs:
             ${{ steps.today_issues.outputs.list }}
 
             ---
-            ## 📅 어제 CEO Brief (채택 항목 진척 추적용 — 이슈 번호 재인용 금지)
+            ## 📅 어제 CEO Brief (채택 항목 진척 추적용)
+            > ⚠️ 번호 인용 절대 규칙: 아래 어제 브리핑의 #번호는 **과거 참조용**이다(진척 추적·반복 탐지에만 사용).
+            > 오늘 신규 제안의 "이슈: #N" 인용은 반드시 위 "📌 오늘 사이클 신규 이슈" 목록의 번호만 사용하라.
+            > 어제 브리핑의 번호를 오늘 신규 항목의 번호로 재인용하면 사고다.
             ${{ needs.prepare.outputs.yesterday_brief }}
 
             ---
@@ -1630,13 +1904,25 @@ jobs:
         env:
           MERGED_PRS: ${{ needs.prepare.outputs.merged_prs }}
           CLOSED_ISSUES: ${{ needs.prepare.outputs.closed_issues }}
+          LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
           TODAY: ${{ needs.prepare.outputs.today }}
         run: |
           printf '%s' "$MERGED_PRS" > /tmp/merged.txt
+          # done.txt = 닫힌 이슈 + lane-state 의 DONE/KILLED 제목 (반복 탐지 강화, Task 4)
           printf '%s' "$CLOSED_ISSUES" > /tmp/done.txt
+          printf '%s' "$LANE_STATE" > /tmp/lane-state.json
+          jq -r '
+            [ .[]? | (.done // []), (.killed // []) ] | flatten
+            | .[]? | "- #\(.number) \(.title)"
+          ' /tmp/lane-state.json >> /tmp/done.txt 2>/dev/null || true
           npx -y tsx@4.19.2 scripts/ceo-brief-fallback.ts \
             /tmp/digest.json /tmp/merged.txt /tmp/done.txt "$TODAY" /tmp/brief.md
           echo "used=true" >> $GITHUB_OUTPUT
+          # 옵저버빌리티(9.2): 폴백 발동을 job summary 에 명시
+          {
+            echo "## ⚠️ CEO Brief 자동 폴백 발동 ($TODAY)"
+            echo "LLM 브리핑 실패/빈응답 → 규칙 기반 폴백으로 생성됨. 품질 저하 가능 — 확인 요망."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Create CEO Brief Issue
         if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true' && (steps.brief.outputs.response != '' || steps.fallback.outputs.used == 'true')
         env:

--- a/scripts/__tests__/build-lane-state.test.ts
+++ b/scripts/__tests__/build-lane-state.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildLaneState,
+  renderLaneSliceMarkdown,
+  renderLaneStateJson,
+  extractIssueRefs,
+  mergedPrIssueRefs,
+  type BuildInput,
+} from "../build-lane-state";
+
+describe("extractIssueRefs", () => {
+  it("#NNN / closes #NNN 형태를 모두 추출하고 중복 제거한다", () => {
+    expect(extractIssueRefs("fix: foo (closes #262) and #262 also #270").sort()).toEqual([262, 270]);
+    expect(extractIssueRefs("")).toEqual([]);
+  });
+});
+
+describe("mergedPrIssueRefs", () => {
+  it("PR 제목+본문에서 참조 이슈 번호를 모은다", () => {
+    const refs = mergedPrIssueRefs([
+      { number: 300, title: "feat: SWR (closes #267)", body: "also #268" },
+      { number: 301, title: "chore: noop", body: "" },
+    ]);
+    expect([...refs].sort()).toEqual([267, 268]);
+  });
+});
+
+describe("buildLaneState 분류", () => {
+  it("머지 PR 연결된 닫힌 이슈 → DONE", () => {
+    const input: BuildInput = {
+      mergedPRs: [{ number: 262, title: "feat: SWR TTL (closes #267)" }],
+      closedIssues: [{ number: 267, title: "[CTO] SWR TTL 차등화", lane: "cto" }],
+      openIssues: [],
+    };
+    const state = buildLaneState(input);
+    expect(state.cto.done.map((e) => e.number)).toEqual([267]);
+    expect(state.cto.killed).toEqual([]);
+    expect(state.cto.closedUnknown).toEqual([]);
+  });
+
+  it("머지 PR 연결 없는 score-missing 닫힌 이슈 → KILLED(reason)", () => {
+    const input: BuildInput = {
+      mergedPRs: [],
+      closedIssues: [
+        { number: 277, title: "[CTO] SWR TTL 최적화", lane: "cto", scoreLabel: "score-missing" },
+      ],
+      openIssues: [],
+    };
+    const state = buildLaneState(input);
+    expect(state.cto.killed).toHaveLength(1);
+    expect(state.cto.killed[0].number).toBe(277);
+    expect(state.cto.killed[0].reason).toBe("score-missing");
+    expect(state.cto.done).toEqual([]);
+  });
+
+  it("연결·라벨 둘 다 애매 → CLOSED(사유불명), KILLED 아님", () => {
+    const input: BuildInput = {
+      mergedPRs: [],
+      closedIssues: [{ number: 290, title: "[PM] 모호한 제안", lane: "pm" }],
+      openIssues: [],
+    };
+    const state = buildLaneState(input);
+    expect(state.pm.killed).toEqual([]);
+    expect(state.pm.closedUnknown.map((e) => e.number)).toEqual([290]);
+  });
+
+  it("CEO 킬리스트 번호 → KILLED(ceo-killlist)", () => {
+    const input: BuildInput = {
+      mergedPRs: [],
+      closedIssues: [{ number: 288, title: "[Designer] 글로우 효과", lane: "design" }],
+      openIssues: [],
+      ceoKilledNumbers: [288],
+    };
+    const state = buildLaneState(input);
+    expect(state.design.killed[0].reason).toBe("ceo-killlist");
+  });
+
+  it("open score-strong/conditional → IN-PROGRESS, 그 외 open 은 무시", () => {
+    const input: BuildInput = {
+      mergedPRs: [],
+      closedIssues: [],
+      openIssues: [
+        { number: 269, title: "[QA] THREE_CARD", lane: "qa", scoreLabel: "score-strong" },
+        { number: 270, title: "[QA] 미채점", lane: "qa", scoreLabel: "score-none" },
+      ],
+    };
+    const state = buildLaneState(input);
+    expect(state.qa.inProgress.map((e) => e.number)).toEqual([269]);
+  });
+});
+
+describe("renderLaneSliceMarkdown", () => {
+  it("DONE/KILLED/IN-PROGRESS 섹션을 정확히 포함한다", () => {
+    const input: BuildInput = {
+      mergedPRs: [{ number: 262, title: "feat (closes #267)" }],
+      closedIssues: [
+        { number: 267, title: "[CTO] SWR 차등화", lane: "cto" },
+        { number: 277, title: "[CTO] SWR 최적화", lane: "cto", scoreLabel: "score-missing" },
+      ],
+      openIssues: [{ number: 269, title: "[CTO] 캐시 워밍", lane: "cto", scoreLabel: "score-strong" }],
+    };
+    const md = renderLaneSliceMarkdown(buildLaneState(input), "cto");
+    expect(md).toContain("✅ DONE");
+    expect(md).toContain("#267");
+    expect(md).toContain("❌ KILLED");
+    expect(md).toContain("#277");
+    expect(md).toContain("🔄 IN-PROGRESS");
+    expect(md).toContain("#269");
+  });
+
+  it("빈 lane → '이력 없음' 안내", () => {
+    const md = renderLaneSliceMarkdown(buildLaneState({ mergedPRs: [], closedIssues: [], openIssues: [] }), "pm");
+    expect(md).toContain("이력 없음");
+  });
+
+  it("degrade 마커 → 보수적 조회 실패 안내", () => {
+    const degraded = JSON.parse('{"__degraded__": true}');
+    const md = renderLaneSliceMarkdown(degraded, "pm");
+    expect(md).toContain("조회 실패");
+    expect(md).toContain("자제");
+  });
+});
+
+describe("renderLaneStateJson", () => {
+  it("round-trip 파싱 가능한 JSON 을 만든다", () => {
+    const state = buildLaneState({ mergedPRs: [], closedIssues: [], openIssues: [] });
+    const json = renderLaneStateJson(state);
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(JSON.parse(json).pm).toBeDefined();
+  });
+});

--- a/scripts/build-lane-state.ts
+++ b/scripts/build-lane-state.ts
@@ -1,0 +1,264 @@
+/**
+ * Lane-State 원장 빌더 (Phase 1).
+ *
+ * 매 사이클 1회 prepare job 에서 호출되어, lane(직군)별로
+ *   DONE(완료) / KILLED(거부) / IN-PROGRESS(진행중) / CLOSED(사유불명)
+ * 를 정리한 작은 파생 원장을 만든다. 각 에이전트는 자기 lane 슬라이스를 받아
+ * "이미 끝났거나 거부된 영역"을 재제안하지 않는다 (이슈 #282 반복 제안 박멸).
+ *
+ * 완료 vs 거부의 결정론적 신호: "닫힌 이슈가 머지된 PR과 연결(#NNN)됐는가".
+ *  - 머지 PR 연결 → DONE
+ *  - 연결 없음 + 거부 라벨(score-missing) 또는 CEO 킬리스트 → KILLED (reason)
+ *  - 연결도 라벨도 애매 → CLOSED(사유불명) (KILLED 아님 — 멀쩡한 재제안 막지 않음)
+ *
+ * 순수 export 함수 + main() CLI (process.argv[1] 가드). 외부 호출 없음 — 결정론적.
+ * Phase 0 scripts/ceo-brief-fallback.ts 구조를 템플릿으로 따름.
+ */
+
+import { readFileSync } from "node:fs";
+
+/** 알려진 lane 라벨 (Create Issue 라벨 == self-history 필터 라벨과 일치) */
+export const KNOWN_LANES = [
+  "pm",
+  "frontend",
+  "backend",
+  "design",
+  "qa",
+  "cto",
+  "marketing",
+  "security",
+  "prompt",
+] as const;
+
+export interface Entry {
+  number: number;
+  title: string;
+  reason?: string;
+}
+
+export interface LaneBucket {
+  done: Entry[];
+  killed: Entry[];
+  inProgress: Entry[];
+  closedUnknown: Entry[];
+}
+
+export type LaneState = Record<string, LaneBucket>;
+
+export interface MergedPR {
+  number: number;
+  title: string;
+  body?: string;
+}
+
+export interface ClosedIssue {
+  number: number;
+  title: string;
+  lane: string;
+  scoreLabel?: string;
+}
+
+export interface OpenIssue {
+  number: number;
+  title: string;
+  lane: string;
+  scoreLabel?: string;
+}
+
+export interface BuildInput {
+  mergedPRs: MergedPR[];
+  closedIssues: ClosedIssue[];
+  openIssues: OpenIssue[];
+  /** CEO Brief 킬리스트로 명시 거부된 이슈 번호 (선택) */
+  ceoKilledNumbers?: number[];
+}
+
+/** 거부로 간주하는 점수 라벨 */
+const REJECTION_LABELS = new Set(["score-missing"]);
+
+/** 텍스트에서 #NNN / closes #NNN 형태의 이슈 번호를 추출. */
+export function extractIssueRefs(text: string): number[] {
+  if (!text) return [];
+  const out = new Set<number>();
+  const re = /#(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n > 0) out.add(n);
+  }
+  return Array.from(out);
+}
+
+function emptyBucket(): LaneBucket {
+  return { done: [], killed: [], inProgress: [], closedUnknown: [] };
+}
+
+function ensureLane(state: LaneState, lane: string): LaneBucket {
+  const key = lane && lane.length > 0 ? lane : "unknown";
+  if (!state[key]) state[key] = emptyBucket();
+  return state[key];
+}
+
+/** 머지된 PR들이 참조하는 모든 이슈 번호 집합. */
+export function mergedPrIssueRefs(mergedPRs: MergedPR[]): Set<number> {
+  const refs = new Set<number>();
+  for (const pr of mergedPRs) {
+    for (const n of extractIssueRefs(`${pr.title ?? ""} ${pr.body ?? ""}`)) {
+      refs.add(n);
+    }
+  }
+  return refs;
+}
+
+/** lane-state 원장 빌드 (순수 함수). */
+export function buildLaneState(input: BuildInput): LaneState {
+  const state: LaneState = {};
+  // 알려진 lane 을 미리 생성 — 슬라이스 렌더 시 누락 방지
+  for (const lane of KNOWN_LANES) ensureLane(state, lane);
+
+  const linkedRefs = mergedPrIssueRefs(input.mergedPRs);
+  const ceoKilled = new Set(input.ceoKilledNumbers ?? []);
+
+  // IN-PROGRESS: open + score-strong/conditional
+  for (const issue of input.openIssues) {
+    if (issue.scoreLabel === "score-strong" || issue.scoreLabel === "score-conditional") {
+      ensureLane(state, issue.lane).inProgress.push({
+        number: issue.number,
+        title: issue.title,
+        reason: issue.scoreLabel,
+      });
+    }
+  }
+
+  // 닫힌 이슈 분류
+  for (const issue of input.closedIssues) {
+    const bucket = ensureLane(state, issue.lane);
+    if (linkedRefs.has(issue.number)) {
+      bucket.done.push({ number: issue.number, title: issue.title, reason: "머지 PR 연결" });
+    } else if (ceoKilled.has(issue.number)) {
+      bucket.killed.push({ number: issue.number, title: issue.title, reason: "ceo-killlist" });
+    } else if (issue.scoreLabel && REJECTION_LABELS.has(issue.scoreLabel)) {
+      bucket.killed.push({ number: issue.number, title: issue.title, reason: issue.scoreLabel });
+    } else {
+      bucket.closedUnknown.push({
+        number: issue.number,
+        title: issue.title,
+        reason: "사유불명",
+      });
+    }
+  }
+
+  return state;
+}
+
+function renderEntries(entries: Entry[], withReason: boolean): string[] {
+  return entries.map((e) => {
+    const reason = withReason && e.reason ? ` — 사유: ${e.reason}` : "";
+    return `- #${e.number} ${e.title}${reason}`;
+  });
+}
+
+/** 특정 lane 슬라이스를 에이전트 프롬프트용 마크다운으로 렌더. */
+export function renderLaneSliceMarkdown(state: LaneState, lane: string): string {
+  // 조회 실패 degrade 가드 (9.3) — 빈 화면 금지, 보수적 안내
+  if ((state as Record<string, unknown>).__degraded__ === true) {
+    return [
+      "## 🧾 우리 직군 상태 원장 — ⚠️ 조회 실패",
+      "원장 조회에 실패했다(gh rate limit 등). 보수적으로: 최근 머지 PR 제목과",
+      "겹치는 제안은 자제하고, 재제안 시 반드시 '기존 위에 무엇을 추가하는가'를 명시하라.",
+    ].join("\n");
+  }
+
+  const bucket = state[lane] ?? emptyBucket();
+  const total =
+    bucket.done.length +
+    bucket.killed.length +
+    bucket.inProgress.length +
+    bucket.closedUnknown.length;
+
+  if (total === 0) {
+    return "이력 없음 — 새 영역 제안 가능.";
+  }
+
+  const lines: string[] = [];
+  lines.push(`## 🧾 [${lane}] 우리 직군 상태 원장 — 같은 항목 재제안 시 자동 킬`);
+
+  lines.push("### ✅ DONE (이미 구현 완료 — 절대 재제안 금지)");
+  lines.push(bucket.done.length ? renderEntries(bucket.done, true).join("\n") : "- (없음)");
+
+  lines.push("### ❌ KILLED (거부됨 — 같은 주제 재제안 금지)");
+  lines.push(bucket.killed.length ? renderEntries(bucket.killed, true).join("\n") : "- (없음)");
+
+  lines.push("### 🔄 IN-PROGRESS (진행 중 — 중복 제안 금지)");
+  lines.push(
+    bucket.inProgress.length ? renderEntries(bucket.inProgress, true).join("\n") : "- (없음)",
+  );
+
+  if (bucket.closedUnknown.length) {
+    lines.push("### ℹ️ CLOSED (사유 불명 — 재제안 전 확인 권장)");
+    lines.push(renderEntries(bucket.closedUnknown, false).join("\n"));
+  }
+
+  return lines.join("\n");
+}
+
+/** 폴백/디버그용 전체 JSON 문자열. */
+export function renderLaneStateJson(state: LaneState): string {
+  return JSON.stringify(state);
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI 엔트리
+//   build <merged.json> <closed.json> <open.json> [ceoKilled.json]
+//       → lane-state JSON 을 stdout 으로 출력
+//   slice <lane> <lane-state.json>
+//       → 해당 lane 슬라이스 마크다운을 stdout 으로 출력
+// ─────────────────────────────────────────────────────────────
+
+function readJson<T>(path: string | undefined, fallback: T): T {
+  if (!path) return fallback;
+  try {
+    const raw = readFileSync(path, "utf8").trim();
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function cmdBuild(argv: string[]): void {
+  const input: BuildInput = {
+    mergedPRs: readJson<MergedPR[]>(argv[3], []),
+    closedIssues: readJson<ClosedIssue[]>(argv[4], []),
+    openIssues: readJson<OpenIssue[]>(argv[5], []),
+    ceoKilledNumbers: readJson<number[]>(argv[6], []),
+  };
+  const state = buildLaneState(input);
+  process.stdout.write(renderLaneStateJson(state));
+}
+
+function cmdSlice(argv: string[]): void {
+  const lane = argv[3] ?? "";
+  const state = readJson<LaneState>(argv[4], {});
+  process.stdout.write(renderLaneSliceMarkdown(state, lane));
+}
+
+function main(): void {
+  const argv = process.argv;
+  const cmd = argv[2];
+  if (cmd === "build") {
+    cmdBuild(argv);
+  } else if (cmd === "slice") {
+    cmdSlice(argv);
+  } else {
+    console.error(
+      "usage:\n  tsx scripts/build-lane-state.ts build <merged.json> <closed.json> <open.json> [ceoKilled.json]\n  tsx scripts/build-lane-state.ts slice <lane> <lane-state.json>",
+    );
+    process.exit(1);
+  }
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("build-lane-state")) {
+  main();
+}


### PR DESCRIPTION
## Summary

Phase 1 — 각 에이전트가 "내 직군에서 뭐가 이미 끝났고(DONE)/킬됐는지(KILLED)"를 구조화된 형태로 받게 만들어 같은 lane 반복 제안을 차단. yesterday_brief 정보 손실(2000자 컷·번호 마스킹)도 복구. (Phase 0 #283/#284 위에 얹음)

- **Task 1 — lane-state 원장**: `scripts/build-lane-state.ts` 순수 함수. 머지 PR ↔ 닫힌 이슈 `#NNN` 연결로 DONE/KILLED 결정론적 구분 (애매하면 CLOSED 사유불명 — 멀쩡한 재제안 막지 않음). `prepare`가 `lane_state_json` 출력.
- **Task 2 — 에이전트 주입**: 9개 ctx step이 tested TS의 `slice` 모드로 자기 lane 슬라이스 렌더 + self-history에 DONE/KILLED 판정 부착(번호 매칭). 프롬프트에 원장 섹션 + 재제안 금지 규칙 추가.
- **Task 3 — yesterday_brief 정밀화**: `head -c 2000` 컷·번호 마스킹 제거, 킬리스트/우선순위 하단 섹션 보존. 마스킹 목적은 ceo_brief 프롬프트 "신규 번호는 today list만 인용" 규칙으로 대체.
- **Task 4 + 옵저버빌리티**: 폴백 `detectRepeats`에 lane-state DONE/KILLED 제목 추가 공급. lane-state job summary + 아티팩트 업로드(9.1), 폴백 발동 summary 명시(9.2), 원장 조회 실패 degrade 가드(9.3).

근본 원인: self-history에 CEO 판정이 없고 yesterday_brief가 손상돼 에이전트가 "이미 끝난 영역"을 추적 못함 → 동일 lane 반복 (#282).

## 변경 범위 (충돌 최소화)
- `.github/workflows/idea-proposal.yml` — prepare + 9개 ctx step + ceo_brief 프롬프트. 채점규칙(`score_and_filter`)·제안 본문 템플릿 미변경.
- `scripts/build-lane-state.ts` (신규, 외부 의존성 없음 — `node:fs`만)
- `scripts/__tests__/build-lane-state.test.ts` (신규, 11케이스)

## Test plan
- [x] `npx vitest run` — 229 passed (22 files; lane-state 11케이스: DONE/KILLED/CLOSED애매/CEO킬/IN-PROGRESS/슬라이스/degrade)
- [x] `npm run typecheck` — 전 워크스페이스 통과
- [x] `npm run build:web` — 성공
- [x] 두 스크립트 strict standalone 타입체크 통과
- [x] CLI build/slice + lane 파생 jq + verdict 태깅 jq end-to-end 검증
- [ ] (수동) `gh workflow run idea-proposal.yml` 1회 → 에이전트 이슈에 원장 반영·다음 사이클 반복 감소 관찰

Related: #282 · Out of scope: Slack 전부, 채점 규칙, Phase 2(standing constraints)/Phase 3(의미 dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)