### PR TITLE
feat(harness): B1b — 제안 Target-Metric 태깅 + 머지 시점 베팅 카드

### DIFF
--- a/.github/agent-scoring-guide.md
+++ b/.github/agent-scoring-guide.md
@@ -17,3 +17,22 @@
 - 총합 4-10 → 자동 close (임계값 미달)
 
 자기 평가를 솔직하게. 모든 축 4점이면 점수 시스템 무의미해집니다.
+
+---
+
+### 목표 지표 (B1 결과-접지 — 권장, 누락 시 보완 요청)
+
+점수 줄 근처에, 이 제안이 **어떤 OKR 지표를 어느 방향으로 움직이려는가**를 명시:
+`Target-Metric: <지표 id>`
+`Expected-Direction: up|down`
+
+사용 가능한 지표 id (generated/outcomes/metric-registry.json):
+- `o1-kr3-blockers` — 출시 차단 이슈 수 (down)
+- `o4-kr2-techdebt` — 열린 기술부채 이슈 수 (down)
+- `o4-kr1-e2e` — E2E 테스트 스펙 수 (up)
+- `o1-kr5-safety` — AI 안전검사 테스트 수 (up)
+- `o2-kr3-crash` — 앱 크래시율 (down)
+- `o2-kr2-satisfaction` — AI 해석 만족도 (up)
+
+목록에 딱 맞는 지표가 없으면 `Target-Metric: 신규 지표 제안 — <한줄 설명>`.
+이 필드가 있어야 머지 후 "이 베팅이 지표를 실제로 움직였는지" 추적 가능(없으면 보완 요청, 차단은 아님).

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -170,6 +170,41 @@ jobs:
             esac
           done
 
