### PR TITLE
fix: auto-implement에 id-token: write 권한 추가

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -18,7 +18,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  models: read
+  id-token: write
 
 jobs:
   implement:


### PR DESCRIPTION
claude-code-action이 OIDC 토큰을 요구 → `Could not fetch an OIDC token` 으로 실패. `id-token: write` 권한 추가, 미사용 `models: read` 제거. (run [26769190024](https://github.com/mlender-ai/taro-stock-app/actions/runs/26769190024) 오류 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)