### PR TITLE
feat(slack): 피드백 적재 + 스레드 넘은 기억 (Step 3)

### DIFF
--- a/apps/web/__tests__/slack-actions.test.ts
+++ b/apps/web/__tests__/slack-actions.test.ts
@@ -52,9 +52,18 @@ describe("parseActions", () => {
   });
 });
 
+describe("log_feedback 액션", () => {
+  it("note 페이로드 파싱", () => {
+    const r = parseActions('기억할게요 [[ACTION:log_feedback]] {"note":"온보딩은 토스 스타일 선호"}');
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0]!.name).toBe("log_feedback");
+    expect(r.actions[0]!.payload).toEqual({ note: "온보딩은 토스 스타일 선호" });
+  });
+});
+
 describe("액션 집합", () => {
-  it("KNOWN_ACTIONS 에 6개 포함", () => {
-    for (const a of ["run_council", "implement", "merge", "approve", "comment", "add_constraint"]) {
+  it("KNOWN_ACTIONS 에 7개 포함", () => {
+    for (const a of ["run_council", "implement", "merge", "approve", "comment", "add_constraint", "log_feedback"]) {
       expect(KNOWN_ACTIONS.has(a)).toBe(true);
     }
   });

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -13,6 +13,8 @@ import {
   mergePR,
   addLabel,
   addIssueComment,
+  appendFeedbackLog,
+  getRecentFeedbackLog,
 } from "@/lib/slack/github";
 import { classifyIntent, truncate } from "@/lib/slack/intent";
 import { parseActions, type ParsedAction } from "@/lib/slack/actions";
@@ -165,12 +167,15 @@ async function handleAgentChat(
     // ── Step 1: 의도 분류 → 필요한 데이터를 본문까지 깊게 로드 ──
     const intent = classifyIntent(question);
 
-    // 컨텍스트 수집 (병렬) — 항상 최신 CEO Brief 본문 + 오픈 PR/실행 상태
-    const [prs, latestBrief, runs] = await Promise.allSettled([
+    // 컨텍스트 수집 (병렬) — 항상 최신 CEO Brief 본문 + 오픈 PR/실행 상태 + 최근 피드백
+    const [prs, latestBrief, runs, feedbackLog] = await Promise.allSettled([
       getOpenPRs(5),
       getLatestCEOBrief(),
       getWorkflowRuns("auto-implement.yml", 5),
+      getRecentFeedbackLog(1500),
     ]);
+    const feedbackSection =
+      feedbackLog.status === "fulfilled" && feedbackLog.value ? feedbackLog.value : "(적재된 피드백 없음)";
 
     const prList = prs.status === "fulfilled"
       ? (prs.value as { number: number; title: string; html_url: string }[])
@@ -230,6 +235,9 @@ ${briefSection}
 ## 질문에서 언급된 이슈/PR 상세
 ${detailSection}
 
+## 최근 CEO 피드백 로그 (스레드 넘은 기억 — "어제 뭐라 했지?"에 답할 때 활용)
+${feedbackSection}
+
 ## 최근 auto-implement 실행
 ${runList || "(없음)"}
 
@@ -248,7 +256,9 @@ ${runList || "(없음)"}
   \`[[ACTION:approve]] {"issue":298}\` — 이슈에 implement-approved 라벨
   \`[[ACTION:comment]] {"issue":298,"body":"..."}\` — 이슈/PR에 코멘트 (= 피드백 반영의 1차 형태)
   \`[[ACTION:add_constraint]] {"rule":"...","scope":["all"],"kind":"prohibition","permanent":true}\` — 영구 규칙(standing constraint) 적재
+  \`[[ACTION:log_feedback]] {"note":"..."}\` — CEO의 피드백·방향·판정을 기억에 적재 (다음 Agent Council 입력에 반영)
 - JSON 페이로드는 반드시 한 줄. scope kind 는 정해진 값만.
+- CEO가 제품 방향·선호·평가("X는 별로", "Y 방향 좋아", "온보딩은 토스처럼")를 주면 log_feedback 으로 기억에 남긴다(영구 규칙까진 아닌 소프트 피드백). 영구 금지/규칙이면 add_constraint.
 - **단순 질문·요약·상태 확인·의견 요청에는 절대 토큰을 출력하지 마라.** 실행 의도가 명확할 때만.
 - merge/implement/add_constraint 는 비가역·고영향이다 — CEO가 명시적으로 그 동작을 지시했을 때만 토큰을 낸다. 애매하면 토큰 없이 "진행할까요?"라고 먼저 묻는다.
 - add_constraint 는 "앞으로 항상/절대" 류의 반복 규칙에만. 1회성 지시("오늘은 온보딩부터")엔 금지.`;
@@ -353,6 +363,12 @@ async function executeAction(
         });
         const scope = Array.isArray(action.payload.scope) ? action.payload.scope.join(", ") : "all";
         return `🔒 *Standing Constraint 추가 요청됨*: "${rule}" (scope: ${scope}). 리뷰 PR이 생성됩니다.`;
+      }
+      case "log_feedback": {
+        const note = typeof action.payload.note === "string" ? action.payload.note : "";
+        if (!note) return "⚠️ log_feedback: note 누락으로 적재하지 않았습니다.";
+        const res = await appendFeedbackLog(note);
+        return `🧠 *피드백 기억에 적재됨* (#${res.number}). 다음 Agent Council 사이클 입력에 반영됩니다.`;
       }
       default:
         return "";

--- a/apps/web/lib/slack/actions.ts
+++ b/apps/web/lib/slack/actions.ts
@@ -18,7 +18,8 @@ export type ActionName =
   | "merge"
   | "approve"
   | "comment"
-  | "add_constraint";
+  | "add_constraint"
+  | "log_feedback";
 
 export const KNOWN_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
   "run_council",
@@ -27,6 +28,7 @@ export const KNOWN_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
   "approve",
   "comment",
   "add_constraint",
+  "log_feedback",
 ]);
 
 /** 비가역/고영향 — 실행 전 신중해야 하는 액션 */

--- a/apps/web/lib/slack/github.ts
+++ b/apps/web/lib/slack/github.ts
@@ -163,6 +163,60 @@ export async function getPR(n: number): Promise<{
   };
 }
 
+// ── Step 3 (기억 천장): CEO 피드백 로그 적재/조회 ──────────────────
+// prepare 가 읽는 feedback-log 라벨 이슈에 누적 → 다음 Agent Council 사이클에 자동 반영.
+const FEEDBACK_LOG_TITLE = "[Slack] CEO Feedback Log";
+
+interface IssueLite {
+  number: number;
+  title: string;
+  body: string | null;
+}
+
+async function findFeedbackLogIssue(): Promise<IssueLite | undefined> {
+  const issues = (await githubApi(
+    `/repos/${REPO}/issues?labels=feedback-log&state=open&per_page=30&sort=created&direction=desc`
+  )) as IssueLite[];
+  return issues.find((i) => i.title === FEEDBACK_LOG_TITLE);
+}
+
+/** CEO 피드백을 rolling feedback-log 이슈 본문에 누적 (최근 40개 유지). */
+export async function appendFeedbackLog(note: string): Promise<{ number: number }> {
+  const date = new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+  const entry = `- [${date}] ${note.replace(/\n/g, " ").trim()}`;
+  const existing = await findFeedbackLogIssue();
+  if (existing) {
+    const lines = (existing.body ?? "")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith("- ["));
+    lines.push(entry);
+    const capped = lines.slice(-40).join("\n");
+    await githubApi(`/repos/${REPO}/issues/${existing.number}`, {
+      method: "PATCH",
+      body: JSON.stringify({ body: `# Slack CEO 피드백 로그\n\n${capped}` }),
+    });
+    return { number: existing.number };
+  }
+  const created = (await githubApi(`/repos/${REPO}/issues`, {
+    method: "POST",
+    body: JSON.stringify({
+      title: FEEDBACK_LOG_TITLE,
+      body: `# Slack CEO 피드백 로그\n\n${entry}`,
+      labels: ["feedback-log"],
+    }),
+  })) as { number: number };
+  return { number: created.number };
+}
+
+/** 최근 적재된 CEO 피드백 (스레드 넘은 컨텍스트용). */
+export async function getRecentFeedbackLog(maxChars = 1500): Promise<string> {
+  const existing = await findFeedbackLogIssue();
+  if (!existing || !existing.body) return "";
+  const body = existing.body;
+  return body.length > maxChars ? body.slice(body.length - maxChars) : body;
+}
+
 export async function getFileContent(path: string): Promise<string> {
   const res = (await githubApi(
     `/repos/${REPO}/contents/${path}`


### PR DESCRIPTION
## Summary

Slack Agent Track **Step 3 (기억 천장)** — 스레드를 넘어 CEO 대화·피드백·결정이 누적된다. "데이터 적재"의 실체. **option B**(feedback-log 이슈 → 다음 Agent Council 입력 자동 합류) 채택 — 즉효.

- `github.ts`: `appendFeedbackLog(note)` — rolling `[Slack] CEO Feedback Log` 이슈(`feedback-log` 라벨) 본문에 날짜별 누적(최근 40개 유지). `prepare`가 이미 읽는 채널이라 다음 사이클 에이전트가 자동으로 본다. `getRecentFeedbackLog()` 조회
- `actions.ts`: `log_feedback` 액션 추가
- `events/route.ts`: `log_feedback` executeAction 처리 + 컨텍스트에 최근 피드백 로그 주입("내가 어제 온보딩 관련 뭐라 했지?" 응답 가능) + systemPrompt 규칙(소프트 피드백→log_feedback, 영구 규칙→add_constraint 구분)

## 동작
- 스레드에서 "온보딩은 토스 스타일 선호" → `log_feedback`으로 적재 + 다음 council 반영
- 새 스레드에서 "어제 뭐라고 했지?" → 적재된 피드백 기반 답변

## Test plan
- [x] `npx vitest run` — 267 passed (log_feedback 파싱 + KNOWN_ACTIONS 7개)
- [x] `npm run typecheck:web` + `npm run build:web` — 통과
- [ ] (수동) Slack 피드백 → feedback-log 이슈 누적 확인 → 새 스레드 회상

Phase 2(standing constraints)와 자연 합류: 소프트 피드백 누적 → 반복되면 constraint로 distill. Out of scope: Step 4(자율·푸시) — 다음 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)