### PR TITLE
feat(fomo): 국내 커뮤니티 소스 — 네이버 종목토론실 라이브 연동

### DIFF
--- a/packages/fomo-core/__tests__/naver-fetcher.test.ts
+++ b/packages/fomo-core/__tests__/naver-fetcher.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseNaverBoard,
+  classifyKoreanTitle,
+  KR_BULLISH,
+  KR_BEARISH,
+} from "../src/index-engine/naverFetcher";
+
+describe("classifyKoreanTitle", () => {
+  it("강세 키워드 → bull", () => {
+    expect(classifyKoreanTitle("내일 삼전 가즈아 풀매수")).toBe("bull");
+    expect(classifyKoreanTitle("존버 간다")).toBe("bull");
+  });
+  it("약세 키워드 → bear", () => {
+    expect(classifyKoreanTitle("손절했다 폭락 한강간다")).toBe("bear");
+  });
+  it("둘 다/없음 → neutral", () => {
+    expect(classifyKoreanTitle("오늘 거래량 어떤가요")).toBe("neutral");
+    expect(classifyKoreanTitle("매수했는데 손절각")).toBe("neutral"); // bull+bear
+  });
+  it("키워드 세트 비어있지 않음", () => {
+    expect(KR_BULLISH.length).toBeGreaterThan(5);
+    expect(KR_BEARISH.length).toBeGreaterThan(5);
+  });
+});
+
+// 네이버 종토 마크업 모사 픽스처 (board_read 앵커 title + 날짜 셀)
+function fixture(posts: { title: string; date: string }[]): string {
+  const rows = posts
+    .map(
+      (p) =>
+        `<td class="title"><a href="/item/board_read.naver?code=005930&nid=1&page=1" title="${p.title}">${p.title}</a></td>` +
+        `<td class="tah p10 gray03">${p.date}</td>`,
+    )
+    .join("\n");
+  return `<html><body><table>${rows}</table></body></html>`;
+}
+
+describe("parseNaverBoard", () => {
+  const NOW = Date.parse("2026-06-08T18:00:00+09:00");
+
+  it("24h 내 게시물만 집계 + bullishRatio 산출", () => {
+    const html = fixture([
+      { title: "삼전 가즈아 풀매수", date: "2026.06.08 17:50" }, // bull, 24h내
+      { title: "손절 폭락 한강", date: "2026.06.08 17:40" }, // bear, 24h내
+      { title: "가즈아 떡상 기대", date: "2026.06.08 17:30" }, // bull, 24h내
+      { title: "어제 글 가즈아", date: "2026.06.06 10:00" }, // 24h 밖 → 제외
+    ]);
+    const sig = parseNaverBoard(html, "005930", NOW);
+    expect(sig).not.toBeNull();
+    expect(sig!.source).toBe("naver/005930");
+    expect(sig!.postCount).toBe(3); // 어제 글 제외
+    // bull 2, bear 1 → 2/3
+    expect(sig!.bullishRatio).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("감성 표명 글 없으면 중립 0.5", () => {
+    const html = fixture([{ title: "오늘 거래량 질문", date: "2026.06.08 17:00" }]);
+    expect(parseNaverBoard(html, "005930", NOW)!.bullishRatio).toBe(0.5);
+  });
+
+  it("게시물 없으면 null", () => {
+    expect(parseNaverBoard("<html>no posts</html>", "005930", NOW)).toBeNull();
+  });
+
+  it("날짜 개수 불일치 시 전체 사용(보수적, 크래시 없음)", () => {
+    const html =
+      `<a href="board_read.naver?code=005930&nid=1" title="가즈아">가즈아</a>` +
+      `<a href="board_read.naver?code=005930&nid=2" title="손절">손절</a>`; // 날짜 셀 없음
+    const sig = parseNaverBoard(html, "005930", NOW);
+    expect(sig!.postCount).toBe(2);
+  });
+});

--- a/packages/fomo-core/src/index-engine/community.ts
+++ b/packages/fomo-core/src/index-engine/community.ts
@@ -13,6 +13,7 @@
  */
 
 import { fetchRedditSignals } from "./redditFetcher";
+import { fetchNaverSignals } from "./naverFetcher";
 import type { CommunitySourceSignal } from "./types";
 
 export type { CommunitySourceSignal };
@@ -70,12 +71,26 @@ function stubProvider(id: string, label: string): CommunityProvider {
   };
 }
 
+// ── 네이버 종목토론실 (라이브, 국내) — finance.naver.com HTML 파싱 ──
+const naverProvider: CommunityProvider = {
+  id: "naver",
+  label: "네이버 종목토론실",
+  enabled: true,
+  async fetch() {
+    try {
+      return await fetchNaverSignals();
+    } catch {
+      return [];
+    }
+  },
+};
+
 export const COMMUNITY_PROVIDERS: readonly CommunityProvider[] = [
-  redditProvider,
+  naverProvider, // 국내 우선 (라이브)
+  redditProvider, // 해외 (공개 JSON 403 가능 — OAuth 후속)
   stubProvider("x", "X (트위터)"),
   stubProvider("telegram", "Telegram"),
-  stubProvider("toss", "토스증권 커뮤니티"),
-  stubProvider("naver", "네이버 종목토론/카페"),
+  stubProvider("toss", "토스증권 커뮤니티"), // 공개 API 부재 — 연동 보류
 ];
 
 export interface CommunityFetchResult {

--- a/packages/fomo-core/src/index-engine/naverFetcher.ts
+++ b/packages/fomo-core/src/index-engine/naverFetcher.ts
@@ -1,0 +1,143 @@
+/**
+ * 네이버 종목토론실 커뮤니티 시그널 페처 (국내 소스).
+ *
+ * 공식 공개 API가 없어 finance.naver.com 종목토론실 HTML을 파싱한다(무료·무인증).
+ * docs/FOMO_INDEX.md Community Heat. 정직한 숫자: 파싱 실패/도달 불가 시 빈 배열(폴백).
+ *
+ * 파싱은 순수 함수(parseNaverBoard)로 분리해 vitest로 검증(네트워크 불필요).
+ * 마크업 변경에 견고하도록 실패는 조용히 [] 로 degrade(빈 화면/에러 노출 금지).
+ */
+
+import type { CommunitySourceSignal } from "./types";
+
+/** 한국 개인투자자 커뮤니티 강세(bullish) 키워드. */
+export const KR_BULLISH = [
+  "가즈아", "가즈", "매수", "풀매수", "존버", "익절", "오른다", "오를", "상승", "떡상",
+  "불기둥", "고고", "기대", "반등", "신고가", "추매가즈아", "가보자", "줍줍", "홀딩",
+];
+/** 약세(bearish) 키워드. */
+export const KR_BEARISH = [
+  "손절", "물렸", "물림", "폭락", "하락", "떡락", "공매도", "추매", "물타기", "흑우",
+  "패닉", "탈출", "도망", "악재", "신저가", "나락", "한강",
+];
+
+/** 제목 한 줄 분류: bull | bear | neutral. */
+export function classifyKoreanTitle(title: string): "bull" | "bear" | "neutral" {
+  const t = title.replace(/\s+/g, "");
+  const bull = KR_BULLISH.some((k) => t.includes(k));
+  const bear = KR_BEARISH.some((k) => t.includes(k));
+  if (bull && !bear) return "bull";
+  if (bear && !bull) return "bear";
+  return "neutral";
+}
+
+/** "YYYY.MM.DD HH:MM" → epoch ms (KST 가정). 실패 시 null. */
+function parseNaverDate(s: string): number | null {
+  const m = s.match(/(\d{4})\.(\d{2})\.(\d{2}) (\d{2}):(\d{2})/);
+  if (!m) return null;
+  // KST(+09:00) 기준으로 해석
+  const iso = `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:00+09:00`;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * 네이버 종목토론실 HTML → CommunitySourceSignal (순수).
+ * @param html  board.naver 응답 HTML
+ * @param code  종목코드 (source 라벨용)
+ * @param nowMs 현재 시각(ms) — 24h 필터 기준 (테스트 주입용)
+ * 게시물 0건이거나 파싱 실패 시 null.
+ */
+export function parseNaverBoard(html: string, code: string, nowMs: number): CommunitySourceSignal | null {
+  try {
+    // 게시물 제목: board_read 앵커의 title 속성
+    const titles = [...html.matchAll(/board_read\.naver\?[^"]*"[^>]*title="([^"]*)"/g)]
+      .map((m) => (m[1] ?? "").trim())
+      .filter((t) => t.length > 0);
+    if (titles.length === 0) return null;
+
+    // 날짜 셀(게시물과 병렬). 개수가 맞으면 24h 필터, 아니면 전체 사용(보수적).
+    const dates = [...html.matchAll(/(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2})/g)].map((m) => m[1] ?? "");
+    const cutoff = nowMs - 24 * 3600 * 1000;
+
+    const considered: string[] =
+      dates.length === titles.length
+        ? titles.filter((_, i) => {
+            const t = parseNaverDate(dates[i]!);
+            return t == null ? true : t >= cutoff;
+          })
+        : titles;
+
+    if (considered.length === 0) return null;
+
+    let bull = 0;
+    let bear = 0;
+    for (const title of considered) {
+      const c = classifyKoreanTitle(title);
+      if (c === "bull") bull += 1;
+      else if (c === "bear") bear += 1;
+    }
+    const decided = bull + bear;
+    // 감성 표명 글이 없으면 중립(0.5). 있으면 bull 비율.
+    const bullishRatio = decided === 0 ? 0.5 : bull / decided;
+
+    return {
+      source: `naver/${code}`,
+      postCount: considered.length,
+      // 네이버 종토는 글당 좋아요/댓글 파싱이 불안정 → 글 수를 engagement 가중으로(정직: 실측 글 수만)
+      totalUpvotes: considered.length,
+      totalComments: 0,
+      bullishRatio,
+      fetchedAt: new Date(nowMs).toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** 추적 대상 대표 종목 (개인투자자 관심 상위). */
+export const DEFAULT_NAVER_CODES: readonly string[] = [
+  "005930", // 삼성전자
+  "000660", // SK하이닉스
+  "035720", // 카카오
+  "035420", // NAVER
+  "247540", // 에코프로비엠
+];
+
+const UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+/** 단일 종목 종토 시그널 fetch (실패 시 null). */
+export async function fetchNaverBoardSignal(
+  code: string,
+  timeoutMs = 5000,
+  nowMs: number = Date.now(),
+): Promise<CommunitySourceSignal | null> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    const res = await fetch(`https://finance.naver.com/item/board.naver?code=${encodeURIComponent(code)}`, {
+      headers: { "User-Agent": UA, "Accept-Language": "ko-KR,ko;q=0.9" },
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const html = await res.text();
+    return parseNaverBoard(html, code, nowMs);
+  } catch {
+    return null;
+  }
+}
+
+/** 여러 종목 병렬 수집 → CommunitySourceSignal[] (실패분 제외). */
+export async function fetchNaverSignals(
+  codes: readonly string[] = DEFAULT_NAVER_CODES,
+  timeoutMs = 5000,
+): Promise<CommunitySourceSignal[]> {
+  const now = Date.now();
+  const settled = await Promise.allSettled(codes.map((c) => fetchNaverBoardSignal(c, timeoutMs, now)));
+  return settled
+    .filter((r): r is PromiseFulfilledResult<CommunitySourceSignal | null> => r.status === "fulfilled")
+    .map((r) => r.value)
+    .filter((v): v is CommunitySourceSignal => v != null);
+}

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -13,5 +13,6 @@ export * from "./index-engine/summary";
 export * from "./index-engine/health";
 export * from "./index-engine/community";
 export * from "./index-engine/whaleEvents";
+export * from "./index-engine/naverFetcher";
 // @author 안티그래비티 — 1-A: Reddit 페처 export
 export * from "./index-engine/redditFetcher";


### PR DESCRIPTION
## Summary
레딧 보류(공개 JSON 403) → **국내 소스부터 연결**. 네이버 종목토론실을 Community Heat 라이브 프로바이더로 추가.

- **`naverFetcher.ts`**: `finance.naver.com` 종목토론실 HTML 파싱(무료·무인증).
  - `parseNaverBoard` **순수함수** — 24h 필터 + 한국어 강세/약세 키워드 분류 → bullishRatio
  - `classifyKoreanTitle`: 강세(가즈아/매수/존버/떡상…) vs 약세(손절/물렸/폭락/한강…)
  - 대표 5종목(삼성전자·SK하이닉스·카카오·NAVER·에코프로비엠) 병렬 수집
  - 파싱 실패/도달 불가 → `[]` (정직한 폴백). vitest 9 (순수 — 네트워크 불필요, 픽스처 기반)
- **`community.ts`**: `naverProvider` enabled 등록(국내 우선). 토스증권 커뮤니티는 **공개 API 부재로 스텁 유지**.

## 운영 확인 (라이브 dry-run)
```
community: 1/2 provider 가용(등록 5) · 시그널 5건
📊 FOMO Index — 실데이터 1/4 Heat (was 0/4)
🟠 community 20/30 (low, 1/3)   ← 폴백 → 실데이터 전환!
```
네이버 5종목 실수집 → Community Heat 라이브화. (Reddit 403 → 0, whale 오늘 변동 적어 0 = 정직)

## Test plan
- [x] `npx vitest run` — 512 passed (naver 파서 9 신규)
- [x] fomo-core typecheck + `npm run build:web` 통과
- [x] 실제 네이버 HTML 파싱 + 파이프라인 라이브 dry-run으로 지수 반영 확인

## 후속 (프레임워크 위 provider 추가)
- 토스증권 커뮤니티(공개 엔드포인트 확보 시), X/Telegram, Reddit OAuth — 각 provider 1개 추가로 끝.
- 네이버 키워드 세트·종목 리스트 튜닝(현재 ratio 0.5 근처 — 키워드 확장 여지).

Ref: docs/FOMO_INDEX.md · #407(프레임워크)

🤖 Generated with [Claude Code](https://claude.com/claude-code)