### PR TITLE
feat(harness): B1a — OKR 측정신호 매핑 + 스냅샷 메커니즘

### DIFF
--- a/.github/workflows/autonomy-report.yml
+++ b/.github/workflows/autonomy-report.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write  # B1a: OKR 스냅샷 시계열 커밋
   issues: read
   pull-requests: read
 
@@ -20,6 +20,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # ── 0. B1a: OKR 지표 스냅샷 시계열 적재 ────────────────────
+      - name: Capture OKR snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+          npx -y tsx@4.19.2 scripts/outcome-snapshot.ts \
+            generated/outcomes/metric-registry.json generated/outcomes "$TODAY" || echo "스냅샷 실패 — 계속 진행"
+          if [ -f "generated/outcomes/okr-snapshot-${TODAY}.json" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "generated/outcomes/okr-snapshot-${TODAY}.json"
+            git diff --cached --quiet || {
+              git commit -m "chore(outcomes): OKR 스냅샷 ${TODAY} [skip ci]"
+              git push origin HEAD:main || { git pull --rebase origin main && git push origin HEAD:main || echo "push 실패 — 다음 주기"; }
+            }
+          fi
 
       # ── 1. 지난 7일 자율 활동 집계 ─────────────────────────────
       - name: Collect metrics

--- a/generated/outcomes/metric-registry.json
+++ b/generated/outcomes/metric-registry.json
@@ -1,0 +1,65 @@
+{
+  "_doc": "B1 Outcome Grounding — KR↔측정신호 매핑. auto=true 는 자동 취득(github-issues/repo-files), auto=false 는 Slack/수동 입력 슬롯. direction+target 으로 움직임의 좋고나쁨 판정.",
+  "metrics": [
+    {
+      "id": "o1-kr3-blockers",
+      "okr": "O1/KR3",
+      "label": "출시 차단 이슈 수",
+      "source": "github-issues",
+      "query": "label:launch-blocker state:open",
+      "direction": "down",
+      "target": 0,
+      "auto": true
+    },
+    {
+      "id": "o4-kr2-techdebt",
+      "okr": "O4/KR2",
+      "label": "열린 기술부채 이슈 수",
+      "source": "github-issues",
+      "query": "label:tech-debt state:open",
+      "direction": "down",
+      "target": 0,
+      "auto": true
+    },
+    {
+      "id": "o4-kr1-e2e",
+      "okr": "O4/KR1",
+      "label": "E2E 테스트 스펙 수",
+      "source": "repo-files",
+      "query": "apps/web/e2e/*.spec.ts",
+      "direction": "up",
+      "target": 5,
+      "auto": true
+    },
+    {
+      "id": "o1-kr5-safety",
+      "okr": "O1/KR5",
+      "label": "AI 안전검사 테스트 파일 수",
+      "source": "repo-files",
+      "query": "packages/tarot-core/__tests__/*safety*.test.ts",
+      "direction": "up",
+      "target": 1,
+      "auto": true
+    },
+    {
+      "id": "o2-kr3-crash",
+      "okr": "O2/KR3",
+      "label": "앱 크래시율(%)",
+      "source": "manual",
+      "query": "",
+      "direction": "down",
+      "target": 1.0,
+      "auto": false
+    },
+    {
+      "id": "o2-kr2-satisfaction",
+      "okr": "O2/KR2",
+      "label": "AI 해석 만족도(5점)",
+      "source": "manual",
+      "query": "",
+      "direction": "up",
+      "target": 4.0,
+      "auto": false
+    }
+  ]
+}

--- a/scripts/__tests__/outcome-snapshot.test.ts
+++ b/scripts/__tests__/outcome-snapshot.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  captureSnapshot,
+  parseIssueQuery,
+  type Registry,
+  type Fetcher,
+  type Metric,
+} from "../outcome-snapshot";
+
+const registry: Registry = {
+  metrics: [
+    { id: "blockers", okr: "O1/KR3", label: "차단", source: "github-issues", query: "label:launch-blocker state:open", direction: "down", target: 0, auto: true },
+    { id: "e2e", okr: "O4/KR1", label: "e2e", source: "repo-files", query: "apps/web/e2e/*.spec.ts", direction: "up", auto: true },
+    { id: "crash", okr: "O2/KR3", label: "크래시", source: "manual", query: "", direction: "down", target: 1, auto: false },
+    { id: "ci", okr: "O1/KR5", label: "ci", source: "ci-or-test", query: "", direction: "up", auto: true },
+  ],
+};
+
+describe("parseIssueQuery", () => {
+  it("label/state 토큰을 파싱", () => {
+    expect(parseIssueQuery("label:launch-blocker state:open")).toEqual({ labels: ["launch-blocker"], state: "open" });
+  });
+  it("복수 label + 기본 state=open", () => {
+    expect(parseIssueQuery("label:a label:b")).toEqual({ labels: ["a", "b"], state: "open" });
+  });
+});
+
+describe("captureSnapshot", () => {
+  it("auto 지표는 fetcher 값, manual 은 null", () => {
+    const fetchers: Partial<Record<Metric["source"], Fetcher>> = {
+      "github-issues": () => 3,
+      "repo-files": () => 1,
+    };
+    const snap = captureSnapshot(registry, fetchers, "2026-06-04");
+    expect(snap.date).toBe("2026-06-04");
+    expect(snap.values.blockers).toBe(3);
+    expect(snap.values.e2e).toBe(1);
+    expect(snap.values.crash).toBeNull(); // manual
+    expect(snap.values.ci).toBeNull(); // fetcher 없음(ci-or-test 미주입)
+  });
+
+  it("fetcher 가 throw 하면 null degrade", () => {
+    const fetchers: Partial<Record<Metric["source"], Fetcher>> = {
+      "github-issues": () => {
+        throw new Error("gh 실패");
+      },
+      "repo-files": () => 2,
+    };
+    const snap = captureSnapshot(registry, fetchers, "2026-06-04");
+    expect(snap.values.blockers).toBeNull(); // 취득 실패 → null
+    expect(snap.values.e2e).toBe(2);
+  });
+
+  it("비유한값(NaN/Infinity) 반환 시 null", () => {
+    const fetchers: Partial<Record<Metric["source"], Fetcher>> = {
+      "github-issues": () => NaN,
+      "repo-files": () => Infinity,
+    };
+    const snap = captureSnapshot(registry, fetchers, "2026-06-04");
+    expect(snap.values.blockers).toBeNull();
+    expect(snap.values.e2e).toBeNull();
+  });
+
+  it("모든 지표 id 가 values 에 존재(누락 없음)", () => {
+    const snap = captureSnapshot(registry, {}, "2026-06-04");
+    expect(Object.keys(snap.values).sort()).toEqual(["blockers", "ci", "crash", "e2e"]);
+    expect(Object.values(snap.values).every((v) => v === null)).toBe(true);
+  });
+});

