### PR TITLE
fix(slack): workflow dispatch 204 처리 + 개발 인텐트 강화

### DIFF
--- a/apps/web/__tests__/slack-github-response.test.ts
+++ b/apps/web/__tests__/slack-github-response.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { parseGitHubResponse } from "@/lib/slack/github";
+
+describe("parseGitHubResponse", () => {
+  it("204 No Content → null (workflow dispatch 성공 케이스)", async () => {
+    const res = new Response(null, { status: 204 });
+    expect(await parseGitHubResponse(res)).toBeNull();
+  });
+
+  it("205 → null", async () => {
+    const res = new Response(null, { status: 205 });
+    expect(await parseGitHubResponse(res)).toBeNull();
+  });
+
+  it("200 + 빈 본문 → null (Unexpected end of JSON input 방지)", async () => {
+    const res = new Response("", { status: 200 });
+    expect(await parseGitHubResponse(res)).toBeNull();
+  });
+
+  it("200 + 공백 본문 → null", async () => {
+    const res = new Response("   \n  ", { status: 200 });
+    expect(await parseGitHubResponse(res)).toBeNull();
+  });
+
+  it("200 + 유효 JSON → 파싱된 객체", async () => {
+    const res = new Response(JSON.stringify({ number: 291, title: "x" }), { status: 200 });
+    expect(await parseGitHubResponse(res)).toEqual({ number: 291, title: "x" });
+  });
+
+  it("200 + JSON 배열 → 배열", async () => {
+    const res = new Response(JSON.stringify([{ a: 1 }]), { status: 200 });
+    expect(await parseGitHubResponse(res)).toEqual([{ a: 1 }]);
+  });
+});

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -259,8 +259,15 @@ ${runList || "(없음)"}
   \`[[ACTION:log_feedback]] {"note":"..."}\` — CEO의 피드백·방향·판정을 기억에 적재 (다음 Agent Council 입력에 반영)
 - JSON 페이로드는 반드시 한 줄. scope kind 는 정해진 값만.
 - CEO가 제품 방향·선호·평가("X는 별로", "Y 방향 좋아", "온보딩은 토스처럼")를 주면 log_feedback 으로 기억에 남긴다(영구 규칙까진 아닌 소프트 피드백). 영구 금지/규칙이면 add_constraint.
-- **단순 질문·요약·상태 확인·의견 요청에는 절대 토큰을 출력하지 마라.** 실행 의도가 명확할 때만.
-- merge/implement/add_constraint 는 비가역·고영향이다 — CEO가 명시적으로 그 동작을 지시했을 때만 토큰을 낸다. 애매하면 토큰 없이 "진행할까요?"라고 먼저 묻는다.
+
+**개발/구현 실행 트리거 (자주 쓰임 — 반드시 정확히 인식)**:
+- 다음과 같은 발화는 **개발 실행 지시**다 → 반드시 \`[[ACTION:implement]]\` 토큰을 출력한다(거의 항상 date 생략 = 오늘 브리핑 구현):
+  "개발해", "개발 진행해", "개발진행해", "구현해", "구현 시작", "만들어줘", "진행해", "이거 개발해줘", "우선순위 개발해", "리스트 개발하고 알려줘", "오늘 브리핑 구현해".
+- 위 발화에 "리스트", "우선순위", "알려줘" 같은 단어가 섞여 있어도 **'개발/구현/진행' 동사가 있으면 실행 지시**다. 단순 조회로 오해하지 마라. (예: "오늘 처리 우선순위 리스트 개발하고 알려줘" = implement 실행 + 진행 상황 안내)
+- 답변엔 "개발(auto-implement)을 시작하겠다"는 한 문장 + 토큰만. 우선순위를 또 길게 나열하지 마라.
+
+- **순수 조회·요약·상태 확인·의견 질문**("브리핑 알려줘", "PR 뭐 있어", "상태 어때")에는 토큰을 내지 않는다.
+- merge/add_constraint 는 비가역·고영향 — CEO가 그 동작을 명시했을 때만. 정말 애매하면 토큰 없이 "구현을 시작할까요?"라고 한 번만 되묻는다(단, '개발/구현/진행' 동사가 있으면 되묻지 말고 바로 implement).
 - add_constraint 는 "앞으로 항상/절대" 류의 반복 규칙에만. 1회성 지시("오늘은 온보딩부터")엔 금지.`;
 
     const res = await fetch(AI_URL, {
@@ -330,7 +337,9 @@ async function executeAction(
         return "🗳️ *Agent Council 실행* — 잠시 후 제안 이슈들이 생성됩니다.";
       }
       case "implement": {
-        const date = typeof action.payload.date === "string" ? action.payload.date : kstDate();
+        const raw = action.payload.date;
+        // 유효한 YYYY-MM-DD 만 사용, 아니면(placeholder 포함) 오늘 KST
+        const date = typeof raw === "string" && /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : kstDate();
         await triggerWorkflow("auto-implement.yml", { brief_date: date });
         return `🚀 *auto-implement 실행* (날짜: ${date}). 진행은 \`@봇 status\`로 확인하세요.`;
       }

--- a/apps/web/lib/slack/github.ts
+++ b/apps/web/lib/slack/github.ts
@@ -1,6 +1,19 @@
 const GITHUB_PAT = process.env.GITHUB_PAT;
 const REPO = process.env.GITHUB_REPO || "mlender-ai/taro-stock-app";
 
+/**
+ * GitHub 응답을 안전하게 파싱.
+ * workflow dispatch 등 일부 엔드포인트는 성공 시 204 No Content(빈 본문)를 반환한다.
+ * 그때 res.json() 을 부르면 "Unexpected end of JSON input" 으로 터지므로
+ * 204/205/빈 본문은 null 을 반환한다. (순수 함수 — vitest 로 검증)
+ */
+export async function parseGitHubResponse(res: Response): Promise<unknown> {
+  if (res.status === 204 || res.status === 205) return null;
+  const text = await res.text();
+  if (!text || !text.trim()) return null;
+  return JSON.parse(text);
+}
+
 async function githubApi(path: string, options?: RequestInit) {
   if (!GITHUB_PAT) throw new Error("GITHUB_PAT not configured");
 
@@ -19,7 +32,7 @@ async function githubApi(path: string, options?: RequestInit) {
     throw new Error(`GitHub API ${res.status}: ${text}`);
   }
 
-  return res.json();
+  return parseGitHubResponse(res);
 }
 
 export async function triggerWorkflow(
@@ -85,8 +98,10 @@ export async function getPRFiles(prNumber: number) {
 export async function getMergedPRs(since: string, limit = 20) {
   return githubApi(
     `/repos/${REPO}/pulls?state=closed&per_page=${limit}&sort=updated&direction=desc`
-  ).then((prs: Array<{ merged_at: string | null; [key: string]: unknown }>) =>
-    prs.filter((pr) => pr.merged_at && pr.merged_at > since)
+  ).then((v) =>
+    (v as Array<{ merged_at: string | null; [key: string]: unknown }>).filter(
+      (pr) => pr.merged_at && pr.merged_at > since
+    )
   );
 }
 
@@ -228,7 +243,9 @@ export async function getFileContent(path: string): Promise<string> {
 export async function getRecentIssues(label: string, since: string, limit = 20) {
   return githubApi(
     `/repos/${REPO}/issues?labels=${encodeURIComponent(label)}&state=all&per_page=${limit}&sort=created&direction=desc`
-  ).then((issues: Array<{ created_at: string; [key: string]: unknown }>) =>
-    issues.filter((i) => i.created_at > since)
+  ).then((v) =>
+    (v as Array<{ created_at: string; [key: string]: unknown }>).filter(
+      (i) => i.created_at > since
+    )
   );
 }


### PR DESCRIPTION
## Summary

Slack에서 "개발진행해" 지시가 `⚠️ 액션(implement) 실행 실패: Unexpected end of JSON input`으로 실패하던 버그 + 개발 명령을 조회로 오해하던 맥락 문제를 함께 수정.

### 버그 1 — dispatch 204 (근본 원인)
GitHub의 **Create workflow dispatch** 엔드포인트는 성공 시 **204 No Content**(빈 본문)를 반환하는데, `githubApi`가 `res.json()`을 무조건 호출 → 빈 본문에서 `Unexpected end of JSON input` throw. `triggerWorkflow`를 쓰는 **implement / run_council / add_constraint 전부** 같은 증상(워크플로는 실제로 트리거됐는데 봇만 실패로 보고).
- `parseGitHubResponse` 순수 함수 분리: 204/205/빈 본문 → `null`. vitest 6케이스.
- `getMergedPRs`/`getRecentIssues`의 `.then` 타입 캐스팅 보정(`githubApi`가 `unknown` 반환).

### 버그 2 — 개발 인텐트 오해
"오늘 처리 우선순위 리스트 **개발하고** 알려줘" → 봇이 리스트만 나열(개발 안 함). systemPrompt 강화:
- 개발/구현/진행/만들어 류 동사 발화는 **implement 실행 지시**로 인식. "리스트/우선순위/알려줘"가 섞여도 개발 동사가 있으면 implement.
- 실행 시 우선순위 재나열 금지, "개발 시작" 한 문장 + 토큰만.
- implement `date` 검증 강화(YYYY-MM-DD 아니면 오늘 KST — placeholder 방지).

## Test plan
- [x] `npx vitest run` — 273 passed (26 files; parseGitHubResponse 6케이스: 204/205/빈본문/공백→null, 유효 JSON·배열 파싱)
- [x] `npm run typecheck:web` + `npm run build:web` — 통과
- [ ] (수동) Slack "개발진행해" → auto-implement 실행 성공 메시지 / "의회 돌려" → run_council 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)