### PR TITLE
feat(slack): CEO Brief 본문 읽기 + 의도 기반 컨텍스트 로딩 (Step 1)

### DIFF
--- a/apps/web/__tests__/slack-intent.test.ts
+++ b/apps/web/__tests__/slack-intent.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { classifyIntent, extractNumbers, truncate } from "@/lib/slack/intent";
+
+describe("extractNumbers", () => {
+  it("#NNN 을 추출하고 중복 제거", () => {
+    expect(extractNumbers("이슈 #298 과 #298, #301 봐줘")).toEqual([298, 301]);
+    expect(extractNumbers("번호 없음")).toEqual([]);
+  });
+  it("최대 5개", () => {
+    expect(extractNumbers("#1 #2 #3 #4 #5 #6 #7")).toHaveLength(5);
+  });
+});
+
+describe("classifyIntent", () => {
+  it("브리핑 질문 → brief", () => {
+    expect(classifyIntent("오늘자 CEO 브리핑 내용 알려줘").kind).toBe("brief");
+  });
+  it("PR + 번호 → pr, prNumbers 채움", () => {
+    const r = classifyIntent("이 PR #291 머지해줘");
+    expect(r.kind).toBe("pr");
+    expect(r.prNumbers).toEqual([291]);
+    expect(r.issueNumbers).toEqual([]);
+  });
+  it("이슈 번호만 → issue, issueNumbers 채움", () => {
+    const r = classifyIntent("#298 이슈 뭐야?");
+    expect(r.kind).toBe("issue");
+    expect(r.issueNumbers).toEqual([298]);
+    expect(r.prNumbers).toEqual([]);
+  });
+  it("의회/실행 → workflow", () => {
+    expect(classifyIntent("지금 의회 한 번 돌려").kind).toBe("workflow");
+    expect(classifyIntent("현재 진행 상황 status").kind).toBe("workflow");
+  });
+  it("규칙 → constraints", () => {
+    expect(classifyIntent("등록된 규칙 목록 보여줘").kind).toBe("constraints");
+  });
+  it("일반 잡담 → general, 번호 없음", () => {
+    const r = classifyIntent("안녕 오늘 기분 어때");
+    expect(r.kind).toBe("general");
+    expect(r.issueNumbers).toEqual([]);
+    expect(r.prNumbers).toEqual([]);
+  });
+  it("브리핑이 PR 키워드보다 우선", () => {
+    // 브리핑 질문에 우연히 숫자가 있어도 brief 로 분류
+    expect(classifyIntent("브리핑 #298 요약").kind).toBe("brief");
+  });
+});
+
+describe("truncate", () => {
+  it("긴 텍스트를 자르고 생략 표기", () => {
+    const t = truncate("a".repeat(5000), 3000);
+    expect(t.length).toBeLessThan(3100);
+    expect(t).toContain("생략");
+  });
+  it("짧으면 그대로", () => {
+    expect(truncate("짧음", 3000)).toBe("짧음");
+  });
+});

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -5,10 +5,13 @@ import { postMessage, getThreadHistory } from "@/lib/slack/client";
 import { dispatchCommand, KNOWN_COMMANDS } from "@/lib/slack/commands";
 import {
   getOpenPRs,
-  getCEOBriefIssues,
   getWorkflowRuns,
   triggerWorkflow,
+  getLatestCEOBrief,
+  getIssue,
+  getPR,
 } from "@/lib/slack/github";
