### PR TITLE
feat(tarot): Signal Engine(B4) — 해석을 데이터로 접지하는 백단 척추

### DIFF
--- a/apps/web/app/api/tarot/news-insight/route.ts
+++ b/apps/web/app/api/tarot/news-insight/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { drawCards, getFallbackInterpretation, buildInterpretationPromptV2_4, checkSafety, generateFallbackInsight, type FinancialContext } from "@taro/core";
+import { drawCards, getFallbackInterpretation, buildInterpretationPromptV2_5, checkSafety, generateFallbackInsight, type FinancialContext } from "@taro/core";
 import { fetchMarketSnapshot } from "@/lib/tarot/market";
 import type { StockQuote } from "@trading/shared/src/stockTypes";
 
@@ -110,7 +110,7 @@ export async function GET(req: NextRequest) {
 
     try {
       // v2.3.0: 단일 카드는 v2.2.0과 동일. 3장 스프레드에서 슬롯별 심리 지형 강화.
-      const prompt = buildInterpretationPromptV2_4(marketSnapshot, [drawn], financialCtx);
+      const prompt = buildInterpretationPromptV2_5(marketSnapshot, [drawn], financialCtx);
       const result = await callLlmForInsight(prompt);
 
       const safetyResult = checkSafety(`${result.headline} ${result.summary}`);

--- a/apps/web/lib/tarot/interpret.ts
+++ b/apps/web/lib/tarot/interpret.ts
@@ -5,6 +5,7 @@ import {
   buildInterpretationPromptV2_1,
   buildInterpretationPromptV2_2,
   buildInterpretationPromptV2_4,
+  buildInterpretationPromptV2_5,
   checkSafety,
   getFallbackInterpretation,
   REQUIRED_DISCLAIMER,
@@ -100,7 +101,7 @@ export async function generateInterpretation(
 
   // 3차: LLM 호출
   try {
-    const prompt = buildInterpretationPromptV2_4(market, cards, financialCtx);
+    const prompt = buildInterpretationPromptV2_5(market, cards, financialCtx);
     const raw = await callLlm(prompt);
     const parsed = parseLlmJson(raw);
 

--- a/apps/web/lib/tarot/market.ts
+++ b/apps/web/lib/tarot/market.ts
@@ -202,6 +202,23 @@ export async function fetchMarketSnapshot(
   if (meta?.shortName) snapshot.name = meta.shortName;
   if (fiftyTwoWeekPosition !== undefined) snapshot.fiftyTwoWeekPosition = fiftyTwoWeekPosition;
 
+  // 시간축(trajectory) 메트릭 — 신호 엔진(computeSignal) 접지용. 1y 캔들에서 파생.
+  if (closes.length >= 21) {
+    const past = closes[closes.length - 21];
+    if (past && past > 0) {
+      snapshot.momentum20 = parseFloat((((price - past) / past) * 100).toFixed(1));
+    }
+  }
+  if (sma200 !== null) {
+    // 현재 200일선 위를 연속으로 유지한 봉 수(근사 — 현 SMA200 기준 최근 연속).
+    let days = 0;
+    for (let i = closes.length - 1; i >= 0; i--) {
+      if ((closes[i] ?? 0) >= sma200) days++;
+      else break;
+    }
+    if (days > 0) snapshot.daysAboveSma200 = days;
+  }
+
   marketCache.set(cacheKey, { snapshot, expiresAt: now + MARKET_CACHE_TTL_MS });
   return snapshot;
 }

--- a/packages/tarot-core/src/__tests__/compute-signal.test.ts
+++ b/packages/tarot-core/src/__tests__/compute-signal.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { computeSignal } from "../signal/computeSignal.js";
+import { checkSafety } from "../safety/forbidden.js";
+import type { MarketSnapshot } from "../types.js";
+import type { FinancialContext } from "../prompts/interpret-v2.2.0.js";
+
+function base(): MarketSnapshot {
+  return {
+    ticker: "AAPL",
+    market: "US",
+    price: 200,
+    changePercent: 0,
+    volume: 1_000_000,
+    condition: "neutral",
+    summary: "",
+  };
+}
+
+function bull(): MarketSnapshot {
+  return {
+    ...base(),
+    price: 200,
+    changePercent: 1.5,
+    rsi: 68,
+    macdHistogram: 1.2,
+    sma20: 190,
+    sma200: 170,
+    fiftyTwoWeekPosition: 0.85,
+    momentum20: 20,
+    daysAboveSma200: 12,
+    condition: "bullish",
+  };
+}
+
+function bear(): MarketSnapshot {
+  return {
+    ...base(),
+    price: 150,
+    changePercent: -2,
+    rsi: 32,
+    macdHistogram: -1.1,
+    sma20: 160,
+    sma200: 185,
+    fiftyTwoWeekPosition: 0.15,
+    momentum20: -18,
+    condition: "bearish",
+  };
+}
+
+const bullCtx: FinancialContext = { revenueGrowth: 0.3, profitMargins: 0.25, returnOnEquity: 0.22, debtToEquity: 80 };
+const bearCtx: FinancialContext = { revenueGrowth: -0.1, profitMargins: 0.02, returnOnEquity: 0.03, debtToEquity: 250 };
+
+describe("computeSignal — 결정론적 척추 점수", () => {
+  it("상승 스냅샷 → 높은 점수·상위 등급·bullish 상태", () => {
+    const s = computeSignal(bull(), bullCtx);
+    expect(s.score).toBeGreaterThanOrEqual(70);
+    expect(["S", "AA", "A"]).toContain(s.grade);
+    expect(s.state).toBe("bullish");
+  });
+
+  it("하락 스냅샷 → 낮은 점수·bearish 상태", () => {
+    const s = computeSignal(bear(), bearCtx);
+    expect(s.score).toBeLessThanOrEqual(35);
+    expect(s.state).toBe("bearish");
+  });
+
+  it("중립(단서 거의 없음) → 40~60 사이", () => {
+    const s = computeSignal({ ...base(), rsi: 50, fiftyTwoWeekPosition: 0.5 });
+    expect(s.score).toBeGreaterThanOrEqual(40);
+    expect(s.score).toBeLessThanOrEqual(60);
+  });
+
+  it("결정론적 — 같은 입력 같은 출력", () => {
+    expect(computeSignal(bull(), bullCtx)).toEqual(computeSignal(bull(), bullCtx));
+  });
+});
+
+describe("computeSignal — 드라이버", () => {
+  it("드라이버는 정량 detail을 갖고 기여도순 정렬", () => {
+    const s = computeSignal(bull(), bullCtx);
+    expect(s.drivers.length).toBeGreaterThan(0);
+    for (const d of s.drivers) {
+      expect(d.detail.length).toBeGreaterThan(0);
+      expect(["up", "down", "flat"]).toContain(d.direction);
+    }
+    // weight*|contribution| 내림차순
+    const mag = s.drivers.map((d) => Math.abs(d.contribution) * d.weight);
+    for (let i = 1; i < mag.length; i++) expect(mag[i - 1]).toBeGreaterThanOrEqual(mag[i]!);
+  });
+
+  it("ctx 없으면 fundamental 드라이버 없음(있는 입력만)", () => {
+    const s = computeSignal(bull());
+    expect(s.drivers.every((d) => d.kind === "technical")).toBe(true);
+  });
+
+  it("RSI 드라이버 방향은 값과 일치", () => {
+    const s = computeSignal(bull(), bullCtx);
+    const rsi = s.drivers.find((d) => d.key === "rsi");
+    expect(rsi?.direction).toBe("up");
+  });
+});
+
+describe("computeSignal — 시간축 trajectory & 규제", () => {
+  it("momentum/200일선 일수가 있으면 trajectory 문장 생성", () => {
+    const s = computeSignal(bull(), bullCtx);
+    expect(s.trajectory.length).toBeGreaterThan(0);
+    expect(s.trajectory.join(" ")).toMatch(/200일선|20봉|모멘텀/);
+  });
+
+  it("드라이버 detail은 투자조언 금칙어를 포함하지 않는다(BLOCKED 아님)", () => {
+    const s = computeSignal(bull(), bullCtx);
+    const text = s.drivers.map((d) => d.detail).join(" ") + " " + s.trajectory.join(" ");
+    expect(checkSafety(text).result).not.toBe("BLOCKED");
+  });
+});

--- a/packages/tarot-core/src/__tests__/prompt-v2.5-grounding.test.ts
+++ b/packages/tarot-core/src/__tests__/prompt-v2.5-grounding.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { buildInterpretationPromptV2_5 } from "../prompts/interpret-v2.5.0.js";
+import { buildInterpretationPromptV2_4 } from "../prompts/interpret-v2.4.0.js";
+import { checkSafety } from "../safety/forbidden.js";
+import type { FinancialContext } from "../prompts/interpret-v2.2.0.js";
+import type { MarketSnapshot, DrawnCard } from "../types.js";
+
+function bullMarket(): MarketSnapshot {
+  return {
+    ticker: "AAPL",
+    market: "US",
+    price: 200,
+    changePercent: 1.5,
+    volume: 1_000_000,
+    rsi: 68,
+    macdHistogram: 1.2,
+    sma20: 190,
+    sma200: 170,
+    fiftyTwoWeekPosition: 0.85,
+    momentum20: 20,
+    daysAboveSma200: 12,
+    condition: "bullish",
+    summary: "AAPL 200 (+1.50%) — 강세",
+  };
+}
+
+function card(id: string, nameKo: string, orientation: "upright" | "reversed" = "upright"): DrawnCard {
+  return {
+    card: {
+      id, name: id, nameKo, arcana: "major", number: 0,
+      keywords: ["change"], keywordsKo: ["변화"],
+      meaningUpright: "흔들림", meaningReversed: "회복",
+      imageUrl: `/cards/${id}.jpg`, toneGuide: "차분한", isActive: true,
+    },
+    orientation,
+  };
+}
+
+const ctx: FinancialContext = { revenueGrowth: 0.3, profitMargins: 0.25, debtToEquity: 80 };
+
+describe("interpret-v2.5.0 — 신호 척추 접지", () => {
+  it("흐름 상태·드라이버·접지 규칙이 주입된다", () => {
+    const prompt = buildInterpretationPromptV2_5(bullMarket(), [card("the-sun", "태양")], ctx);
+    expect(prompt).toContain("흐름의 상태");
+    expect(prompt).toContain("이 흐름을 만든 근거");
+    expect(prompt).toContain("접지 규칙");
+    // 구체 드라이버 사실이 들어간다
+    expect(prompt).toMatch(/RSI 68|매출성장 \+30%|200일선/);
+  });
+
+  it("v2.4를 감싸 더 길고, v2.4 품질 레이어를 보존한다", () => {
+    const market = bullMarket();
+    const cards = [card("the-sun", "태양")];
+    const v25 = buildInterpretationPromptV2_5(market, cards, ctx);
+    const v24 = buildInterpretationPromptV2_4(market, cards, ctx);
+    expect(v25.length).toBeGreaterThan(v24.length);
+    expect(v25).toContain("패의 결");
+    expect(v25).toContain("안티-클리셰");
+  });
+
+  it("점수/등급 숫자 자체는 프롬프트에 출력하지 않는다(내부 척추)", () => {
+    const prompt = buildInterpretationPromptV2_5(bullMarket(), [card("the-sun", "태양")], ctx);
+    // 등급 라벨이나 "83점" 같은 점수 노출이 없어야 함
+    expect(prompt).not.toMatch(/\d+점/);
+    expect(prompt).toContain("숫자 자체는 사용자에게 출력하지 마라");
+  });
+
+  it("접지 규칙은 미래 예측·매매 권유를 명시적으로 금지한다", () => {
+    // 주의: checkSafety는 LLM '출력'용 게이트다. 프롬프트는 금칙어를 '금지 지시'로 포함하므로
+    // 프롬프트 자체에 checkSafety를 걸지 않는다. 대신 주입한 사실 드라이버가 안전한지만 확인.
+    const prompt = buildInterpretationPromptV2_5(bullMarket(), [card("the-sun", "태양")], ctx);
+    expect(prompt).toContain("미래 가격");
+    expect(prompt).toContain("권유");
+    // 우리가 주입하는 사실 드라이버 라인(예: "RSI 68 — 상승 우위")은 BLOCKED 단어가 없어야 함
+    const driverFacts = "RSI 68 — 상승 우위 매출성장 +30% 200일선 위 12봉째";
+    expect(checkSafety(driverFacts).result).not.toBe("BLOCKED");
+  });
+
+  it("지표가 없으면 신호 섹션 없이 접지 규칙만 추가(하위호환)", () => {
+    const bare: MarketSnapshot = {
+      ticker: "X", market: "US", price: 10, changePercent: 0, volume: 0,
+      condition: "neutral", summary: "",
+    };
+    const prompt = buildInterpretationPromptV2_5(bare, [card("the-sun", "태양")]);
+    expect(prompt).toContain("접지 규칙");
+  });
+});

--- a/packages/tarot-core/src/index.ts
+++ b/packages/tarot-core/src/index.ts
@@ -13,3 +13,10 @@ export { buildInterpretationPromptV2_1, PROMPT_VERSION_2_1 } from "./prompts/int
 export { buildInterpretationPromptV2_2, PROMPT_VERSION_2_2, type FinancialContext } from "./prompts/interpret-v2.2.0.js";
 export { buildInterpretationPromptV2_3, PROMPT_VERSION_2_3 } from "./prompts/interpret-v2.3.0.js";
 export { buildInterpretationPromptV2_4, PROMPT_VERSION_2_4 } from "./prompts/interpret-v2.4.0.js";
+export { buildInterpretationPromptV2_5, PROMPT_VERSION_2_5 } from "./prompts/interpret-v2.5.0.js";
+export {
+  computeSignal,
+  type Signal,
+  type SignalDriver,
+  type SignalGrade,
+} from "./signal/computeSignal.js";

--- a/packages/tarot-core/src/prompts/interpret-v2.5.0.ts
+++ b/packages/tarot-core/src/prompts/interpret-v2.5.0.ts
@@ -1,0 +1,73 @@
+import type { DrawnCard, MarketSnapshot } from "../types.js";
+import { buildInterpretationPromptV2_4 } from "./interpret-v2.4.0.js";
+import type { FinancialContext } from "./interpret-v2.2.0.js";
+import { computeSignal, type Signal } from "../signal/computeSignal.js";
+
+// 프롬프트 버전: v2.5.0
+// 핵심 변경: 결정론적 신호 엔진(computeSignal)을 백단 "척추"로 주입.
+// - 흐름의 상태(정성 라벨) + 시간축 + 정량 드라이버(사실)를 프롬프트에 넣어 해석을 데이터에 접지.
+// - 점수/등급 숫자 자체는 사용자에게 노출 금지(내부 척추). 미래 예측·매매 권유 금지.
+// v2.4 대비: 안티-클리셰·패의 결은 유지하고, "왜 지금 이 패가 이 종목에 맞는지"를 구체 사실로 접지.
+export const PROMPT_VERSION_2_5 = "2.5.0";
+
+function stateLine(s: Signal): string {
+  switch (s.state) {
+    case "bullish":
+      return s.score >= 80
+        ? "지금 이 종목은 뚜렷한 상승 흐름의 한가운데에 있습니다"
+        : "지금 이 종목은 상승 쪽으로 기운 흐름에 있습니다";
+    case "bearish":
+      return s.score <= 20
+        ? "지금 이 종목은 뚜렷한 하락 흐름에 눌려 있습니다"
+        : "지금 이 종목은 하락 쪽으로 기운 흐름에 있습니다";
+    case "volatile":
+      return "지금 이 종목은 변동성이 큰, 방향이 출렁이는 흐름에 있습니다";
+    case "consolidating":
+      return "지금 이 종목은 방향을 정하지 못하고 다지는 흐름에 있습니다";
+    default:
+      return "지금 이 종목은 어느 쪽으로도 확실히 기울지 않은 중립 흐름에 있습니다";
+  }
+}
+
+function buildSignalSection(market: MarketSnapshot, ctx?: FinancialContext): string {
+  const s = computeSignal(market, ctx);
+  const top = s.drivers.slice(0, 3);
+  if (top.length === 0) return "";
+
+  const lines: string[] = [
+    "## 흐름의 상태 (신호 척추 — 내부 근거)",
+    "> 아래는 해석을 데이터에 접지하기 위한 내부 근거다. 점수·등급 숫자 자체는 사용자에게 출력하지 마라.",
+    `- ${stateLine(s)}`,
+  ];
+  if (s.trajectory.length > 0) {
+    lines.push("### 시간축");
+    for (const t of s.trajectory) lines.push(`- ${t}`);
+  }
+  lines.push("### 이 흐름을 만든 근거 (사실 — 매매 신호 아님)");
+  for (const d of top) lines.push(`- ${d.detail}`);
+  lines.push("");
+  return lines.join("\n") + "\n";
+}
+
+const GROUNDING_RULE = `
+## 접지 규칙 (v2.5 — 가장 중요)
+- headline·summary·detail 은 위 "이 흐름을 만든 근거(드라이버)" 중 **1-2개의 구체적 사실**(예: 200일선 회복, 매출성장, RSI 위치)에 반드시 접지한다. 추상적 일반론("에너지가 흐른다")만으로 끝내지 말고, 카드의 상징을 그 구체 사실과 엮어 "왜 지금 이 패가 이 종목에 들어맞는지"를 또렷하게 말한다.
+- 단, **금지**: (1) 미래 가격·수익률 예측("오를 것", "% 상승"), (2) 매수·매도·보유 권유나 타이밍 제시, (3) 점수·등급 숫자 자체를 출력, (4) 드라이버의 판정어("상승 구간", "과열권" 등)를 그대로 옮기지 말고 카드 상징의 언어로 바꿔 말한다, (5) 현재 시점을 매매·진입의 '적기'로 규정하는 어떤 비유도 금지. 위 근거는 "지금까지·현재의 사실"을 묘사하는 재료일 뿐이다.
+- 결과: 막연한 위로가 아니라 데이터에 발 붙인 날카로운 해석. 그러나 끝까지 '해석'이지 '조언'이 아니다.
+`;
+
+/**
+ * v2.5.0 프롬프트 빌더. 시그니처는 v2.4 호환.
+ * - 신호 척추 섹션을 "## 뽑힌 카드" 앞에 삽입하고, 접지 규칙을 말미에 덧붙인다.
+ * - 드라이버가 하나도 없으면(지표 부재) v2.4와 동일하게 동작 + 접지 규칙만 추가.
+ */
+export function buildInterpretationPromptV2_5(
+  market: MarketSnapshot,
+  cards: DrawnCard[],
+  ctx?: FinancialContext,
+): string {
+  const base = buildInterpretationPromptV2_4(market, cards, ctx);
+  const signalSection = buildSignalSection(market, ctx);
+  const enhanced = signalSection ? base.replace("## 뽑힌 카드", `${signalSection}## 뽑힌 카드`) : base;
+  return enhanced + GROUNDING_RULE;
+}

--- a/packages/tarot-core/src/safety/forbidden.ts
+++ b/packages/tarot-core/src/safety/forbidden.ts
@@ -6,7 +6,7 @@ export const FORBIDDEN_TERMS_BLOCKED: string[] = [
   "사세요", "파세요", "사야", "팔아야",
   // 수익 보장
   "수익 보장", "guaranteed return", "guaranteed profit",
-  "반드시 오른다", "반드시 내린다", "확실히",
+  "반드시 오른다", "반드시 내린다", "확실히", "확실한",
   "무조건 상승", "무조건 하락",
   // 투자 추천
   "투자 추천", "investment advice", "투자 조언",
@@ -20,6 +20,8 @@ export const FORBIDDEN_TERMS_RISK: string[] = [
   "좋은 타이밍", "적기입니다", "최적의 시기",
   "강한 매수세", "강한 매도세",
   "수익률 %", "% 상승 예상", "% 하락 예상",
+  // 신호 드라이버 판정어가 출력에 에코될 때 대비 (방향성 우열 암시)
+  "상승 우위", "하락 우위", "방향 우위",
 ];
 
 export const REQUIRED_DISCLAIMER =

--- a/packages/tarot-core/src/signal/computeSignal.ts
+++ b/packages/tarot-core/src/signal/computeSignal.ts
@@ -1,0 +1,264 @@
+import type { MarketSnapshot, MarketCondition } from "../types.js";
+import type { FinancialContext } from "../prompts/interpret-v2.2.0.js";
+
+/**
+ * Signal Engine (B4) — 타로 해석의 결정론적 "척추".
+ *
+ * docs/AGENT_HARNESS_ROADMAP.md B4 구현. 시장/재무 신호를 결정론적으로 0~100 점수 +
+ * 등급 + 정량 드라이버 + 시간축 trajectory 로 분해한다. 점수 자체는 사용자에게 노출하지
+ * 않는 *내부 척추*이며(투자권유 아님), 타로 프롬프트(interpret-v2.5.0)가 이 드라이버를
+ * 구체 사실로 접지해 해석을 날카롭게 만든다.
+ *
+ * 드라이버 detail 은 "사실 묘사"(예: "RSI 68 — 상승 우위", "매출성장 +30%")이지 매매
+ * 신호가 아니다. 순수 함수 — packages/tarot-core/src/__tests__/compute-signal.test.ts 검증.
+ *
+ * 재사용: apps/web/lib/tarot/market.ts inferCondition 의 bull/bear 가중 로직을 0~100 으로
+ * 일반화하고 드라이버별 기여도로 분해한 형태.
+ */
+
+export type SignalGrade = "S" | "AA" | "A" | "B" | "C";
+
+export interface SignalDriver {
+  key: string;
+  /** 짧은 라벨 (예: "RSI", "매출성장") */
+  label: string;
+  /** 정량 사실 묘사 (예: "RSI 68 — 상승 우위") */
+  detail: string;
+  /** 점수 기여 방향 */
+  direction: "up" | "down" | "flat";
+  /** 정규화 기여도 [-1, 1] */
+  contribution: number;
+  /** 가중치 (중요도) */
+  weight: number;
+  kind: "technical" | "fundamental";
+}
+
+export interface Signal {
+  /** 내부 척추 점수 0~100 (사용자 미노출) */
+  score: number;
+  grade: SignalGrade;
+  /** 점수에서 파생한 흐름 상태 */
+  state: MarketCondition;
+  /** 기여도순 정렬된 드라이버 */
+  drivers: SignalDriver[];
+  /** 단일 스냅샷에서 파생한 시간축 문장 (지속성 DB 없이 1y 캔들 기반) */
+  trajectory: string[];
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function dirOf(c: number): "up" | "down" | "flat" {
+  if (c > 0.05) return "up";
+  if (c < -0.05) return "down";
+  return "flat";
+}
+
+interface DriverSpec {
+  key: string;
+  label: string;
+  kind: "technical" | "fundamental";
+  weight: number;
+  /** 입력이 없으면 null(드라이버 제외), 있으면 [기여도, detail] */
+  evaluate(m: MarketSnapshot, ctx?: FinancialContext): [number, string] | null;
+}
+
+const SPECS: DriverSpec[] = [
+  {
+    key: "rsi",
+    label: "RSI",
+    kind: "technical",
+    weight: 1.2,
+    evaluate: (m) => {
+      if (m.rsi == null) return null;
+      const c = clamp((m.rsi - 50) / 30, -1, 1);
+      // 판정어는 중립 기술용어로 — "우위" 같은 방향성 우열 암시 회피(규제)
+      const tone =
+        m.rsi >= 70 ? "과열권" : m.rsi <= 30 ? "침체권" : m.rsi >= 55 ? "상승 구간" : m.rsi <= 45 ? "하락 구간" : "중립";
+      return [c, `RSI ${m.rsi.toFixed(0)} — ${tone}`];
+    },
+  },
+  {
+    key: "macd",
+    label: "MACD",
+    kind: "technical",
+    weight: 1.0,
+    evaluate: (m) => {
+      if (m.macdHistogram == null) return null;
+      const c = m.macdHistogram > 0 ? 0.6 : m.macdHistogram < 0 ? -0.6 : 0;
+      return [c, `MACD 히스토그램 ${m.macdHistogram > 0 ? "양(+)" : m.macdHistogram < 0 ? "음(-)" : "0"}`];
+    },
+  },
+  {
+    key: "sma200",
+    label: "200일선",
+    kind: "technical",
+    weight: 1.1,
+    evaluate: (m) => {
+      if (m.sma200 == null || !m.price) return null;
+      const above = m.price >= m.sma200;
+      const days = m.daysAboveSma200 != null && above ? ` ${m.daysAboveSma200}봉째` : "";
+      return [above ? 0.7 : -0.7, `200일선 ${above ? "위" : "아래"}${days}`];
+    },
+  },
+  {
+    key: "sma20",
+    label: "20일선",
+    kind: "technical",
+    weight: 0.6,
+    evaluate: (m) => {
+      if (m.sma20 == null || !m.price) return null;
+      const above = m.price >= m.sma20;
+      return [above ? 0.4 : -0.4, `20일선 ${above ? "위" : "아래"}`];
+    },
+  },
+  {
+    key: "pos52w",
+    label: "52주 위치",
+    kind: "technical",
+    weight: 0.9,
+    evaluate: (m) => {
+      if (m.fiftyTwoWeekPosition == null) return null;
+      const c = clamp((m.fiftyTwoWeekPosition - 0.5) * 2, -1, 1);
+      return [c, `52주 범위 ${Math.round(m.fiftyTwoWeekPosition * 100)}% 지점`];
+    },
+  },
+  {
+    key: "momentum20",
+    label: "모멘텀",
+    kind: "technical",
+    weight: 1.0,
+    evaluate: (m) => {
+      if (m.momentum20 == null) return null;
+      const c = clamp(m.momentum20 / 15, -1, 1);
+      return [c, `최근 20봉 ${m.momentum20 > 0 ? "+" : ""}${m.momentum20.toFixed(0)}%`];
+    },
+  },
+  {
+    key: "change",
+    label: "당일",
+    kind: "technical",
+    weight: 0.4,
+    evaluate: (m) => {
+      if (!Number.isFinite(m.changePercent)) return null;
+      const c = clamp(m.changePercent / 5, -1, 1);
+      return [c, `당일 ${m.changePercent > 0 ? "+" : ""}${m.changePercent.toFixed(1)}%`];
+    },
+  },
+  {
+    key: "revenueGrowth",
+    label: "매출성장",
+    kind: "fundamental",
+    weight: 1.0,
+    evaluate: (_m, ctx) => {
+      if (ctx?.revenueGrowth == null) return null;
+      const c = clamp(ctx.revenueGrowth / 0.3, -1, 1);
+      return [c, `매출성장 ${ctx.revenueGrowth > 0 ? "+" : ""}${Math.round(ctx.revenueGrowth * 100)}%`];
+    },
+  },
+  {
+    key: "profitMargins",
+    label: "순이익률",
+    kind: "fundamental",
+    weight: 0.7,
+    evaluate: (_m, ctx) => {
+      if (ctx?.profitMargins == null) return null;
+      const c = clamp((ctx.profitMargins - 0.1) / 0.2, -1, 1);
+      return [c, `순이익률 ${Math.round(ctx.profitMargins * 100)}%`];
+    },
+  },
+  {
+    key: "roe",
+    label: "ROE",
+    kind: "fundamental",
+    weight: 0.6,
+    evaluate: (_m, ctx) => {
+      if (ctx?.returnOnEquity == null) return null;
+      const c = clamp((ctx.returnOnEquity - 0.1) / 0.2, -1, 1);
+      return [c, `ROE ${Math.round(ctx.returnOnEquity * 100)}%`];
+    },
+  },
+  {
+    key: "debt",
+    label: "부채비율",
+    kind: "fundamental",
+    weight: 0.6,
+    evaluate: (_m, ctx) => {
+      if (ctx?.debtToEquity == null) return null;
+      const c = clamp(-(ctx.debtToEquity - 100) / 150, -1, 1);
+      return [c, `부채비율 ${Math.round(ctx.debtToEquity)}`];
+    },
+  },
+];
+
+function gradeOf(score: number): SignalGrade {
+  if (score >= 90) return "S";
+  if (score >= 80) return "AA";
+  if (score >= 65) return "A";
+  if (score >= 45) return "B";
+  return "C";
+}
+
+function stateOf(score: number, m: MarketSnapshot): MarketCondition {
+  if (m.condition === "volatile") return "volatile";
+  if (score >= 65) return "bullish";
+  if (score <= 35) return "bearish";
+  if (m.condition === "consolidating") return "consolidating";
+  return "neutral";
+}
+
+function buildTrajectory(m: MarketSnapshot): string[] {
+  const out: string[] = [];
+  if (m.daysAboveSma200 != null && m.daysAboveSma200 > 0) {
+    out.push(`200일선 위 흐름을 ${m.daysAboveSma200}봉째 이어가는 중`);
+  }
+  if (m.momentum20 != null) {
+    out.push(
+      m.momentum20 >= 0
+        ? `최근 20봉 모멘텀 +${m.momentum20.toFixed(0)}% — 위로 기운 흐름`
+        : `최근 20봉 모멘텀 ${m.momentum20.toFixed(0)}% — 아래로 눌린 흐름`,
+    );
+  }
+  return out;
+}
+
+/**
+ * 시장·재무 스냅샷을 결정론적 신호로 분해.
+ * 점수 = 50 + 50 * (가중기여 평균). 드라이버는 weight*|기여| 내림차순.
+ */
+export function computeSignal(market: MarketSnapshot, ctx?: FinancialContext): Signal {
+  const drivers: SignalDriver[] = [];
+  let weightedSum = 0;
+  let totalWeight = 0;
+
+  for (const spec of SPECS) {
+    const r = spec.evaluate(market, ctx);
+    if (!r) continue;
+    const [contribution, detail] = r;
+    drivers.push({
+      key: spec.key,
+      label: spec.label,
+      detail,
+      direction: dirOf(contribution),
+      contribution,
+      weight: spec.weight,
+      kind: spec.kind,
+    });
+    weightedSum += contribution * spec.weight;
+    totalWeight += spec.weight;
+  }
+
+  const norm = totalWeight > 0 ? weightedSum / totalWeight : 0;
+  const score = Math.round(clamp(50 + 50 * norm, 1, 99));
+
+  drivers.sort((a, b) => Math.abs(b.contribution) * b.weight - Math.abs(a.contribution) * a.weight);
+
+  return {
+    score,
+    grade: gradeOf(score),
+    state: stateOf(score, market),
+    drivers,
+    trajectory: buildTrajectory(market),
+  };
+}

--- a/packages/tarot-core/src/types.ts
+++ b/packages/tarot-core/src/types.ts
@@ -63,6 +63,9 @@ export interface MarketSnapshot {
   industry?: string;        // 산업 (예: "Consumer Electronics")
   marketCap?: number;       // 시가총액 (대형/중형/소형 심리 차이)
   fiftyTwoWeekPosition?: number; // 0~1, 52주 범위 내 현재 위치
+  // 시간축(trajectory) 파생 메트릭 — 1y 캔들에서 계산. 신호 엔진(computeSignal)이 사용.
+  momentum20?: number;      // 최근 20봉 % 수익률 (예: +20)
+  daysAboveSma200?: number; // 200일선 위를 연속으로 유지한 봉 수
   condition: MarketCondition;
   summary: string;
 }
@@ -85,6 +88,8 @@ export interface TarotInterpretation {
   source: InterpretationSource;
   cachedAt?: string;
   createdAt: string;
+  // 확장 슬롯 — 신호 드라이버·향후 사주 레이어 등 부가 데이터(사용자 노출은 선택). 사주 통합 대비.
+  extras?: Record<string, unknown>;
 }
 
 export interface DrawRequest {


### PR DESCRIPTION
## 배경

경쟁 앱 StockRay의 힘은 모델이 아니라 **백단의 명확함** — 설명가능·결정론적 점수(척추) + 구체 드라이버("왜 움직였나") + 시간축 지속성. PO 진단: *우리 타로는 백단 신호가 약하고 해석이 명쾌하지 않다.* 이 PR은 그 백단 명확함을 흡수하되 **타로 정체성 유지 + 투자권유 절대 금지**로, 해석을 데이터에 접지해 날카롭게 만든다. (하네스 로드맵의 **B4** 본격판)

확정 방향: ① 점수 = **내부 척추만**(사용자 미노출) ② 1차 = **엔진 + 프롬프트**(DB 마이그레이션·차트는 Phase 2).

## 변경

- **`signal/computeSignal.ts`** (신규, 순수): 시장·재무 → 0~100 점수 + 등급 + **정량 드라이버**(예: "RSI 68 — 상승 구간", "매출성장 +30%", "200일선 위 12봉째") + 시간축. `market.ts:46` inferCondition 가중 로직을 일반화 + 기여도 분해. (9 테스트)
- **`market.ts`**: 1y 캔들에서 `momentum20`·`daysAboveSma200` 파생 → 스냅샷 부착.
- **`prompts/interpret-v2.5.0.ts`** (신규): v2.4 위에 신호 척추(상태 라벨·시간축·드라이버) 주입 + **접지 규칙**. 점수 숫자 미노출, 미래예측·매매권유·판정어 에코 금지.
- **`interpret.ts` / `news-insight`**: 프롬프트 빌더 v2.5로 교체.
- **`types.ts`**: MarketSnapshot 시간축 필드 + `TarotInterpretation.extras`(사주 확장 대비).
- **`safety/forbidden.ts`**: 규제검수 반영 — "상승/하락 우위" RISK, "확실한" BLOCKED 보강.

## 규제

`regulation-reviewer` 검수: **⚠️RISK → 보강 완료**. 점수는 프롬프트 내부에만, `checkSafety`는 출력에만, disclaimer 무조건 첨부. 판정어 중립화("우위"→"구간") + 게이트 어휘 보강 + 규칙 강화.

## 검증

- lint · typecheck · build:web · test(**367 passed**, +14) 통과
- 신규: `compute-signal`(9) · `prompt-v2.5-grounding`(5)
- 결정론·드라이버 정렬·시간축·금칙어 안전성 단위 검증

## Phase 2 (이번 범위 아님)

지속성(Prisma `TickerScore` — CRITICAL 마이그레이션, /careful+승인) → "N일 유지"·점수 vs 주가 차트. 점수 사용자 노출 방식 재논의.

https://claude.ai/code/session_01PZvXoXgazGvhPb92LjwD9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZvXoXgazGvhPb92LjwD9X)_