### PR TITLE
feat(harness): B1c — 베팅 재측정·판정 + ledger + 결과 나침반

### DIFF
--- a/.github/workflows/autonomy-report.yml
+++ b/.github/workflows/autonomy-report.yml
@@ -169,6 +169,43 @@ jobs:
           echo "$TOP" >> "$GITHUB_OUTPUT"
           echo "__TOP_EOF__" >> "$GITHUB_OUTPUT"
 
+      # ── 2.7 B1c: 결과-접지 나침반 (베팅이 지표를 실제로 움직였나) ──
+      - name: Collect outcome metrics
+        id: outcomes
+        run: |
+          set -uo pipefail
+          SINCE_DATE=$(TZ=Asia/Seoul date -d '7 days ago' '+%Y-%m-%d' 2>/dev/null || TZ=Asia/Seoul date -v-7d '+%Y-%m-%d')
+          MOVED=0; FLAT=0; WORSENED=0; UNKNOWN=0
+          LEDGER="generated/outcomes/ledger.jsonl"
+          if [ -f "$LEDGER" ]; then
+            # 이번 주(checkedAt >= since) 판정만 집계
+            AGG=$(jq -s --arg s "$SINCE_DATE" '
+              [.[] | select(.checkedAt >= $s)]
+              | { moved: ([.[]|select(.verdict=="moved")]|length),
+                  flat: ([.[]|select(.verdict=="flat")]|length),
+                  worsened: ([.[]|select(.verdict=="worsened")]|length),
+                  unknown: ([.[]|select(.verdict=="unknown")]|length) }
+            ' "$LEDGER" 2>/dev/null || echo '{}')
+            MOVED=$(echo "$AGG" | jq -r '.moved // 0')
+            FLAT=$(echo "$AGG" | jq -r '.flat // 0')
+            WORSENED=$(echo "$AGG" | jq -r '.worsened // 0')
+            UNKNOWN=$(echo "$AGG" | jq -r '.unknown // 0')
+          fi
+          MOVED=${MOVED:-0}; FLAT=${FLAT:-0}; WORSENED=${WORSENED:-0}; UNKNOWN=${UNKNOWN:-0}
+          DECIDED=$((MOVED + FLAT + WORSENED))
+          # STUCK 조기신호: 판정 3건 이상인데 moved 가 (flat+worsened) 보다 적으면 정체
+          STUCK=""
+          if [ "$DECIDED" -ge 3 ] && [ "$MOVED" -lt $((FLAT + WORSENED)) ]; then
+            STUCK="⚠️ *진척 정체 신호*: 활동은 했지만 목표 지표가 움직인 베팅(${MOVED})보다 정체·역효과(${FLAT}+${WORSENED})가 많습니다. 접근 각도나 목표 자체를 재검토할 시점."
+          fi
+          echo "moved=$MOVED" >> "$GITHUB_OUTPUT"
+          echo "flat=$FLAT" >> "$GITHUB_OUTPUT"
+          echo "worsened=$WORSENED" >> "$GITHUB_OUTPUT"
+          echo "unknown=$UNKNOWN" >> "$GITHUB_OUTPUT"
+          echo "stuck<<__STUCK_EOF__" >> "$GITHUB_OUTPUT"
+          echo "$STUCK" >> "$GITHUB_OUTPUT"
+          echo "__STUCK_EOF__" >> "$GITHUB_OUTPUT"
+
       # ── 3. Slack 리포트 전송 ────────────────────────────────────
       - name: Send weekly report
         env:
@@ -184,6 +221,11 @@ jobs:
           C_NEW_PRS: ${{ steps.constraints.outputs.new_prs }}
           C_REVIEW_PENDING: ${{ steps.constraints.outputs.review_pending }}
           C_TOP: ${{ steps.constraints.outputs.top }}
+          O_MOVED: ${{ steps.outcomes.outputs.moved }}
+          O_FLAT: ${{ steps.outcomes.outputs.flat }}
+          O_WORSENED: ${{ steps.outcomes.outputs.worsened }}
+          O_UNKNOWN: ${{ steps.outcomes.outputs.unknown }}
+          O_STUCK: ${{ steps.outcomes.outputs.stuck }}
         run: |
           WEEK_START=$(TZ=Asia/Seoul date -d '7 days ago' '+%m/%d' 2>/dev/null || \
                       TZ=Asia/Seoul date -v-7d '+%m/%d')
@@ -217,6 +259,11 @@ jobs:
             "• 이번 주 사전 차단한 제안: *${C_HITS_WEEK}건* — 그만큼 CEO가 같은 피드백을 반복하지 않아도 됐습니다" \
             "• 자주 작동한 규칙: ${C_TOP}" \
             "• 이번 주 새로 학습한 규칙 후보(PR): ${C_NEW_PRS}건 / 리뷰 대기: ${C_REVIEW_PENDING}건" \
+            "" \
+            "*🧭 결과 나침반 (베팅이 지표를 움직였나):*" \
+            "• ✅ 움직임(moved): ${O_MOVED} · ➖ 정체(flat): ${O_FLAT} · 🔻 역효과(worsened): ${O_WORSENED} · ❔ 측정불가(unknown): ${O_UNKNOWN}" \
+            "• 이번 주 머지된 베팅 중 ${O_MOVED}건이 목표 지표를 실제로 움직였습니다 (상관 기록 — 인과 단정 아님)" \
+            "${O_STUCK}" \
             "" \
             "_Hermes 자율 루프 — CEO 개입 없이 자동 운영 중_")
 

