### PR TITLE
feat(slack): 범용 액션 토큰 체계 — 대화로 실행 (Step 2)

### DIFF
--- a/apps/web/__tests__/slack-actions.test.ts
+++ b/apps/web/__tests__/slack-actions.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { parseActions, KNOWN_ACTIONS, HIGH_IMPACT_ACTIONS } from "@/lib/slack/actions";
+
+describe("parseActions", () => {
+  it("페이로드 없는 액션을 파싱하고 토큰 제거", () => {
+    const r = parseActions("의회 돌릴게요.\n[[ACTION:run_council]]");
+    expect(r.actions).toEqual([{ name: "run_council", payload: {} }]);
+    expect(r.cleaned).toBe("의회 돌릴게요.");
+  });
+
+  it("JSON 페이로드 액션 파싱", () => {
+    const r = parseActions('머지합니다.\n[[ACTION:merge]] {"pr":291}');
+    expect(r.actions).toEqual([{ name: "merge", payload: { pr: 291 } }]);
+    expect(r.cleaned).toBe("머지합니다.");
+  });
+
+  it("comment 액션 본문 파싱", () => {
+    const r = parseActions('남길게요 [[ACTION:comment]] {"issue":298,"body":"온보딩은 토스 스타일로"}');
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0]!.name).toBe("comment");
+    expect(r.actions[0]!.payload).toEqual({ issue: 298, body: "온보딩은 토스 스타일로" });
+  });
+
+  it("하위호환: [[TRIGGER_IMPLEMENT]] → implement", () => {
+    const r = parseActions("개발 시작!\n[[TRIGGER_IMPLEMENT]]");
+    expect(r.actions).toEqual([{ name: "implement", payload: {} }]);
+    expect(r.cleaned).toBe("개발 시작!");
+  });
+
+  it("하위호환: [[ADD_CONSTRAINT]]{json} → add_constraint", () => {
+    const r = parseActions('규칙 등록합니다 [[ADD_CONSTRAINT]]{"rule":"X 금지","scope":["all"]}');
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0]!.name).toBe("add_constraint");
+    expect(r.actions[0]!.payload).toEqual({ rule: "X 금지", scope: ["all"] });
+    expect(r.cleaned).toBe("규칙 등록합니다");
+  });
+
+  it("알 수 없는 액션은 무시", () => {
+    const r = parseActions("[[ACTION:delete_everything]] {}");
+    expect(r.actions).toEqual([]);
+  });
+
+  it("액션 없으면 빈 배열 + 원문 유지", () => {
+    const r = parseActions("그냥 일반 답변입니다.");
+    expect(r.actions).toEqual([]);
+    expect(r.cleaned).toBe("그냥 일반 답변입니다.");
+  });
+
+  it("잘못된 JSON 은 빈 payload 로 안전 처리", () => {
+    const r = parseActions("[[ACTION:implement]] {bad json}");
+    expect(r.actions).toEqual([{ name: "implement", payload: {} }]);
+  });
+});
+
+describe("액션 집합", () => {
+  it("KNOWN_ACTIONS 에 6개 포함", () => {
+    for (const a of ["run_council", "implement", "merge", "approve", "comment", "add_constraint"]) {
+      expect(KNOWN_ACTIONS.has(a)).toBe(true);
+    }
+  });
+  it("HIGH_IMPACT 에 merge/implement/add_constraint", () => {
+    expect(HIGH_IMPACT_ACTIONS.has("merge")).toBe(true);
+    expect(HIGH_IMPACT_ACTIONS.has("run_council")).toBe(false);
+  });
+});

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -10,8 +10,12 @@ import {
   getLatestCEOBrief,
   getIssue,
   getPR,
+  mergePR,
+  addLabel,
+  addIssueComment,
 } from "@/lib/slack/github";
 import { classifyIntent, truncate } from "@/lib/slack/intent";
