### PR TITLE
feat(fomo): FOMO Index 라이브 소스 연동 — 커뮤니티 다중 프로바이더 + Whale

### DIFF
--- a/packages/fomo-core/__tests__/community-providers.test.ts
+++ b/packages/fomo-core/__tests__/community-providers.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  fetchCommunity,
+  COMMUNITY_PROVIDERS,
+  type CommunityProvider,
+  type CommunitySourceSignal,
+} from "../src/index-engine/community";
+import { communityHeat } from "../src/index-engine/communityHeat";
+import { whaleEventsFromCrypto } from "../src/index-engine/whaleEvents";
+
+const sig = (source: string, bullish: number): CommunitySourceSignal => ({
+  source,
+  postCount: 10,
+  totalUpvotes: 100,
+  totalComments: 20,
+  bullishRatio: bullish,
+  fetchedAt: "2026-06-08T00:00:00Z",
+});
+
+describe("COMMUNITY_PROVIDERS 레지스트리", () => {
+  it("Reddit 라이브 + X/Telegram/Toss/Naver 스캐폴드 등록", () => {
+    const ids = COMMUNITY_PROVIDERS.map((p) => p.id);
+    expect(ids).toEqual(expect.arrayContaining(["reddit", "x", "telegram", "toss", "naver"]));
+    expect(COMMUNITY_PROVIDERS.find((p) => p.id === "reddit")!.enabled).toBe(true);
+    expect(COMMUNITY_PROVIDERS.find((p) => p.id === "x")!.enabled).toBe(false);
+  });
+});
+
+describe("fetchCommunity (provider 주입)", () => {
+  it("enabled provider 만 수집, providersAvailable 은 실제 시그널 반환 수", async () => {
+    const providers: CommunityProvider[] = [
+      { id: "reddit", label: "Reddit", enabled: true, fetch: async () => [sig("reddit/wsb", 0.7)] },
+      { id: "x", label: "X", enabled: true, fetch: async () => [] }, // enabled지만 0건
+      { id: "toss", label: "Toss", enabled: false, fetch: async () => [sig("toss/x", 0.9)] }, // disabled → 무시
+    ];
+    const r = await fetchCommunity(providers);
+    expect(r.providersTotal).toBe(3);
+    expect(r.providersEnabled).toBe(2);
+    expect(r.providersAvailable).toBe(1); // reddit만 시그널
+    expect(r.sources).toHaveLength(1);
+    expect(r.sources[0]!.source).toBe("reddit/wsb");
+  });
+
+  it("provider fetch 가 throw 해도 전체는 죽지 않음(정직한 폴백)", async () => {
+    const providers: CommunityProvider[] = [
+      { id: "x", label: "X", enabled: true, fetch: async () => { throw new Error("api down"); } },
+      { id: "reddit", label: "Reddit", enabled: true, fetch: async () => [sig("reddit/a", 0.5)] },
+    ];
+    const r = await fetchCommunity(providers);
+    expect(r.providersAvailable).toBe(1);
+    expect(r.sources).toHaveLength(1);
+  });
+});
+
+describe("communityHeat — sources 채널 반영", () => {
+  it("sources 가 engagement 풀에 들어가 폴백을 벗어난다", () => {
+    const h = communityHeat({ sources: [sig("x/$NVDA", 0.8), sig("reddit/wsb", 0.6)] });
+    expect(h.meta!.confidence).not.toBe("fallback");
+    expect(h.score).toBeGreaterThan(0);
+  });
+  it("입력 없으면 폴백 유지(기존 동작)", () => {
+    expect(communityHeat({}).meta!.confidence).toBe("fallback");
+  });
+});
+
+describe("whaleEventsFromCrypto", () => {
+  it("±8%↑ 변동만 이벤트, BTC 가중 +1", () => {
+    const ev = whaleEventsFromCrypto({
+      coins: [
+        { symbol: "BTC", change24h: 16 }, // 15+ → 3, +BTC 1 = 4
+        { symbol: "ETH", change24h: -9 }, // 8~15 → 2
+        { symbol: "XRP", change24h: 3 }, // 무시
+      ],
+    });
+    expect(ev).toHaveLength(2);
+    expect(ev.find((e) => e.label!.includes("BTC"))!.weight).toBe(4);
+    expect(ev.find((e) => e.label!.includes("ETH"))!.weight).toBe(2);
+  });
+  it("글로벌 시총 ±5%↑ → 이벤트 1건 추가", () => {
+    const ev = whaleEventsFromCrypto({ coins: [], marketCapChangePct: -6 });
+    expect(ev).toHaveLength(1);
+    expect(ev[0]!.weight).toBe(2);
+  });
+  it("변동 없으면 빈 배열(정직 — 가짜 이벤트 없음)", () => {
+    expect(whaleEventsFromCrypto({ coins: [{ symbol: "BTC", change24h: 1 }] })).toEqual([]);
+  });
+});