--- a/.github/workflows/outcome-check.yml
+++ b/.github/workflows/outcome-check.yml
@@ -1,0 +1,57 @@
+name: Outcome Check
+
+# B1c — 결과-접지 나침반. 매일 pending 베팅 중 기한 도래분을 현재 지표로 재측정·판정 →
+# generated/outcomes/ledger.jsonl 에 적재. "이 베팅이 OKR 지표를 실제로 움직였나"를 기록.
+# 상관 기록만(인과 단정 안 함). 측정 불가는 unknown 으로 안전 처리.
+
+on:
+  schedule:
+    - cron: "0 23 * * *"  # 매일 오전 8시 KST (UTC 23:00 전날)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+
+concurrency:
+  group: outcome-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Re-measure due bets + judge
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+
+          # 베팅 디렉토리 없으면 조용히 종료
+          if [ ! -d generated/outcomes/bets ]; then
+            echo "베팅 카드 없음 — 종료"; exit 0
+          fi
+
+          # 현재 지표 스냅샷(재측정용 — /tmp, 커밋 안 함)
+          npx -y tsx@4.19.2 scripts/outcome-snapshot.ts \
+            generated/outcomes/metric-registry.json /tmp "$TODAY" || echo "스냅샷 실패 — unknown 처리됨"
+
+          # 기한 도래 pending 베팅 판정 → ledger append + 베팅 status=checked
+          npx -y tsx@4.19.2 scripts/outcome-judge.ts \
+            generated/outcomes/bets "/tmp/okr-snapshot-${TODAY}.json" generated/outcomes/ledger.jsonl "$TODAY"
+
+      - name: Commit ledger + checked bets
+        run: |
+          set -uo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add generated/outcomes/ledger.jsonl generated/outcomes/bets 2>/dev/null || true
+          git diff --cached --quiet && { echo "변경 없음 — 커밋 생략"; exit 0; }
+          git commit -m "chore(outcomes): outcome ledger 갱신 $(TZ=Asia/Seoul date '+%Y-%m-%d') [skip ci]"
+          git push origin HEAD:main || { git pull --rebase origin main && git push origin HEAD:main || echo "push 실패 — 다음 주기"; }

