### PR TITLE
feat(council): standing constraints — CEO 판정 자동 규칙화 + Slack 싱크

### DIFF
--- a/.github/workflows/compact-constraints.yml
+++ b/.github/workflows/compact-constraints.yml
@@ -1,0 +1,76 @@
+name: Compact Standing Constraints
+
+# weekly — 만료/중복 standing constraint 정리. 변경 있으면 리뷰 PR.
+# 무한 성장 방지 (Phase 2 Task 5).
+
+on:
+  schedule:
+    - cron: "0 21 * * 0"  # 매주 월요일 오전 6시 KST (UTC 일 21:00)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: compact-constraints
+  cancel-in-progress: false
+
+jobs:
+  compact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Compact constraints
+        id: compact
+        run: |
+          set -uo pipefail
+          if [ ! -f constraints/active.json ]; then
+            echo "active.json 없음 — skip"; echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+          echo "today=$TODAY" >> "$GITHUB_OUTPUT"
+          BEFORE=$(jq '.constraints | length' constraints/active.json)
+          npx -y tsx@4.19.2 scripts/constraints.ts compact constraints/active.json "$TODAY" > /tmp/compacted.json 2>/dev/null || true
+          if ! jq empty /tmp/compacted.json 2>/dev/null; then
+            echo "compact 실패 — 변경 없음"; echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          AFTER=$(jq '.constraints | length' /tmp/compacted.json)
+          echo "before=$BEFORE after=$AFTER"
+          # 내용 동일하면 변경 없음
+          if diff -q <(jq -S . constraints/active.json) <(jq -S . /tmp/compacted.json) >/dev/null 2>&1; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            cp /tmp/compacted.json constraints/active.json
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "removed=$((BEFORE - AFTER))" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create review PR
+        if: steps.compact.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TODAY="${{ steps.compact.outputs.today }}"
+          REMOVED="${{ steps.compact.outputs.removed }}"
+          BRANCH="constraints/compact-${TODAY}-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add constraints/active.json
+          git commit -m "chore(constraints): compact — 만료/중복 ${REMOVED}건 정리 (${TODAY})"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "🧹 Standing Constraints 압축 — ${REMOVED}건 정리 (${TODAY})" \
+            --body "weekly compact: 만료(expiresAt 경과)·정규화 중복 constraint를 제거했습니다. 검토 후 머지하세요." \
+            --label "constraints,needs-ceo-review" \
+            --repo "${{ github.repository }}"
+
+      - name: No change
+        if: steps.compact.outputs.changed != 'true'
+        run: echo "정리할 constraint 없음 — PR 생성 안 함."