+import { parseActions, type ParsedAction } from "@/lib/slack/actions";
 
 interface SlackEvent {
   type: string;
@@ -235,17 +239,19 @@ ${runList || "(없음)"}
 - **위 컨텍스트에 본문이 주어졌으면 "확인할 수 없다"고 답하지 말고 그 내용을 직접 요약·인용해 답한다.**
 - 본문에 없는 정보만 "확인 불가"로 답한다
 
-개발 실행 규칙 (중요):
-- 사용자가 **실제 코드 개발·구현 실행**을 지시하면(예: "개발해줘", "구현해줘", "만들어줘", "우선 개발해", "진행해"), 답변 맨 끝에 정확히 \`[[TRIGGER_IMPLEMENT]]\` 토큰을 단독 줄로 출력한다. 이 토큰은 실제 auto-implement 워크플로우를 실행시킨다.
-- 단순 질문·요약·상태 확인·의견 요청에는 절대 이 토큰을 출력하지 마라.
-- 토큰을 출력할 때는 "개발을 시작하겠다"는 취지의 답변과 함께 출력한다.
-
-Standing Constraint 규칙 (중요):
-- CEO가 **앞으로 계속 지켜야 할 규칙·방향·금지사항**을 지시하면(예: "앞으로 X 하지 마", "항상 토스처럼 가", "그건 영구 금지", "이제부터 Y는 금지"), 답변 끝에 단독 줄로 정확히 다음을 출력한다:
-  \`[[ADD_CONSTRAINT]]{"rule":"<한 문장 규칙>","scope":["pm"|"frontend"|"backend"|"design"|"qa"|"cto"|"marketing"|"security"|"prompt"|"all"],"kind":"prohibition"|"preference"|"priority"|"mental-model","permanent":true}\`
-  JSON은 반드시 한 줄. 전체 적용이면 scope를 ["all"]로.
-- **1회성 지시**("이번엔 이거 해", "오늘은 온보딩부터")에는 절대 이 토큰을 출력하지 마라 — 반복 적용 가능한 영구 규칙일 때만.
-- 토큰 출력 시 "규칙으로 등록하겠다"는 취지의 답변과 함께 출력한다.`;
+액션 실행 규칙 (중요 — tool use):
+- CEO가 **명확히 실행을 지시**하면, 답변 끝에 단독 줄로 액션 토큰을 정확히 출력한다. 한 메시지당 1개만.
+- 사용 가능한 액션:
+  \`[[ACTION:run_council]]\` — Agent Council(idea-proposal) 즉시 실행 ("의회 돌려", "제안 받아")
+  \`[[ACTION:implement]] {"date":"YYYY-MM-DD"}\` — auto-implement 트리거 (date 생략 시 오늘) ("구현 시작", "개발 진행")
+  \`[[ACTION:merge]] {"pr":291}\` — PR squash 머지 ("이 PR 머지해")
+  \`[[ACTION:approve]] {"issue":298}\` — 이슈에 implement-approved 라벨
+  \`[[ACTION:comment]] {"issue":298,"body":"..."}\` — 이슈/PR에 코멘트 (= 피드백 반영의 1차 형태)
+  \`[[ACTION:add_constraint]] {"rule":"...","scope":["all"],"kind":"prohibition","permanent":true}\` — 영구 규칙(standing constraint) 적재
+- JSON 페이로드는 반드시 한 줄. scope kind 는 정해진 값만.
+- **단순 질문·요약·상태 확인·의견 요청에는 절대 토큰을 출력하지 마라.** 실행 의도가 명확할 때만.
+- merge/implement/add_constraint 는 비가역·고영향이다 — CEO가 명시적으로 그 동작을 지시했을 때만 토큰을 낸다. 애매하면 토큰 없이 "진행할까요?"라고 먼저 묻는다.
+- add_constraint 는 "앞으로 항상/절대" 류의 반복 규칙에만. 1회성 지시("오늘은 온보딩부터")엔 금지.`;
 
     const res = await fetch(AI_URL, {
       method: "POST",
@@ -281,38 +287,11 @@ Standing Constraint 규칙 (중요):
 
     if (!reply) throw new Error("AI 응답이 비어있습니다");
 
-    // Standing Constraint 적재 인텐트 감지 → distill-constraints 워크플로우에 위임 (main 직접 push 금지)
-    const constraintMatch = reply.match(/\[\[ADD_CONSTRAINT\]\]\s*(\{[^\n]*\})/);
-    if (constraintMatch && constraintMatch[1]) {
-      reply = reply.replace(/\[\[ADD_CONSTRAINT\]\]\s*\{[^\n]*\}/g, "").trim();
-      const payloadRaw: string = constraintMatch[1];
-      try {
-        const parsed = JSON.parse(payloadRaw) as { rule?: string; scope?: unknown };
-        if (!parsed.rule || typeof parsed.rule !== "string") {
-          throw new Error("rule 필드 누락");
-        }
-        const sourceHint = `slack/${channel}/${rootThreadTs || threadTs || ""}`;
-        await triggerWorkflow("distill-constraints.yml", {
-          manual_constraint: payloadRaw,
-          source_hint: sourceHint,
-        });
-        const scopeStr = Array.isArray(parsed.scope) ? parsed.scope.join(", ") : "all";
-        reply += `\n\n🔒 *Standing Constraint 추가 요청됨*: "${parsed.rule}" (scope: ${scopeStr}).\n리뷰 PR이 생성됩니다 — 머지하면 다음 사이클부터 모든 에이전트가 준수합니다.`;
-      } catch (e) {
-        reply += `\n\n⚠️ Constraint 적재 실패: ${e instanceof Error ? e.message : String(e)}`;
-      }
-    }
-
-    // 개발 실행 인텐트 감지 → 실제 auto-implement 워크플로우 트리거
-    if (reply.includes("[[TRIGGER_IMPLEMENT]]")) {
-      reply = reply.replace(/\[\[TRIGGER_IMPLEMENT\]\]/g, "").trim();
-      const kstDate = new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
-      try {
-        await triggerWorkflow("auto-implement.yml", { brief_date: kstDate });
-        reply += `\n\n🚀 *auto-implement 워크플로우를 실제로 실행했습니다* (날짜: ${kstDate}).\n진행 상황은 \`@Taro Agent Bot status\` 로 확인하세요.`;
-      } catch (e) {
-        reply += `\n\n⚠️ 워크플로우 실행 실패: ${e instanceof Error ? e.message : String(e)}`;
-      }
+    // ── Step 2: 범용 액션 토큰 파싱 → 실행 (대화로 실행) ──
+    const { actions, cleaned } = parseActions(reply);
+    reply = cleaned;
+    for (const action of actions) {
+      reply += "\n\n" + (await executeAction(action, channel, rootThreadTs || threadTs));
     }
 
     await postMessage(channel, reply, threadTs);
@@ -323,5 +302,62 @@ Standing Constraint 규칙 (중요):
       `❌ 답변 생성 실패: ${msg}\n커맨드는 \`/taro help\`를 입력하세요.`,
       threadTs
     ).catch(() => {});
+  }
+}
+
+// ── Step 2: 액션 실행기 — 대화에서 파싱된 액션을 GitHub 안전 동작으로 실행 ──
+// (코드 변경은 워크플로 경유, main 직접 push 없음)
+async function executeAction(
+  action: ParsedAction,
+  channel: string,
+  threadTs: string | undefined
+): Promise<string> {
+  const kstDate = () => new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+  try {
+    switch (action.name) {
+      case "run_council": {
+        await triggerWorkflow("idea-proposal.yml", { agent: "all" });
+        return "🗳️ *Agent Council 실행* — 잠시 후 제안 이슈들이 생성됩니다.";
+      }
+      case "implement": {
+        const date = typeof action.payload.date === "string" ? action.payload.date : kstDate();
+        await triggerWorkflow("auto-implement.yml", { brief_date: date });
+        return `🚀 *auto-implement 실행* (날짜: ${date}). 진행은 \`@봇 status\`로 확인하세요.`;
+      }
+      case "merge": {
+        const pr = Number(action.payload.pr);
+        if (!Number.isInteger(pr) || pr <= 0) return "⚠️ merge: PR 번호가 올바르지 않아 실행하지 않았습니다.";
+        await mergePR(pr);
+        return `✅ *PR #${pr} squash 머지 완료*.`;
+      }
+      case "approve": {
+        const issue = Number(action.payload.issue);
+        if (!Number.isInteger(issue) || issue <= 0) return "⚠️ approve: 이슈 번호가 올바르지 않습니다.";
+        await addLabel(issue, ["implement-approved"]);
+        return `🏷️ *#${issue} implement-approved 라벨 추가*.`;
+      }
+      case "comment": {
+        const issue = Number(action.payload.issue);
+        const body = typeof action.payload.body === "string" ? action.payload.body : "";
+        if (!Number.isInteger(issue) || issue <= 0 || !body) return "⚠️ comment: 이슈 번호/본문이 올바르지 않습니다.";
+        await addIssueComment(issue, `🗣️ (CEO via Slack): ${body}`);
+        return `💬 *#${issue}에 코멘트 작성 완료*.`;
+      }
+      case "add_constraint": {
+        const rule = action.payload.rule;
+        if (typeof rule !== "string" || !rule) return "⚠️ add_constraint: rule 누락으로 실행하지 않았습니다.";
+        const sourceHint = `slack/${channel}/${threadTs || ""}`;
+        await triggerWorkflow("distill-constraints.yml", {
+          manual_constraint: JSON.stringify(action.payload),
+          source_hint: sourceHint,
+        });
+        const scope = Array.isArray(action.payload.scope) ? action.payload.scope.join(", ") : "all";
+        return `🔒 *Standing Constraint 추가 요청됨*: "${rule}" (scope: ${scope}). 리뷰 PR이 생성됩니다.`;
+      }
+      default:
+        return "";
+    }
+  } catch (e) {
+    return `⚠️ 액션(${action.name}) 실행 실패: ${e instanceof Error ? e.message : String(e)}`;
   }
 }

--- a/apps/web/lib/slack/actions.ts
+++ b/apps/web/lib/slack/actions.ts
@@ -1,0 +1,93 @@
+/**
+ * Slack Agent Track — Step 2 (행동 천장).
+ *
+ * 봇 답변에서 액션 토큰을 파싱한다. Groq(텍스트 모델)에서도 동작하는 tool-use 패턴.
+ * 형식:
+ *   [[ACTION:name]]              — 페이로드 없는 액션
+ *   [[ACTION:name]] {json}       — JSON 페이로드 (한 줄)
+ * 하위호환:
+ *   [[TRIGGER_IMPLEMENT]]        → implement
+ *   [[ADD_CONSTRAINT]]{json}     → add_constraint
+ *
+ * 순수 함수 — apps/web/__tests__ 에서 vitest 로 검증. 실행은 events/route.ts 가 담당.
+ */
+
+export type ActionName =
+  | "run_council"
+  | "implement"
+  | "merge"
+  | "approve"
+  | "comment"
+  | "add_constraint";
+
+export const KNOWN_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
+  "run_council",
+  "implement",
+  "merge",
+  "approve",
+  "comment",
+  "add_constraint",
+]);
+
+/** 비가역/고영향 — 실행 전 신중해야 하는 액션 */
+export const HIGH_IMPACT_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
+  "merge",
+  "implement",
+  "add_constraint",
+]);
+
+export interface ParsedAction {
+  name: ActionName;
+  payload: Record<string, unknown>;
+}
+
+export interface ParseResult {
+  actions: ParsedAction[];
+  /** 토큰을 제거한 사용자 표시용 텍스트 */
+  cleaned: string;
+}
+
+function safeJson(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const v: unknown = JSON.parse(raw);
+    return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * 답변 문자열에서 액션을 파싱하고 토큰을 제거한 cleaned 텍스트를 반환.
+ * 알 수 없는 액션 이름은 무시(실행 안 함).
+ */
+export function parseActions(reply: string): ParseResult {
+  const actions: ParsedAction[] = [];
+  let cleaned = reply;
+
+  // 1) 범용 [[ACTION:name]] {json}?
+  const actionRe = /\[\[ACTION:(\w+)\]\]\s*(\{[^\n]*\})?/g;
+  let m: RegExpExecArray | null;
+  while ((m = actionRe.exec(reply)) !== null) {
+    const name = m[1];
+    if (name && KNOWN_ACTIONS.has(name)) {
+      actions.push({ name: name as ActionName, payload: safeJson(m[2]) });
+    }
+  }
+  cleaned = cleaned.replace(actionRe, "").trim();
+
+  // 2) 하위호환: [[TRIGGER_IMPLEMENT]]
+  if (/\[\[TRIGGER_IMPLEMENT\]\]/.test(cleaned)) {
+    actions.push({ name: "implement", payload: {} });
+    cleaned = cleaned.replace(/\[\[TRIGGER_IMPLEMENT\]\]/g, "").trim();
+  }
+
+  // 3) 하위호환: [[ADD_CONSTRAINT]]{json}
+  const addC = cleaned.match(/\[\[ADD_CONSTRAINT\]\]\s*(\{[^\n]*\})/);
+  if (addC && addC[1]) {
+    actions.push({ name: "add_constraint", payload: safeJson(addC[1]) });
+    cleaned = cleaned.replace(/\[\[ADD_CONSTRAINT\]\]\s*\{[^\n]*\}/g, "").trim();
+  }
+
+  return { actions, cleaned };
+}

--- a/apps/web/lib/slack/github.ts
+++ b/apps/web/lib/slack/github.ts
@@ -51,6 +51,13 @@ export async function addLabel(issueNumber: number, labels: string[]) {
   });
 }
 
