### PR TITLE
feat(fomo): FOMO Index 운영 관측 — 건강 리포트 + 실패/저하 Slack 알림

### DIFF
--- a/.github/workflows/fomo-index-pipeline.yml
+++ b/.github/workflows/fomo-index-pipeline.yml
@@ -30,9 +30,34 @@ jobs:
         run: npm run prisma:generate
 
       - name: Compute FOMO Index snapshot
+        id: compute
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AI_API_URL: ${{ secrets.AI_API_URL }}
           AI_API_KEY: ${{ secrets.AI_API_KEY }}
           AI_MODEL: ${{ secrets.AI_MODEL }}
         run: npm run fomo:index
+
+      # 운영 관측 — 실패/저하를 Slack 에 가시화(정직한 숫자 원칙). 무알림 사고(06-06) 재발 방지.
+      - name: Report health to Slack
+        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          OUTCOME: ${{ steps.compute.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          URL="$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')"
+          if [ "$OUTCOME" != "success" ]; then
+            MSG=$(printf '%s\n%s' "🔴 *FOMO Index 파이프라인 실패* — 오늘 지수 스냅샷 미생성 (정직한 숫자: 데이터 누락)" ">${RUN_URL}")
+            jq -n --arg t "$MSG" '{text:$t}' > /tmp/fomo_health.json
+          elif [ -f fomo-index-health.json ]; then
+            jq '{text: (
+              "📊 FOMO Index \(.date) — \(.score) (\(.state))\n실데이터 \(.realCount)/4 Heat · 감정투표 \(.voteCount)표"
+              + (if .degraded then "\n⚠️ 폴백 \(.fallbackCount)개 Heat (라이브 소스 미연동/실패)" else "" end)
+              + "\n" + ([.heats[] | "\(.key):\(.confidence)"] | join(" · "))
+            )}' fomo-index-health.json > /tmp/fomo_health.json
+          else
+            jq -n --arg t "⚠️ FOMO Index — 건강 리포트 파일 없음(드라이런/스킵). ${RUN_URL}" '{text:$t}' > /tmp/fomo_health.json
+          fi
+          curl -s -X POST "$URL" -H "Content-Type: application/json" -d @/tmp/fomo_health.json || true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ prisma/dev.db
 test-results/
 playwright-report/
 playwright/.cache/
+fomo-index-health.json

--- a/packages/fomo-core/__tests__/health.test.ts
+++ b/packages/fomo-core/__tests__/health.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { computeFomoIndex } from "../src/index-engine/calculate";
+import { summarizeHealth, renderHealthReport, confidenceRank } from "../src/index-engine/health";
+
+describe("summarizeHealth", () => {
+  it("입력 전무 → 4 Heat 모두 폴백, degraded=true", () => {
+    const idx = computeFomoIndex({}, "2026-06-08");
+    const h = summarizeHealth(idx, 0);
+    expect(h.heats).toHaveLength(4);
+    expect(h.fallbackCount).toBe(4);
+    expect(h.realCount).toBe(0);
+    expect(h.degraded).toBe(true);
+    expect(h.voteCount).toBe(0);
+    expect(h.date).toBe("2026-06-08");
+  });
+
+  it("감정 투표 충분 → emotion Heat 실데이터(폴백 아님), 나머지 폴백", () => {
+    const idx = computeFomoIndex({ emotion: { fomo: 30, fear: 25 } }, "2026-06-08");
+    const h = summarizeHealth(idx, 55);
+    const emotion = h.heats.find((x) => x.key === "emotion")!;
+    expect(emotion.fallback).toBe(false);
+    expect(emotion.confidence).not.toBe("fallback");
+    expect(h.realCount).toBeGreaterThanOrEqual(1);
+    expect(h.voteCount).toBe(55);
+  });
+
+  it("각 heat에 confidence/sources 메타 포함", () => {
+    const h = summarizeHealth(computeFomoIndex({}, "2026-06-08"));
+    for (const x of h.heats) {
+      expect(["high", "medium", "low", "fallback"]).toContain(x.confidence);
+      expect(typeof x.sourcesTotal).toBe("number");
+    }
+  });
+});
+
+describe("renderHealthReport", () => {
+  it("저하 시 폴백 경고 라인 포함(정직한 표기)", () => {
+    const txt = renderHealthReport(summarizeHealth(computeFomoIndex({}, "2026-06-08"), 0));
+    expect(txt).toContain("FOMO Index 2026-06-08");
+    expect(txt).toContain("폴백");
+    expect(txt).toContain("실데이터 0/4");
+  });
+  it("실데이터 있으면 score/state 표기", () => {
+    const txt = renderHealthReport(summarizeHealth(computeFomoIndex({ emotion: { fomo: 60 } }, "2026-06-08"), 60));
+    expect(txt).toContain("감정투표 60표");
+  });
+});
+
+describe("confidenceRank", () => {
+  it("fallback < low < medium < high", () => {
+    expect(confidenceRank("fallback")).toBeLessThan(confidenceRank("low"));
+    expect(confidenceRank("low")).toBeLessThan(confidenceRank("medium"));
+    expect(confidenceRank("medium")).toBeLessThan(confidenceRank("high"));
+  });
+});