--- a/scripts/outcome-snapshot.ts
+++ b/scripts/outcome-snapshot.ts
@@ -1,0 +1,142 @@
+/**
+ * B1a — Outcome Grounding 스냅샷.
+ *
+ * KR↔측정신호 매핑(metric-registry.json)을 읽어 각 지표의 현재값을 한 번에 떠서
+ * generated/outcomes/okr-snapshot-<date>.json 으로 남긴다. 시계열이 쌓인다.
+ *
+ * "활동(제안→머지)"만 보던 시스템에 "지표가 실제로 움직였는가(결과)"를 보는
+ * 나침반의 베이스라인. 취득 실패 지표는 null(unknown) — 파이프라인 안 죽음(폴백 철학).
+ *
+ * 순수 함수(captureSnapshot) + 주입 fetcher → vitest. 외부 취득은 CLI 경계에서만.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+export type MetricSource = "github-issues" | "repo-files" | "ci-or-test" | "manual";
+export type Direction = "up" | "down";
+
+export interface Metric {
+  id: string;
+  okr: string;
+  label: string;
+  source: MetricSource;
+  query: string;
+  direction: Direction;
+  target?: number;
+  auto: boolean;
+}
+
+export interface Registry {
+  metrics: Metric[];
+}
+
+export interface Snapshot {
+  date: string;
+  values: Record<string, number | null>;
+}
+
+/** 소스별 취득 함수. number 반환 또는 null(측정 불가). 절대 throw 밖으로 내보내지 않음. */
+export type Fetcher = (m: Metric) => number | null;
+
+export function loadRegistry(path: string): Registry {
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as { metrics?: unknown };
+  if (!Array.isArray(parsed.metrics)) throw new Error("metric-registry: metrics 배열 필요");
+  return { metrics: parsed.metrics as Metric[] };
+}
+
+/**
+ * 레지스트리의 각 지표를 fetcher 로 취득해 스냅샷 생성(순수).
+ * - auto=false 또는 해당 source fetcher 없음 → null
+ * - fetcher 가 throw 하거나 비유한값 반환 → null (degrade)
+ */
+export function captureSnapshot(
+  registry: Registry,
+  fetchers: Partial<Record<MetricSource, Fetcher>>,
+  today: string,
+): Snapshot {
+  const values: Record<string, number | null> = {};
+  for (const m of registry.metrics) {
+    if (!m.auto) {
+      values[m.id] = null;
+      continue;
+    }
+    const fetcher = fetchers[m.source];
+    if (!fetcher) {
+      values[m.id] = null;
+      continue;
+    }
+    try {
+      const v = fetcher(m);
+      values[m.id] = typeof v === "number" && Number.isFinite(v) ? v : null;
+    } catch {
+      values[m.id] = null;
+    }
+  }
+  return { date: today, values };
+}
+
+// ─────────────────────────────────────────────────────────────
+// 실 취득 fetcher (CLI 경계 — execFile/fs)
+// ─────────────────────────────────────────────────────────────
+
+/** "label:X state:open author:Y" 형태 쿼리를 gh issue list 인자로 파싱. */
+export function parseIssueQuery(query: string): { labels: string[]; state: string } {
+  const labels: string[] = [];
+  let state = "open";
+  for (const tok of query.split(/\s+/)) {
+    const [k, v] = tok.split(":");
+    if (k === "label" && v) labels.push(v);
+    else if (k === "state" && v) state = v;
+  }
+  return { labels, state };
+}
+
+function githubIssuesFetcher(m: Metric): number | null {
+  const { labels, state } = parseIssueQuery(m.query);
+  const args = ["issue", "list", "--state", state, "--limit", "200", "--json", "number"];
+  for (const l of labels) args.push("--label", l);
+  const out = execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  const arr = JSON.parse(out) as unknown[];
+  return Array.isArray(arr) ? arr.length : null;
+}
+
+function repoFilesFetcher(m: Metric): number | null {
+  // git ls-files 는 glob 패턴을 지원. 추적 파일만 카운트(결정론적).
+  const out = execFileSync("git", ["ls-files", "--", m.query], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return out.split("\n").filter((l) => l.trim().length > 0).length;
+}
+
+export const REAL_FETCHERS: Partial<Record<MetricSource, Fetcher>> = {
+  "github-issues": githubIssuesFetcher,
+  "repo-files": repoFilesFetcher,
+  // ci-or-test, manual 은 B1a 에서 null(향후/수동)
+};
+
+// ─────────────────────────────────────────────────────────────
+// CLI: outcome-snapshot.ts <registry.json> <outDir> [today]
+// ─────────────────────────────────────────────────────────────
+
+function main(): void {
+  const argv = process.argv;
+  const registryPath = argv[2] ?? "generated/outcomes/metric-registry.json";
+  const outDir = argv[3] ?? "generated/outcomes";
+  const today = argv[4] ?? new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+
+  const registry = loadRegistry(registryPath);
+  const snapshot = captureSnapshot(registry, REAL_FETCHERS, today);
+  mkdirSync(outDir, { recursive: true });
+  const outPath = `${outDir}/okr-snapshot-${today}.json`;
+  writeFileSync(outPath, JSON.stringify(snapshot, null, 2) + "\n", "utf8");
+  process.stdout.write(`snapshot → ${outPath}\n`);
+  process.stdout.write(JSON.stringify(snapshot) + "\n");
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("outcome-snapshot")) {
+  main();
+}


### PR DESCRIPTION
## Summary

**B1 결과-접지 루프(Outcome Grounding)의 1단계.** "제안→머지→성공률"(활동)만 보던 시스템에, "이 베팅이 OKR 지표를 실제로 움직였나"(결과)를 측정하는 나침반 — 그 **측정 대상부터** 정의한다.

- `generated/outcomes/metric-registry.json`: KR↔측정신호 매핑.
  - auto 4개: 출시 차단 이슈 수(`launch-blocker`), 기술부채 이슈 수(`tech-debt`), E2E 스펙 수, 안전검사 테스트 수
  - manual 슬롯 2개: 크래시율, 만족도 (강제 안 함 — CEO/Slack 입력 통로는 B1b 8.1)
  - `direction`(up/down)+`target`으로 움직임의 좋고나쁨 판정 가능
- `scripts/outcome-snapshot.ts`: `captureSnapshot` 순수함수(주입 fetcher, 취득 실패 → `null` degrade) + 실 fetcher(`github-issues`=gh count, `repo-files`=git ls-files) + CLI. 취득 불가 지표는 `null`(unknown) — 파이프라인 안 죽음.
- `autonomy-report.yml`: 주간 스냅샷 step → `generated/outcomes/okr-snapshot-<date>.json` 커밋(`[skip ci]`). 시계열 적재.

실측 결과(로컬): `{blockers:0, techdebt:1, e2e:1, safety:1, crash:null, satisfaction:null}` — 정상.

## Test plan
- [x] `npx vitest run` — 365 passed (34 files; outcome-snapshot 6케이스: auto/manual, throw→null, NaN→null, 누락 없음)
- [x] outcome-snapshot.ts strict standalone typecheck
- [x] 실 CLI 스냅샷 end-to-end + registry/YAML 유효성
- [ ] (자동) 주간 autonomy-report 실행 시 okr-snapshot 커밋 확인

상관 기록만 — 인과 단정 안 함(중립). B1b(베팅 태깅)/B1c(재측정·판정)의 입력.
Ref: docs/AGENT_HARNESS_ROADMAP.md B1 · Out of scope: B1b/B1c/B2/B3/B4/Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)