--- a/packages/fomo-core/src/index-engine/community.ts
+++ b/packages/fomo-core/src/index-engine/community.ts
@@ -1,0 +1,127 @@
+/**
+ * Community Heat — 다중 소스 프로바이더 프레임워크 (확장형).
+ *
+ * docs/FOMO_INDEX.md Community Heat = X/Reddit/Stocktwits 등 언급량·감성.
+ * 소스를 플러그인(provider)으로 추상화해 Reddit 외 X·Telegram·토스커뮤니티·네이버카페를
+ * 쉽게 추가할 수 있게 한다. 각 provider 는 정규화된 CommunitySourceSignal[] 을 반환.
+ * 정직한 숫자: 미연동/실패 provider 는 enabled=false 또는 빈 배열 → 집계에서 제외.
+ *
+ * 새 소스 추가 절차:
+ *   1) CommunityProvider 구현({ id, label, enabled:true, fetch })
+ *   2) COMMUNITY_PROVIDERS 에 등록
+ *   → communityHeat 가 자동으로 가중 평균에 포함(엔진 변경 불필요).
+ */
+
+import { fetchRedditSignals } from "./redditFetcher";
+import type { CommunitySourceSignal } from "./types";
+
+export type { CommunitySourceSignal };
+
+/**
+ * 커뮤니티 소스 프로바이더. enabled=false 면 스캐폴드(미연동) — 집계 제외.
+ * fetch 는 실패 시 빈 배열(throw 금지 — 정직한 폴백).
+ */
+export interface CommunityProvider {
+  id: string;
+  label: string;
+  enabled: boolean;
+  fetch: () => Promise<CommunitySourceSignal[]>;
+}
+
+// ── Reddit (라이브) — 기존 redditFetcher 재사용 ──────────────────
+const redditProvider: CommunityProvider = {
+  id: "reddit",
+  label: "Reddit",
+  enabled: true,
+  async fetch() {
+    try {
+      const signals = await fetchRedditSignals();
+      return signals.map((s) => ({
+        source: `reddit/${s.subreddit}`,
+        postCount: s.postCount,
+        totalUpvotes: s.totalUpvotes,
+        totalComments: s.totalComments,
+        bullishRatio: s.bullishRatio,
+        fetchedAt: s.fetchedAt,
+      }));
+    } catch {
+      return [];
+    }
+  },
+};
+
+/**
+ * 확장 예정 소스 — 스캐폴드(enabled=false). 실제 연동 시 enabled=true + fetch 구현.
+ * 정직한 숫자: 연동 전엔 집계에 들어가지 않으며 providersAvailable 에도 안 잡힌다.
+ *
+ * - x:        X(트위터) — 검색 API(유료) 또는 nitter 스크래핑. $TICKER 멘션·좋아요·리트윗.
+ * - telegram: 공개 채널/그룹 — Bot API getUpdates 또는 공개 채널 웹 스크래핑.
+ * - toss:     토스증권 커뮤니티 — 종목 토론방 게시물/공감.
+ * - naver:    네이버 증권 종목토론실 / 카페 — 게시물·댓글·공감.
+ */
+function stubProvider(id: string, label: string): CommunityProvider {
+  return {
+    id,
+    label,
+    enabled: false,
+    async fetch() {
+      return []; // 미연동 — 연동 시 이 함수만 구현하면 됨
+    },
+  };
+}
+
+export const COMMUNITY_PROVIDERS: readonly CommunityProvider[] = [
+  redditProvider,
+  stubProvider("x", "X (트위터)"),
+  stubProvider("telegram", "Telegram"),
+  stubProvider("toss", "토스증권 커뮤니티"),
+  stubProvider("naver", "네이버 종목토론/카페"),
+];
+
+export interface CommunityFetchResult {
+  sources: CommunitySourceSignal[];
+  /** 등록된 전체 provider 수(스캐폴드 포함). */
+  providersTotal: number;
+  /** enabled 인 provider 수(연동 시도 대상). */
+  providersEnabled: number;
+  /** 실제로 1건 이상 시그널을 반환한 provider 수(정직한 가용 소스). */
+  providersAvailable: number;
+  /** provider 별 수집 건수(관측/디버그). */
+  perProvider: { id: string; enabled: boolean; count: number }[];
+}
+
+/**
+ * 등록된 모든 enabled provider 를 병렬 수집해 정규화 시그널로 합산(순수 X — fetch 주입형).
+ * providers 인자로 테스트 시 mock 주입 가능.
+ */
+export async function fetchCommunity(
+  providers: readonly CommunityProvider[] = COMMUNITY_PROVIDERS,
+): Promise<CommunityFetchResult> {
+  const enabled = providers.filter((p) => p.enabled);
+  const settled = await Promise.allSettled(enabled.map((p) => p.fetch()));
+
+  const sources: CommunitySourceSignal[] = [];
+  const perProvider: CommunityFetchResult["perProvider"] = providers.map((p) => ({
+    id: p.id,
+    enabled: p.enabled,
+    count: 0,
+  }));
+  let providersAvailable = 0;
+
+  enabled.forEach((p, i) => {
+    const r = settled[i];
+    const got = r && r.status === "fulfilled" && Array.isArray(r.value) ? r.value : [];
+    if (got.length > 0) providersAvailable += 1;
+    sources.push(...got);
+    const rec = perProvider.find((x) => x.id === p.id);
+    if (rec) rec.count = got.length;
+  });
+
+  return {
+    sources,
+    providersTotal: providers.length,
+    providersEnabled: enabled.length,
+    providersAvailable,
+    perProvider,
+  };
+}

