### PR TITLE
feat(council): 폐루프화 — distill 자동화 + 위반 게이트 + hits 가시화 (Phase 2.5)

### DIFF
--- a/.github/workflows/autonomy-report.yml
+++ b/.github/workflows/autonomy-report.yml
@@ -108,6 +108,45 @@ jobs:
           echo "$FEATURES" >> "$GITHUB_OUTPUT"
           echo "__FEAT_EOF__" >> "$GITHUB_OUTPUT"
 
+      # ── 2.5 Standing Constraint 효과 지표 (Phase 2.5 — "규칙이 일한다"를 숫자로) ──
+      - name: Collect constraint metrics
+        id: constraints
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          ACTIVE=0
+          if [ -f constraints/active.json ]; then ACTIVE=$(jq '.constraints | length' constraints/active.json 2>/dev/null || echo 0); fi
+          SINCE_DATE=$(TZ=Asia/Seoul date -d '7 days ago' '+%Y-%m-%d' 2>/dev/null || TZ=Asia/Seoul date -v-7d '+%Y-%m-%d')
+
+          # 이번 주 막은 제안 수 + 상위 규칙 (generated/constraint-hits/<date>.json 이벤트 로그 합산)
+          HITS_WEEK=0; TOP="(없음)"
+          WEEK_FILES=""
+          if ls generated/constraint-hits/*.json >/dev/null 2>&1; then
+            for f in generated/constraint-hits/*.json; do
+              b=$(basename "$f" .json)
+              if [ "$b" \> "$SINCE_DATE" ] || [ "$b" = "$SINCE_DATE" ]; then WEEK_FILES="$WEEK_FILES $f"; fi
+            done
+            if [ -n "$WEEK_FILES" ]; then
+              HITS_WEEK=$(jq -s 'reduce .[] as $m (0; . + ([$m[]] | add // 0))' $WEEK_FILES 2>/dev/null || echo 0)
+            fi
+            TOP=$(jq -s 'reduce .[] as $m ({}; reduce ($m|to_entries[]) as $e (.; .[$e.key] += $e.value)) | to_entries | sort_by(-.value) | .[0:3] | map("\(.key)(\(.value))") | join(", ")' generated/constraint-hits/*.json 2>/dev/null || echo "(없음)")
+            [ -z "$TOP" ] && TOP="(없음)"
+          fi
+
+          # 이번 주 신규 constraint 후보 PR (distill) + 리뷰 대기
+          NEW_PRS=$(gh pr list --label "constraints" --state all --limit 30 --json createdAt --repo "${{ github.repository }}" 2>/dev/null \
+            | jq --arg s "${SINCE_DATE}T00:00:00Z" '[.[] | select(.createdAt >= $s)] | length' || echo 0)
+          REVIEW_PENDING=$(gh pr list --label "needs-ceo-review" --state open --limit 30 --json number --repo "${{ github.repository }}" 2>/dev/null | jq 'length' || echo 0)
+
+          echo "active=$ACTIVE" >> "$GITHUB_OUTPUT"
+          echo "hits_week=${HITS_WEEK:-0}" >> "$GITHUB_OUTPUT"
+          echo "new_prs=${NEW_PRS:-0}" >> "$GITHUB_OUTPUT"
+          echo "review_pending=${REVIEW_PENDING:-0}" >> "$GITHUB_OUTPUT"
+          echo "top<<__TOP_EOF__" >> "$GITHUB_OUTPUT"
+          echo "$TOP" >> "$GITHUB_OUTPUT"
+          echo "__TOP_EOF__" >> "$GITHUB_OUTPUT"
+
       # ── 3. Slack 리포트 전송 ────────────────────────────────────
       - name: Send weekly report
         env:
@@ -118,6 +157,11 @@ jobs:
           IMPL_RUNS: ${{ steps.metrics.outputs.impl_runs }}
           SUCCESS_RATE: ${{ steps.metrics.outputs.success_rate }}
           FEATURES: ${{ steps.features.outputs.features }}
+          C_ACTIVE: ${{ steps.constraints.outputs.active }}
+          C_HITS_WEEK: ${{ steps.constraints.outputs.hits_week }}
+          C_NEW_PRS: ${{ steps.constraints.outputs.new_prs }}
+          C_REVIEW_PENDING: ${{ steps.constraints.outputs.review_pending }}
+          C_TOP: ${{ steps.constraints.outputs.top }}
         run: |
           WEEK_START=$(TZ=Asia/Seoul date -d '7 days ago' '+%m/%d' 2>/dev/null || \
                       TZ=Asia/Seoul date -v-7d '+%m/%d')
@@ -132,20 +176,29 @@ jobs:
             RATE_EMOJI="🔴"
           fi
 
-          MESSAGE="📊 *주간 자율 운영 리포트* (${WEEK_START} ~ ${WEEK_END})
+          # 메시지를 printf 로 조립(YAML 블록 안 들여쓰기 정상화 — 멀티라인 리터럴 회피)
+          MESSAGE=$(printf '%s\n' \
+            "📊 *주간 자율 운영 리포트* (${WEEK_START} ~ ${WEEK_END})" \
+            "" \
+            "*이번 주 자율 파이프라인 요약:*" \
+            "• 📋 CEO Brief 생성: ${CEO_BRIEFS}건" \
+            "• 🤖 Auto PR 생성: ${PRS_CREATED}건" \
+            "• ✅ Auto PR 머지: ${PRS_MERGED}건" \
+            "• ⚙️ 파이프라인 실행: ${IMPL_RUNS}회" \
+            "• ${RATE_EMOJI} 성공률: ${SUCCESS_RATE}%" \
+            "" \
+            "*머지된 기능:*" \
+            "${FEATURES}" \
+            "" \
+            "*🔒 Standing Constraints (CEO와의 싱크):*" \
+            "• 활성 규칙: ${C_ACTIVE}개" \
+            "• 이번 주 사전 차단한 제안: *${C_HITS_WEEK}건* — 그만큼 CEO가 같은 피드백을 반복하지 않아도 됐습니다" \
+            "• 자주 작동한 규칙: ${C_TOP}" \
+            "• 이번 주 새로 학습한 규칙 후보(PR): ${C_NEW_PRS}건 / 리뷰 대기: ${C_REVIEW_PENDING}건" \
+            "" \
+            "_Hermes 자율 루프 — CEO 개입 없이 자동 운영 중_")
 
-*이번 주 자율 파이프라인 요약:*
-• 📋 CEO Brief 생성: ${CEO_BRIEFS}건
-• 🤖 Auto PR 생성: ${PRS_CREATED}건
-• ✅ Auto PR 머지: ${PRS_MERGED}건
-• ⚙️ 파이프라인 실행: ${IMPL_RUNS}회
-• ${RATE_EMOJI} 성공률: ${SUCCESS_RATE}%
-
-*머지된 기능:*
-${FEATURES}
-
-_Hermes 자율 루프 — CEO 개입 없이 자동 운영 중_"
-
+          jq -n --arg text "$MESSAGE" '{"text": $text}' > /tmp/report_payload.json
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{\"text\": $(echo "$MESSAGE" | jq -Rs .)}"
+            -d @/tmp/report_payload.json

--- a/.github/workflows/distill-constraints.yml
+++ b/.github/workflows/distill-constraints.yml
@@ -15,6 +15,11 @@ on:
         description: "source 표기 (예: slack/<channel>/<ts>)"
         required: false
         default: ""
+  # 고리1 (Phase 2.5): Daily Agent Council(=CEO Brief 생성) 성공 후 자동 distill.
+  # 후보 0건이면 PR 미생성(조용히 종료), 중복 후보는 add dedup 가 거름(멱등).
+  workflow_run:
+    workflows: ["Daily Agent Council"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -29,6 +34,8 @@ concurrency:
 jobs:
   distill:
     runs-on: ubuntu-latest
+    # workflow_run 으로 트리거되면 성공한 경우에만 (실패 브리핑은 distill 안 함). 수동은 항상 허용.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write  # score_and_filter 가 constraint hits 파일을 커밋(Phase 2.5)
   issues: write
   models: read
 
@@ -1741,9 +1741,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Parse scores and label/close
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Parse scores + constraint 위반 게이트 (Phase 2.5)
         env:
           GH_TOKEN: ${{ github.token }}
+          TODAY: ${{ needs.prepare.outputs.today }}
         run: |
           set -uo pipefail
           # 오늘 생성된 agent-council 라벨 open 이슈만 (24시간 이내)
@@ -1760,14 +1765,14 @@ jobs:
           COUNT=$(jq 'length' /tmp/issues.json)
           echo "Found $COUNT today's open agent-council issues"
 
-          STRONG=0
-          CONDITIONAL=0
-          CLOSED=0
-          MISSING=0
+          # lane 파생 jq (Phase 0/1 과 동일 규칙)
+          LANEJQ='([.labels[].name] - ["idea","agent-council","mobile","tech-debt","daily","score-strong","score-conditional","score-missing","constraint-violation"]) | (.[0] // "unknown")'
+          : > /tmp/violated_ids.txt   # 위반 constraint id 누적(파일 — 서브셸 안전)
 
           jq -c '.[]' /tmp/issues.json | while read -r issue; do
             NUM=$(echo "$issue" | jq -r '.number')
-            BODY=$(echo "$issue" | jq -r '.body')
+            echo "$issue" | jq -r '.body' > /tmp/body.txt
+            LANE=$(echo "$issue" | jq -r "$LANEJQ")
 
             # 이미 점수 라벨이 있으면 skip (재실행 안전성)
             HAS_LABEL=$(echo "$issue" | jq -r '.labels[].name' | grep -E 'score-(strong|conditional|missing)' || true)
@@ -1776,15 +1781,30 @@ jobs:
               continue
             fi
 
+            # ── Standing Constraint 위반 게이트 (고리 3, 결정론) ──
+            VIOL=$(npx -y tsx@4.19.2 scripts/constraints.ts check constraints/active.json "$LANE" /tmp/body.txt "$TODAY" 2>/dev/null || echo "[]")
+            if [ "$(echo "$VIOL" | jq 'length')" -gt 0 ]; then
+              RULE=$(echo "$VIOL" | jq -r '.[0].rule')
+              MATCHED=$(echo "$VIOL" | jq -r '[.[].matched] | join(", ")')
+              echo "$VIOL" | jq -r '.[].id' >> /tmp/violated_ids.txt
+              printf '%s\n' \
+                "⛔ Standing Constraint 위반 — 자동 폐기. 매칭: \`${MATCHED}\`" \
+                "> ${RULE}" \
+                "이 영역은 CEO가 확정한 규칙으로 금지됩니다. 규칙이 부당하면 constraints/active.json 리뷰 PR로 조정하세요." > /tmp/viol_comment.md
+              gh issue edit "$NUM" --add-label "constraint-violation,score-missing" --repo "${{ github.repository }}" || true
+              gh issue comment "$NUM" --repo "${{ github.repository }}" --body-file /tmp/viol_comment.md || true
+              gh issue close "$NUM" --repo "${{ github.repository }}" || true
+              continue
+            fi
+
             # 점수 파싱 — "Score: U=X F=Y N=Z A=W" 형식
-            SCORE_LINE=$(echo "$BODY" | grep -oE 'Score:[[:space:]]*U=[1-4][[:space:]]+F=[1-4][[:space:]]+N=[1-4][[:space:]]+A=[1-4]' | head -1 || true)
+            SCORE_LINE=$(grep -oE 'Score:[[:space:]]*U=[1-4][[:space:]]+F=[1-4][[:space:]]+N=[1-4][[:space:]]+A=[1-4]' /tmp/body.txt | head -1 || true)
 
             if [ -z "$SCORE_LINE" ]; then
               echo "#$NUM: 점수 형식 누락"
               gh issue edit "$NUM" --add-label "score-missing" --repo "${{ github.repository }}" || true
               gh issue comment "$NUM" --repo "${{ github.repository }}" \
                 --body "🤖 자동 점수 시스템: 본문에서 \`Score: U=X F=Y N=Z A=W\` 형식을 찾지 못했습니다. system-prompt 출력 가이드 확인 필요." || true
-              MISSING=$((MISSING+1))
               continue
             fi
 
@@ -1794,28 +1814,44 @@ jobs:
             A=$(echo "$SCORE_LINE" | grep -oE 'A=[1-4]' | grep -oE '[1-4]')
             TOTAL=$((U + F + N + A))
 
-            echo "#$NUM: U=$U F=$F N=$N A=$A 총합 $TOTAL"
+            echo "#$NUM: U=$U F=$F N=$N A=$A 총합 $TOTAL (lane=$LANE)"
 
             if [ "$TOTAL" -ge 14 ]; then
               gh issue edit "$NUM" --add-label "score-strong" --repo "${{ github.repository }}" || true
-              STRONG=$((STRONG+1))
             elif [ "$TOTAL" -ge 11 ]; then
               gh issue edit "$NUM" --add-label "score-conditional" --repo "${{ github.repository }}" || true
-              CONDITIONAL=$((CONDITIONAL+1))
             else
               gh issue comment "$NUM" --repo "${{ github.repository }}" \
                 --body "🤖 자동 점수 시스템: 총합 ${TOTAL}/16점 (U=$U F=$F N=$N A=$A). 임계값(11) 미달로 자동 폐기. 점수가 부당하다고 판단되면 이슈를 재개해 주세요." || true
               gh issue close "$NUM" --repo "${{ github.repository }}" || true
-              CLOSED=$((CLOSED+1))
             fi
           done
 
-          echo "---"
-          echo "## Daily scoring summary"
-          echo "- score-strong (≥14): $STRONG"
-          echo "- score-conditional (11-13): $CONDITIONAL"
-          echo "- auto-closed (≤10): $CLOSED"
-          echo "- score-missing: $MISSING"
+          # ── hits 집계 → generated/constraint-hits/<TODAY>.json (충돌 회피: 주간 compact 가 합산) ──
+          if [ -s /tmp/violated_ids.txt ]; then
+            mkdir -p generated/constraint-hits
+            sort /tmp/violated_ids.txt | uniq -c | \
+              jq -Rn '[inputs | ltrimstr(" ") | capture("(?<n>[0-9]+) +(?<id>.+)") | {(.id): (.n|tonumber)}] | add // {}' \
+              > "generated/constraint-hits/${TODAY}.json"
+            echo "constraint hits 기록:"; cat "generated/constraint-hits/${TODAY}.json"
+          else
+            echo "이번 사이클 constraint 위반 없음."
+          fi
+      - name: Commit constraint hits
+        if: always()
+        env:
+          TODAY: ${{ needs.prepare.outputs.today }}
+        run: |
+          set -uo pipefail
+          FILE="generated/constraint-hits/${TODAY}.json"
+          [ -f "$FILE" ] || { echo "hits 파일 없음 — 커밋 생략"; exit 0; }
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$FILE"
+          git diff --cached --quiet && { echo "변경 없음"; exit 0; }
+          git commit -m "chore(constraints): bump hits ${TODAY} [skip ci]"
+          # 동시 push 충돌 시 rebase 후 1회 재시도(보수적 — 실패해도 다음 사이클이 합산)
+          git push origin HEAD:main || { git pull --rebase origin main && git push origin HEAD:main || echo "push 실패 — 다음 사이클로 미룸"; }
 
   ceo_brief:
     needs: [prepare, pm, frontend, backend, designer, qa, cto, marketer, security, prompt_engineer, score_and_filter]

--- a/.github/workflows/slack-retro.yml
+++ b/.github/workflows/slack-retro.yml
@@ -44,8 +44,29 @@ jobs:
             CONS=0
           fi
 
-          MERGED=${MERGED:-0}; CLOSED=${CLOSED:-0}; OPEN=${OPEN:-0}; CONS=${CONS:-0}
+          # Standing Constraint 효과 (Phase 2.5): 이번 주 막은 제안 + 신규 후보 + 리뷰 대기
+          SINCE_DATE=$(date -u -d '7 days ago' '+%Y-%m-%d' 2>/dev/null || date -u -v-7d '+%Y-%m-%d')
+          HITS_WEEK=0
+          if ls generated/constraint-hits/*.json >/dev/null 2>&1; then
+            WEEK_FILES=""
+            for f in generated/constraint-hits/*.json; do
+              b=$(basename "$f" .json)
+              if [ "$b" \> "$SINCE_DATE" ] || [ "$b" = "$SINCE_DATE" ]; then WEEK_FILES="$WEEK_FILES $f"; fi
+            done
+            [ -n "$WEEK_FILES" ] && HITS_WEEK=$(jq -s 'reduce .[] as $m (0; . + ([$m[]] | add // 0))' $WEEK_FILES 2>/dev/null || echo 0)
+          fi
+          NEW_PRS=$(gh pr list --label "constraints" --state all --limit 30 --json createdAt --repo "$REPO" 2>/dev/null \
+            | jq --arg s "${SINCE_DATE}T00:00:00Z" '[.[] | select(.createdAt >= $s)] | length' || echo 0)
+          REVIEW_PENDING=$(gh pr list --label "needs-ceo-review" --state open --limit 30 --json number --repo "$REPO" 2>/dev/null | jq 'length' || echo 0)
 
-          TEXT="🔄 *주간 회고* (지난 7일)\n• 머지된 PR: *${MERGED}*\n• 처리/폐기된 제안 이슈: *${CLOSED}*\n• 현재 열린 제안: *${OPEN}*\n• 등록된 standing constraints: *${CONS}*\n\n*CEO께 질문:*\n1. 이번 주 가장 잘된 것 / 막힌 것은?\n2. 다음 주 우선순위 방향은? (이 스레드에 답하면 기억에 적재됩니다 — @봇 멘션)"
+          MERGED=${MERGED:-0}; CLOSED=${CLOSED:-0}; OPEN=${OPEN:-0}; CONS=${CONS:-0}
+          HITS_WEEK=${HITS_WEEK:-0}; NEW_PRS=${NEW_PRS:-0}; REVIEW_PENDING=${REVIEW_PENDING:-0}
+
+          QUESTION3=""
+          if [ "$REVIEW_PENDING" -gt 0 ]; then
+            QUESTION3="\n3. 리뷰 대기 중인 규칙 PR이 *${REVIEW_PENDING}건* 있습니다. 지금 확인하시겠어요?"
+          fi
+
+          TEXT="🔄 *주간 회고* (지난 7일)\n• 머지된 PR: *${MERGED}*\n• 처리/폐기된 제안 이슈: *${CLOSED}*\n• 현재 열린 제안: *${OPEN}*\n\n*🔒 규칙이 한 일:*\n• 활성 규칙: *${CONS}개*\n• 이번 주 사전 차단한 제안: *${HITS_WEEK}건*\n• 새로 학습한 규칙 후보(PR): *${NEW_PRS}건* / 리뷰 대기: *${REVIEW_PENDING}건*\n\n*CEO께 질문:*\n1. 이번 주 가장 잘된 것 / 막힌 것은?\n2. 다음 주 우선순위 방향은? (이 스레드에 답하면 기억에 적재됩니다 — @봇 멘션)${QUESTION3}"
           PAYLOAD=$(jq -n --arg text "$TEXT" '{"text": $text}')
           curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"

--- a/constraints/active.json
+++ b/constraints/active.json
@@ -9,7 +9,8 @@
       "permanent": true,
       "createdAt": "2026-05-30",
       "expiresAt": null,
-      "hits": 0
+      "hits": 0,
+      "keywords": ["DataMismatchBanner", "불일치 배너", "데이터 불일치 알림", "결측 경고 배너", "데이터가 일치하지 않습니다", "정합성 경고 배너"]
     },
     {
       "id": "c-20260526-effectsban",
@@ -20,7 +21,8 @@
       "permanent": true,
       "createdAt": "2026-05-26",
       "expiresAt": null,
-      "hits": 0
+      "hits": 0,
+      "keywords": ["햅틱", "글로우", "파티클", "반짝임", "BGM", "사운드 이펙트", "장식 애니메이션", "버튼 펄스", "진동 효과", "싱크로 효과"]
     },
     {
       "id": "c-20260522-tossmentalmodel",

--- a/scripts/__tests__/constraints.test.ts
+++ b/scripts/__tests__/constraints.test.ts
@@ -9,6 +9,10 @@ import {
   makeId,
   normalizeIncoming,
   mergeConstraints,
+  constraintKeywords,
+  checkViolations,
+  sumHitMaps,
+  applyHits,
   type Constraint,
 } from "../constraints";
 
@@ -140,5 +144,61 @@ describe("normalizeIncoming / mergeConstraints", () => {
     const merged = mergeConstraints([], [{ rule: "" }], "2026-06-02");
     expect(merged.added).toHaveLength(0);
     expect(merged.skipped).toHaveLength(1);
+  });
+  it("keywords 를 보존한다", () => {
+    const c = normalizeIncoming({ rule: "배너 금지", keywords: ["DataMismatchBanner"] }, "2026-06-02");
+    expect(c.keywords).toEqual(["DataMismatchBanner"]);
+  });
+});
+
+describe("constraintKeywords", () => {
+  it("명시 keywords 를 우선 사용", () => {
+    expect(constraintKeywords(base({ keywords: ["햅틱", "글로우"] }))).toEqual(["햅틱", "글로우"]);
+  });
+  it("없으면 따옴표·CamelCase 토큰 추출", () => {
+    const kws = constraintKeywords(base({ rule: '"DataMismatchBanner" 류와 MismatchAlert 금지', keywords: undefined }));
+    expect(kws).toContain("DataMismatchBanner");
+    expect(kws).toContain("MismatchAlert");
+  });
+});
+
+describe("checkViolations", () => {
+  const dm = base({
+    id: "dm",
+    rule: "데이터 불일치 배너 금지",
+    scope: ["frontend", "all"],
+    kind: "prohibition",
+    keywords: ["DataMismatchBanner", "불일치 배너"],
+  });
+  const toss = base({ id: "toss", rule: "토스 멘탈모델", scope: ["all"], kind: "mental-model", keywords: ["토스"] });
+
+  it("금지 키워드를 포함한 제안을 위반으로 잡는다", () => {
+    const v = checkViolations("DataMismatchBanner 컴포넌트를 추가하자", [dm], "frontend");
+    expect(v).toHaveLength(1);
+    expect(v[0]!.constraint.id).toBe("dm");
+    expect(v[0]!.matched).toBe("DataMismatchBanner");
+  });
+  it("무관한 제안은 위반 아님", () => {
+    expect(checkViolations("뉴스 탭 무한 스크롤 추가", [dm], "frontend")).toEqual([]);
+  });
+  it("lane 이 다르면(scope 불포함) 검사 안 함", () => {
+    const pmOnly = base({ id: "x", rule: "x", scope: ["pm"], kind: "prohibition", keywords: ["배너"] });
+    expect(checkViolations("배너 추가", [pmOnly], "qa")).toEqual([]);
+  });
+  it("prohibition 이 아닌 kind 는 위반 대상 아님", () => {
+    expect(checkViolations("토스 레퍼런스 적용", [toss], "frontend")).toEqual([]);
+  });
+});
+
+describe("hits 집계", () => {
+  it("sumHitMaps 가 여러 맵을 합산", () => {
+    expect(sumHitMaps([{ a: 1, b: 2 }, { a: 3 }, {}])).toEqual({ a: 4, b: 2 });
+  });
+  it("applyHits 가 id 매칭해 hits 누적(불변)", () => {
+    const cs = [base({ id: "a", hits: 1 }), base({ id: "b", hits: 0 })];
+    const out = applyHits(cs, { a: 2 });
+    expect(out[0]!.hits).toBe(3);
+    expect(out[1]!.hits).toBe(0);
+    expect(cs[0]!.hits).toBe(1); // 원본 불변
   });
 });

--- a/scripts/constraints.ts
+++ b/scripts/constraints.ts
@@ -33,6 +33,8 @@ export interface Constraint {
   expiresAt: string | null;
   /** 이 제약이 실제로 제안을 막은 횟수(가치 측정) */
   hits: number;
