### PR TITLE
feat(fomo-web): 진입 여정 재설계 — 스플래시 → 감정 게이트 → 홈

### DIFF
--- a/apps/fomo-web/app/globals.css
+++ b/apps/fomo-web/app/globals.css
@@ -39,6 +39,26 @@ body {
   animation: fomo-marquee 26s linear infinite;
 }
 
+/* 스플래시 — 로고/포모가 떠오르고, 떠날 땐 부드럽게 사라진다 */
+@keyframes fomo-splash-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}
+.fomo-splash-in { animation: fomo-splash-in 600ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+
+@keyframes fomo-fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+.fomo-fade-out { animation: fomo-fade-out 320ms ease forwards; }
+
+/* phase 전환 — 다음 화면이 아래에서 떠오르며 들어온다 */
+@keyframes fomo-phase-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.fomo-phase-in { animation: fomo-phase-in 460ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; }
 }

--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -1,23 +1,10 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
-import {
-  EMOTION_TYPES,
-  EMOTION_LABELS,
-  EMOTION_COLORS,
-  scoreToFace,
-  scoreToState,
-  marketLine,
-  mineLine,
-  isCalmDay,
-  restorativeLine,
-  type EmotionType,
-  type FomoFace as FomoFaceType,
-  type FomoState,
-} from "@fomo/core";
-import { FomoFace } from "@/components/FomoFace";
-import { RollingBanner } from "@/components/RollingBanner";
-import { EmotionCalendar } from "@/components/EmotionCalendar";
+import { useEffect, useState, useCallback, useRef } from "react";
+import type { EmotionType } from "@fomo/core";
+import { SplashScreen } from "@/components/SplashScreen";
+import { EmotionGate } from "@/components/EmotionGate";
+import { HomeView } from "@/components/HomeView";
 import { getSessionId } from "@/lib/session";
 import {
   fetchIndex,
@@ -31,19 +18,46 @@ import {
   type CalendarResponse,
 } from "@/lib/fomoApi";
 
+type Phase = "splash" | "gate" | "home";
+
+const SPLASH_MIN_MS = 1200;
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
+  );
+}
+
+/**
+ * 진입 여정 오케스트레이터 — splash → (오늘 미선택 시) gate → home.
+ * 데이터 페칭/투표를 여기서 관리하고 하위 화면에 props로 내려준다.
+ * 정체성: 감정 게이트가 '시장의 포모 → 나의 포모' 두 단계 전환의 무대(docs/MASCOT.md §5).
+ */
 export default function Home() {
+  const [phase, setPhase] = useState<Phase>("splash");
+  const [leavingSplash, setLeavingSplash] = useState(false);
+  const [gateReopen, setGateReopen] = useState(false);
+
   const [index, setIndex] = useState<FomoIndexResponse | null>(null);
   const [tally, setTally] = useState<TallyResponse | null>(null);
   const [pulse, setPulse] = useState<string[]>([]);
   const [whale, setWhale] = useState<string[]>([]);
-  const [mine, setMine] = useState<EmotionType | null>(null);
   const [calendar, setCalendar] = useState<CalendarResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [voting, setVoting] = useState(false);
+  const [mine, setMine] = useState<EmotionType | null>(null);
 
+  // 스플래시 동안 데이터 프리페치 + 최소 표시시간 보장 후 분기
+  const startedRef = useRef(false);
   useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
     const sid = getSessionId();
-    Promise.allSettled([
+    const minDelay = prefersReducedMotion()
+      ? Promise.resolve()
+      : new Promise((r) => setTimeout(r, SPLASH_MIN_MS));
+
+    const load = Promise.allSettled([
       fetchIndex(),
       fetchToday(),
       fetchPulse(),
@@ -54,178 +68,72 @@ export default function Home() {
       if (t.status === "fulfilled") setTally(t.value);
       if (p.status === "fulfilled") setPulse(p.value.items);
       if (w.status === "fulfilled") setWhale(w.value.items);
+      let todays: EmotionType | null = null;
       if (c.status === "fulfilled") {
         setCalendar(c.value);
-        // 오늘 이미 남긴 감정이 있으면 2단계(나의 포모)로 복원
-        const todays = c.value.days[c.value.today];
-        if (todays) setMine(todays as EmotionType);
+        const v = c.value.days[c.value.today];
+        if (v) {
+          todays = v as EmotionType;
+          setMine(todays);
+        }
       }
-      setLoading(false);
+      return todays;
+    });
+
+    Promise.all([load, minDelay]).then(([todays]) => {
+      // 스플래시를 부드럽게 내보내고 다음 phase로
+      setLeavingSplash(true);
+      setTimeout(() => setPhase(todays ? "home" : "gate"), 300);
     });
   }, []);
 
   const vote = useCallback(async (e: EmotionType) => {
-    setVoting(true);
-    setMine(e); // 2단계 즉시 전환(낙관적)
+    setMine(e); // 낙관적
     try {
       const res = await postVote(getSessionId(), e);
       setTally(res);
-      // 캘린더 오늘 칸 즉시 반영(낙관적)
       setCalendar((prev) =>
         prev ? { ...prev, days: { ...prev.days, [prev.today]: e } } : prev
       );
     } catch {
       /* 선택 상태 유지 */
-    } finally {
-      setVoting(false);
     }
   }, []);
 
-  const stage: "market" | "mine" = mine ? "mine" : "market";
-  const state: FomoState | null = index ? scoreToState(index.score) : null;
-  const marketFace: FomoFaceType = index ? scoreToFace(index.score) : "curious";
-  const line = mine ? mineLine(mine) : state ? marketLine(state) : "";
+  const reopenGate = useCallback(() => {
+    setGateReopen(true);
+    setPhase("gate");
+  }, []);
+
+  const finishGate = useCallback(() => {
+    setGateReopen(false);
+    setPhase("home");
+  }, []);
+
+  if (phase === "splash") {
+    return <SplashScreen leaving={leavingSplash} />;
+  }
+
+  if (phase === "gate") {
+    return (
+      <EmotionGate
+        score={index ? index.score : null}
+        onVote={vote}
+        onDone={finishGate}
+        reopen={gateReopen}
+      />
+    );
+  }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center px-6 pb-10 pt-5">
-      {/* 헤더 */}
-      <div className="mb-4 flex w-full items-center justify-between">
-        <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-        <span className="text-xs text-muted">가입 없이 둘러보기</span>
-      </div>
-
-      {/* 혼자가 아님의 신호 — 고래·시장 신호를 시장 무관 단일 카드 문법으로 통일 (M3) */}
-      <div className="mb-4 w-full">
-        <RollingBanner items={[...whale, ...pulse]} />
-      </div>
-
-      {/* 주인공: 포모 */}
-      <p className="mb-2 text-xs text-muted">
-        {stage === "market" ? "오늘의 포모" : "나의 포모"}
-      </p>
-      <FomoFace
-        face={stage === "market" ? marketFace : "calm"}
-        glow={stage === "mine" && mine ? EMOTION_COLORS[mine] : state ? STATE_GLOW(index!.score) : undefined}
-        size={120}
-      />
-
-      {/* 보조: FOMO Index (픽셀) */}
-      <div className="mt-3 flex flex-col items-center">
-        {loading ? (
-          <p className="text-sm text-muted">불러오는 중…</p>
-        ) : index ? (
-          <>
-            <p className="font-pixel text-4xl leading-none text-whiteout">{index.score}</p>
-            <p className="mt-1.5 font-pixel text-xs text-muted">
-              FOMO INDEX · {index.state}
-              {index.prevDayDelta ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}` : ""}
-            </p>
-          </>
-        ) : (
-          <p className="font-pixel text-sm text-muted">FOMO INDEX · 집계 준비 중</p>
-        )}
-      </div>
-
-      {/* 포모의 담담한 한마디 (전환 시 떠오름) */}
-      {line && (
-        <p key={stage + (mine ?? "")} className="fomo-rise mt-3 max-w-xs text-center text-sm leading-5 text-whiteout">
-          {line}
-        </p>
-      )}
-
-      {/* 잔잔한 날 = 치유의 날 — 변동성 없는 날에도 열 이유 (M2) */}
-      {state && index && isCalmDay(state) && (
-        <div className="fomo-rise mt-4 flex w-full items-start gap-2.5 rounded-xl border border-hairline bg-surface px-4 py-3">
-          <span className="mt-0.5 text-sm" aria-hidden>
-            🌙
-          </span>
-          <div>
-            <p className="text-xs text-muted">오늘의 쉼</p>
-            <p className="mt-0.5 text-sm leading-5 text-whiteout">{restorativeLine(index.date)}</p>
-          </div>
-        </div>
-      )}
-
-      {/* 오늘의 감정 투표 */}
-      <section className="mt-7 w-full">
-        <h2 className="text-base font-semibold text-whiteout">오늘 당신의 감정은?</h2>
-        <p className="mb-3 text-xs text-muted">하루 한 번, 지금 마음에 가까운 걸로.</p>
-
-        <div className="flex flex-wrap gap-2">
-          {EMOTION_TYPES.map((e) => {
-            const selected = mine === e;
-            return (
-              <button
-                key={e}
-                disabled={voting}
-                onClick={() => vote(e)}
-                className="rounded-xl border px-3.5 py-2.5 text-sm transition-all duration-200 disabled:opacity-60"
-                style={{
-                  borderColor: selected ? EMOTION_COLORS[e] : "#2A2A2A",
-                  backgroundColor: selected ? EMOTION_COLORS[e] + "20" : "#0E0E0E",
-                  color: selected ? EMOTION_COLORS[e] : "#FAFAFA",
-                  boxShadow: selected ? `0 0 18px ${EMOTION_COLORS[e]}55` : "none",
-                }}
-              >
-                {EMOTION_LABELS[e]}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* 집계 — 정직한 숫자 */}
-        {tally && (
-          <div className="mt-5">
-            <p className="text-xs text-muted">
-              오늘 <span className="font-pixel text-whiteout">{tally.total}</span>명이 마음을 남겼어요
-              {mine ? " · 너도 그 안에 있어" : ""}
-            </p>
-            {/* 혼자가 아님의 직접 체감 — 너와 같은 마음인 사람 수 (M3) */}
-            {mine && (tally.counts[mine] ?? 0) > 1 && (
-              <p key={mine} className="fomo-rise mt-1.5 text-sm leading-5 text-whiteout">
-                지금 너처럼{" "}
-                <span className="font-pixel" style={{ color: EMOTION_COLORS[mine] }}>
-                  {EMOTION_LABELS[mine]}
-                </span>
-                인 사람,{" "}
-                <span className="font-pixel" style={{ color: EMOTION_COLORS[mine] }}>
-                  {tally.counts[mine]}
-                </span>
-                명. 너만 그런 거 아니야.
-              </p>
-            )}
-            <div className="mt-2.5 flex flex-col gap-1.5">
-              {EMOTION_TYPES.map((e) => (
-                <div key={e} className="flex items-center gap-2.5">
-                  <span className="w-10 text-xs" style={{ color: EMOTION_COLORS[e] }}>{EMOTION_LABELS[e]}</span>
-                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-elevated">
-                    <div
-                      className="h-full rounded-full transition-[width] duration-500 ease-out"
-                      style={{ width: `${tally.ratios[e] ?? 0}%`, backgroundColor: EMOTION_COLORS[e] }}
-                    />
-                  </div>
-                  <span className="w-9 text-right font-pixel text-xs text-muted">{tally.ratios[e] ?? 0}%</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </section>
-
-      {/* 감정 캘린더 — 매일 돌아올 이유 (M2) */}
-      {calendar && <EmotionCalendar data={calendar} />}
-
-      {/* 면책 — 담담하게 */}
-      <p className="mt-7 text-center text-[11px] leading-5 text-muted">
-        FOMO Index는 감정 체감 지표예요. 투자 조언이 아니에요.
-      </p>
-    </main>
+    <HomeView
+      index={index}
+      tally={tally}
+      pulse={pulse}
+      whale={whale}
+      calendar={calendar}
+      mine={mine}
+      onReopenGate={reopenGate}
+    />
   );
-}
-
-// 시장의 포모: 지수가 높을수록 옅은 따뜻함, 낮으면 차분(무채색에 가깝게)
-function STATE_GLOW(score: number): string | undefined {
-  if (score >= 61) return EMOTION_COLORS.fomo; // 달아오름
-  if (score >= 41) return "#5A5A5A"; // 관심 — 옅은 무채색
-  return undefined; // 관망/무관심 — 잔잔, glow 없음
 }

--- a/apps/fomo-web/components/EmotionGate.tsx
+++ b/apps/fomo-web/components/EmotionGate.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  EMOTION_TYPES,
+  EMOTION_LABELS,
+  EMOTION_COLORS,
+  scoreToFace,
+  scoreToState,
+  marketLine,
+  mineLine,
+  type EmotionType,
+} from "@fomo/core";
+import { FomoFace } from "@/components/FomoFace";
+import { stateGlow } from "@/lib/fomoVisual";
+
+/**
+ * 감정 게이트 — 진입 직후 두 단계 감정 변화가 일어나는 전용 무대 (docs/MASCOT.md §5).
+ * 1단계(시장의 포모): FOMO Index 표정·색. 2단계(나의 포모): 감정 선택 시 내 색으로 물들며 멘트.
+ * 선택 → onVote(저장) → 2단계 전환 유지 후 onDone()으로 홈 전환.
+ */
+export function EmotionGate({
+  score,
+  onVote,
+  onDone,
+  reopen = false,
+}: {
+  /** 오늘 FOMO Index 점수. null이면 집계 준비 중. */
+  score: number | null;
+  onVote: (e: EmotionType) => Promise<void> | void;
+  onDone: () => void;
+  /** 홈에서 '다시 고르기'로 재진입한 경우 카피를 살짝 바꾼다. */
+  reopen?: boolean;
+}) {
+  const [picked, setPicked] = useState<EmotionType | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const state = score != null ? scoreToState(score) : null;
+  const marketFace = score != null ? scoreToFace(score) : "curious";
+  const stage: "market" | "mine" = picked ? "mine" : "market";
+  const line = picked ? mineLine(picked) : state ? marketLine(state) : "";
+
+  const handlePick = useCallback(
+    async (e: EmotionType) => {
+      if (busy) return;
+      setBusy(true);
+      setPicked(e); // 2단계 즉시 전환(낙관적)
+      try {
+        await onVote(e);
+      } catch {
+        /* 선택 상태 유지 — 저장 실패해도 경험은 이어진다 */
+      }
+      // 2단계 전환(감정색 물듦 + 멘트)을 잠깐 머금고 홈으로
+      setTimeout(onDone, 1100);
+    },
+    [busy, onVote, onDone]
+  );
+
+  return (
+    <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col items-center justify-center px-6 py-10">
+      <p className="mb-2 text-xs text-muted">{stage === "market" ? "오늘의 포모" : "나의 포모"}</p>
+
+      <FomoFace
+        face={stage === "market" ? marketFace : "calm"}
+        glow={
+          stage === "mine" && picked
+            ? EMOTION_COLORS[picked]
+            : score != null
+              ? stateGlow(score)
+              : undefined
+        }
+        size={132}
+      />
+
+      {/* FOMO Index (픽셀) */}
+      <div className="mt-3 flex flex-col items-center">
+        {score != null ? (
+          <>
+            <p className="font-pixel text-4xl leading-none text-whiteout">{score}</p>
+            <p className="mt-1.5 font-pixel text-xs text-muted">
+              FOMO INDEX · {state}
+            </p>
+          </>
+        ) : (
+          <p className="font-pixel text-sm text-muted">FOMO INDEX · 집계 준비 중</p>
+        )}
+      </div>
+
+      {/* 포모의 담담한 한마디 */}
+      {line && (
+        <p
+          key={stage + (picked ?? "")}
+          className="fomo-rise mt-3 max-w-xs text-center text-sm leading-5 text-whiteout"
+        >
+          {line}
+        </p>
+      )}
+
+      {/* 감정 선택 — 게이트의 본분 */}
+      <section className="mt-9 w-full">
+        <h2 className="text-center text-base font-semibold text-whiteout">
+          {reopen ? "지금 마음은 어때?" : "오늘 당신의 감정은?"}
+        </h2>
+        <p className="mb-4 mt-1 text-center text-xs text-muted">
+          하루 한 번, 지금 마음에 가까운 걸로.
+        </p>
+
+        <div className="flex flex-wrap justify-center gap-2">
+          {EMOTION_TYPES.map((e) => {
+            const selected = picked === e;
+            return (
+              <button
+                key={e}
+                disabled={busy}
+                onClick={() => handlePick(e)}
+                className="rounded-xl border px-4 py-2.5 text-sm transition-all duration-200 disabled:cursor-default"
+                style={{
+                  borderColor: selected ? EMOTION_COLORS[e] : "#2A2A2A",
+                  backgroundColor: selected ? EMOTION_COLORS[e] + "20" : "#0E0E0E",
+                  color: selected ? EMOTION_COLORS[e] : "#FAFAFA",
+                  boxShadow: selected ? `0 0 18px ${EMOTION_COLORS[e]}55` : "none",
+                  opacity: busy && !selected ? 0.4 : 1,
+                }}
+              >
+                {EMOTION_LABELS[e]}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import {
+  EMOTION_TYPES,
+  EMOTION_LABELS,
+  EMOTION_COLORS,
+  scoreToFace,
+  scoreToState,
+  marketLine,
+  mineLine,
+  isCalmDay,
+  restorativeLine,
+  type EmotionType,
+} from "@fomo/core";
+import { FomoFace } from "@/components/FomoFace";
+import { RollingBanner } from "@/components/RollingBanner";
+import { EmotionCalendar } from "@/components/EmotionCalendar";
+import { stateGlow } from "@/lib/fomoVisual";
+import type {
+  FomoIndexResponse,
+  TallyResponse,
+  CalendarResponse,
+} from "@/lib/fomoApi";
+
+/**
+ * 메인 홈 — '나의 포모' 상태로 진입(감정은 게이트에서 이미 선택됨).
+ * 감정 칩 섹션은 게이트로 이전. 대신 '오늘의 너' 요약 + 다시 고르기.
+ * 집계의 '너처럼 N명'(M3)·캘린더(M2)는 유지.
+ */
+export function HomeView({
+  index,
+  tally,
+  pulse,
+  whale,
+  calendar,
+  mine,
+  onReopenGate,
+}: {
+  index: FomoIndexResponse | null;
+  tally: TallyResponse | null;
+  pulse: string[];
+  whale: string[];
+  calendar: CalendarResponse | null;
+  mine: EmotionType | null;
+  onReopenGate: () => void;
+}) {
+  const state = index ? scoreToState(index.score) : null;
+  const marketFace = index ? scoreToFace(index.score) : "curious";
+  const stage: "market" | "mine" = mine ? "mine" : "market";
+  const line = mine ? mineLine(mine) : state ? marketLine(state) : "";
+
+  return (
+    <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col items-center px-6 pb-10 pt-5">
+      {/* 헤더 */}
+      <div className="mb-4 flex w-full items-center justify-between">
+        <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
+        <span className="text-xs text-muted">가입 없이 둘러보기</span>
+      </div>
+
+      {/* 혼자가 아님의 신호 — 시장 무관 단일 카드 문법 (M3) */}
+      <div className="mb-4 w-full">
+        <RollingBanner items={[...whale, ...pulse]} />
+      </div>
+
+      {/* 주인공: 포모 */}
+      <p className="mb-2 text-xs text-muted">{stage === "market" ? "오늘의 포모" : "나의 포모"}</p>
+      <FomoFace
+        face={stage === "market" ? marketFace : "calm"}
+        glow={
+          stage === "mine" && mine
+            ? EMOTION_COLORS[mine]
+            : index
+              ? stateGlow(index.score)
+              : undefined
+        }
+        size={120}
+      />
+
+      {/* 보조: FOMO Index (픽셀) */}
+      <div className="mt-3 flex flex-col items-center">
+        {index ? (
+          <>
+            <p className="font-pixel text-4xl leading-none text-whiteout">{index.score}</p>
+            <p className="mt-1.5 font-pixel text-xs text-muted">
+              FOMO INDEX · {index.state}
+              {index.prevDayDelta
+                ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}`
+                : ""}
+            </p>
+          </>
+        ) : (
+          <p className="font-pixel text-sm text-muted">FOMO INDEX · 집계 준비 중</p>
+        )}
+      </div>
+
+      {/* 포모의 담담한 한마디 */}
+      {line && (
+        <p
+          key={stage + (mine ?? "")}
+          className="fomo-rise mt-3 max-w-xs text-center text-sm leading-5 text-whiteout"
+        >
+          {line}
+        </p>
+      )}
+
+      {/* 오늘의 너 — 게이트에서 고른 감정 요약 + 다시 고르기 */}
+      {mine && (
+        <div className="mt-4 flex items-center gap-2.5 rounded-full border border-hairline bg-surface px-4 py-2">
+          <span className="text-xs text-muted">오늘의 너</span>
+          <span className="font-pixel text-sm" style={{ color: EMOTION_COLORS[mine] }}>
+            {EMOTION_LABELS[mine]}
+          </span>
+          <span className="text-hairline" aria-hidden>
+            ·
+          </span>
+          <button
+            onClick={onReopenGate}
+            className="text-xs text-muted underline-offset-2 transition-colors hover:text-whiteout"
+          >
+            다시 고르기
+          </button>
+        </div>
+      )}
+
+      {/* 잔잔한 날 = 치유의 날 (M2) */}
+      {state && index && isCalmDay(state) && (
+        <div className="fomo-rise mt-4 flex w-full items-start gap-2.5 rounded-xl border border-hairline bg-surface px-4 py-3">
+          <span className="mt-0.5 text-sm" aria-hidden>
+            🌙
+          </span>
+          <div>
+            <p className="text-xs text-muted">오늘의 쉼</p>
+            <p className="mt-0.5 text-sm leading-5 text-whiteout">{restorativeLine(index.date)}</p>
+          </div>
+        </div>
+      )}
+
+      {/* 집계 — 정직한 숫자 */}
+      {tally && (
+        <section className="mt-7 w-full">
+          <p className="text-xs text-muted">
+            오늘 <span className="font-pixel text-whiteout">{tally.total}</span>명이 마음을 남겼어요
+            {mine ? " · 너도 그 안에 있어" : ""}
+          </p>
+          {/* 혼자가 아님의 직접 체감 (M3) */}
+          {mine && (tally.counts[mine] ?? 0) > 1 && (
+            <p key={mine} className="fomo-rise mt-1.5 text-sm leading-5 text-whiteout">
+              지금 너처럼{" "}
+              <span className="font-pixel" style={{ color: EMOTION_COLORS[mine] }}>
+                {EMOTION_LABELS[mine]}
+              </span>
+              인 사람,{" "}
+              <span className="font-pixel" style={{ color: EMOTION_COLORS[mine] }}>
+                {tally.counts[mine]}
+              </span>
+              명. 너만 그런 거 아니야.
+            </p>
+          )}
+          <div className="mt-2.5 flex flex-col gap-1.5">
+            {EMOTION_TYPES.map((e) => (
+              <div key={e} className="flex items-center gap-2.5">
+                <span className="w-10 text-xs" style={{ color: EMOTION_COLORS[e] }}>
+                  {EMOTION_LABELS[e]}
+                </span>
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-elevated">
+                  <div
+                    className="h-full rounded-full transition-[width] duration-500 ease-out"
+                    style={{ width: `${tally.ratios[e] ?? 0}%`, backgroundColor: EMOTION_COLORS[e] }}
+                  />
+                </div>
+                <span className="w-9 text-right font-pixel text-xs text-muted">
+                  {tally.ratios[e] ?? 0}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 감정 캘린더 (M2) */}
+      {calendar && <EmotionCalendar data={calendar} />}
+
+      {/* 면책 — 담담하게 */}
+      <p className="mt-7 text-center text-[11px] leading-5 text-muted">
+        FOMO Index는 감정 체감 지표예요. 투자 조언이 아니에요.
+      </p>
+    </main>
+  );
+}

--- a/apps/fomo-web/components/SplashScreen.tsx
+++ b/apps/fomo-web/components/SplashScreen.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { FomoFace } from "@/components/FomoFace";
+
+/**
+ * 스플래시 — 진입 여정의 첫 호흡. 검정 배경에 포모가 떠오르고 로고/태그라인이 뜬다.
+ * 타이밍은 오케스트레이터(app/page.tsx)가 관리. 여기는 표시만.
+ * leaving=true면 부드럽게 사라진다(다음 phase로 양보).
+ */
+export function SplashScreen({ leaving = false }: { leaving?: boolean }) {
+  return (
+    <main
+      className={`flex min-h-screen flex-col items-center justify-center bg-ink px-6 ${
+        leaving ? "fomo-fade-out" : ""
+      }`}
+    >
+      <div className="fomo-splash-in flex flex-col items-center">
+        <FomoFace face="calm" size={108} />
+        <p className="mt-7 font-pixel text-lg tracking-wide text-whiteout">FOMO CLUB</p>
+        <p className="mt-2 text-sm text-muted">나만 그런 게 아니구나.</p>
+      </div>
+    </main>
+  );
+}

--- a/apps/fomo-web/lib/fomoVisual.ts
+++ b/apps/fomo-web/lib/fomoVisual.ts
@@ -1,0 +1,12 @@
+import { EMOTION_COLORS } from "@fomo/core";
+
+/**
+ * 시장의 포모 glow — FOMO Index 점수에 따른 배경광 색.
+ * 지수가 높을수록 옅은 따뜻함(달아오름), 낮으면 차분(무채색~없음).
+ * 게이트(1단계)와 홈이 공유. docs/MASCOT.md 색 체계.
+ */
+export function stateGlow(score: number): string | undefined {
+  if (score >= 61) return EMOTION_COLORS.fomo; // 달아오름
+  if (score >= 41) return "#5A5A5A"; // 관심 — 옅은 무채색
+  return undefined; // 관망/무관심 — 잔잔, glow 없음
+}


### PR DESCRIPTION
## 진입 여정 재설계 — 스플래시 → 감정 게이트 → 홈

### 문제
홈에 감정 칩이 상시 깔려 있어 어수선하고, "하루 한 번 고른다"는 행위의 무게가 사라짐. 진입 단계(스플래시)도 없어 첫인상이 밋밋함.

### 해결
감정 선택을 단순히 떼어내지 않고, **`docs/MASCOT.md`·`DESIGN_FOMO.md`가 규정한 "시장의 포모(1단계) → 감정 선택 → 나의 포모(2단계) 전환"의 전용 무대로 격상**.

```
splash ──(데이터 로드 AND 최소 1.2s)──> 오늘 선택함? ─yes→ home
                                                  └─no → gate
gate ──(감정 선택 → 2단계 전환 애니)──> home
home ──("다시 고르기")──> gate ──> home
```

### 변경
| 파일 | 내용 |
|---|---|
| `app/page.tsx` | phase 오케스트레이터(splash/gate/home) + 데이터 프리페치 + 최소 스플래시 시간 |
| `components/SplashScreen.tsx` | 신규 — 포모 페이드인 + 로고 + 태그라인 |
| `components/EmotionGate.tsx` | 신규 — 1단계 시장의 포모 + 감정 선택 + 2단계 전환 멘트(420ms) |
| `components/HomeView.tsx` | 신규 — 기존 홈에서 **감정 칩 제거**, "오늘의 너 · 다시 고르기" 추가. 집계·캘린더 유지 |
| `lib/fomoVisual.ts` | `stateGlow` 공유 헬퍼 추출 |
| `app/globals.css` | 스플래시/phase 전환 키프레임 (prefers-reduced-motion 존중) |

백엔드·`@fomo/core` 변경 없음. 색·멘트·표정 매핑 전부 기존 단일 소스 재사용.

### 정체성/규제
- 두 단계 감정 변화 + 전환 애니 + 담담한 멘트 유지(MASCOT.md:127)
- 포모 감정색 glow는 NORTH_STAR 킬리스트 예외(AGENTS.md 반영됨)
- 노출 텍스트 금칙어 0, 면책 문구 홈 유지

### 검증
- ✅ fomo-web 타입체크 + `next build`
- ✅ fomo-core 테스트 31개
- 런타임: 첫 방문/재방문/다시 고르기/reduced-motion 흐름 (프리뷰에서 확인 예정)

https://claude.ai/code/session_01NLUnQzMMaFhGXLgSMXy517

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLUnQzMMaFhGXLgSMXy517)_