### PR TITLE
feat: CEO Brief 2026-06-09 — FOMO 품질·UX·테스트·성능 개선

### DIFF
--- a/apps/fomo-web/components/FomoFace.tsx
+++ b/apps/fomo-web/components/FomoFace.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { FomoFace as FomoFaceType } from "@fomo/core";
 
 /**
@@ -77,7 +78,8 @@ const OUTLINE = "#6E6E82";
 const BODY = "#F2F2EA";
 const EYE = "#2A2A35";
 
-export function FomoFace({
+// props(face/glow/size)가 바뀌지 않으면 리렌더링 건너뜀 — 부모 상태 업데이트 시 불필요한 SVG 재계산 방지(#410)
+export const FomoFace = memo(function FomoFace({
   face,
   glow,
   size = 168,
@@ -132,4 +134,4 @@ export function FomoFace({
       </svg>
     </div>
   );
-}
+});

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import {
   EMOTION_TYPES,
   EMOTION_LABELS,
   EMOTION_COLORS,
   scoreToFace,
   scoreToState,
+  scoreToColor,
   marketLine,
   mineLine,
   isCalmDay,
@@ -17,6 +18,7 @@ import { FomoFace } from "@/components/FomoFace";
 import { RollingBanner } from "@/components/RollingBanner";
 import { EmotionCalendar } from "@/components/EmotionCalendar";
 import { SignupGate } from "@/components/SignupGate";
+import { FomoIndexSkeleton, TallySkeleton } from "@/components/SkeletonLoader";
 import { stateGlow } from "@/lib/fomoVisual";
 import type {
   FomoIndexResponse,
@@ -52,8 +54,13 @@ export function HomeView({
 }) {
   const [tab, setTab] = useState<Tab>("home");
 
-  const state = index ? scoreToState(index.score) : null;
-  const marketFace = index ? scoreToFace(index.score) : "curious";
+  // useMemo로 index 기반 파생값 메모이제이션 — index prop이 바뀔 때만 재계산
+  const { state, marketFace, indexColor } = useMemo(() => ({
+    state: index ? scoreToState(index.score) : null,
+    marketFace: index ? scoreToFace(index.score) : "curious" as const,
+    indexColor: index ? scoreToColor(index.score) : null,
+  }), [index]);
+
   const stage: "market" | "mine" = mine ? "mine" : "market";
   const line = mine ? mineLine(mine) : state ? marketLine(state) : "";
 
@@ -73,45 +80,52 @@ export function HomeView({
               <RollingBanner items={banner} />
             </div>
 
-            {/* 주인공: 포모 */}
-            <p className="mb-2 text-xs text-muted">{stage === "market" ? "오늘의 포모" : "나의 포모"}</p>
-            <FomoFace
-              face={stage === "market" ? marketFace : "calm"}
-              glow={
-                stage === "mine" && mine
-                  ? EMOTION_COLORS[mine]
-                  : index
-                    ? stateGlow(index.score)
-                    : undefined
-              }
-              size={84}
-            />
+            {/* 주인공: 포모 — 데이터 미비 시 스켈레톤으로 빈 화면 방지(#409) */}
+            {!index ? (
+              <FomoIndexSkeleton />
+            ) : (
+              <>
+                <p className="mb-2 text-xs text-muted">{stage === "market" ? "오늘의 포모" : "나의 포모"}</p>
+                <FomoFace
+                  face={stage === "market" ? marketFace : "calm"}
+                  glow={
+                    stage === "mine" && mine
+                      ? EMOTION_COLORS[mine]
+                      : stateGlow(index.score)
+                  }
+                  size={84}
+                />
 
-            {/* 보조: FOMO Index (픽셀) */}
-            <div className="mt-3 flex flex-col items-center">
-              {index ? (
-                <>
-                  <p className="font-pixel text-4xl leading-none text-whiteout">{index.score}</p>
+                {/* FOMO Index 수치 — 감정 포인트 색 강조(#412) */}
+                <div className="mt-3 flex flex-col items-center">
+                  <p
+                    className="font-pixel text-5xl font-bold leading-none"
+                    style={{ color: indexColor ?? "#FAFAFA" }}
+                  >
+                    {index.score}
+                  </p>
                   <p className="mt-1.5 font-pixel text-xs text-muted">
                     FOMO INDEX · {index.state}
                     {index.prevDayDelta
                       ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}`
                       : ""}
                   </p>
-                </>
-              ) : (
-                <p className="font-pixel text-sm text-muted">FOMO INDEX · 집계 준비 중</p>
-              )}
-            </div>
+                  {/* 3초 안에 읽히는 맥락 문장(#412) */}
+                  <p className="mt-1 text-center text-xs leading-4 text-muted">
+                    오늘의 집단 감정은 <span style={{ color: indexColor ?? "#FAFAFA" }}>{index.state}</span> 상태예요.
+                  </p>
+                </div>
 
-            {/* 포모의 담담한 한마디 */}
-            {line && (
-              <p
-                key={stage + (mine ?? "")}
-                className="fomo-rise mt-3 max-w-xs text-center text-sm leading-5 text-whiteout"
-              >
-                {line}
-              </p>
+                {/* 포모의 담담한 한마디 */}
+                {line && (
+                  <p
+                    key={stage + (mine ?? "")}
+                    className="fomo-rise mt-3 max-w-xs text-center text-sm leading-5 text-whiteout"
+                  >
+                    {line}
+                  </p>
+                )}
+              </>
             )}
 
             {/* 오늘의 너 — 게이트에서 고른 감정 요약 + 다시 고르기 */}
@@ -142,9 +156,11 @@ export function HomeView({
               </div>
             )}
 
-            {/* 집계 — 정직한 숫자 */}
-            {tally && (
-              <section className="mt-7 w-full">
+            {/* 집계 — 정직한 숫자 / 로딩 중 스켈레톤(#409) */}
+            {!tally ? (
+              <TallySkeleton />
+            ) : (
+            <section className="mt-7 w-full">
                 <p className="text-xs text-muted">
                   오늘 <span className="font-pixel text-whiteout">{tally.total}</span>명이 마음을 남겼어요
                   {mine ? " · 너도 그 안에 있어" : ""}

--- a/apps/fomo-web/components/SkeletonLoader.tsx
+++ b/apps/fomo-web/components/SkeletonLoader.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * FOMO Club 스켈레톤 로딩 컴포넌트.
+ * 데이터가 준비되기 전 빈 화면 노출을 막아 정직한 숫자 원칙 유지(#409).
+ * 디자인: 검정 배경 + 어두운 shimmer — DESIGN_FOMO.md 색 체계 준수.
+ */
+
+interface SkeletonBlockProps {
+  width?: string;
+  height?: string;
+  className?: string;
+  rounded?: "sm" | "md" | "full";
+}
+
+function SkeletonBlock({
+  width = "100%",
+  height = "1rem",
+  className = "",
+  rounded = "md",
+}: SkeletonBlockProps) {
+  const roundClass = rounded === "full" ? "rounded-full" : rounded === "sm" ? "rounded" : "rounded-xl";
+  return (
+    <div
+      className={`animate-pulse bg-elevated ${roundClass} ${className}`}
+      style={{ width, height }}
+      aria-hidden
+    />
+  );
+}
+
+/** 홈 화면 FOMO Index 영역 스켈레톤 */
+export function FomoIndexSkeleton() {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {/* 마스코트 자리 */}
+      <SkeletonBlock width="84px" height="84px" rounded="full" />
+      {/* Index 수치 */}
+      <SkeletonBlock width="64px" height="40px" rounded="md" className="mt-1" />
+      {/* 상태 텍스트 */}
+      <SkeletonBlock width="120px" height="12px" rounded="sm" />
+      {/* 포모 멘트 */}
+      <SkeletonBlock width="200px" height="12px" rounded="sm" className="mt-2" />
+      <SkeletonBlock width="160px" height="12px" rounded="sm" />
+    </div>
+  );
+}
+
+/** 집계(감정 투표 바) 스켈레톤 */
+export function TallySkeleton() {
+  return (
+    <div className="mt-7 flex w-full flex-col gap-2">
+      <SkeletonBlock width="140px" height="12px" rounded="sm" />
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-2.5">
+          <SkeletonBlock width="40px" height="12px" rounded="sm" />
+          <SkeletonBlock height="8px" rounded="full" className="flex-1" />
+          <SkeletonBlock width="36px" height="12px" rounded="sm" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/fomo-core/__tests__/engine.test.ts
+++ b/packages/fomo-core/__tests__/engine.test.ts
@@ -238,3 +238,67 @@ describe("communityHeat — Reddit 소스 확장 (1-A)", () => {
     expect(h.meta!.sourcesAvailable).toBe(2);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #413: FOMO Index 스냅샷 생성 및 데이터 정합성 회귀 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("FOMO Index 스냅샷 정합성 — 폴백 회귀 테스트 (#413)", () => {
+  // 시나리오 1: 모든 데이터 소스 정상 → 스냅샷 정확히 생성
+  it("Given 전체 소스 정상 When computeFomoIndex Then 스냅샷 1건 + 컴포넌트 4개 반환", () => {
+    const idx = computeFomoIndex(
+      {
+        market: { volumeChangePct: 30, turnoverChangePct: 20 },
+        community: { mentionChangePct: 50, bullishRatio: 0.6 },
+        emotion: { fomo: 10, greed: 5, fear: 3 },
+        whale: [{ weight: 3, label: "BTC 신고가" }],
+      },
+      "2026-06-09"
+    );
+    expect(idx.date).toBe("2026-06-09");
+    expect(idx.score).toBeGreaterThan(0);
+    expect(idx.score).toBeLessThanOrEqual(100);
+    expect(idx.components).toHaveLength(4);
+    // 각 컴포넌트 점수가 max를 초과하지 않아야 함
+    for (const c of idx.components) {
+      expect(c.score).toBeGreaterThanOrEqual(0);
+      expect(c.score).toBeLessThanOrEqual(c.max);
+    }
+  });
+
+  // 시나리오 2: 일부 소스 실패(결측) → 폴백 값으로 대체, 오류 노출 없음
+  it("Given 일부 소스 결측 When computeFomoIndex Then 폴백 적용하여 정상 스냅샷 생성", () => {
+    // market/whale 미제공 → 폴백(중립)
+    const idx = computeFomoIndex(
+      { emotion: { fomo: 5, fear: 5 } },
+      "2026-06-09"
+    );
+    expect(idx.score).toBeGreaterThan(0);
+    expect(idx.components).toHaveLength(4);
+    const market = idx.components.find((c) => c.key === "market")!;
+    const whale = idx.components.find((c) => c.key === "whale")!;
+    expect(market.meta!.confidence).toBe("fallback");
+    expect(whale.meta!.confidence).toBe("fallback");
+    // 감정은 실제 데이터 기반이므로 fallback 아님
+    const emotion = idx.components.find((c) => c.key === "emotion")!;
+    expect(emotion.meta!.confidence).not.toBe("fallback");
+  });
+
+  // 시나리오 3: 전체 소스 미제공 → 중립 스냅샷 (15+15+15+0=45)
+  it("Given 전체 소스 미제공 When computeFomoIndex Then 중립 스냅샷(score=45, 관심) 반환", () => {
+    const idx = computeFomoIndex({}, "2026-06-09");
+    expect(idx.score).toBe(45);
+    expect(idx.state).toBe("관심");
+    for (const c of idx.components) {
+      expect(c.meta!.confidence).toBe("fallback");
+    }
+  });
+
+  // buildSummary — 폴백 데이터로도 요약 문장이 생성됨
+  it("폴백 스냅샷에서도 buildSummary가 비어있지 않음", () => {
+    const idx = computeFomoIndex({}, "2026-06-09");
+    const summary = buildSummary(idx, {});
+    expect(summary.length).toBeGreaterThan(0);
+    expect(summary).not.toMatch(/undefined|null|NaN/);
+  });
+});

--- a/packages/fomo-core/src/index-engine/calculate.ts
+++ b/packages/fomo-core/src/index-engine/calculate.ts
@@ -1,8 +1,8 @@
 import type { FomoIndex, HeatComponent } from "../types";
 import { scoreToState } from "../state";
-import { marketHeat } from "./marketHeat";
-import { communityHeat } from "./communityHeat";
-import { emotionHeat } from "./emotionHeat";
+import { marketHeat, MARKET_HEAT_MAX } from "./marketHeat";
+import { communityHeat, COMMUNITY_HEAT_MAX } from "./communityHeat";
+import { emotionHeat, EMOTION_HEAT_MAX } from "./emotionHeat";
 import { whaleHeat } from "./whaleHeat";
 import type { MarketSignals, CommunitySignals, EmotionTally, WhaleEvent } from "./types";
 
@@ -13,18 +13,39 @@ export interface FomoIndexInputs {
   whale?: WhaleEvent[];
 }
 
+// 소스별 안전한 폴백값 — 중립(half-max) 또는 보너스 미발생(0).
+const FALLBACK_COMPONENTS: HeatComponent[] = [
+  { key: "market",    score: MARKET_HEAT_MAX / 2,    max: MARKET_HEAT_MAX,    meta: { confidence: "fallback", sourcesTotal: 4, sourcesAvailable: 0 } },
+  { key: "community", score: COMMUNITY_HEAT_MAX / 2, max: COMMUNITY_HEAT_MAX, meta: { confidence: "fallback", sourcesTotal: 3, sourcesAvailable: 0 } },
+  { key: "emotion",   score: EMOTION_HEAT_MAX / 2,   max: EMOTION_HEAT_MAX,   meta: { confidence: "fallback", sourcesTotal: 1, sourcesAvailable: 0 } },
+  { key: "whale",     score: 0,                       max: 10,                 meta: { confidence: "fallback", sourcesTotal: 1, sourcesAvailable: 0 } },
+];
+
 /**
  * 4개 Heat를 합산하여 FOMO Index(0~100) + 상태를 산출한다.
  * Market 30 + Community 30 + Emotion 30 + Whale 10. docs/FOMO_INDEX.md.
- * 모든 입력 미비 시에도 중립 스냅샷을 반환한다(절대 에러 없음).
+ * 모든 입력 미비 또는 예외 시에도 중립 스냅샷을 반환한다(절대 에러 전파 없음).
  */
 export function computeFomoIndex(inputs: FomoIndexInputs, date: string): FomoIndex {
   const components: HeatComponent[] = [
-    marketHeat(inputs.market),
-    communityHeat(inputs.community),
-    emotionHeat(inputs.emotion),
-    whaleHeat(inputs.whale),
+    safeHeat("market",    () => marketHeat(inputs.market),       FALLBACK_COMPONENTS[0]!),
+    safeHeat("community", () => communityHeat(inputs.community), FALLBACK_COMPONENTS[1]!),
+    safeHeat("emotion",   () => emotionHeat(inputs.emotion),     FALLBACK_COMPONENTS[2]!),
+    safeHeat("whale",     () => whaleHeat(inputs.whale),         FALLBACK_COMPONENTS[3]!),
   ];
   const score = components.reduce((acc, c) => acc + c.score, 0);
   return { date, score, state: scoreToState(score), components };
+}
+
+function safeHeat(
+  key: string,
+  fn: () => HeatComponent,
+  fallback: HeatComponent
+): HeatComponent {
+  try {
+    return fn();
+  } catch (err) {
+    console.warn(`[fomo-core] ${key} Heat 산출 오류 — 폴백 적용:`, err);
+    return fallback;
+  }
 }

--- a/packages/fomo-core/src/index-engine/summary.ts
+++ b/packages/fomo-core/src/index-engine/summary.ts
@@ -1,4 +1,4 @@
-import type { FomoIndex } from "../types";
+import type { FomoIndex, HeatComponent } from "../types";
 import { scoreToEmoji } from "../state";
 import type { EmotionTally } from "./types";
 import { EMOTION_LABELS } from "../types";
@@ -11,15 +11,51 @@ import { EMOTION_LABELS } from "../types";
 export function buildSummary(index: FomoIndex, tally: EmotionTally = {}): string {
   const emoji = scoreToEmoji(index.score);
   const moodLine = STATE_LINE[index.state];
+  const heatCtx = buildHeatContext(index.components);
 
   const entries = (Object.entries(tally) as [keyof typeof EMOTION_LABELS, number][]).filter(
     ([, n]) => (n ?? 0) > 0
   );
   if (entries.length === 0) {
-    return `${emoji} 오늘 시장 감정은 '${index.state}' 부근입니다. ${moodLine}`;
+    const base = `${emoji} 오늘 시장 감정은 '${index.state}' 부근입니다. ${moodLine}`;
+    return heatCtx ? `${base} ${heatCtx}` : base;
   }
   const [topEmotion] = entries.sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))[0]!;
-  return `${emoji} 오늘 시장 감정은 '${index.state}'. 가장 많이 선택된 감정은 「${EMOTION_LABELS[topEmotion]}」이에요. ${moodLine}`;
+  const base = `${emoji} 오늘 시장 감정은 '${index.state}'. 가장 많이 선택된 감정은 「${EMOTION_LABELS[topEmotion]}」이에요. ${moodLine}`;
+  return heatCtx ? `${base} ${heatCtx}` : base;
+}
+
+/**
+ * 4 Heat 구성 중 가장 두드러진 항목을 담담하게 한 줄로 짚는다.
+ * fallback 소스만 있을 때는 문장을 생략해 빈 데이터 노출을 막는다(정직한 숫자 원칙).
+ * 최대 18자 이내 — 3초 안에 읽히는 길이.
+ */
+function buildHeatContext(components: HeatComponent[]): string {
+  // 각 Heat 비율(0~1)로 정규화
+  const normalized = components.map((c) => ({
+    key: c.key,
+    ratio: c.max > 0 ? c.score / c.max : 0,
+    confidence: c.meta?.confidence ?? "fallback",
+  }));
+
+  // 데이터가 있는 소스만 추림 (fallback 제외)
+  const live = normalized.filter((n) => n.confidence !== "fallback");
+  if (live.length === 0) return "";
+
+  const top = live.reduce((a, b) => (a.ratio > b.ratio ? a : b));
+  const HEAT_LABEL: Record<string, string> = {
+    market: "시장",
+    community: "커뮤니티",
+    emotion: "감정",
+    whale: "고래",
+  };
+
+  const label = HEAT_LABEL[top.key] ?? top.key;
+  const pct = Math.round(top.ratio * 100);
+
+  if (pct >= 70) return `${label}이 특히 뜨거워요(${pct}%).`;
+  if (pct <= 30) return `${label}은 차분한 편이에요(${pct}%).`;
+  return "";
 }
 
 const STATE_LINE: Record<FomoIndex["state"], string> = {


### PR DESCRIPTION
## 구현 항목

### #417 — FOMO 감정 요약/멘트 품질 개선 (Prompt Engineer, 정렬도 5/5)
- `packages/fomo-core/src/index-engine/summary.ts`: `buildHeatContext()` 추가
  - 4 Heat 중 가장 두드러진 항목을 담담하게 한 줄 언급 (예: "감정이 특히 뜨거워요(78%).")
  - fallback 소스만 있을 때는 문장 생략 → 빈 데이터 노출 방지 (정직한 숫자 원칙)

### #415 — 기술 부채 최적화, FOMO Index 파이프라인 예외 처리 강화 (CTO, 정렬도 3/5)
- `packages/fomo-core/src/index-engine/calculate.ts`: `safeHeat()` 래퍼 도입
  - 각 Heat 함수를 try/catch로 보호 + `console.warn` 로깅
  - 소스별 안전한 폴백 상수(`FALLBACK_COMPONENTS`) 명시적 정의

### #413 — 폴백 기능 회귀 테스트 강화 (QA, 정렬도 4/5)
- `packages/fomo-core/__tests__/engine.test.ts`에 Given/When/Then 4개 케이스 추가
  1. 전체 소스 정상 → 스냅샷 1건 + 컴포넌트 4개, 각 max 미초과
  2. 일부 소스 결측 → fallback 적용, 에러 노출 없음, 실제 데이터 소스는 non-fallback
  3. 전체 소스 미제공 → 중립 스냅샷 (score=45, 관심, 전 컴포넌트 fallback)
  4. 폴백 스냅샷에서도 buildSummary 비어있지 않음 (undefined/null/NaN 없음)

### #409 — 오늘의 감정 투표 UX 개선 / 스켈레톤 로딩 (PM, 정렬도 4/5)
- `apps/fomo-web/components/SkeletonLoader.tsx` 신설
  - `FomoIndexSkeleton`: 마스코트·수치·멘트 자리 animate-pulse 스켈레톤
  - `TallySkeleton`: 집계 바 5개 스켈레톤
- `HomeView.tsx`: `index=null` → FomoIndexSkeleton, `tally=null` → TallySkeleton
  - 빈 화면 노출 완전 차단

### #412 — UX/UI 개선, FOMO Index 타이포그래피/배치 (Designer, 정렬도 5/5)
- FOMO Index 수치 폰트: `text-4xl` → `text-5xl font-bold`
- 수치 색상: 흰색 고정 → `scoreToColor()` 감정 포인트 색 적용 (DESIGN_FOMO.md 토큰 참조)
- 상태 텍스트 아래 맥락 문장 추가: "오늘의 집단 감정은 {state} 상태예요." (3초 이내 직관)

### #410 — Frontend 성능 및 안정성 개선 (Frontend, 정렬도 4/5)
- `FomoFace.tsx`: `React.memo()` 래핑 → face/glow/size 동일 시 리렌더링 건너뜀
- `HomeView.tsx`: `useMemo` 적용 → state/marketFace/indexColor를 index prop 기반 메모이제이션

---

## 킬리스트 (미구현)

| 항목 | 사유 |
|------|------|
| #352 타로 해석 서사 강화 | 타로 신규 작업 거부 규칙 (CLAUDE.md) |
| #394 데이터 소스 검증 및 정합성 강화 | 이슈 오너(mlender-ai)가 이미 `not_planned`으로 close |
| #397 스미싱 방지 계정 복구 보안 강화 | 이슈 오너(mlender-ai)가 이미 `not_planned`으로 close |

---

## 검증

- [x] lint 통과 (에러 0 — TS5101 baseUrl deprecation은 pre-existing, 내 변경과 무관)
- [x] typecheck 통과 (fomo-core, fomo-web 실제 타입 에러 0)
- [x] build:web 통과
- [x] test 통과 (522 tests, 50 files — 신규 4개 포함 전체 통과)

## 참조

이슈: #418 (CEO Brief 2026-06-09)

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqeCQc1RiZHxJw7dBtjUi2)_