+  /** 위반 탐지용 키워드(선택). 없으면 rule 에서 추출. */
+  keywords?: string[];
 }
 
 const KIND_LABEL: Record<ConstraintKind, string> = {
@@ -74,8 +76,14 @@ export function validateConstraint(obj: unknown, idx = 0): Constraint {
     throw new Error(`${where}: 비영구 constraint 는 expiresAt 필수`);
   }
   if (typeof o.hits !== "number" || !Number.isFinite(o.hits)) throw new Error(`${where}: hits number 필수`);
+  if (
+    o.keywords !== undefined &&
+    (!Array.isArray(o.keywords) || !o.keywords.every((k) => typeof k === "string"))
+  ) {
+    throw new Error(`${where}: keywords 는 string 배열`);
+  }
 
-  return {
+  const out: Constraint = {
     id: o.id,
     rule: o.rule.trim(),
     scope: o.scope as string[],
@@ -86,6 +94,8 @@ export function validateConstraint(obj: unknown, idx = 0): Constraint {
     expiresAt: (o.expiresAt as string | null) ?? null,
     hits: o.hits,
   };
+  if (Array.isArray(o.keywords) && o.keywords.length > 0) out.keywords = o.keywords as string[];
+  return out;
 }
 
 function validateAll(arr: unknown): Constraint[] {
@@ -198,6 +208,7 @@ export interface IncomingConstraint {
   permanent?: boolean;
   expiresAt?: string | null;
   id?: string;
+  keywords?: string[];
 }
 
 /** 외부(distill/Slack) 입력을 검증된 Constraint 로 정규화. */
@@ -222,6 +233,7 @@ export function normalizeIncoming(input: IncomingConstraint, today: string): Con
     createdAt: today,
     expiresAt,
     hits: 0,
+    ...(Array.isArray(input.keywords) && input.keywords.length > 0 ? { keywords: input.keywords } : {}),
   });
 }
 