--- a/packages/fomo-core/src/index-engine/health.ts
+++ b/packages/fomo-core/src/index-engine/health.ts
@@ -1,0 +1,97 @@
+/**
+ * FOMO Index 운영 관측 — 스냅샷 건강 요약 (정직한 숫자 원칙의 운영 측정).
+ *
+ * computeFomoIndex 결과의 각 Heat `meta.confidence`를 읽어 "오늘 지수가 실제 데이터로
+ * 산출됐는지 / 폴백(중립 기본값)인지"를 결정론적으로 요약한다.
+ * docs/FOMO_INDEX.md "데이터 소스 미비 시 폴백, 빈 값/에러 노출 0".
+ *
+ * 순수 함수 — vitest 로 검증. 파이프라인(scripts/fomo-index-pipeline.ts)이 이걸로
+ * Slack 건강 리포트를 만들고, 실패/저하를 가시화한다.
+ */
+
+import type { FomoIndex, HeatComponent } from "../types";
+import type { HeatConfidence } from "./types";
+
+export interface HeatHealth {
+  key: string;
+  score: number;
+  max: number;
+  confidence: HeatConfidence;
+  sourcesAvailable: number;
+  sourcesTotal: number;
+  /** 폴백(중립 기본값) 사용 여부. */
+  fallback: boolean;
+}
+
+export interface IndexHealth {
+  date: string;
+  score: number;
+  state: string;
+  heats: HeatHealth[];
+  /** confidence === "fallback" 인 Heat 수. */
+  fallbackCount: number;
+  /** 실데이터(폴백 아님) Heat 수. */
+  realCount: number;
+  /** 폴백이 하나라도 있으면 true (저하 상태). */
+  degraded: boolean;
+  /** 감정 투표 수(있으면). 정직한 숫자 — 실제 집계. */
+  voteCount: number;
+}
+
+const CONF_RANK: Record<HeatConfidence, number> = { fallback: 0, low: 1, medium: 2, high: 3 };
+
+/** FOMO Index 스냅샷의 건강 상태 요약(순수). voteCount 는 감정 집계 총합(없으면 0). */
+export function summarizeHealth(index: FomoIndex, voteCount = 0): IndexHealth {
+  const heats: HeatHealth[] = (index.components ?? []).map((c: HeatComponent) => {
+    const conf = c.meta?.confidence ?? "fallback";
+    return {
+      key: c.key,
+      score: c.score,
+      max: c.max,
+      confidence: conf,
+      sourcesAvailable: c.meta?.sourcesAvailable ?? 0,
+      sourcesTotal: c.meta?.sourcesTotal ?? 0,
+      fallback: conf === "fallback",
+    };
+  });
+  const fallbackCount = heats.filter((h) => h.fallback).length;
+  return {
+    date: index.date,
+    score: index.score,
+    state: index.state,
+    heats,
+    fallbackCount,
+    realCount: heats.length - fallbackCount,
+    degraded: fallbackCount > 0,
+    voteCount,
+  };
+}
+
+const CONF_EMOJI: Record<HeatConfidence, string> = {
+  high: "🟢",
+  medium: "🟡",
+  low: "🟠",
+  fallback: "⚪",
+};
+
+/** Slack/로그용 한 줄 + 분해 렌더. 정직하게: 폴백이면 폴백이라고 표기. */
+export function renderHealthReport(h: IndexHealth): string {
+  const lines: string[] = [];
+  lines.push(
+    `📊 *FOMO Index ${h.date}* — ${h.score} (${h.state}) · 실데이터 ${h.realCount}/4 Heat · 감정투표 ${h.voteCount}표`,
+  );
+  if (h.degraded) {
+    lines.push(`⚠️ 폴백 ${h.fallbackCount}개 Heat (중립 기본값 — 라이브 소스 미연동/실패)`);
+  }
+  lines.push(
+    h.heats
+      .map((x) => `${CONF_EMOJI[x.confidence]} ${x.key} ${x.score}/${x.max}(${x.confidence} ${x.sourcesAvailable}/${x.sourcesTotal})`)
+      .join("  "),
+  );
+  return lines.join("\n");
+}
+
+/** confidence 순위 비교 헬퍼(테스트/정렬용). */
+export function confidenceRank(c: HeatConfidence): number {
+  return CONF_RANK[c];
+}

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -10,5 +10,6 @@ export * from "./index-engine/emotionHeat";
 export * from "./index-engine/whaleHeat";
 export * from "./index-engine/calculate";
 export * from "./index-engine/summary";
