### PR TITLE
feat(slack): CEO Brief 본문 자동 푸시 + weekly 회고 (Step 4)

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: read
 
 jobs:
   notify:
@@ -105,7 +106,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
-      # ── Daily Agent Council 완료 ────────────────────────────
+      # ── Daily Agent Council 완료: CEO Brief 본문 요약 푸시 (Step 4) ──
       - name: Council completed
         if: |
           github.event_name == 'workflow_run' &&
@@ -114,19 +115,28 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "$CONCLUSION" = "success" ]; then
-            PAYLOAD=$(jq -n \
-              --arg text "📋 *Daily Agent Council 완료*\nCEO Brief 이슈가 생성되었습니다. Auto-implement가 곧 실행됩니다.\n>${RUN_URL}" \
-              '{"text": $text}')
-          else
-            PAYLOAD=$(jq -n \
-              --arg text "⚠️ *Daily Agent Council 실패*\n>${RUN_URL}" \
-              '{"text": $text}')
+          set -uo pipefail
+          if [ "$CONCLUSION" != "success" ]; then
+            jq -n --arg t "⚠️ *Daily Agent Council 실패*\n>${RUN_URL}" '{"text": $t}' > /tmp/payload.json
+            curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/payload.json
+            exit 0
           fi
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
+          # 최신 CEO Brief 본문을 단일 jq 패스로 Slack 페이로드화 (재파싱·개행 이슈 회피)
+          gh issue list --label "ceo-brief" --state all --limit 1 \
+            --json number,title,body,url --repo "${{ github.repository }}" 2>/dev/null \
+            | jq --arg run "$RUN_URL" '
+                (.[0] // null) as $b
+                | if $b == null
+                  then {text: ("📋 *Daily Agent Council 완료* — CEO Brief 생성됨.\n>" + $run)}
+                  else {text: (
+                    "📋 *CEO Daily Brief #\($b.number)*\n" + $b.title + "\n" + $b.url + "\n\n"
+                    + (($b.body // "") | gsub("\\|"; "") | .[0:1800])
+                    + "\n\n_… 전체는 GitHub 이슈에서. 피드백은 이 스레드에 @봇 멘션으로._"
+                  )}
+                  end' > /tmp/payload.json
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/payload.json
 
       # ── Auto Implement 완료 ─────────────────────────────────
       - name: Auto implement completed

--- a/.github/workflows/slack-retro.yml
+++ b/.github/workflows/slack-retro.yml
@@ -1,0 +1,51 @@
+name: Slack Weekly Retro
+
+# weekly — 봇이 회고 스레드를 먼저 연다 (Slack Agent Track Step 4 / 6.3).
+# 지난주 머지/킬/제안/constraint 통계 + CEO에게 질문. CEO가 스레드에 답하면
+# 기존 thread-reply 핸들러(handleAgentChat)가 응답하고 log_feedback 으로 적재됨.
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"  # 매주 월요일 오전 9시 KST (UTC 월 00:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  retro:
+    runs-on: ubuntu-latest
+    if: vars.SLACK_WEBHOOK_URL != ''
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build + push weekly retro
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          SINCE=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-7d '+%Y-%m-%dT%H:%M:%SZ')
+          REPO="${{ github.repository }}"
+
+          # 지난주 머지된 PR 수
+          MERGED=$(gh pr list --state merged --limit 50 --json mergedAt,title --repo "$REPO" 2>/dev/null \
+            | jq --arg s "$SINCE" '[.[] | select(.mergedAt >= $s)] | length')
+          # 지난주 닫힌 agent-council 이슈 수
+          CLOSED=$(gh issue list --label "agent-council" --state closed --limit 50 --json closedAt --repo "$REPO" 2>/dev/null \
+            | jq --arg s "$SINCE" '[.[] | select(.closedAt >= $s)] | length')
+          # 현재 열린 제안 수
+          OPEN=$(gh issue list --label "agent-council" --state open --limit 50 --json number --repo "$REPO" 2>/dev/null | jq 'length')
+          # active constraint 수
+          if [ -f constraints/active.json ]; then
+            CONS=$(jq '.constraints | length' constraints/active.json 2>/dev/null || echo 0)
+          else
+            CONS=0
+          fi
+
+          MERGED=${MERGED:-0}; CLOSED=${CLOSED:-0}; OPEN=${OPEN:-0}; CONS=${CONS:-0}
+
+          TEXT="🔄 *주간 회고* (지난 7일)\n• 머지된 PR: *${MERGED}*\n• 처리/폐기된 제안 이슈: *${CLOSED}*\n• 현재 열린 제안: *${OPEN}*\n• 등록된 standing constraints: *${CONS}*\n\n*CEO께 질문:*\n1. 이번 주 가장 잘된 것 / 막힌 것은?\n2. 다음 주 우선순위 방향은? (이 스레드에 답하면 기억에 적재됩니다 — @봇 멘션)"
+          PAYLOAD=$(jq -n --arg text "$TEXT" '{"text": $text}')
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"


### PR DESCRIPTION
## Summary

Slack Agent Track **Step 4 (자율·능동)** — 봇이 *먼저* 말을 건다. 수동 응답 → 능동 협업.

- **6.1 CEO Brief 푸시**: `slack-notify.yml`의 "Council completed"가 기존엔 "이슈 생성됨"만 알렸는데, 이제 최신 CEO Brief **본문 요약**을 Slack에 자동 푸시. 스크린샷의 "깃허브 브리핑을 슬랙으로도 받고 싶다" 니즈 직접 해결. 단일 jq 패스로 페이로드 생성(재파싱·개행 이슈 회피), `issues:read` 권한 추가.
- **6.3 weekly 회고**: `slack-retro.yml`(신규) — 매주 월요일 봇이 회고 스레드를 먼저 연다. 지난주 머지 PR/처리된 제안/열린 제안/active constraint 통계 + CEO 질문 2개. CEO가 스레드에 답하면 기존 thread-reply 핸들러가 응답하고 `log_feedback`(Step 3)으로 적재.

기존 webhook(`vars.SLACK_WEBHOOK_URL`) 재사용 — 미설정 시 `if`로 graceful no-op.

## Test plan
- [x] 두 워크플로 YAML 유효성 검증
- [x] 단일 jq 페이로드 생성 로컬 검증(유효 JSON·개행·파이프 처리)
- [x] TS 무변경 → 기존 게이트(typecheck/build/vitest 267) 영향 없음
- [ ] (수동) council 실행 → Slack 본문 요약 푸시 확인 / weekly retro 트리거

Out of scope: 6.2 능동 clarify(브리핑 중 봇이 먼저 질문)는 Phase 3 drift 감지 표면으로 이관. provider(Groq) 유지.

Slack Agent Track 4단계(읽기→행동→기억→자율) 완료 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)