--- a/scripts/__tests__/outcome-judge.test.ts
+++ b/scripts/__tests__/outcome-judge.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { judge, isDue, addDays, type Bet } from "../outcome-judge";
+
+const bet = (over: Partial<Bet>): Bet => ({
+  pr: 1,
+  issue: 10,
+  metricId: "o1-kr3-blockers",
+  expectedDirection: "down",
+  baselineValue: 4,
+  mergedAt: "2026-06-04",
+  checkAfterDays: 7,
+  status: "pending",
+  ...over,
+});
+
+describe("addDays", () => {
+  it("날짜 산술", () => {
+    expect(addDays("2026-06-04", 7)).toBe("2026-06-11");
+    expect(addDays("2026-06-30", 1)).toBe("2026-07-01");
+  });
+});
+
+describe("isDue", () => {
+  it("pending + 기한 도래 → true", () => {
+    expect(isDue(bet({ mergedAt: "2026-06-04", checkAfterDays: 7 }), "2026-06-11")).toBe(true);
+    expect(isDue(bet({ mergedAt: "2026-06-04", checkAfterDays: 7 }), "2026-06-12")).toBe(true);
+  });
+  it("기한 전 → false", () => {
+    expect(isDue(bet({ mergedAt: "2026-06-04", checkAfterDays: 7 }), "2026-06-10")).toBe(false);
+  });
+  it("이미 checked → false", () => {
+    expect(isDue(bet({ status: "checked" }), "2026-12-31")).toBe(false);
+  });
+});
+
+describe("judge", () => {
+  it("원하는 방향(down)으로 의미있게 이동 → moved", () => {
+    const v = judge(bet({ baselineValue: 4, expectedDirection: "down" }), 1, "2026-06-11");
+    expect(v.verdict).toBe("moved");
+    expect(v.baseline).toBe(4);
+    expect(v.after).toBe(1);
+  });
+  it("반대 방향(증가했는데 down 기대) → worsened", () => {
+    expect(judge(bet({ baselineValue: 4, expectedDirection: "down" }), 7, "x").verdict).toBe("worsened");
+  });
+  it("거의 변화 없음 → flat (5% 미만)", () => {
+    expect(judge(bet({ baselineValue: 100, expectedDirection: "up" }), 102, "x").verdict).toBe("flat");
+  });
+  it("baseline 0 → 절대 1 이상 변화해야 이동", () => {
+    expect(judge(bet({ baselineValue: 0, expectedDirection: "down" }), 0, "x").verdict).toBe("flat");
+    expect(judge(bet({ baselineValue: 0, expectedDirection: "up" }), 2, "x").verdict).toBe("moved");
+  });
+  it("baseline 또는 현재값 null → unknown", () => {
+    expect(judge(bet({ baselineValue: null }), 3, "x").verdict).toBe("unknown");
+    expect(judge(bet({ baselineValue: 4 }), null, "x").verdict).toBe("unknown");
+  });
+  it("방향 미지정 + 변화 있음 → moved(중립 움직임)", () => {
+    expect(judge(bet({ expectedDirection: null, baselineValue: 10 }), 4, "x").verdict).toBe("moved");
+  });
+  it("ledger 엔트리 형식", () => {
+    const v = judge(bet({}), 1, "2026-06-11");
+    expect(v).toMatchObject({ pr: 1, issue: 10, metricId: "o1-kr3-blockers", checkedAt: "2026-06-11" });
+  });
+});