+export * from "./index-engine/health";
 // @author 안티그래비티 — 1-A: Reddit 페처 export
 export * from "./index-engine/redditFetcher";

--- a/scripts/fomo-index-pipeline.ts
+++ b/scripts/fomo-index-pipeline.ts
@@ -9,9 +9,12 @@
 import {
   computeFomoIndex,
   buildSummary,
+  summarizeHealth,
+  renderHealthReport,
   type EmotionTally,
   type EmotionType,
 } from "@fomo/core";
+import { writeFileSync } from "node:fs";
 
 /** Asia/Seoul 기준 YYYY-MM-DD. */
 function kstDate(offsetDays = 0): string {
@@ -110,6 +113,17 @@ async function main() {
       `[dry-run] date=${date} score=${index.score} state=${index.state} summary=${aiSummary}\n`
     );
   }
+
+  // 5. 운영 관측 — 건강 요약(정직한 숫자: 실데이터 vs 폴백) 산출 + 파일 기록.
+  //    워크플로가 이 파일을 읽어 Slack 에 푸시하고 저하/실패를 가시화한다.
+  const voteCount = Object.values(tally).reduce((a, n) => a + (n ?? 0), 0);
+  const health = summarizeHealth(index, voteCount);
+  try {
+    writeFileSync("fomo-index-health.json", JSON.stringify(health), "utf8");
+  } catch (err) {
+    process.stderr.write(`건강 리포트 기록 실패(무시): ${String(err)}\n`);
+  }
+  process.stdout.write(renderHealthReport(health) + "\n");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## 문제 (진단)
`fomo-index-pipeline`의 **실패가 완전히 조용함**: 06-06 run이 `prisma generate` 검증 오류로 실패했는데 Slack 알림 0(slack-notify가 이 워크플로를 안 봄). 또 4 Heat(Market/Community/Emotion/Whale)가 **실데이터인지 폴백(중립 기본값)인지 기록·노출되지 않음** → North Star 이번 주 테마 "정직한 숫자/폴백 0"이 운영에서 **미측정**. (엔진은 `meta.confidence`를 산출하지만 파이프라인이 버렸음)

## 조치
- **`packages/fomo-core/index-engine/health.ts`**: `summarizeHealth(index, voteCount)` 순수함수 — 각 Heat `meta.confidence`로 실데이터/폴백 구분, `degraded`/`fallbackCount`/`realCount` + `renderHealthReport`. vitest 6.
- **파이프라인 스크립트**: 산출 후 건강 요약을 `fomo-index-health.json`에 기록 + 로그(드라이런 포함).
- **`fomo-index-pipeline.yml`**: compute 후 `always()` Slack step — **실패 시 🔴 알림**, 성공 시 "실데이터 N/4 Heat · 폴백 M개 · 감정투표 K표" 요약 푸시(정직한 숫자). webhook 공백 트림.

## 운영 사실 (이게 핵심 발견)
현재 dry-run 기준 **4/4 Heat가 폴백**(라이브 시장/커뮤니티/웨일 소스 미연동, 감정은 투표 있을 때만 실데이터). 즉 지금 FOMO Index는 사실상 중립 기본값. 이제 매일 Slack에 **정직하게** 노출되어, 라이브 소스 연동이 다음 우선순위임이 숫자로 드러납니다.

## Test plan
- [x] `npx vitest run` — 496 passed (health 6: 전폴백/일부실데이터/정직 렌더)
- [x] fomo-core typecheck (자체 tsconfig) OK
- [x] 파이프라인 dry-run → 건강 파일·리포트 생성, Slack jq 텍스트 렌더 검증
- [x] YAML 유효
- [ ] (자동) 다음 파이프라인 cron → Slack 건강 푸시 / 실패 시 🔴 알림 확인

후속 권장: 라이브 소스 연동(Market/Community/Whale)으로 폴백 → 실데이터 전환. Ref: docs/FOMO_INDEX.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)