--- a/packages/fomo-core/src/index-engine/communityHeat.ts
+++ b/packages/fomo-core/src/index-engine/communityHeat.ts
@@ -91,12 +91,23 @@ export function communityHeat(signals: CommunitySignals = {}): HeatComponent {
       ? null
       : Math.max(0, Math.min(1, signals.bullishRatio));
 
-  const reddit = redditEngagementScore(signals.reddit ?? []);
+  // reddit(레거시) + sources(다중 프로바이더: X/Telegram/Toss/Naver…)를 하나의 engagement 풀로 합산.
+  const reddit = redditEngagementScore([
+    ...(signals.reddit ?? []),
+    ...(signals.sources ?? []).map((s) => ({
+      subreddit: s.source,
+      postCount: s.postCount,
+      totalUpvotes: s.totalUpvotes,
+      totalComments: s.totalComments,
+      bullishRatio: s.bullishRatio,
+      fetchedAt: s.fetchedAt,
+    })),
+  ]);
 
   // ── 가중 평균 산출 ──
   const parts = [mention, bullish, reddit].filter((v): v is number => v != null);
 
-  const SOURCES_TOTAL = 3; // mentionChangePct, bullishRatio, reddit
+  const SOURCES_TOTAL = 3; // mentionChangePct, bullishRatio, 커뮤니티집계(reddit+sources)
   const sourcesAvailable = parts.length;
 
   const score =

--- a/packages/fomo-core/src/index-engine/types.ts
+++ b/packages/fomo-core/src/index-engine/types.ts
@@ -66,6 +66,20 @@ export interface CommunitySignals {
   bullishRatio?: number;
   /** Reddit 소스 집계 결과 (1-A 확장). */
   reddit?: RedditSignal[];
+  /** 다중 프로바이더(Reddit/X/Telegram/Toss/Naver…) 정규화 시그널 — community.ts 확장. */
+  sources?: CommunitySourceSignal[];
+}
+
+/** 플랫폼 무관 정규화 커뮤니티 시그널 (다중 프로바이더 — community.ts). */
+export interface CommunitySourceSignal {
+  /** 소스 키 (예: "reddit/wallstreetbets", "x/$NVDA"). */
+  source: string;
+  postCount: number;
+  /** 긍정 반응 수(좋아요/추천/upvote). engagement 가중치. */
+  totalUpvotes: number;
+  totalComments: number;
+  bullishRatio: number;
+  fetchedAt: string;
 }
 
 /**

--- a/packages/fomo-core/src/index-engine/whaleEvents.ts
+++ b/packages/fomo-core/src/index-engine/whaleEvents.ts
@@ -1,0 +1,50 @@
+/**
+ * Whale Heat 입력 매퍼 — 실측 크립토 신호(CoinGecko)를 WhaleEvent[] 로 변환(순수).
+ *
+ * docs/FOMO_INDEX.md Whale Heat = 대형 청산/급등/Short Squeeze 등 이벤트 가중.
+ * CoinGecko 24h 변동률을 "이벤트"로 정직하게 환산한다(가짜 이벤트 생성 금지 — 실제 변동만).
+ */
+
+import type { WhaleEvent } from "./types";
+
+export interface CryptoMover {
+  /** 심볼/이름 (예: "BTC"). */
+  symbol: string;
+  /** 24시간 변동률(%). */
+  change24h: number;
+}
+
+export interface CryptoSignals {
+  coins: CryptoMover[];
+  /** 글로벌 시총 24h 변동률(%). */
+  marketCapChangePct?: number;
+}
+
+/** 변동 크기 → 이벤트 가중치(정직: 실제 변동률 기반). |Δ|<8% 는 이벤트 아님. */
+function weightFor(absChange: number): number {
+  if (absChange >= 15) return 3;
+  if (absChange >= 8) return 2;
+  return 0;
+}
+
+/**
+ * 실측 크립토 변동 → WhaleEvent[]. 큰 변동(±8%↑)만 이벤트로 잡는다.
+ * BTC 는 대표성으로 +1 가중. 글로벌 시총 급변(±5%↑)도 1건.
+ */
+export function whaleEventsFromCrypto(signals: CryptoSignals): WhaleEvent[] {
+  const events: WhaleEvent[] = [];
+  for (const c of signals.coins ?? []) {
+    if (!Number.isFinite(c.change24h)) continue;
+    const abs = Math.abs(c.change24h);
+    let w = weightFor(abs);
+    if (w === 0) continue;
+    if (c.symbol.toUpperCase() === "BTC") w += 1; // 대표 자산 가중
+    const dir = c.change24h > 0 ? "급등" : "급락";
+    events.push({ weight: w, label: `${c.symbol} 24h ${dir} ${c.change24h.toFixed(1)}%` });
+  }
+  const mc = signals.marketCapChangePct;
+  if (typeof mc === "number" && Number.isFinite(mc) && Math.abs(mc) >= 5) {
+    events.push({ weight: 2, label: `크립토 시총 24h ${mc > 0 ? "급등" : "급락"} ${mc.toFixed(1)}%` });
+  }
+  return events;
+}

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -11,5 +11,7 @@ export * from "./index-engine/whaleHeat";
 export * from "./index-engine/calculate";
 export * from "./index-engine/summary";
 export * from "./index-engine/health";
+export * from "./index-engine/community";
+export * from "./index-engine/whaleEvents";
 // @author 안티그래비티 — 1-A: Reddit 페처 export
 export * from "./index-engine/redditFetcher";

--- a/scripts/fomo-index-pipeline.ts
+++ b/scripts/fomo-index-pipeline.ts
@@ -11,10 +11,42 @@ import {
   buildSummary,
   summarizeHealth,
   renderHealthReport,
+  fetchCommunity,
+  whaleEventsFromCrypto,
   type EmotionTally,
   type EmotionType,
+  type CommunitySourceSignal,
+  type WhaleEvent,
+  type CryptoSignals,
 } from "@fomo/core";
 import { writeFileSync } from "node:fs";
+
+/** CoinGecko 공개 API에서 24h 변동(글로벌 시총 + 상위 코인)을 가져온다(실패 시 빈 신호). */
+async function fetchCrypto(): Promise<CryptoSignals> {
+  try {
+    const [g, m] = await Promise.all([
+      fetch("https://api.coingecko.com/api/v3/global"),
+      fetch(
+        "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&price_change_percentage=24h",
+      ),
+    ]);
+    let marketCapChangePct: number | undefined;
+    if (g.ok) {
+      const gj = (await g.json()) as { data?: { market_cap_change_percentage_24h_usd?: number } };
+      marketCapChangePct = gj.data?.market_cap_change_percentage_24h_usd;
+    }
+    let coins: CryptoSignals["coins"] = [];
+    if (m.ok) {
+      const mj = (await m.json()) as { symbol: string; price_change_percentage_24h: number | null }[];
+      coins = mj
+        .filter((c) => c.price_change_percentage_24h != null)
+        .map((c) => ({ symbol: c.symbol.toUpperCase(), change24h: c.price_change_percentage_24h as number }));
+    }
+    return { coins, marketCapChangePct };
+  } catch {
+    return { coins: [] };
+  }
+}
 
 /** Asia/Seoul 기준 YYYY-MM-DD. */
 function kstDate(offsetDays = 0): string {
@@ -56,8 +88,32 @@ async function main() {
     }
   }
 
-  // 2. FOMO Index 산출 (market/community/whale은 Phase 2 중립 폴백)
-  const index = computeFomoIndex({ emotion: tally }, date);
+  // 1.5 라이브 소스 — Community(다중 프로바이더: Reddit 라이브 + 확장 스텁) + Whale(CoinGecko).
+  //     실패는 빈 값으로 degrade(정직한 폴백). Market 은 무료 실시간 소스 부재로 폴백 유지.
+  let communitySignals: CommunitySourceSignal[] = [];
+  try {
+    const c = await fetchCommunity();
+    communitySignals = c.sources;
+    process.stdout.write(
+      `community: ${c.providersAvailable}/${c.providersEnabled} provider 가용(등록 ${c.providersTotal}) · 시그널 ${c.sources.length}건\n`,
+    );
+  } catch (err) {
+    process.stderr.write(`community 수집 실패(폴백): ${String(err)}\n`);
+  }
+
+  let whaleEvents: WhaleEvent[] = [];
+  try {
+    whaleEvents = whaleEventsFromCrypto(await fetchCrypto());
+    process.stdout.write(`whale: 이벤트 ${whaleEvents.length}건\n`);
+  } catch (err) {
+    process.stderr.write(`whale(coingecko) 수집 실패(폴백): ${String(err)}\n`);
+  }
+
+  // 2. FOMO Index 산출 (Market 은 무료 소스 부재로 폴백 유지 — 정직)
+  const index = computeFomoIndex(
+    { emotion: tally, community: { sources: communitySignals }, whale: whaleEvents },
+    date,
+  );
   const aiSummary = buildSummary(index, tally);
 
   // 3. 전일/30일 평균 대비


### PR DESCRIPTION
## 진단 (사용자 질문 "라이브 연동된 거 아니야?"에 대한 답)
- **롤링 배너는 라이브였음**: `api/fomo/banner`가 Stooq(미증시/반도체)·CoinGecko(BTC)·감정을 실제로 가져옴.
- **그러나 FOMO Index 점수 자체는 폴백이었음**: 파이프라인이 `computeFomoIndex({emotion})`만 먹여 market/community/whale Heat가 항상 중립 기본값. 배너 데이터가 지수에 안 들어감.

## 변경 — 라이브 소스를 지수에 연결 + 커뮤니티 확장형 설계
- **`community.ts` 다중 소스 프로바이더 프레임워크**: `CommunityProvider` 인터페이스 + `COMMUNITY_PROVIDERS` 레지스트리. **Reddit 라이브** + **X / Telegram / 토스커뮤니티 / 네이버 종목토론·카페** 스캐폴드(`enabled:false`). `fetchCommunity()`는 enabled provider 병렬 수집·정규화, 실패 시 빈 배열(정직한 폴백), `providersAvailable`=실제 데이터 반환 수. **새 소스 추가 = provider 1개 등록으로 끝**(엔진 무변경).
- **`communityHeat`**: `sources` 채널을 reddit과 합쳐 engagement-weighted 집계(하위호환).
- **`whaleEvents.ts`**: CoinGecko 24h 변동(±8%↑, BTC 가중, 시총±5%)을 실측 WhaleEvent로 변환(가짜 이벤트 금지).
- **파이프라인**: community(Reddit) + whale(CoinGecko) 라이브 fetch → 지수에 주입. **Market은 무료 실시간 소스(거래량/검색/ETF) 부재로 폴백 유지(정직)**.

## 운영 확인 (정직한 숫자)
- CoinGecko HTTP 200 정상 — 오늘은 변동 적어 whale 이벤트 0(=정직, 가짜 안 만듦).
- Reddit 공개 JSON **HTTP 403**(데이터센터 IP 차단, 로컬·CI 공통) → community 폴백.
  → **Reddit 실데이터는 OAuth 자격증명(`REDDIT_CLIENT_ID/SECRET`)이 필요**. 프레임워크는 준비됨 — provider fetch에 OAuth만 추가하면 됨(후속, 시크릿 필요).
- 프레임워크·연동·폴백은 정상 동작하며, #406 건강 리포트가 매일 실데이터/폴백 현황을 Slack에 노출.

## Test plan
- [x] `npx vitest run` — 504 passed (community 프로바이더 6 + whale 매퍼 3 신규)
- [x] fomo-core typecheck + `npm run build:web`(prisma generate 후) 통과
- [x] 파이프라인 라이브 dry-run: community/whale fetch 실행·정직 폴백 확인
- [ ] (자동) 다음 파이프라인 cron → 건강 리포트에 whale 변동일 실데이터 반영 확인

## 후속 (확장 로드맵 — 프레임워크 위에 provider만 추가)
1. Reddit OAuth(자격증명) → community 실데이터화 — 가장 빠른 win
2. X / 토스 / 네이버 / Telegram provider 구현(각 enabled:true + fetch)
3. Market Heat 실소스(거래량/검색 트렌드) 확보 시 연결

Ref: docs/FOMO_INDEX.md · 정직한 숫자 원칙

🤖 Generated with [Claude Code](https://claude.com/claude-code)