### PR TITLE
fix(slack): 자동 알림 복구 — webhook URL 공백 방어 트림

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -152,7 +152,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
-          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+          curl -s -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "{
               \"text\": \"🚀 *자동 머지 완료* — Hermes\n>#${PR_NUMBER}: ${PR_TITLE}\n>${PR_URL}\"
@@ -187,7 +187,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
-          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+          curl -s -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "{
               \"text\": \"🚫 *자동 머지 차단* — 수동 검토 필요\n>#${PR_NUMBER}: ${PR_TITLE}\n>사유: ${REASON}\n>${PR_URL}\"

--- a/.github/workflows/autonomy-report.yml
+++ b/.github/workflows/autonomy-report.yml
@@ -199,6 +199,6 @@ jobs:
             "_Hermes 자율 루프 — CEO 개입 없이 자동 운영 중_")
 
           jq -n --arg text "$MESSAGE" '{"text": $text}' > /tmp/report_payload.json
-          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+          curl -s -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d @/tmp/report_payload.json

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -36,7 +36,7 @@ jobs:
           MSG: ${{ github.event.inputs.message }}
         run: |
           PAYLOAD=$(jq -n --arg text "📢 $MSG" '{"text": $text}')
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
@@ -55,7 +55,7 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg text "🤖 *Auto PR 생성됨*\n>#${PR_NUMBER}: ${PR_TITLE}\n>${PR_URL}\n\n✅ CI가 자동 실행 중입니다." \
             '{"text": $text}')
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
@@ -75,7 +75,7 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg text "✅ *Auto PR 머지됨*\n>#${PR_NUMBER}: ${PR_TITLE}\n>${PR_URL}" \
             '{"text": $text}')
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
@@ -102,7 +102,7 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg text "${EMOJI} *CI ${STATUS}* — \`${BRANCH}\`\n>${RUN_URL}" \
             '{"text": $text}')
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
@@ -120,7 +120,7 @@ jobs:
           set -uo pipefail
           if [ "$CONCLUSION" != "success" ]; then
             jq -n --arg t "⚠️ *Daily Agent Council 실패*\n>${RUN_URL}" '{"text": $t}' > /tmp/payload.json
-            curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/payload.json
+            curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" -H "Content-Type: application/json" -d @/tmp/payload.json
             exit 0
           fi
           # 최신 CEO Brief 본문을 단일 jq 패스로 Slack 페이로드화 (재파싱·개행 이슈 회피)
@@ -136,7 +136,7 @@ jobs:
                     + "\n\n_… 전체는 GitHub 이슈에서. 피드백은 이 스레드에 @봇 멘션으로._"
                   )}
                   end' > /tmp/payload.json
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/payload.json
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" -H "Content-Type: application/json" -d @/tmp/payload.json
 
       # ── Auto Implement 완료 ─────────────────────────────────
       - name: Auto implement completed
@@ -157,6 +157,6 @@ jobs:
               --arg text "❌ *Auto Implement 실패*\n>${RUN_URL}" \
               '{"text": $text}')
           fi
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"

--- a/.github/workflows/slack-retro.yml
+++ b/.github/workflows/slack-retro.yml
@@ -69,4 +69,4 @@ jobs:
 
           TEXT="🔄 *주간 회고* (지난 7일)\n• 머지된 PR: *${MERGED}*\n• 처리/폐기된 제안 이슈: *${CLOSED}*\n• 현재 열린 제안: *${OPEN}*\n\n*🔒 규칙이 한 일:*\n• 활성 규칙: *${CONS}개*\n• 이번 주 사전 차단한 제안: *${HITS_WEEK}건*\n• 새로 학습한 규칙 후보(PR): *${NEW_PRS}건* / 리뷰 대기: *${REVIEW_PENDING}건*\n\n*CEO께 질문:*\n1. 이번 주 가장 잘된 것 / 막힌 것은?\n2. 다음 주 우선순위 방향은? (이 스레드에 답하면 기억에 적재됩니다 — @봇 멘션)${QUESTION3}"
           PAYLOAD=$(jq -n --arg text "$TEXT" '{"text": $text}')
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"
+          curl -sf -X POST "$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')" -H "Content-Type: application/json" -d "$PAYLOAD"


### PR DESCRIPTION
## 문제
CEO가 "어디까지 개발됐어? 다됐어?"를 **매번 직접 물어봐야 하는 병목**. 봇이 PR 머지·개발 완료를 자동으로 보고하지 못함.

## 진단 (로그)
`slack-notify.yml`의 `workflow_run` 트리거 실행이 **전부 실패**(exit 3). 원인: 저장소 변수 `SLACK_WEBHOOK_URL` 값 끝에 **공백 4칸**이 붙어 있어 `curl`이 URL malformed로 실패. 그래서 PR 머지·Council 완료·auto-implement 완료 등 **모든 자동 Slack 푸시가 조용히 무효화**돼 있었음. (봇의 스레드 *응답*은 bot token 기반이라 별개로 동작 → 그래서 "물어보면 답하는데 자동 보고는 안 되는" 상태였음)

## 조치
1. **변수 트림** (`gh variable set`, 82→81자) — 즉시 복구. 테스트 전송 **HTTP 200 ok** 확인(Slack에 "자동 알림 연결 복구됨" 메시지 도착).
2. **재발 방지 하드닝**: `slack-notify`·`autonomy-report`·`slack-retro`·`auto-merge`의 모든 webhook `curl`이 URL을 인라인 트림(`printf | tr -d '[:space:]'`)하도록 변경. 향후 변수에 공백이 다시 들어가도 안 깨짐.

## 효과
이제 자동으로 Slack에 보고됨 (CEO 개입 불필요):
- ✅ Auto PR 머지 → "개발 완료" 푸시
- 📋 Daily Agent Council 완료 → CEO Brief 본문 요약 푸시 (Step 4)
- 🚀 auto-implement 완료 / 자동 머지 완료 푸시
- 📊 주간 autonomy-report + 월요일 retro

## Test plan
- [x] 트림된 webhook 실제 전송 HTTP 200 확인
- [x] 5개 워크플로 YAML 유효성
- [ ] (자동) 다음 PR 머지/council 완료 시 Slack 자동 푸시 도착 확인

워크플로만 변경(앱 코드·봇 대화 로직 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)