+export async function addIssueComment(issueNumber: number, body: string) {
+  return githubApi(`/repos/${REPO}/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+}
+
 export async function mergePR(prNumber: number) {
   return githubApi(`/repos/${REPO}/pulls/${prNumber}/merge`, {
     method: "PUT",


### PR DESCRIPTION
## Summary

Slack Agent Track **Step 2 (행동 천장)** — CEO가 대화로 지시하면 봇이 알맞은 동작을 골라 실행. 기존 `[[TRIGGER_IMPLEMENT]]` 단일 토큰을 범용 액션 체계로 확장.

- `lib/slack/actions.ts`: `parseActions` 순수 파서 — `[[ACTION:name]] {json}` 형식. 액션: `run_council`/`implement`/`merge`/`approve`/`comment`/`add_constraint`. **하위호환** `[[TRIGGER_IMPLEMENT]]`→implement, `[[ADD_CONSTRAINT]]{json}`→add_constraint
- `github.ts`: `addIssueComment(n, body)` 추가 (피드백 반영 1차 형태)
- `events/route.ts`: 분리돼 있던 토큰 핸들러 2개 → `executeAction` 통합 실행기. 코드 변경은 워크플로 경유(**main 직접 push 없음**), 잘못된 payload는 실행 안 함
- systemPrompt: 액션 목록 + tool-use 규칙. merge/implement/add_constraint(고영향)는 **명시적 실행 지시 시에만** 토큰, 애매하면 먼저 질문

## 동작 예
- "지금 의회 한 번 돌려" → council 실행
- "#298 채택 항목 구현 시작해" → auto-implement(날짜 자동)
- "이 PR(#291) 머지해" → squash 머지
- "#298에 '온보딩은 토스 스타일로' 코멘트 남겨줘" → 이슈 코멘트
- 단순 질문엔 액션 토큰이 안 나옴(오작동 방지)

## Test plan
- [x] `npx vitest run` — 266 passed (26 files; actions 10케이스: 파싱·페이로드·하위호환·미지액션 무시·잘못JSON 안전처리)
- [x] `npm run typecheck:web` + `npm run build:web` — 통과
- [ ] (수동) Slack에서 각 액션 실행 확인

Out of scope: Step 3(기억)/Step 4(자율) — 후속 PR. provider(Groq) 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)