@@ -260,6 +272,85 @@ export function mergeConstraints(
     seen.set(key, candidate);
   }
   return result;
+}
+
+// ─────────────────────────────────────────────────────────────
+// 위반 탐지 (고리 3) + hits 집계 (고리 2) — Phase 2.5
+// ─────────────────────────────────────────────────────────────
+
+const STOPWORD_RE = /^(제안|금지|사용|등의|관련|있는|없는|해야|하지|대한|위한|으로|에서|이다|한다|및|또는|the|and|for|with)$/;
+
+/** constraint 의 위반 탐지 키워드 — 명시 keywords 우선, 없으면 rule 에서 보수적으로 추출. */
+export function constraintKeywords(c: Constraint): string[] {
+  if (c.keywords && c.keywords.length > 0) return c.keywords;
+  const out = new Set<string>();
+  // 1) 따옴표로 강조된 토큰 ("DataMismatchBanner" 등)
+  for (const m of c.rule.matchAll(/["'“”‘’]([^"'“”‘’]{2,40})["'“”‘’]/g)) {
+    if (m[1]) out.add(m[1].trim());
+  }
+  // 2) CamelCase/식별자형 영문 (DataMismatchBanner)
+  for (const m of c.rule.matchAll(/[A-Z][A-Za-z]{3,}/g)) {
+    if (m[0]) out.add(m[0]);
+  }
+  // 3) 가운뎃점(·)으로 나열된 금지 카테고리 토큰 (이펙트·사운드·햅틱·글로우…)
+  for (const seg of c.rule.split(/[()]/)) {
+    if (seg.includes("·")) {
+      for (const tok of seg.split(/[·,/]/)) {
+        const t = tok.trim();
+        if (t.length >= 2 && t.length <= 12 && !STOPWORD_RE.test(t)) out.add(t);
+      }
+    }
+  }
+  return Array.from(out);
+}
+
+export interface Violation {
+  constraint: Constraint;
+  matched: string;
+}
+
+/**
+ * 제안 텍스트가 해당 lane(+all) 의 *금지(prohibition)* constraint 키워드를 포함하면 위반.
+ * 보수적: prohibition kind 만, 키워드 정확 부분일치. 거짓양성 최소화(Phase 1 철학).
+ */
+export function checkViolations(
+  proposalText: string,
+  constraints: Constraint[],
+  lane: string,
+): Violation[] {
+  const text = (proposalText || "").toLowerCase();
+  if (!text) return [];
+  const result: Violation[] = [];
+  for (const c of constraints) {
+    if (c.kind !== "prohibition") continue;
+    if (!appliesToLane(c, lane)) continue;
+    for (const kw of constraintKeywords(c)) {
+      const k = kw.trim().toLowerCase();
+      if (k.length >= 2 && text.includes(k)) {
+        result.push({ constraint: c, matched: kw });
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+/** 여러 사이클 hit 맵({id:count})을 합산. */
+export function sumHitMaps(maps: Record<string, number>[]): Record<string, number> {
+  const total: Record<string, number> = {};
+  for (const m of maps) {
+    for (const [id, n] of Object.entries(m)) {
+      if (typeof n === "number" && Number.isFinite(n)) total[id] = (total[id] ?? 0) + n;
+    }
+  }
+  return total;
+}
+
+/** hit 맵을 constraints 에 누적 반영(불변 — 새 배열 반환). */
+export function applyHits(constraints: Constraint[], hitMap: Record<string, number>): Constraint[] {
+  return constraints.map((c) =>
+    hitMap[c.id] ? { ...c, hits: c.hits + hitMap[c.id]! } : c,
+  );
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -313,9 +404,38 @@ function main(): void {
     const merged = mergeConstraints(existing, incoming, argv[5] ?? today);
     process.stdout.write(JSON.stringify({ constraints: merged.constraints }, null, 2));
     process.stderr.write(`added=${merged.added.length} skipped=${merged.skipped.length}\n`);
+  } else if (cmd === "check") {
+    // check <active.json> <lane> <proposal.txt> [today]
+    const all = loadConstraints(argv[3] ?? "");
+    const active = activeConstraints(all, argv[6] ?? today);
+    const lane = argv[4] ?? "";
+    let text = "";
+    try {
+      text = readFileSync(argv[5] ?? "", "utf8");
+    } catch {
+      text = "";
+    }
+    const violations = checkViolations(text, active, lane);
+    process.stdout.write(
+      JSON.stringify(violations.map((v) => ({ id: v.constraint.id, rule: v.constraint.rule, matched: v.matched }))),
+    );
+  } else if (cmd === "apply-hits") {
+    // apply-hits <active.json> <hitfile1> [hitfile2 ...] → {constraints:[]} (hits 누적)
+    const all = loadConstraints(argv[3] ?? "");
+    const maps: Record<string, number>[] = [];
+    for (const p of argv.slice(4)) {
+      try {
+        const raw = readFileSync(p, "utf8").trim();
+        if (raw) maps.push(JSON.parse(raw) as Record<string, number>);
+      } catch {
+        /* 파일 없거나 불량이면 무시 */
+      }
+    }
+    const updated = applyHits(all, sumHitMaps(maps));
+    process.stdout.write(JSON.stringify({ constraints: updated }, null, 2));
   } else {
     console.error(
-      "usage:\n  active <active.json> <today>\n  render-lane <lane> <array.json>\n  render-brief <array.json>\n  compact <active.json> <today>\n  add <active.json> <payload.json> <today>",
+      "usage:\n  active <active.json> <today>\n  render-lane <lane> <array.json>\n  render-brief <array.json>\n  compact <active.json> <today>\n  add <active.json> <payload.json> <today>\n  check <active.json> <lane> <proposal.txt> [today]\n  apply-hits <active.json> <hitfile...>",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Phase 2가 만든 standing constraints를 "구조만 있는 상태"에서 **"실제로 자율 작동하고, 효과가 CEO 눈에 숫자로 보이는 상태"**로. 끊겨 있던 3개 고리를 닫음.

### 고리 1 — distill 자동 트리거
`distill-constraints.yml` `on:`에 `workflow_run`(Daily Agent Council completed, **success만**) 추가 → CEO Brief 생성 시 **자동 distill**. 후보 0건이면 PR 미생성, 중복 후보는 `add` dedup이 거름(멱등). 수동 dispatch도 유지.

### 고리 3 — score 단계 결정론 강제
- `constraints.ts checkViolations(text, constraints, lane)`: `prohibition` kind의 `keywords`(명시 우선, 없으면 따옴표·CamelCase·가운뎃점 토큰 추출) 부분일치로 위반 탐지. 보수적(거짓양성 최소, Phase 1 철학).
- `active.json` 금지 2건(datamismatch·effectsban)에 `keywords` 추가.
- `score_and_filter`에 위반 게이트: 위반 시 `constraint-violation`+`score-missing` 라벨 + 코멘트 + 자동 close. **LLM 선의 의존 → 결정론 게이트로 승격** (Phase 1 lane-state 강제력과 동등).

### 고리 2 — hits 측정 + 가시화
- 위반 시 constraint id를 `generated/constraint-hits/<date>.json` **이벤트 로그**에 기록(`[skip ci]` 자동 커밋, rebase 재시도). `sumHitMaps`/`applyHits` 순수함수 + `check`/`apply-hits` CLI.
- `autonomy-report.yml`·`slack-retro.yml`이 로그를 jq 합산 → **"이번 주 사전 차단한 제안 N건 / 자주 작동한 규칙 Top3 / 신규 규칙 후보 PR / 리뷰 대기"** 노출. retro는 리뷰 대기 PR이 있으면 능동 질문.
- 이벤트 로그 방식이라 active.json 동시 쓰기 경쟁·중복 카운트 없음 (문서 4.3의 "주간 합산" 대안 채택).

### 부수 수정
`autonomy-report.yml`의 멀티라인 메시지가 `run: |` 블록 들여쓰기를 깨 **YAML이 무효**이던 잠재 버그를 `printf` 조립로 수정(이제 유효).

## Test plan
- [x] `npx vitest run` — 301 passed (28 files; constraints 25케이스: keywords 보존/추출, checkViolations 위반·무관·lane·kind, sumHitMaps/applyHits 불변)
- [x] `npm run typecheck:web` + `npm run build:web` — 통과
- [x] constraints.ts strict standalone, 5개 워크플로 YAML 유효성, check/apply-hits CLI + hits 집계 jq end-to-end
- [ ] (수동) distill 자동 트리거 / datamismatch류 위반 제안 → score에서 차단 + hits 증가 → 리포트 반영

정책 유지: distill PR은 `needs-ceo-review`(자동 머지 안 됨). Slack 봇 대화 로직·provider 미변경.
Related: #282 #300 · Out of scope: 의미 dedup(Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)