--- a/scripts/outcome-judge.ts
+++ b/scripts/outcome-judge.ts
@@ -1,0 +1,164 @@
+/**
+ * B1c — 베팅 재측정 · 판정.
+ *
+ * 베팅 카드(generated/outcomes/bets/<pr>.json) 중 기한이 도래한 pending 을 찾아
+ * 같은 지표의 *현재값*을 다시 재서 baseline 과 비교 → 판정:
+ *   moved    — 원하는 방향(direction)으로 의미있게 이동
+ *   flat     — 거의 변화 없음
+ *   worsened — 반대 방향으로 이동
+ *   unknown  — baseline 또는 현재값이 null(측정 불가)
+ *
+ * ⚠️ 상관 기록만. "지표가 움직였다 = 이 PR 덕분"이라 단정하지 않는다(중립어).
+ * 순수 함수(judge) + CLI + vitest. 외부 취득은 outcome-snapshot 재사용(CLI 경계).
+ */
+
+import { readFileSync, writeFileSync, appendFileSync, readdirSync, mkdirSync } from "node:fs";
+
+export type Verdict = "moved" | "flat" | "worsened" | "unknown";
+export type Direction = "up" | "down";
+
+export interface Bet {
+  pr: number;
+  issue: number | null;
+  metricId: string;
+  expectedDirection: Direction | null;
+  baselineValue: number | null;
+  mergedAt: string;
+  checkAfterDays: number;
+  status: "pending" | "checked";
+}
+
+export interface LedgerEntry {
+  pr: number;
+  issue: number | null;
+  metricId: string;
+  baseline: number | null;
+  after: number | null;
+  direction: Direction | null;
+  verdict: Verdict;
+  checkedAt: string;
+}
+
+/** 의미있는 이동으로 볼 최소 상대 변화(5%) — 노이즈 컷. */
+const MIN_REL_CHANGE = 0.05;
+
+/**
+ * 베팅 + 현재값 → 판정(순수).
+ * direction 이 null 이면 절대 변화 방향을 좋다/나쁘다로 못 정하므로,
+ * 변화가 있으면 moved, 없으면 flat (보수적).
+ */
+export function judge(bet: Bet, currentValue: number | null, checkedAt: string): LedgerEntry {
+  const base = bet.baselineValue;
+  const after = currentValue;
+
+  let verdict: Verdict;
+  if (base === null || after === null || !Number.isFinite(base) || !Number.isFinite(after)) {
+    verdict = "unknown";
+  } else {
+    const delta = after - base;
+    // 변화량 임계 — baseline 이 0이면 절대 1 이상 변화, 아니면 5% 이상
+    const threshold = base === 0 ? 1 : Math.abs(base) * MIN_REL_CHANGE;
+    if (Math.abs(delta) < threshold) {
+      verdict = "flat";
+    } else if (bet.expectedDirection === null) {
+      // 방향 미지정 → 변화는 있으나 좋고나쁨 판단 불가 → moved(중립적 "움직임")
+      verdict = "moved";
+    } else {
+      const movedDesiredWay =
+        (bet.expectedDirection === "up" && delta > 0) ||
+        (bet.expectedDirection === "down" && delta < 0);
+      verdict = movedDesiredWay ? "moved" : "worsened";
+    }
+  }
+
+  return {
+    pr: bet.pr,
+    issue: bet.issue,
+    metricId: bet.metricId,
+    baseline: base,
+    after,
+    direction: bet.expectedDirection,
+    verdict,
+    checkedAt,
+  };
+}
+
+/** 베팅이 지금 재측정 대상인가 (pending && mergedAt + checkAfterDays <= today). */
+export function isDue(bet: Bet, today: string): boolean {
+  if (bet.status !== "pending") return false;
+  const due = addDays(bet.mergedAt, bet.checkAfterDays);
+  return due <= today;
+}
+
+/** YYYY-MM-DD + days → YYYY-MM-DD (UTC 기준 산술). */
+export function addDays(ymd: string, days: number): string {
+  const d = new Date(`${ymd}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI: outcome-judge.ts <betsDir> <snapshotFile> <ledgerFile> [today]
+//   - betsDir 의 pending && due 베팅을 snapshot 현재값으로 판정
+//   - ledgerFile(jsonl)에 append, 베팅 status=checked 로 갱신
+// ─────────────────────────────────────────────────────────────
+
+function loadSnapshotValues(path: string): Record<string, number | null> {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { values?: Record<string, number | null> };
+    return parsed.values ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function main(): void {
+  const argv = process.argv;
+  const betsDir = argv[2] ?? "generated/outcomes/bets";
+  const snapshotFile = argv[3] ?? "";
+  const ledgerFile = argv[4] ?? "generated/outcomes/ledger.jsonl";
+  const today = argv[5] ?? new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+
+  const values = loadSnapshotValues(snapshotFile);
+
+  let files: string[] = [];
+  try {
+    files = readdirSync(betsDir).filter((f) => f.endsWith(".json"));
+  } catch {
+    process.stdout.write("no bets dir\n");
+    return;
+  }
+
+  const judged: LedgerEntry[] = [];
+  for (const f of files) {
+    const path = `${betsDir}/${f}`;
+    let bet: Bet;
+    try {
+      bet = JSON.parse(readFileSync(path, "utf8")) as Bet;
+    } catch {
+      continue;
+    }
+    if (!isDue(bet, today)) continue;
+    const current = Object.prototype.hasOwnProperty.call(values, bet.metricId)
+      ? values[bet.metricId]
+      : null;
+    const entry = judge(bet, current ?? null, today);
+    judged.push(entry);
+    // 베팅 status 갱신
+    bet.status = "checked";
+    writeFileSync(path, JSON.stringify(bet, null, 2) + "\n", "utf8");
+  }
+
+  if (judged.length > 0) {
+    mkdirSync(ledgerFile.replace(/\/[^/]*$/, "") || ".", { recursive: true });
+    appendFileSync(ledgerFile, judged.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf8");
+  }
+
+  process.stdout.write(`judged=${judged.length}\n`);
+  process.stdout.write(JSON.stringify(judged) + "\n");
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("outcome-judge")) {
+  main();
+}


### PR DESCRIPTION
## Summary

**B1 결과-접지 루프 완성(3/3).** 베팅 후 N일 뒤 같은 지표를 다시 재서 "움직였나"를 판정·기록 — 나침반의 바늘.

- `scripts/outcome-judge.ts`: `judge(bet, current)` → `moved`/`flat`/`worsened`/`unknown` 순수함수. 5% 노이즈 컷, baseline 0 특수처리, null→unknown, 방향 미지정 시 중립("움직임") 처리. `isDue`/`addDays` + CLI(기한 도래 pending 베팅 판정 → ledger append + status=checked). vitest 11케이스.
- `outcome-check.yml`(신규, **daily**): 현재 지표 스냅샷 재측정 → 기한 도래 베팅 판정 → `generated/outcomes/ledger.jsonl` 적재 + 베팅 status 갱신 커밋(`[skip ci]`). 멱등(checked는 재판정 안 함).
- `autonomy-report.yml`: **🧭 결과 나침반** 섹션 — 이번 주 moved/flat/worsened/unknown 집계 + **STUCK 조기신호**(판정 3건↑인데 moved < flat+worsened면 "진척 정체" 경고, B2 다리).

판정은 **상관 기록만** — "지표 움직임 = 이 PR 덕분"이라 단정하지 않음(중립어). 측정 불가는 `unknown` 안전 처리.

## Test plan
- [x] `npx vitest run` — 386 passed (36 files; outcome-judge 11케이스: moved/flat/worsened/unknown, baseline 0, 방향 미지정, isDue/addDays)
- [x] outcome-judge.ts strict standalone + CLI end-to-end(즉시판정 + 멱등 재실행 judged=0)
- [x] 나침반 jq 주간 필터 집계 검증 + 2개 워크플로 YAML 유효
- [ ] (수동) checkAfterDays:0 베팅 → outcome-check 1회 → ledger 적재 확인

Ref: docs/AGENT_HARNESS_ROADMAP.md B1 · ledger가 B2(STUCK 재접지)/Phase 3 그래프 결과엣지의 입력

🤖 Generated with [Claude Code](https://claude.com/claude-code)