+      # B1b: 머지 시점 베팅 카드 — 제안의 Target-Metric + 현재 지표 baseline 스냅샷
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Record outcome bet
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+        run: |
+          set -uo pipefail
+          TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+          gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json title,body \
+            -q '(.title // "") + "\n" + (.body // "")' > /tmp/pr_body.md 2>/dev/null || echo "" > /tmp/pr_body.md
+          # 머지 시점 현재 지표 스냅샷(baseline 취득용 — 커밋 안 함, /tmp)
+          npx -y tsx@4.19.2 scripts/outcome-snapshot.ts \
+            generated/outcomes/metric-registry.json /tmp "$TODAY" || true
+          npx -y tsx@4.19.2 scripts/outcome-bet.ts \
+            "$PR_NUMBER" /tmp/pr_body.md "/tmp/okr-snapshot-${TODAY}.json" "$TODAY" generated/outcomes/bets 7 || true
+          if [ -f "generated/outcomes/bets/${PR_NUMBER}.json" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "generated/outcomes/bets/${PR_NUMBER}.json"
+            git diff --cached --quiet || {
+              git commit -m "chore(outcomes): bet card #${PR_NUMBER} [skip ci]"
+              git push origin HEAD:main || { git pull --rebase origin main && git push origin HEAD:main || echo "push 실패 — 무시"; }
+            }
+            echo "베팅 카드 기록: #${PR_NUMBER}"
+          else
+            echo "Target-Metric 없음 — 베팅 카드 생략 (#${PR_NUMBER})"
+          fi
+
       - name: Notify Slack (success)
         if: vars.SLACK_WEBHOOK_URL != ''
         env:

--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1843,6 +1843,12 @@ jobs:
 
             echo "#$NUM: U=$U F=$F N=$N A=$A 총합 $TOTAL (lane=$LANE)"
 
+            # B1b: Target-Metric 누락 보완 요청 (소프트 — 차단 아님)
+            if ! grep -qiE 'Target-Metric:[[:space:]]*\S' /tmp/body.txt; then
+              gh issue comment "$NUM" --repo "${{ github.repository }}" \
+                --body "📐 보완 요청(B1 결과-접지): 본문에 \`Target-Metric: <지표 id>\` / \`Expected-Direction: up|down\` 이 없습니다. 이게 있어야 머지 후 이 베팅이 OKR 지표를 실제로 움직였는지 추적됩니다. (이번엔 차단하지 않음 — 다음부터 포함 권장)" || true
+            fi
+
             if [ "$TOTAL" -ge 14 ]; then
               gh issue edit "$NUM" --add-label "score-strong" --repo "${{ github.repository }}" || true
             elif [ "$TOTAL" -ge 11 ]; then

--- a/scripts/__tests__/outcome-bet.test.ts
+++ b/scripts/__tests__/outcome-bet.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { parseTargetMetric, parseIssueRef, buildBet } from "../outcome-bet";
+
+describe("parseTargetMetric", () => {
+  it("Target-Metric / Expected-Direction 추출", () => {
+    const t = "## 제안\nTarget-Metric: o1-kr3-blockers\nExpected-Direction: down";
+    expect(parseTargetMetric(t)).toEqual({ metricId: "o1-kr3-blockers", direction: "down" });
+  });
+  it("필드 없으면 null", () => {
+    expect(parseTargetMetric("그냥 제안")).toEqual({ metricId: null, direction: null });
+  });
+  it("placeholder(none/tbd/metric)는 무시", () => {
+    expect(parseTargetMetric("Target-Metric: none").metricId).toBeNull();
+    expect(parseTargetMetric("Target-Metric: <metric id>").metricId).toBeNull();
+  });
+  it("direction 만 있고 metric 없으면 metricId null", () => {
+    expect(parseTargetMetric("Expected-Direction: up")).toEqual({ metricId: null, direction: "up" });
+  });
+});
+
+describe("parseIssueRef", () => {
+  it("첫 #NNN 추출", () => {
+    expect(parseIssueRef("closes #305 and #307")).toBe(305);
+  });
+  it("없으면 null", () => {
+    expect(parseIssueRef("no ref")).toBeNull();
+  });
+});
+
+describe("buildBet", () => {
+  const base = {
+    pr: 312,
+    snapshotValues: { "o1-kr3-blockers": 4, "o4-kr1-e2e": 1 },
+    mergedAt: "2026-06-04",
+  };
+
+  it("Target-Metric 있으면 baseline 과 함께 베팅 카드 생성", () => {
+    const bet = buildBet({
+      ...base,
+      text: "closes #300\nTarget-Metric: o1-kr3-blockers\nExpected-Direction: down",
+    });
+    expect(bet).not.toBeNull();
+    expect(bet!.pr).toBe(312);
+    expect(bet!.issue).toBe(300);
+    expect(bet!.metricId).toBe("o1-kr3-blockers");
+    expect(bet!.expectedDirection).toBe("down");
+    expect(bet!.baselineValue).toBe(4);
+    expect(bet!.checkAfterDays).toBe(7);
+    expect(bet!.status).toBe("pending");
+  });
+
+  it("Target-Metric 없으면 null(베팅 카드 안 만듦)", () => {
+    expect(buildBet({ ...base, text: "일반 PR, 지표 없음" })).toBeNull();
+  });
+
+  it("스냅샷에 해당 지표 없으면 baseline=null(unknown)", () => {
+    const bet = buildBet({ ...base, text: "Target-Metric: o2-kr3-crash" });
+    expect(bet).not.toBeNull();
+    expect(bet!.baselineValue).toBeNull();
+  });
+
+  it("checkAfterDays 오버라이드", () => {
+    const bet = buildBet({ ...base, text: "Target-Metric: o4-kr1-e2e", checkAfterDays: 0 });
+    expect(bet!.checkAfterDays).toBe(0);
+    expect(bet!.baselineValue).toBe(1);
+  });
+});

--- a/scripts/outcome-bet.ts
+++ b/scripts/outcome-bet.ts
@@ -1,0 +1,141 @@
+/**
+ * B1b — 머지 시점 "베팅 카드" 생성.
+ *
+ * Auto PR 이 머지될 때, 그 PR 이 참조한 제안의 Target-Metric 을 읽어
+ * 해당 지표의 *현재 스냅샷값(baseline)* 과 함께 베팅 카드를 만든다.
+ *   generated/outcomes/bets/<pr>.json
+ * N일 뒤 B1c 가 같은 지표를 재측정해 "움직였나"를 판정한다.
+ *
+ * 순수 함수(buildBet/parseTargetMetric) + CLI + vitest. 외부 취득 없음.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+
+export type Direction = "up" | "down";
+
+export interface Bet {
+  pr: number;
+  issue: number | null;
+  metricId: string;
+  expectedDirection: Direction | null;
+  baselineValue: number | null;
+  mergedAt: string;
+  checkAfterDays: number;
+  status: "pending" | "checked";
+}
+
+/** 제안/PR 본문에서 Target-Metric / Expected-Direction 필드 추출. */
+export function parseTargetMetric(text: string): {
+  metricId: string | null;
+  direction: Direction | null;
+} {
+  const t = text || "";
+  const midMatch = t.match(/Target-Metric:\s*([A-Za-z0-9_\-]+)/i);
+  const dirMatch = t.match(/Expected-Direction:\s*(up|down)/i);
+  const metricId = midMatch && midMatch[1] ? midMatch[1].trim() : null;
+  const direction = dirMatch && dirMatch[1] ? (dirMatch[1].toLowerCase() as Direction) : null;
+  // placeholder/none 류는 무시
+  if (!metricId || /^(none|n\/a|na|tbd|metric|id)$/i.test(metricId)) {
+    return { metricId: null, direction };
+  }
+  return { metricId, direction };
+}
+
+/** 본문에서 첫 번째 이슈 참조(#NNN)를 추출. */
+export function parseIssueRef(text: string): number | null {
+  const m = (text || "").match(/#(\d+)/);
+  return m && m[1] ? Number(m[1]) : null;
+}
+
+export interface BuildBetInput {
+  pr: number;
+  text: string;
+  /** okr-snapshot 의 values (metricId → number|null) */
+  snapshotValues: Record<string, number | null>;
+  mergedAt: string;
+  checkAfterDays?: number;
+}
+
+/**
+ * 베팅 카드 생성(순수). Target-Metric 이 없으면 null(베팅 카드 안 만듦).
+ * baseline 은 스냅샷에서 가져오되, 없으면 null(unknown — 측정 불가).
+ */
+export function buildBet(input: BuildBetInput): Bet | null {
+  const { metricId, direction } = parseTargetMetric(input.text);
+  if (!metricId) return null;
+  const baseline = Object.prototype.hasOwnProperty.call(input.snapshotValues, metricId)
+    ? input.snapshotValues[metricId]
+    : null;
+  return {
+    pr: input.pr,
+    issue: parseIssueRef(input.text),
+    metricId,
+    expectedDirection: direction,
+    baselineValue: baseline ?? null,
+    mergedAt: input.mergedAt,
+    checkAfterDays: input.checkAfterDays ?? 7,
+    status: "pending",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI: outcome-bet.ts <pr> <bodyFile> <snapshotFile> <mergedAt> <outDir> [checkAfterDays]
+// ─────────────────────────────────────────────────────────────
+
+function loadSnapshotValues(path: string): Record<string, number | null> {
+  try {
+    const raw = readFileSync(path, "utf8").trim();
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as { values?: Record<string, number | null> };
+    return parsed.values ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function main(): void {
+  const argv = process.argv;
+  const pr = Number(argv[2]);
+  const bodyFile = argv[3] ?? "";
+  const snapshotFile = argv[4] ?? "";
+  const mergedAt = argv[5] ?? new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+  const outDir = argv[6] ?? "generated/outcomes/bets";
+  const checkAfterDays = argv[7] ? Number(argv[7]) : 7;
+
+  if (!Number.isInteger(pr) || pr <= 0) {
+    console.error("usage: outcome-bet.ts <pr> <bodyFile> <snapshotFile> <mergedAt> <outDir> [checkAfterDays]");
+    process.exit(1);
+    return;
+  }
+
+  let text = "";
+  try {
+    text = readFileSync(bodyFile, "utf8");
+  } catch {
+    text = "";
+  }
+
+  const bet = buildBet({
+    pr,
+    text,
+    snapshotValues: loadSnapshotValues(snapshotFile),
+    mergedAt,
+    checkAfterDays,
+  });
+
+  if (!bet) {
+    process.stdout.write("no-target-metric\n");
+    return;
+  }
+
+  mkdirSync(outDir, { recursive: true });
+  const outPath = `${outDir}/${pr}.json`;
+  writeFileSync(outPath, JSON.stringify(bet, null, 2) + "\n", "utf8");
+  process.stdout.write(`bet → ${outPath}\n`);
+  process.stdout.write(JSON.stringify(bet) + "\n");
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("outcome-bet")) {
+  main();
+}


### PR DESCRIPTION
## Summary

**B1 결과-접지 2단계.** 각 제안이 "어떤 KR을 어디로 움직이려는가"를 명시하고, 머지 순간 그 지표의 현재값(baseline)을 떠서 "베팅 카드"를 만든다 → B1c가 N일 뒤 재측정.

- `agent-scoring-guide.md`(9개 에이전트 전부 주입): `Target-Metric`/`Expected-Direction` 출력 필드 + 사용가능 지표 id 목록.
- `score_and_filter`: Target-Metric 누락 시 **보완 요청 코멘트만**(소프트 — 차단/감점 아님, 거짓양성 회피).
- `scripts/outcome-bet.ts`: `parseTargetMetric`/`parseIssueRef`/`buildBet` 순수함수(Target 없으면 베팅 안 만듦, baseline 없으면 `null`) + CLI. vitest 10케이스.
- `auto-merge.yml`: `[Auto]` PR 머지 시 PR 본문의 Target-Metric + 머지 시점 스냅샷 baseline으로 `generated/outcomes/bets/<pr>.json` 생성·커밋(`[skip ci]`).

베팅 카드 예: `{pr:312, issue:300, metricId:"o1-kr3-blockers", expectedDirection:"down", baselineValue:4, mergedAt, checkAfterDays:7, status:"pending"}`

## Test plan
- [x] `npx vitest run` — 375 passed (35 files; outcome-bet 10케이스: 파싱·placeholder 무시·baseline null·no-target null)
- [x] outcome-bet.ts strict standalone + CLI end-to-end(베팅 카드 생성 + no-op)
- [x] auto-merge/idea-proposal YAML 유효
- [ ] (자동) 다음 [Auto] PR 머지 시 bets/<pr>.json 생성 확인

Ref: docs/AGENT_HARNESS_ROADMAP.md B1 · 다음: B1c(재측정·판정·ledger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)