--- a/.github/workflows/distill-constraints.yml
+++ b/.github/workflows/distill-constraints.yml
@@ -1,0 +1,190 @@
+name: Distill Standing Constraints
+
+# CEO 판정(브리핑 킬리스트·인사이트)·Slack 지시를 standing constraint 후보로 추출 →
+# scripts/constraints.ts 로 검증/dedup → constraints/active.json 에 머지 → 사람 리뷰 PR.
+# 자동 머지 비대상(needs-ceo-review). Slack [[ADD_CONSTRAINT]] 는 manual_constraint 로 위임됨.
+
+on:
+  workflow_dispatch:
+    inputs:
+      manual_constraint:
+        description: "Slack/수동 constraint JSON (단일 객체 또는 배열). 비우면 최신 CEO Brief에서 LLM 추출."
+        required: false
+        default: ""
+      source_hint:
+        description: "source 표기 (예: slack/<channel>/<ts>)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+  models: read
+
+concurrency:
+  group: distill-constraints
+  cancel-in-progress: false
+
+jobs:
+  distill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Prepare inputs
+        id: prep
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANUAL: ${{ github.event.inputs.manual_constraint }}
+        run: |
+          set -uo pipefail
+          TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+          echo "today=$TODAY" >> "$GITHUB_OUTPUT"
+          if [ -n "$MANUAL" ]; then
+            echo "mode=manual" >> "$GITHUB_OUTPUT"
+            printf '%s' "$MANUAL" > /tmp/candidates.json
+            echo "Manual constraint payload received."
+          else
+            echo "mode=llm" >> "$GITHUB_OUTPUT"
+            # 최신 CEO Brief 본문 (킬리스트·인사이트·사용자 직접 지시 추출용)
+            gh issue list --label "ceo-brief" --state all --limit 1 \
+              --json number,body --repo "${{ github.repository }}" \
+              | jq -r '.[0] // {} | .body // ""' > /tmp/brief.md || true
+            gh issue list --label "ceo-brief" --state all --limit 1 \
+              --json number --repo "${{ github.repository }}" \
+              | jq -r '.[0].number // 0' > /tmp/brief_num.txt || echo 0 > /tmp/brief_num.txt
+            BBODY=$(head -c 6000 /tmp/brief.md)
+            echo "brief_body<<__BEOF__" >> "$GITHUB_OUTPUT"
+            echo "$BBODY" >> "$GITHUB_OUTPUT"
+            echo "__BEOF__" >> "$GITHUB_OUTPUT"
+          fi
+          # 현재 active constraints (LLM 에 중복 회피용 + 머지 베이스)
+          if [ -f constraints/active.json ]; then cp constraints/active.json /tmp/active.json; else echo '{"constraints":[]}' > /tmp/active.json; fi
+          ACTIVE_RULES=$(jq -r '.constraints[]? | "- " + .rule' /tmp/active.json 2>/dev/null | head -c 4000 || echo "(없음)")
+          echo "active_rules<<__AEOF__" >> "$GITHUB_OUTPUT"
+          echo "$ACTIVE_RULES" >> "$GITHUB_OUTPUT"
+          echo "__AEOF__" >> "$GITHUB_OUTPUT"
+
+      - name: LLM distill (브리핑 모드)
+        if: steps.prep.outputs.mode == 'llm'
+        id: llm
+        uses: actions/ai-inference@v1
+        continue-on-error: true
+        with:
+          model: openai/gpt-4o
+          max-tokens: 1500
+          system-prompt: |
+            당신은 CEO 판정에서 "반복 적용 가능한 영구 규칙"만 추출하는 추출기다.
+            출력은 **JSON 배열만**. 설명/마크다운 금지.
+            각 원소: {"rule": string, "scope": string[], "kind": "prohibition"|"preference"|"priority"|"mental-model", "permanent": boolean}
+            scope 는 ["pm","frontend","backend","design","qa","cto","marketing","security","prompt","all"] 중 해당하는 것. 전체 적용이면 ["all"].
+            규칙:
+            - 1회성 판단("이번 제안 채택", "오늘은 X부터")은 절대 제외. 앞으로 계속 지켜야 할 금지/선호/우선순위/멘탈모델만.
+            - 이미 아래 "현재 constraints"에 의미상 존재하는 것은 제외.
+            - 후보가 없으면 빈 배열 [] 출력.
+            - rule 은 한국어 한 문장, 구체적으로.
+          prompt: |
+            ## 현재 constraints (이것들과 의미가 겹치면 새로 만들지 마라)
+            ${{ steps.prep.outputs.active_rules }}
+
+            ## 최신 CEO Brief 본문 (이 안의 킬리스트·반복경고·CEO 인사이트·사용자 직접 지시에서만 추출)
+            ${{ steps.prep.outputs.brief_body }}
+
+            ---
+            위 브리핑에서 "앞으로 항상/절대 지켜야 할" 영구 규칙만 JSON 배열로 추출하라.
+            1회성 채택/지시는 제외. 후보가 없으면 [] 출력.
+
+      - name: Write LLM candidates
+        if: steps.prep.outputs.mode == 'llm'
+        env:
+          RESP: ${{ steps.llm.outputs.response }}
+        run: |
+          set -uo pipefail
+          # 코드펜스 제거 후 JSON 배열만 추출
+          printf '%s' "$RESP" | sed -E 's/^```[a-zA-Z]*//; s/```$//' > /tmp/resp_raw.txt
+          # 첫 '[' ~ 마지막 ']' 사이만 취함 (앞뒤 잡음 제거)
+          python3 - <<'PY' || echo '[]' > /tmp/candidates.json
+          import re, sys
+          try:
+              t = open('/tmp/resp_raw.txt', encoding='utf-8').read()
+              i, j = t.find('['), t.rfind(']')
+              out = t[i:j+1] if (i != -1 and j != -1 and j > i) else '[]'
+              import json; json.loads(out)  # 유효성 확인
+              open('/tmp/candidates.json','w',encoding='utf-8').write(out)
+          except Exception:
+              open('/tmp/candidates.json','w',encoding='utf-8').write('[]')
+          PY
+          echo "candidates:"; cat /tmp/candidates.json
+
+      - name: Merge into active.json (validate + dedup)
+        id: merge
+        env:
+          SOURCE_HINT: ${{ github.event.inputs.source_hint }}
+          MODE: ${{ steps.prep.outputs.mode }}
+        run: |
+          set -uo pipefail
+          TODAY="${{ steps.prep.outputs.today }}"
+          [ -f /tmp/candidates.json ] || echo '[]' > /tmp/candidates.json
+
+          # source 보강: manual 은 source_hint, llm 은 ceo-brief #번호
+          if [ "$MODE" = "manual" ]; then
+            SRC="${SOURCE_HINT:-slack/manual}"
+          else
+            BNUM=$(cat /tmp/brief_num.txt 2>/dev/null || echo 0)
+            SRC="ceo-brief #${BNUM}"
+          fi
+          # 후보 각 항목에 source/createdAt 보강 (없으면)
+          jq --arg src "$SRC" 'if type=="array" then map(. + {source: (.source // $src)}) else [] end' \
+            /tmp/candidates.json > /tmp/candidates_src.json 2>/dev/null || cp /tmp/candidates.json /tmp/candidates_src.json
+
+          BEFORE=$(jq '.constraints | length' /tmp/active.json)
+          npx -y tsx@4.19.2 scripts/constraints.ts add /tmp/active.json /tmp/candidates_src.json "$TODAY" > /tmp/merged.json 2> /tmp/merge_err.txt || true
+          cat /tmp/merge_err.txt || true
+          if ! jq empty /tmp/merged.json 2>/dev/null; then
+            echo "merge 실패 — 변경 없음"; echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          AFTER=$(jq '.constraints | length' /tmp/merged.json)
+          echo "before=$BEFORE after=$AFTER"
+          if [ "$AFTER" -gt "$BEFORE" ]; then
+            cp /tmp/merged.json constraints/active.json
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "added=$((AFTER - BEFORE))" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create review PR
+        if: steps.merge.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TODAY="${{ steps.prep.outputs.today }}"
+          ADDED="${{ steps.merge.outputs.added }}"
+          BRANCH="constraints/distill-${TODAY}-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add constraints/active.json
+          git commit -m "feat(constraints): distill ${ADDED}개 standing constraint 후보 (${TODAY})"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "🔒 Standing Constraints 후보 ${ADDED}건 — CEO 리뷰 필요 (${TODAY})" \
+            --body "$(printf '%s\n' \
+              "CEO 판정/지시에서 자동 추출된 standing constraint 후보입니다." \
+              "" \
+              "- 출처 모드: ${{ steps.prep.outputs.mode }}" \
+              "- 추가 후보: ${ADDED}건" \
+              "" \
+              "**머지 전 검토**: 잘못된 일반화가 아닌지, 기존 규칙과 모순되지 않는지 확인하세요." \
+              "이 PR은 auto-merge 대상이 아닙니다 (needs-ceo-review).")" \
+            --label "constraints,needs-ceo-review" \
+            --repo "${{ github.repository }}"
+
+      - name: No change
+        if: steps.merge.outputs.changed != 'true'
+        run: echo "신규 constraint 후보 없음 — PR 생성 안 함."

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -44,6 +44,7 @@ jobs:
       today: ${{ steps.fetch.outputs.today }}
       scoring_guide: ${{ steps.fetch.outputs.scoring_guide }}
       lane_state_json: ${{ steps.lane_state.outputs.lane_state_json }}