+import { classifyIntent, truncate } from "@/lib/slack/intent";
 
 interface SlackEvent {
   type: string;
@@ -155,10 +158,13 @@ async function handleAgentChat(
       historyMessages.push({ role: msg.bot_id ? "assistant" : "user", content: cleaned });
     }
 
-    // 컨텍스트 수집 (병렬)
-    const [prs, briefs, runs] = await Promise.allSettled([
+    // ── Step 1: 의도 분류 → 필요한 데이터를 본문까지 깊게 로드 ──
+    const intent = classifyIntent(question);
+
+    // 컨텍스트 수집 (병렬) — 항상 최신 CEO Brief 본문 + 오픈 PR/실행 상태
+    const [prs, latestBrief, runs] = await Promise.allSettled([
       getOpenPRs(5),
-      getCEOBriefIssues(3),
+      getLatestCEOBrief(),
       getWorkflowRuns("auto-implement.yml", 5),
     ]);
 
@@ -168,11 +174,14 @@ async function handleAgentChat(
           .join("\n")
       : "(조회 실패)";
 
-    const briefList = briefs.status === "fulfilled"
-      ? (briefs.value as { number: number; title: string }[])
-          .map((b) => `- #${b.number}: ${b.title}`)
-          .join("\n")
-      : "(조회 실패)";
+    // 최신 CEO Brief — 제목만이 아니라 본문 전문(3000자)을 주입 (스크린샷 이슈 해결)
+    let briefSection = "(없음)";
+    if (latestBrief.status === "fulfilled" && latestBrief.value) {
+      const b = latestBrief.value;
+      briefSection = `#${b.number}: ${b.title}\n\n${truncate(b.body, 3000)}`;
+    } else if (latestBrief.status === "rejected") {
+      briefSection = "(조회 실패)";
+    }
 
     const runList = runs.status === "fulfilled"
       ? (
@@ -183,6 +192,26 @@ async function handleAgentChat(
           .join("\n")
       : "(조회 실패)";
 
+    // 의도에 따라 특정 이슈/PR 본문을 깊게 로드 (#NNN 언급 시)
+    let detailSection = "";
+    const issueDetails = await Promise.allSettled(intent.issueNumbers.map((n) => getIssue(n)));
+    for (const r of issueDetails) {
+      if (r.status === "fulfilled") {
+        const d = r.value;
+        const cmts = d.comments.length ? `\n코멘트: ${truncate(d.comments.join(" / "), 600)}` : "";
+        detailSection += `\n### 이슈 #${d.number}: ${d.title}\n${truncate(d.body, 2500)}${cmts}\n`;
+      }
+    }
+    const prDetails = await Promise.allSettled(intent.prNumbers.map((n) => getPR(n)));
+    for (const r of prDetails) {
+      if (r.status === "fulfilled") {
+        const d = r.value;
+        const files = d.files.length ? `\n변경 파일(${d.files.length}): ${truncate(d.files.join(", "), 800)}` : "";
+        detailSection += `\n### PR #${d.number}: ${d.title} [${d.merged ? "merged" : d.state}]\n${truncate(d.body, 2000)}${files}\n`;
+      }
+    }
+    if (!detailSection) detailSection = "(특정 이슈/PR 언급 없음)";
+
     const systemPrompt = `당신은 Trading Taro 프로젝트의 Hermes 에이전트입니다.
 CEO가 Slack에서 물어보는 질문에 한국어로 간결하게 답합니다.
 현재 파이프라인 상태를 바탕으로 구체적이고 actionable한 답변을 제공하세요.
@@ -191,8 +220,11 @@ CEO가 Slack에서 물어보는 질문에 한국어로 간결하게 답합니다
 ## 오픈 PR
 ${prList || "(없음)"}
 
-## 최근 CEO Brief
-${briefList || "(없음)"}
+## 최신 CEO Brief (본문)
+${briefSection}
+
+## 질문에서 언급된 이슈/PR 상세
+${detailSection}
 
 ## 최근 auto-implement 실행
 ${runList || "(없음)"}
@@ -200,7 +232,8 @@ ${runList || "(없음)"}
 규칙:
 - 답변은 3-5문장 이내로 간결하게
 - Slack mrkdwn 포맷 사용 (*볼드*, _이탤릭_, \`코드\`)
-- 확실하지 않은 것은 솔직하게 모른다고 답변
+- **위 컨텍스트에 본문이 주어졌으면 "확인할 수 없다"고 답하지 말고 그 내용을 직접 요약·인용해 답한다.**
+- 본문에 없는 정보만 "확인 불가"로 답한다
 
 개발 실행 규칙 (중요):
 - 사용자가 **실제 코드 개발·구현 실행**을 지시하면(예: "개발해줘", "구현해줘", "만들어줘", "우선 개발해", "진행해"), 답변 맨 끝에 정확히 \`[[TRIGGER_IMPLEMENT]]\` 토큰을 단독 줄로 출력한다. 이 토큰은 실제 auto-implement 워크플로우를 실행시킨다.

--- a/apps/web/lib/slack/github.ts
+++ b/apps/web/lib/slack/github.ts
@@ -83,6 +83,79 @@ export async function getMergedPRs(since: string, limit = 20) {
   );
 }
 
+// ── Step 1 (읽기 천장): 본문 조회 함수 ──────────────────────────────
+
+/** 가장 최근 ceo-brief 이슈 1건의 본문 전문 (state=all — 닫힌 과거 브리핑도 포함). */
+export async function getLatestCEOBrief(): Promise<{
+  number: number;
+  title: string;
+  body: string;
+} | null> {
+  const issues = (await githubApi(
+    `/repos/${REPO}/issues?labels=ceo-brief&state=all&per_page=1&sort=created&direction=desc`
+  )) as { number: number; title: string; body: string | null }[];
+  const top = issues[0];
+  if (!top) return null;
+  return { number: top.number, title: top.title, body: top.body ?? "" };
+}
+
+/** 특정 이슈의 본문 + 최근 코멘트. */
+export async function getIssue(n: number): Promise<{
+  number: number;
+  title: string;
+  body: string;
+  comments: string[];
+}> {
+  const issue = (await githubApi(`/repos/${REPO}/issues/${n}`)) as {
+    number: number;
+    title: string;
+    body: string | null;
+  };
+  let comments: string[] = [];
+  try {
+    const c = (await githubApi(
+      `/repos/${REPO}/issues/${n}/comments?per_page=10`
+    )) as { body: string | null }[];
+    comments = c.map((x) => x.body ?? "").filter((b) => b.length > 0);
+  } catch {
+    comments = [];
+  }
+  return { number: issue.number, title: issue.title, body: issue.body ?? "", comments };
+}
+
+/** 특정 PR 의 본문 + 상태 + 변경 파일 목록. */
+export async function getPR(n: number): Promise<{
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  merged: boolean;
+  files: string[];
+}> {
+  const pr = (await githubApi(`/repos/${REPO}/pulls/${n}`)) as {
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    merged?: boolean;
+  };
+  let files: string[] = [];
+  try {
+    const f = (await getPRFiles(n)) as { filename: string }[];
+    files = f.map((x) => x.filename);
+  } catch {
+    files = [];
+  }
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body ?? "",
+    state: pr.state,
+    merged: pr.merged ?? false,
+    files,
+  };
+}
+
 export async function getFileContent(path: string): Promise<string> {
   const res = (await githubApi(
     `/repos/${REPO}/contents/${path}`

--- a/apps/web/lib/slack/intent.ts
+++ b/apps/web/lib/slack/intent.ts
@@ -1,0 +1,62 @@
+/**
+ * Slack Agent Track — Step 1 (읽기 천장).
+ *
+ * CEO 질문의 의도를 분류해 어떤 데이터를 깊게 로드할지 결정한다.
+ * 결정론적 키워드/번호 라우팅 (추가 LLM 콜 없음 — 빠르고 토큰 0).
+ * 순수 함수 — apps/web/__tests__ 에서 vitest 로 검증.
+ */
+
+export type IntentKind = "brief" | "pr" | "issue" | "workflow" | "constraints" | "general";
+
+export interface Intent {
+  kind: IntentKind;
+  /** 본문을 깊게 로드할 이슈 번호 */
+  issueNumbers: number[];
+  /** 본문을 깊게 로드할 PR 번호 */
+  prNumbers: number[];
+}
+
+/** 텍스트에서 #NNN 번호를 추출 (중복 제거, 최대 5개). */
+export function extractNumbers(text: string): number[] {
+  const out: number[] = [];
+  const re = /#(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n > 0 && !out.includes(n)) out.push(n);
+    if (out.length >= 5) break;
+  }
+  return out;
+}
+
+const PR_RE = /\bpr\b|풀\s*리퀘|풀리퀘|머지|merge|pull request/i;
+const BRIEF_RE = /브리핑|브리프|brief|데일리|daily/i;
+const WORKFLOW_RE = /의회|council|워크플로|workflow|실행|돌려|run|상태|status|진행\s*상황/i;
+const CONSTRAINTS_RE = /규칙|제약|constraint|컨스트레인/i;
+const ISSUE_RE = /이슈|issue/i;
+
+/** CEO 질문을 분류 + 깊게 로드할 번호 추출. */
+export function classifyIntent(text: string): Intent {
+  const numbers = extractNumbers(text);
+  const isPR = PR_RE.test(text);
+
+  let kind: IntentKind;
+  if (BRIEF_RE.test(text)) kind = "brief";
+  else if (isPR) kind = "pr";
+  else if (CONSTRAINTS_RE.test(text)) kind = "constraints";
+  else if (WORKFLOW_RE.test(text)) kind = "workflow";
+  else if (numbers.length > 0 || ISSUE_RE.test(text)) kind = "issue";
+  else kind = "general";
+
+  // PR 의도면 번호를 PR 로, 그 외 번호는 이슈로 취급
+  const prNumbers = isPR ? numbers : [];
+  const issueNumbers = isPR ? [] : numbers;
+
+  return { kind, issueNumbers, prNumbers };
+}
+
+/** 본문을 토큰 폭주 없이 자르기 (기본 3000자). */
+export function truncate(text: string, max = 3000): string {
+  if (!text) return "";
+  return text.length > max ? text.slice(0, max) + "\n…(이하 생략)" : text;
+}


### PR DESCRIPTION
## Summary

Slack Agent Track **Step 1 (읽기 천장)** — 봇이 CEO Brief·이슈·PR의 *본문*을 읽고 답한다.

**스크린샷 이슈 직접 해결**: CEO가 "오늘자 브리핑 알려줘" → 봇이 "#298 존재하지만 내용은 확인 불가"를 반복하던 문제. 원인은 `handleAgentChat`이 `getCEOBriefIssues`로 받은 본문을 버리고 **제목만** LLM에 넘긴 것.

- `getLatestCEOBrief()`: 최신 ceo-brief 이슈 본문 전문 로드 (`state=all` — 닫힌 과거 브리핑도 포함)
- `getIssue(n)`/`getPR(n)`: 본문·코멘트·변경파일 조회 함수 추가 (`getPRFiles` 재사용)
- `lib/slack/intent.ts`: `classifyIntent` 순수 분류기(brief/pr/issue/workflow/constraints/general) + `#번호` 추출 + `truncate`. 결정론적 키워드 라우팅(추가 LLM 콜 0)
- `handleAgentChat`: 의도 분류 → 최신 브리핑 본문(3000자) 항상 주입 + 언급된 이슈/PR 본문 깊게 로드. systemPrompt에 "본문 주어지면 직접 요약" 규칙
- 토큰 폭주 방지: 본문 길이 제한(이슈 2500 / PR 2000 / 브리핑 3000 / 파일목록 800)

## Test plan
- [x] `npx vitest run` — 256 passed (24 files; intent 11케이스: brief/pr/issue/workflow/constraints/general 분류, 번호 추출, truncate)
- [x] `npm run typecheck:web` — 통과
- [x] `npm run build:web` — 성공
- [ ] (수동) Slack: "오늘자 CEO 브리핑 내용 알려줘" → 본문 요약 응답 / "#NNN 이슈 뭐야?" → 본문 요약

Out of scope: Step 2(행동 토큰)/Step 3(기억)/Step 4(자율) — 후속 PR. provider(Groq) 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)