+      constraints_json: ${{ steps.constraints.outputs.constraints_json }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -224,6 +225,29 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      # ── Standing Constraints (Phase 2) — CEO 확정 규칙 active 필터 ──
+      # constraints/active.json 의 active(permanent || 미만료) 만 추려 각 에이전트에 주입.
+      - name: Load active standing constraints
+        id: constraints
+        run: |
+          set -uo pipefail
+          TODAY="${{ steps.fetch.outputs.today }}"
+          if [ -f constraints/active.json ]; then
+            C_JSON=$(npx -y tsx@4.19.2 scripts/constraints.ts active constraints/active.json "$TODAY" 2>/dev/null || echo '[]')
+            [ -z "$C_JSON" ] && C_JSON='[]'
+          else
+            C_JSON='[]'
+          fi
+          echo "constraints_json<<__CEOF__" >> "$GITHUB_OUTPUT"
+          echo "$C_JSON" >> "$GITHUB_OUTPUT"
+          echo "__CEOF__" >> "$GITHUB_OUTPUT"
+          {
+            echo "### 🔒 Standing Constraints (active)"
+            echo '```json'
+            printf '%s\n' "$C_JSON" | jq . 2>/dev/null || printf '%s\n' "$C_JSON"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # ─────────────────────────────────────────────────────────────
   # 1. PM
   # ─────────────────────────────────────────────────────────────
@@ -243,6 +267,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -255,6 +280,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "pm" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["pm"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["pm"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -332,6 +363,10 @@ jobs:
           prompt: |
             ## 🌟 North Star (이번 주 단일 진실)
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -430,6 +465,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -441,6 +477,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "frontend" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["frontend"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["frontend"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -515,6 +557,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -607,6 +653,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -618,6 +665,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "backend" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["backend"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["backend"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -673,6 +726,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -750,6 +807,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -761,6 +819,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "design" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["design"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["design"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -817,6 +881,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -895,6 +963,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -906,6 +975,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "qa" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["qa"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["qa"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -961,6 +1036,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -1038,6 +1117,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -1049,6 +1129,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "cto" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["cto"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["cto"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -1104,6 +1190,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -1180,6 +1270,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -1191,6 +1282,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "marketing" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["marketing"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["marketing"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -1262,6 +1359,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -1359,6 +1460,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -1370,6 +1472,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "security" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["security"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["security"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -1412,6 +1520,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -1481,6 +1593,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
           LANE_STATE: ${{ needs.prepare.outputs.lane_state_json }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
           COUNT=$(gh issue list --label "agent-council" --state open --limit 10 \
             --json title --repo "${{ github.repository }}" | \
@@ -1492,6 +1605,12 @@ jobs:
           echo "lane_slice<<__EOF__" >> $GITHUB_OUTPUT
           echo "$LANE_SLICE" >> $GITHUB_OUTPUT
           echo "__EOF__" >> $GITHUB_OUTPUT
+          # Standing Constraints 슬라이스 (Phase 2)
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_SLICE=$(npx -y tsx@4.19.2 scripts/constraints.ts render-lane "prompt" /tmp/constraints.json 2>/dev/null || echo "")
+          echo "constraints_slice<<__CEOF__" >> $GITHUB_OUTPUT
+          echo "$C_SLICE" >> $GITHUB_OUTPUT
+          echo "__CEOF__" >> $GITHUB_OUTPUT
 
           DONE_NUMS=$(jq -r '(.["prompt"].done // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
           KILLED_NUMS=$(jq -r '(.["prompt"].killed // []) | map(.number) | join(" ")' /tmp/lane-state.json 2>/dev/null || echo "")
@@ -1547,6 +1666,10 @@ jobs:
           prompt: |
             ## 🌟 North Star
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 위반 시 자동 폐기, 하드코딩 개별 규칙보다 우선)
+            ${{ steps.ctx.outputs.constraints_slice }}
 
             ---
             ## 🧾 우리 직군 상태 원장 (DONE/KILLED/IN-PROGRESS — 재제안 금지)
@@ -1716,7 +1839,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          CONSTRAINTS_JSON: ${{ needs.prepare.outputs.constraints_json }}
         run: |
+          # Standing Constraints 요약 (Phase 2) — 브리핑이 판정 시 기존 규칙과 충돌 방지
+          printf '%s' "$CONSTRAINTS_JSON" > /tmp/constraints.json
+          C_BRIEF=$(npx -y tsx@4.19.2 scripts/constraints.ts render-brief /tmp/constraints.json 2>/dev/null || echo "(constraint 조회 실패)")
+          echo "constraints_brief<<__CBEOF__" >> $GITHUB_OUTPUT
+          echo "$C_BRIEF" >> $GITHUB_OUTPUT
+          echo "__CBEOF__" >> $GITHUB_OUTPUT
+
           # 오늘 사이클 agent-council open 이슈 원본 (번호·제목·라벨·본문)
           gh issue list --label "agent-council" --state open --limit 30 \
             --json number,title,labels,body --repo "${{ github.repository }}" \
@@ -1800,6 +1931,10 @@ jobs:
           prompt: |
             ## 🌟 North Star (이번 주 테마)
             ${{ needs.prepare.outputs.north_star }}
+
+            ---
+            ## 🔒 Standing Constraints (CEO 확정 규칙 — 채점·킬리스트 판단의 상위 기준)
+            ${{ steps.today_issues.outputs.constraints_brief }}
 
             ---
             ## 📌 오늘 사이클 신규 이슈 (정확한 번호 — 우선순위 인용은 이 번호만 사용)

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -205,7 +205,14 @@ ${runList || "(없음)"}
 개발 실행 규칙 (중요):
 - 사용자가 **실제 코드 개발·구현 실행**을 지시하면(예: "개발해줘", "구현해줘", "만들어줘", "우선 개발해", "진행해"), 답변 맨 끝에 정확히 \`[[TRIGGER_IMPLEMENT]]\` 토큰을 단독 줄로 출력한다. 이 토큰은 실제 auto-implement 워크플로우를 실행시킨다.
 - 단순 질문·요약·상태 확인·의견 요청에는 절대 이 토큰을 출력하지 마라.
-- 토큰을 출력할 때는 "개발을 시작하겠다"는 취지의 답변과 함께 출력한다.`;
+- 토큰을 출력할 때는 "개발을 시작하겠다"는 취지의 답변과 함께 출력한다.
+
+Standing Constraint 규칙 (중요):
+- CEO가 **앞으로 계속 지켜야 할 규칙·방향·금지사항**을 지시하면(예: "앞으로 X 하지 마", "항상 토스처럼 가", "그건 영구 금지", "이제부터 Y는 금지"), 답변 끝에 단독 줄로 정확히 다음을 출력한다:
+  \`[[ADD_CONSTRAINT]]{"rule":"<한 문장 규칙>","scope":["pm"|"frontend"|"backend"|"design"|"qa"|"cto"|"marketing"|"security"|"prompt"|"all"],"kind":"prohibition"|"preference"|"priority"|"mental-model","permanent":true}\`
+  JSON은 반드시 한 줄. 전체 적용이면 scope를 ["all"]로.
+- **1회성 지시**("이번엔 이거 해", "오늘은 온보딩부터")에는 절대 이 토큰을 출력하지 마라 — 반복 적용 가능한 영구 규칙일 때만.
+- 토큰 출력 시 "규칙으로 등록하겠다"는 취지의 답변과 함께 출력한다.`;
 
     const res = await fetch(AI_URL, {
       method: "POST",
@@ -240,6 +247,28 @@ ${runList || "(없음)"}
     let reply = data.choices?.[0]?.message?.content?.trim();
 
     if (!reply) throw new Error("AI 응답이 비어있습니다");
+
+    // Standing Constraint 적재 인텐트 감지 → distill-constraints 워크플로우에 위임 (main 직접 push 금지)
+    const constraintMatch = reply.match(/\[\[ADD_CONSTRAINT\]\]\s*(\{[^\n]*\})/);
+    if (constraintMatch && constraintMatch[1]) {
+      reply = reply.replace(/\[\[ADD_CONSTRAINT\]\]\s*\{[^\n]*\}/g, "").trim();
+      const payloadRaw: string = constraintMatch[1];
+      try {
+        const parsed = JSON.parse(payloadRaw) as { rule?: string; scope?: unknown };
+        if (!parsed.rule || typeof parsed.rule !== "string") {
+          throw new Error("rule 필드 누락");
+        }
+        const sourceHint = `slack/${channel}/${rootThreadTs || threadTs || ""}`;
+        await triggerWorkflow("distill-constraints.yml", {
+          manual_constraint: payloadRaw,
+          source_hint: sourceHint,
+        });
+        const scopeStr = Array.isArray(parsed.scope) ? parsed.scope.join(", ") : "all";
+        reply += `\n\n🔒 *Standing Constraint 추가 요청됨*: "${parsed.rule}" (scope: ${scopeStr}).\n리뷰 PR이 생성됩니다 — 머지하면 다음 사이클부터 모든 에이전트가 준수합니다.`;
+      } catch (e) {
+        reply += `\n\n⚠️ Constraint 적재 실패: ${e instanceof Error ? e.message : String(e)}`;
+      }
+    }
 
     // 개발 실행 인텐트 감지 → 실제 auto-implement 워크플로우 트리거
     if (reply.includes("[[TRIGGER_IMPLEMENT]]")) {

--- a/apps/web/lib/slack/commands.ts
+++ b/apps/web/lib/slack/commands.ts
@@ -5,6 +5,7 @@ import {
   addLabel,
   mergePR,
   getWorkflowRuns,
+  getFileContent,
 } from "./github";
 
 interface CommandResult {
@@ -14,10 +15,10 @@ interface CommandResult {
 type CommandHandler = (args: string, userId: string) => Promise<CommandResult>;
 
 // GitHub API 다중 호출 등 3초 초과 가능성 있는 커맨드
-export const SLOW_COMMANDS = new Set(["status", "implement", "council", "merge"]);
+export const SLOW_COMMANDS = new Set(["status", "implement", "council", "merge", "constraints"]);
 
 // 알려진 커맨드 목록 — events/route.ts에서 chat vs command 분기에 사용
-export const KNOWN_COMMANDS = new Set(["implement", "council", "status", "approve", "merge", "help"]);
+export const KNOWN_COMMANDS = new Set(["implement", "council", "status", "approve", "merge", "help", "constraints"]);
 
 const commands: Record<string, CommandHandler> = {
   implement: handleImplement,
@@ -25,6 +26,7 @@ const commands: Record<string, CommandHandler> = {
   status: handleStatus,
   approve: handleApprove,
   merge: handleMerge,
+  constraints: handleConstraints,
   help: handleHelp,
 };
 
@@ -115,6 +117,29 @@ async function handleMerge(args: string): Promise<CommandResult> {
   return { text: `PR #${prNum} 머지 완료 (squash)` };
 }
 
+interface ActiveConstraint {
+  rule: string;
+  scope: string[];
+  kind: string;
+  source: string;
+}
+
+async function handleConstraints(): Promise<CommandResult> {
+  try {
+    const raw = await getFileContent("constraints/active.json");
+    if (!raw) return { text: "등록된 standing constraint가 없습니다." };
+    const parsed = JSON.parse(raw) as { constraints?: ActiveConstraint[] };
+    const list = parsed.constraints ?? [];
+    if (list.length === 0) return { text: "등록된 standing constraint가 없습니다." };
+    const lines = list.map(
+      (c) => `• [${c.kind}] (${c.scope.join(",")}) ${c.rule}  _(${c.source})_`
+    );
+    return { text: `*🔒 Standing Constraints (${list.length}건)*\n\n${lines.join("\n")}` };
+  } catch (e) {
+    return { text: `constraints 조회 실패: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
 async function handleHelp(): Promise<CommandResult> {
   return {
     text: [
@@ -124,6 +149,7 @@ async function handleHelp(): Promise<CommandResult> {
       "`/taro status` — 오픈 PR + CEO Brief + 실행 상태 요약",
       "`/taro approve {이슈#}` — 이슈에 implement-approved 라벨 추가",
       "`/taro merge {PR#}` — PR squash 머지",
+      "`/taro constraints` — 현재 등록된 standing constraints 목록",
       "`/taro help` — 이 도움말",
     ].join("\n"),
   };

--- a/apps/web/lib/slack/github.ts
+++ b/apps/web/lib/slack/github.ts
@@ -83,6 +83,14 @@ export async function getMergedPRs(since: string, limit = 20) {
   );
 }
 
+export async function getFileContent(path: string): Promise<string> {
+  const res = (await githubApi(
+    `/repos/${REPO}/contents/${path}`
+  )) as { content?: string; encoding?: string };
+  if (!res.content) return "";
+  return Buffer.from(res.content, (res.encoding as BufferEncoding) || "base64").toString("utf8");
+}
+
 export async function getRecentIssues(label: string, since: string, limit = 20) {
   return githubApi(
     `/repos/${REPO}/issues?labels=${encodeURIComponent(label)}&state=all&per_page=${limit}&sort=created&direction=desc`

--- a/constraints/active.json
+++ b/constraints/active.json
@@ -1,0 +1,37 @@
+{
+  "constraints": [
+    {
+      "id": "c-20260530-datamismatch",
+      "rule": "데이터 불일치/결측/오류를 사용자에게 직접 알리는 UI(배너·경고·\"데이터가 일치하지 않습니다\" 등) 제안 금지. 정합성 문제는 로딩 스켈레톤을 유지하며 백엔드에서 자동 해결하고, 사용자에게는 항상 정합된 데이터만 보여준다. DataMismatchBanner류 자동 폐기.",
+      "scope": ["pm", "frontend", "backend", "all"],
+      "kind": "prohibition",
+      "source": "ceo-brief / 2026-05-30 CEO 직접 피드백",
+      "permanent": true,
+      "createdAt": "2026-05-30",
+      "expiresAt": null,
+      "hits": 0
+    },
+    {
+      "id": "c-20260526-effectsban",
+      "rule": "이펙트/사운드/햅틱/글로우/파티클/반짝임/싱크로 효과/BGM/장식 애니메이션/버튼 펄스·진동 등 시각적·청각적 폴리싱 제안 금지. 사용자 경험(플로우·정보 위계·접근성)과 콘텐츠(해석 품질·카드 서사·재방문 동기)에만 집중한다.",
+      "scope": ["all"],
+      "kind": "prohibition",
+      "source": "ceo / 2026-05-26 CEO 직접 지시",
+      "permanent": true,
+      "createdAt": "2026-05-26",
+      "expiresAt": null,
+      "hits": 0
+    },
+    {
+      "id": "c-20260522-tossmentalmodel",
+      "rule": "증권 관련 UX(종목 상세·차트·재무·뉴스·공시)의 멘탈모델은 토스증권(tossinvest.com)이다. 정보 위계·레이아웃·데이터 표시는 토스증권을 레퍼런스로 한다. 토스와 동떨어진 금융 UX 제안은 토스 레퍼런스 근거가 필요하다.",
+      "scope": ["pm", "frontend", "design", "all"],
+      "kind": "mental-model",
+      "source": "north-star / 2026-05-22",
+      "permanent": true,
+      "createdAt": "2026-05-22",
+      "expiresAt": null,
+      "hits": 0
+    }
+  ]
+}

--- a/scripts/__tests__/constraints.test.ts
+++ b/scripts/__tests__/constraints.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateConstraint,
+  activeConstraints,
+  renderForLane,
+  renderForBrief,
+  dedupeAndCompact,
+  normalizeRule,
+  makeId,
+  normalizeIncoming,
+  mergeConstraints,
+  type Constraint,
+} from "../constraints";
+
+const base = (over: Partial<Constraint>): Constraint => ({
+  id: "c-1",
+  rule: "테스트 규칙",
+  scope: ["all"],
+  kind: "prohibition",
+  source: "test",
+  permanent: true,
+  createdAt: "2026-01-01",
+  expiresAt: null,
+  hits: 0,
+  ...over,
+});
+
+describe("validateConstraint", () => {
+  it("정상 객체를 통과시킨다", () => {
+    expect(validateConstraint(base({})).id).toBe("c-1");
+  });
+  it("잘못된 kind 는 throw", () => {
+    expect(() => validateConstraint(base({ kind: "bogus" as never }))).toThrow(/kind/);
+  });
+  it("빈 scope 는 throw", () => {
+    expect(() => validateConstraint(base({ scope: [] }))).toThrow(/scope/);
+  });
+  it("비영구인데 expiresAt 없으면 throw", () => {
+    expect(() => validateConstraint(base({ permanent: false, expiresAt: null }))).toThrow(/expiresAt/);
+  });
+});
+
+describe("activeConstraints", () => {
+  it("permanent 와 미만료만 남기고 만료된 것은 제외", () => {
+    const all = [
+      base({ id: "perm", permanent: true }),
+      base({ id: "future", permanent: false, expiresAt: "2026-12-31" }),
+      base({ id: "past", permanent: false, expiresAt: "2026-01-05" }),
+    ];
+    const active = activeConstraints(all, "2026-06-02");
+    expect(active.map((c) => c.id).sort()).toEqual(["future", "perm"]);
+  });
+});
+
+describe("renderForLane", () => {
+  it("scope 에 lane 또는 all 이 포함된 것만 렌더", () => {
+    const cs = [
+      base({ id: "pmonly", rule: "PM 전용", scope: ["pm"] }),
+      base({ id: "ctoonly", rule: "CTO 전용", scope: ["cto"] }),
+      base({ id: "allrule", rule: "전체 규칙", scope: ["all"] }),
+    ];
+    const pm = renderForLane(cs, "pm");
+    expect(pm).toContain("PM 전용");
+    expect(pm).toContain("전체 규칙");
+    expect(pm).not.toContain("CTO 전용");
+  });
+  it("all scope 는 모든 lane 에 나타난다", () => {
+    const cs = [base({ rule: "전체", scope: ["all"] })];
+    for (const lane of ["pm", "frontend", "cto", "security"]) {
+      expect(renderForLane(cs, lane)).toContain("전체");
+    }
+  });
+  it("매칭 없으면 빈 문자열", () => {
+    expect(renderForLane([base({ scope: ["pm"] })], "qa")).toBe("");
+  });
+});
+
+describe("renderForBrief", () => {
+  it("비면 안내, 있으면 전체 나열", () => {
+    expect(renderForBrief([])).toContain("없음");
+    expect(renderForBrief([base({ rule: "X규칙" })])).toContain("X규칙");
+  });
+});
+
+describe("dedupeAndCompact", () => {
+  it("만료 constraint 를 제거한다", () => {
+    const all = [
+      base({ id: "keep", permanent: true }),
+      base({ id: "expired", permanent: false, expiresAt: "2026-01-05" }),
+    ];
+    const { kept, removed } = dedupeAndCompact(all, "2026-06-02");
+    expect(kept.map((c) => c.id)).toEqual(["keep"]);
+    expect(removed.map((c) => c.id)).toEqual(["expired"]);
+  });
+  it("정규화 동일 rule 중복을 제거하고 scope/hits 병합", () => {
+    const all = [
+      base({ id: "a", rule: "데이터 불일치 배너 금지", scope: ["pm"], hits: 2 }),
+      base({ id: "b", rule: "데이터  불일치  배너  금지!!", scope: ["frontend"], hits: 3 }),
+    ];
+    const { kept, removed } = dedupeAndCompact(all, "2026-06-02");
+    expect(kept).toHaveLength(1);
+    expect(removed).toHaveLength(1);
+    expect(kept[0].hits).toBe(5);
+    expect(kept[0].scope.sort()).toEqual(["frontend", "pm"]);
+  });
+});
+
+describe("normalizeRule / makeId", () => {
+  it("공백·구두점·대소문자 차이를 무시", () => {
+    expect(normalizeRule("Hello, World!")).toBe(normalizeRule("helloworld"));
+  });
+  it("makeId 는 결정론적", () => {
+    expect(makeId("데이터 불일치 금지", "2026-05-30")).toBe(makeId("데이터 불일치 금지", "2026-05-30"));
+    expect(makeId("규칙", "2026-05-30")).toMatch(/^c-20260530-/);
+  });
+});
+
+describe("normalizeIncoming / mergeConstraints", () => {
+  it("부분 입력에 기본값을 채운다", () => {
+    const c = normalizeIncoming({ rule: "새 규칙" }, "2026-06-02");
+    expect(c.scope).toEqual(["all"]);
+    expect(c.kind).toBe("prohibition");
+    expect(c.permanent).toBe(true);
+    expect(c.hits).toBe(0);
+    expect(c.createdAt).toBe("2026-06-02");
+  });
+  it("기존과 중복인 후보는 skip, 새 것만 added", () => {
+    const existing = [base({ id: "x", rule: "이미 있는 규칙" })];
+    const merged = mergeConstraints(
+      existing,
+      [{ rule: "이미 있는 규칙" }, { rule: "완전히 새로운 규칙", scope: ["cto"] }],
+      "2026-06-02",
+    );
+    expect(merged.added).toHaveLength(1);
+    expect(merged.added[0].rule).toBe("완전히 새로운 규칙");
+    expect(merged.skipped).toHaveLength(1);
+    expect(merged.constraints).toHaveLength(2);
+  });
+  it("rule 없는 잘못된 후보는 skip", () => {
+    const merged = mergeConstraints([], [{ rule: "" }], "2026-06-02");
+    expect(merged.added).toHaveLength(0);
+    expect(merged.skipped).toHaveLength(1);
+  });
+});

--- a/scripts/constraints.ts
+++ b/scripts/constraints.ts
@@ -1,0 +1,327 @@
+/**
+ * Standing Constraints 코어 (Phase 2).
+ *
+ * CEO가 내리는 판정·지시(브리핑 채택/킬, Slack 스레드 지시)를 사람이 YAML을 손으로
+ * 고치지 않아도 영구 규칙으로 적재하고 매 사이클 9개 에이전트 + ceo_brief 에 주입한다.
+ *
+ * 단일 진실: constraints/active.json (git-tracked, 사람이 PR로 리뷰·수정 가능).
+ *   { "constraints": Constraint[] }
+ *
+ * 순수 export 함수 + main() CLI (process.argv[1] 가드). 외부 호출 없음 — 결정론적.
+ * Phase 0/1 scripts/{ceo-brief-fallback,build-lane-state}.ts 구조를 템플릿으로 따름.
+ */
+
+import { readFileSync } from "node:fs";
+
+export const CONSTRAINT_KINDS = ["prohibition", "preference", "priority", "mental-model"] as const;
+export type ConstraintKind = (typeof CONSTRAINT_KINDS)[number];
+
+export interface Constraint {
+  /** 안정적 id (예: c-2026-0530-data-mismatch) */
+  id: string;
+  rule: string;
+  /** 적용 lane (pm/frontend/... 또는 "all"=전체) */
+  scope: string[];
+  kind: ConstraintKind;
+  /** 출처 추적 (브리핑 #번호 / slack/<channel>/<ts> / manual) */
+  source: string;
+  /** true=만료 안 함, false=expiresAt 까지 */
+  permanent: boolean;
+  /** YYYY-MM-DD */
+  createdAt: string;
+  /** YYYY-MM-DD 또는 null */
+  expiresAt: string | null;
+  /** 이 제약이 실제로 제안을 막은 횟수(가치 측정) */
+  hits: number;
+}
+
+const KIND_LABEL: Record<ConstraintKind, string> = {
+  prohibition: "🚫 금지",
+  preference: "👍 선호",
+  priority: "⭐ 우선순위",
+  "mental-model": "🧭 멘탈모델",
+};
+
+// ─────────────────────────────────────────────────────────────
+// 검증
+// ─────────────────────────────────────────────────────────────
+
+function isYmd(s: unknown): s is string {
+  return typeof s === "string" && /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+/** 단일 constraint 검증 — 불량이면 throw (조용히 무시 금지). */
+export function validateConstraint(obj: unknown, idx = 0): Constraint {
+  if (typeof obj !== "object" || obj === null) {
+    throw new Error(`constraint[${idx}]: 객체가 아님`);
+  }
+  const o = obj as Record<string, unknown>;
+  const where = `constraint[${idx}]${typeof o.id === "string" ? ` (${o.id})` : ""}`;
+
+  if (typeof o.id !== "string" || o.id.length === 0) throw new Error(`${where}: id 필수`);
+  if (typeof o.rule !== "string" || o.rule.trim().length === 0) throw new Error(`${where}: rule 필수`);
+  if (!Array.isArray(o.scope) || o.scope.length === 0 || !o.scope.every((s) => typeof s === "string")) {
+    throw new Error(`${where}: scope 는 비어있지 않은 string 배열`);
+  }
+  if (typeof o.kind !== "string" || !CONSTRAINT_KINDS.includes(o.kind as ConstraintKind)) {
+    throw new Error(`${where}: kind 는 ${CONSTRAINT_KINDS.join("|")} 중 하나`);
+  }
+  if (typeof o.source !== "string") throw new Error(`${where}: source 필수`);
+  if (typeof o.permanent !== "boolean") throw new Error(`${where}: permanent boolean 필수`);
+  if (!isYmd(o.createdAt)) throw new Error(`${where}: createdAt YYYY-MM-DD 필수`);
+  if (o.expiresAt !== null && !isYmd(o.expiresAt)) throw new Error(`${where}: expiresAt 는 null 또는 YYYY-MM-DD`);
+  if (o.permanent === false && o.expiresAt === null) {
+    throw new Error(`${where}: 비영구 constraint 는 expiresAt 필수`);
+  }
+  if (typeof o.hits !== "number" || !Number.isFinite(o.hits)) throw new Error(`${where}: hits number 필수`);
+
+  return {
+    id: o.id,
+    rule: o.rule.trim(),
+    scope: o.scope as string[],
+    kind: o.kind as ConstraintKind,
+    source: o.source,
+    permanent: o.permanent,
+    createdAt: o.createdAt,
+    expiresAt: (o.expiresAt as string | null) ?? null,
+    hits: o.hits,
+  };
+}
+
+function validateAll(arr: unknown): Constraint[] {
+  if (!Array.isArray(arr)) throw new Error("constraints 는 배열이어야 함");
+  return arr.map((c, i) => validateConstraint(c, i));
+}
+
+/** active.json ({constraints:[]}) 로드 — 파일 없으면 []. 불량 항목은 throw. */
+export function loadConstraints(path: string): Constraint[] {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8").trim();
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  const parsed: unknown = JSON.parse(raw);
+  const arr = Array.isArray(parsed) ? parsed : (parsed as { constraints?: unknown }).constraints;
+  if (arr === undefined) return [];
+  return validateAll(arr);
+}
+
+// ─────────────────────────────────────────────────────────────
+// 필터 / 렌더
+// ─────────────────────────────────────────────────────────────
+
+/** permanent 이거나 아직 만료되지 않은(expiresAt >= today) 것만. */
+export function activeConstraints(all: Constraint[], today: string): Constraint[] {
+  return all.filter((c) => c.permanent || (c.expiresAt !== null && c.expiresAt >= today));
+}
+
+function appliesToLane(c: Constraint, lane: string): boolean {
+  return c.scope.includes("all") || c.scope.includes(lane);
+}
+
+/** 특정 lane(+all) 제약을 마크다운으로. 없으면 빈 문자열. */
+export function renderForLane(constraints: Constraint[], lane: string): string {
+  const matched = constraints.filter((c) => appliesToLane(c, lane));
+  if (matched.length === 0) return "";
+  return matched
+    .map((c) => `- [${KIND_LABEL[c.kind]}] ${c.rule} _(출처: ${c.source})_`)
+    .join("\n");
+}
+
+/** ceo_brief 용 전체 요약. */
+export function renderForBrief(constraints: Constraint[]): string {
+  if (constraints.length === 0) return "(등록된 standing constraint 없음)";
+  return constraints
+    .map((c) => `- [${KIND_LABEL[c.kind]}] (${c.scope.join(",")}) ${c.rule} _(${c.source})_`)
+    .join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────
+// dedupe / compact / merge
+// ─────────────────────────────────────────────────────────────
+
+/** rule 정규화 — 중복 탐지용 (공백·구두점·대소문자 제거). */
+export function normalizeRule(rule: string): string {
+  return rule
+    .toLowerCase()
+    .replace(/[\s\p{P}\p{S}]+/gu, "")
+    .trim();
+}
+
+/** 만료 제거 + 동일 rule 중복 제거(먼저 생성된 것 유지). */
+export function dedupeAndCompact(
+  constraints: Constraint[],
+  today: string,
+): { kept: Constraint[]; removed: Constraint[] } {
+  const kept: Constraint[] = [];
+  const removed: Constraint[] = [];
+  const seen = new Map<string, Constraint>();
+
+  for (const c of constraints) {
+    // 만료
+    if (!c.permanent && c.expiresAt !== null && c.expiresAt < today) {
+      removed.push(c);
+      continue;
+    }
+    // 중복 (정규화 rule)
+    const key = normalizeRule(c.rule);
+    const existing = seen.get(key);
+    if (existing) {
+      // 더 많은 hits 를 가진 쪽으로 병합(누적), 둘 중 하나는 removed
+      existing.hits += c.hits;
+      // 더 넓은 scope 병합 (all 흡수)
+      const merged = new Set([...existing.scope, ...c.scope]);
+      existing.scope = merged.has("all") ? ["all"] : Array.from(merged);
+      removed.push(c);
+      continue;
+    }
+    seen.set(key, c);
+    kept.push(c);
+  }
+  return { kept, removed };
+}
+
+/** 안정적 id 생성 — c-YYYYMMDD-<slug>. */
+export function makeId(rule: string, today: string): string {
+  const date = today.replace(/-/g, "").slice(0, 8);
+  const slug = normalizeRule(rule).slice(0, 16) || "rule";
+  return `c-${date}-${slug}`;
+}
+
+export interface IncomingConstraint {
+  rule: string;
+  scope?: string[];
+  kind?: string;
+  source?: string;
+  permanent?: boolean;
+  expiresAt?: string | null;
+  id?: string;
+}
+
+/** 외부(distill/Slack) 입력을 검증된 Constraint 로 정규화. */
+export function normalizeIncoming(input: IncomingConstraint, today: string): Constraint {
+  const rule = (input.rule ?? "").trim();
+  if (!rule) throw new Error("incoming constraint: rule 필수");
+  const kind = (input.kind ?? "prohibition") as ConstraintKind;
+  if (!CONSTRAINT_KINDS.includes(kind)) throw new Error(`incoming constraint: 잘못된 kind ${input.kind}`);
+  const scope = Array.isArray(input.scope) && input.scope.length > 0 ? input.scope : ["all"];
+  const permanent = input.permanent ?? true;
+  const expiresAt = permanent ? null : (input.expiresAt ?? null);
+  if (!permanent && expiresAt === null) {
+    throw new Error("incoming constraint: 비영구는 expiresAt 필수");
+  }
+  return validateConstraint({
+    id: input.id ?? makeId(rule, today),
+    rule,
+    scope,
+    kind,
+    source: input.source ?? "manual",
+    permanent,
+    createdAt: today,
+    expiresAt,
+    hits: 0,
+  });
+}
+
+export interface MergeResult {
+  constraints: Constraint[];
+  added: Constraint[];
+  skipped: IncomingConstraint[];
+  /** 기존과 모순 가능성 (rule 정규화가 "금지↔허용" 토큰만 다른 경우) */
+  conflicts: { incoming: IncomingConstraint; existingId: string }[];
+}
+
+/** 기존 + 신규 후보 병합 (중복 skip, 충돌 플래그). */
+export function mergeConstraints(
+  existing: Constraint[],
+  incoming: IncomingConstraint[],
+  today: string,
+): MergeResult {
+  const result: MergeResult = { constraints: [...existing], added: [], skipped: [], conflicts: [] };
+  const seen = new Map(existing.map((c) => [normalizeRule(c.rule), c]));
+
+  for (const inc of incoming) {
+    let candidate: Constraint;
+    try {
+      candidate = normalizeIncoming(inc, today);
+    } catch {
+      result.skipped.push(inc);
+      continue;
+    }
+    const key = normalizeRule(candidate.rule);
+    if (seen.has(key)) {
+      result.skipped.push(inc);
+      continue;
+    }
+    result.constraints.push(candidate);
+    result.added.push(candidate);
+    seen.set(key, candidate);
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI
+//   active <active.json> <today>        → active 필터된 bare 배열 JSON
+//   render-lane <lane> <array.json>     → lane 슬라이스 마크다운
+//   render-brief <array.json>           → ceo_brief 요약 마크다운
+//   compact <active.json> <today>       → 압축된 {constraints:[]} JSON
+//   add <active.json> <payload.json> <today> → 머지된 {constraints:[]} JSON
+// ─────────────────────────────────────────────────────────────
+
+function readBareArray(path: string): Constraint[] {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8").trim();
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  const parsed: unknown = JSON.parse(raw);
+  const arr = Array.isArray(parsed) ? parsed : (parsed as { constraints?: unknown }).constraints;
+  if (arr === undefined) return [];
+  return validateAll(arr);
+}
+
+function main(): void {
+  const argv = process.argv;
+  const cmd = argv[2];
+  const today = new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+
+  if (cmd === "active") {
+    const all = loadConstraints(argv[3] ?? "");
+    process.stdout.write(JSON.stringify(activeConstraints(all, argv[4] ?? today)));
+  } else if (cmd === "render-lane") {
+    const arr = readBareArray(argv[4] ?? "");
+    process.stdout.write(renderForLane(arr, argv[3] ?? ""));
+  } else if (cmd === "render-brief") {
+    const arr = readBareArray(argv[3] ?? "");
+    process.stdout.write(renderForBrief(arr));
+  } else if (cmd === "compact") {
+    const all = loadConstraints(argv[3] ?? "");
+    const { kept } = dedupeAndCompact(all, argv[4] ?? today);
+    process.stdout.write(JSON.stringify({ constraints: kept }, null, 2));
+  } else if (cmd === "add") {
+    const existing = loadConstraints(argv[3] ?? "");
+    const payloadRaw = readFileSync(argv[4] ?? "", "utf8").trim();
+    const parsed: unknown = payloadRaw ? JSON.parse(payloadRaw) : [];
+    const incoming: IncomingConstraint[] = Array.isArray(parsed)
+      ? (parsed as IncomingConstraint[])
+      : [parsed as IncomingConstraint];
+    const merged = mergeConstraints(existing, incoming, argv[5] ?? today);
+    process.stdout.write(JSON.stringify({ constraints: merged.constraints }, null, 2));
+    process.stderr.write(`added=${merged.added.length} skipped=${merged.skipped.length}\n`);
+  } else {
+    console.error(
+      "usage:\n  active <active.json> <today>\n  render-lane <lane> <array.json>\n  render-brief <array.json>\n  compact <active.json> <today>\n  add <active.json> <payload.json> <today>",
+    );
+    process.exit(1);
+  }
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("constraints")) {
+  main();
+}


### PR DESCRIPTION
## Summary

Phase 2 — CEO가 내리는 판정·지시(브리핑 채택/킬, Slack 스레드 지시)를 사람이 YAML을 손으로 고치지 않아도 standing constraints로 자동 적재하고 매 사이클 9개 에이전트 + ceo_brief에 주입. ("능동적으로 내 생각과 싱크" 니즈의 핵심) Phase 0(#284)/Phase 1(#285) 위에 얹음.

- **Task 1 — 코어**: `constraints/active.json`(git 단일 진실) + `scripts/constraints.ts` 순수 함수(load/validate/active/renderForLane/renderForBrief/dedupeAndCompact/merge) + CLI. vitest 16케이스.
- **Task 2 — 주입**: `prepare`가 `constraints_json` 출력 → 9개 에이전트 ctx가 자기 lane `constraints_slice` 렌더. 프롬프트 순서 NorthStar → **Standing Constraints** → 직군 원장 → self-history. ceo_brief엔 `renderForBrief` 주입.
- **Task 3 — distill**: `distill-constraints.yml` — CEO Brief 판정/Slack 지시에서 LLM이 영구 규칙 후보 추출 → 검증/dedup → active.json 머지 → **사람 리뷰 PR**(`needs-ceo-review`, auto-merge 비대상).
- **Task 4 — Slack 싱크**: `handleAgentChat`에 `[[ADD_CONSTRAINT]]` 토큰 규칙(`[[TRIGGER_IMPLEMENT]]` 패턴 재사용) → `distill-constraints.yml`에 위임(**main 직접 push 없음**) + 스레드 확인 메시지. `/taro constraints` 조회 커맨드.
- **Task 5 — compact**: `compact-constraints.yml` weekly 만료/중복 정리 → 리뷰 PR.
- **Task 6 — 마이그레이션**: 하드코딩 규칙 3건(데이터정합성·이펙트금지·토스 멘탈모델) active.json에 추가(하드코딩 제거는 회귀 위험 분리 위해 다음 PR).

근본 원인: CEO 판정이 system-prompt 하드코딩(수동·확장불가)이거나 Slack 스레드에서 휘발 → 다음 사이클 에이전트가 못 봄.

## 어제자 변경분 충돌 회피
pull로 최신화 후, 어제 변경된 `slack/events/route.ts`·`client.ts`·모바일 컴포넌트의 **현재 버전을 정독한 뒤** additive하게만 수정(`[[ADD_CONSTRAINT]]` 분기·헬퍼 추가). 기존 `[[TRIGGER_IMPLEMENT]]`·Groq·스레드 로직 미변경.

## 변경 범위
- `idea-proposal.yml`(prepare + 9 ctx + ceo_brief) · `distill-constraints.yml`·`compact-constraints.yml`(신규) · `constraints/active.json`(신규) · `scripts/constraints.ts`(+테스트, 외부 의존성 0) · `slack/events/route.ts`·`github.ts`·`commands.ts`

## Test plan
- [x] `npx vitest run` — 245 passed (23 files; constraints 16케이스: 검증 throw/active 만료필터/lane scope/all/compact dedup·만료/merge skip)
- [x] `npm run typecheck` + `typecheck:web` — 통과
- [x] `npm run build:web` — 성공
- [x] 3개 스크립트 strict standalone 타입체크
- [x] CLI active/render-lane/render-brief/compact/add + distill merge 시뮬레이션 end-to-end
- [ ] (수동) Slack 스레드 영구 규칙 지시 → active.json PR → 머지 후 `gh workflow run idea-proposal.yml` → 에이전트 이슈가 규칙 준수 관찰

Related: #282 · Out of scope: 의미 dedup·drift(Phase 3), 제품 그래프(Phase 3), AI provider 교체, 하드코딩 규칙 제거(다음 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)