### PR TITLE
feat(council): CEO Brief 진척 표 실제 PR/머지 grounding (Phase A)

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1965,6 +1965,65 @@ jobs:
             echo "$MD" >> $GITHUB_OUTPUT
             echo "__EOF__" >> $GITHUB_OUTPUT
           fi
+      # ── 진척 원장 (Phase A) — "어제 채택 진척" 표를 LLM 발명이 아닌 실제 PR/머지로 고정 ──
+      - name: Build progress ledger (어제 채택 → 실제 PR/머지)
+        id: progress
+        if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TODAY: ${{ needs.prepare.outputs.today }}
+        run: |
+          set -uo pipefail
+          YESTERDAY=$(TZ=Asia/Seoul date -d 'yesterday' '+%Y-%m-%d' 2>/dev/null || TZ=Asia/Seoul date -v-1d '+%Y-%m-%d')
+          LANEJQ='def lane: ([.labels[].name] - ["idea","agent-council","mobile","tech-debt","daily","score-strong","score-conditional","score-missing"]) | (.[0] // "unknown");'
+
+          # 어제 사이클의 제안(idea) 이슈 전부 — 상태 칸이 실제 결과(머지/PR중/미착수/종료)를 말한다.
+          # (score 라벨은 실제로 안 붙는 경우가 있어 신뢰 불가 → idea 라벨로 선별, ceo-brief 자신은 제외)
+          if gh issue list --label "agent-council" --state all --limit 60 \
+               --json number,title,labels,state --repo "${{ github.repository }}" > /tmp/y_raw.json 2>/dev/null; then
+            jq --arg y "$YESTERDAY" "$LANEJQ"'
+              [ .[]
+              | select(.title | contains($y))
+              | select([.labels[].name] | index("idea"))
+              | {number, title, agent: lane, state} ]' /tmp/y_raw.json > /tmp/adopted.json 2>/dev/null || echo "[]" > /tmp/adopted.json
+          else
+            echo "[]" > /tmp/adopted.json
+          fi
+          [ -s /tmp/adopted.json ] || echo "[]" > /tmp/adopted.json
+
+          # 머지 PR / 오픈 PR (본문의 #NNN 참조로 이슈→PR 연결)
+          gh pr list --state merged --limit 40 --json number,title,body \
+            --repo "${{ github.repository }}" > /tmp/p_merged.json 2>/dev/null || echo "[]" > /tmp/p_merged.json
+          gh pr list --state open --limit 40 --json number,title,body \
+            --repo "${{ github.repository }}" > /tmp/p_open.json 2>/dev/null || echo "[]" > /tmp/p_open.json
+
+          LEDGER=$(npx -y tsx@4.19.2 scripts/build-progress-ledger.ts build \
+            /tmp/adopted.json /tmp/p_merged.json /tmp/p_open.json /tmp/ptable.md /tmp/pship.txt 2>/dev/null || echo "[]")
+          [ -s /tmp/ptable.md ] || echo "| (어제 채택 항목 없음 — 진척 추적 없음) | - | - | - |" > /tmp/ptable.md
+          [ -s /tmp/pship.txt ] || echo "🚢 어제 실제 머지: 없음" > /tmp/pship.txt
+
+          PTABLE=$(cat /tmp/ptable.md)
+          PSHIP=$(cat /tmp/pship.txt)
+          echo "table<<__PTEOF__" >> "$GITHUB_OUTPUT"
+          echo "$PTABLE" >> "$GITHUB_OUTPUT"
+          echo "__PTEOF__" >> "$GITHUB_OUTPUT"
+          echo "shipped<<__PSEOF__" >> "$GITHUB_OUTPUT"
+          echo "$PSHIP" >> "$GITHUB_OUTPUT"
+          echo "__PSEOF__" >> "$GITHUB_OUTPUT"
+
+          # 발행 전 검증용 화이트리스트: 오늘 신규 이슈 번호 ∪ 어제 채택 이슈/연결 PR 번호
+          TODAY_NUMS=$(jq -r '[.[].number] | join(" ")' /tmp/today_raw.json 2>/dev/null || echo "")
+          LEDGER_NUMS=$(printf '%s' "$LEDGER" | jq -r '[ .[] | .issue, (.pr // empty) ] | join(" ")' 2>/dev/null || echo "")
+          echo "allowed=$TODAY_NUMS $LEDGER_NUMS" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### 🚢 진척 원장 (어제 채택 → 실제 상태)"
+            echo "$PSHIP"
+            echo '```'
+            cat /tmp/ptable.md
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: "[CEO Brief]"
         if: steps.dedup.outputs.exists == 'false' && steps.today_issues.outputs.has_issues == 'true'
         uses: actions/ai-inference@v1
@@ -1982,7 +2041,7 @@ jobs:
             === CEO Brief 절대 규칙 ===
             1. North Star "이번 주 테마"가 모든 판단의 1순위.
             2. 각 에이전트 제안을 "North Star 정렬도 0-5점"으로 채점.
-            3. 어제 CEO Brief의 채택 항목 진척을 표로 추적.
+            3. **어제 채택 진척 표는 발명 금지 — 사전 계산된 원장을 그대로 사용 (2026-06-09 절대 규칙)**: "🎯 이번 주 North Star 진척" 표는 아래 prompt 의 **"🚢 진척 원장(실제 PR/머지 기반)"** 블록을 **그대로 복사**한다. 행을 추가/삭제하거나 상태("머지됨/PR 리뷰 중/미착수/종료")를 임의로 바꾸지 마라. "🔄 진행 중", "샘플 수집 완료" 같은 상태를 지어내는 것은 사고다 — 원장에 있는 상태 라벨만 쓴다. "오늘 액션" 칸만 네가 1문장으로 채운다.
             4. 같은 주제가 N일 연속 반복되면 "반복 경고" 표시 후 자동 디플래그.
             5. **킬리스트 사유**: 아래에 해당하면 킬리스트로 분류, 그 외는 모두 그날 처리 우선순위에 포함:
                - 자동 폐기 카테고리 (사운드/햅틱/빛 효과/글로우/파티클/반짝임/싱크로 효과/BGM/결과 화면 장식 애니메이션/버튼 펄스·진동 등) — 정렬도와 무관하게 자동 킬리스트. CEO 직접 지시(2026-05-26).
@@ -2019,8 +2078,19 @@ jobs:
             ${{ steps.today_issues.outputs.list }}
 
             ---
-            ## 📅 어제 CEO Brief (채택 항목 진척 추적용)
-            > ⚠️ 번호 인용 절대 규칙: 아래 어제 브리핑의 #번호는 **과거 참조용**이다(진척 추적·반복 탐지에만 사용).
+            ## 🚢 진척 원장 (어제 채택 → 실제 PR/머지 기반 — 이 표를 그대로 복사)
+            > 이 표는 실제 레포 상태(머지/오픈 PR, 이슈 상태)에서 결정론적으로 계산됐다.
+            > "🎯 이번 주 North Star 진척" 표에 **이 행들을 그대로** 넣고, "오늘 액션" 칸만 1문장씩 채워라.
+            > 상태를 바꾸거나 행을 지어내면 사고다.
+            ${{ steps.progress.outputs.shipped }}
+
+            | 어제 제안 항목 | 담당 | 진척 상태 | PR |
+            |---|---|---|---|
+            ${{ steps.progress.outputs.table }}
+
+            ---
+            ## 📅 어제 CEO Brief (반복 주제 탐지용 — 진척 표 작성에는 위 진척 원장만 사용)
+            > ⚠️ 번호 인용 절대 규칙: 아래 어제 브리핑의 #번호는 **과거 참조용**이다(반복 탐지에만 사용).
             > 오늘 신규 제안의 "이슈: #N" 인용은 반드시 위 "📌 오늘 사이클 신규 이슈" 목록의 번호만 사용하라.
             > 어제 브리핑의 번호를 오늘 신규 항목의 번호로 재인용하면 사고다.
             ${{ needs.prepare.outputs.yesterday_brief }}
@@ -2042,10 +2112,12 @@ jobs:
 
             ## 📋 CEO Daily Brief
 
-            ### 🎯 이번 주 North Star 진척 (실리콘밸리식)
-            | 어제 채택 항목 | 담당 에이전트 | 진척 상태 | 오늘 액션 |
+            {위 "🚢 진척 원장"의 실적 한 줄(🚢 …)을 여기 그대로 적는다}
+
+            ### 🎯 이번 주 North Star 진척 (실리콘밸리식 — 실제 PR/머지 기반)
+            | 어제 제안 항목 | 담당 | 진척 상태 | 오늘 액션 |
             |---|---|---|---|
-            (어제 Brief가 없으면 "사이클 시작 — 진척 추적 없음" 표시)
+            (위 "🚢 진척 원장" 표의 각 행을 그대로 옮기고 — #번호·담당·진척 상태 그대로 — "오늘 액션" 칸만 1문장으로 채운다. 진척 상태를 임의로 바꾸지 마라. 어제 제안 항목이 없으면 "사이클 시작 — 진척 추적 없음" 표시)
 
             ---
 
@@ -2143,6 +2215,7 @@ jobs:
           BODY: ${{ steps.brief.outputs.response }}
           USED_FALLBACK: ${{ steps.fallback.outputs.used }}
           TODAY: ${{ needs.prepare.outputs.today }}
+          ALLOWED: ${{ steps.progress.outputs.allowed }}
         run: |
           if [ "$USED_FALLBACK" = "true" ]; then
             # 폴백 스크립트가 /tmp/brief.md 에 작성함. 제목에 식별 접미사.
@@ -2151,6 +2224,31 @@ jobs:
             printf '%s' "$BODY" > /tmp/brief.md
             TITLE="📋 [CEO Brief] $TODAY 일일 에이전트 브리핑"
           fi
+
+          # ── 발행 전 번호 검증 (Phase A) — 화이트리스트 밖 #번호 인용 탐지 ──
+          # 허용: 오늘 신규 이슈 ∪ 어제 채택 이슈/연결 PR. 그 밖의 #번호는 환각 가능성.
+          if [ -n "${ALLOWED// /}" ]; then
+            CITED=$(grep -oE '#[0-9]+' /tmp/brief.md | tr -d '#' | sort -un)
+            UNKNOWN=""
+            for n in $CITED; do
+              case " $ALLOWED " in
+                *" $n "*) ;;
+                *) UNKNOWN="$UNKNOWN #$n" ;;
+              esac
+            done
+            if [ -n "${UNKNOWN// /}" ]; then
+              {
+                echo ""
+                echo "---"
+                echo "> ⚠️ **번호 검증 경고**: 이 브리핑이 화이트리스트(오늘 신규 이슈 + 어제 채택/연결 PR) 밖의 번호를 인용했습니다 →${UNKNOWN}. 과거 이슈 재인용 또는 환각일 수 있으니 교차 확인하세요."
+              } >> /tmp/brief.md
+              {
+                echo "## ⚠️ CEO Brief 번호 검증 경고 ($TODAY)"
+                echo "화이트리스트 밖 인용:${UNKNOWN}"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
           gh issue create \
             --title "$TITLE" \
             --body-file /tmp/brief.md \

--- a/scripts/__tests__/build-progress-ledger.test.ts
+++ b/scripts/__tests__/build-progress-ledger.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildProgressLedger,
+  renderProgressTable,
+  renderShippedLine,
+  allowedNumbers,
+  type BuildInput,
+} from "../build-progress-ledger";
+
+const base: BuildInput = {
+  adopted: [
+    { number: 417, title: "FOMO 멘트 품질 개선", agent: "prompt", state: "CLOSED" },
+    { number: 410, title: "성능 안정성 개선", agent: "frontend", state: "OPEN" },
+    { number: 409, title: "감정 투표 UX", agent: "pm", state: "OPEN" },
+    { number: 350, title: "보안 점검", agent: "security", state: "CLOSED" },
+  ],
+  mergedPRs: [
+    { number: 419, title: "[Auto] FOMO 멘트 품질", body: "resolves #417", merged: true },
+  ],
+  openPRs: [
+    { number: 420, title: "[Auto] 성능 개선", body: "관련 #410", merged: false },
+  ],
+};
+
+describe("buildProgressLedger", () => {
+  it("머지 PR 참조 이슈는 MERGED + PR 번호", () => {
+    const e = buildProgressLedger(base).find((x) => x.issue === 417)!;
+    expect(e.status).toBe("MERGED");
+    expect(e.pr).toBe(419);
+  });
+  it("오픈 PR 참조 이슈는 OPEN_PR", () => {
+    const e = buildProgressLedger(base).find((x) => x.issue === 410)!;
+    expect(e.status).toBe("OPEN_PR");
+    expect(e.pr).toBe(420);
+  });
+  it("PR 없고 open 이슈는 PENDING", () => {
+    const e = buildProgressLedger(base).find((x) => x.issue === 409)!;
+    expect(e.status).toBe("PENDING");
+    expect(e.pr).toBeNull();
+  });
+  it("PR 없고 closed 이슈는 CLOSED_NO_PR (채택됐는데 미구현 종료)", () => {
+    const e = buildProgressLedger(base).find((x) => x.issue === 350)!;
+    expect(e.status).toBe("CLOSED_NO_PR");
+    expect(e.pr).toBeNull();
+  });
+  it("머지 PR 이 오픈 PR 보다 우선 (둘 다 참조해도 MERGED)", () => {
+    const input: BuildInput = {
+      adopted: [{ number: 5, title: "x", agent: "pm", state: "CLOSED" }],
+      mergedPRs: [{ number: 99, title: "m", body: "#5", merged: true }],
+      openPRs: [{ number: 100, title: "o", body: "#5", merged: false }],
+    };
+    expect(buildProgressLedger(input)[0]!.status).toBe("MERGED");
+    expect(buildProgressLedger(input)[0]!.pr).toBe(99);
+  });
+});
+
+describe("renderProgressTable", () => {
+  it("어제 채택 없으면 안내 행", () => {
+    expect(renderProgressTable([])).toContain("어제 채택 항목 없음");
+  });
+  it("각 항목을 상태 라벨과 함께 행으로 렌더", () => {
+    const md = renderProgressTable(buildProgressLedger(base));
+    expect(md).toContain("#417");
+    expect(md).toContain("✅ 머지됨");
+    expect(md).toContain("PR #419");
+    expect(md).toContain("⏳ 미착수");
+    expect(md).toContain("⚠️ 종료(미구현)");
+  });
+});
+
+describe("renderShippedLine", () => {
+  it("머지된 항목만 실적으로 집계", () => {
+    const line = renderShippedLine(buildProgressLedger(base));
+    expect(line).toContain("1건");
+    expect(line).toContain("PR #419");
+  });
+  it("머지 없으면 '없음'", () => {
+    expect(renderShippedLine([])).toContain("없음");
+  });
+});
+
+describe("allowedNumbers", () => {
+  it("오늘 번호 + 어제 이슈/PR 번호를 화이트리스트로 합친다", () => {
+    const set = allowedNumbers(buildProgressLedger(base), [409, 410, 412]);
+    expect(set.has(412)).toBe(true); // today
+    expect(set.has(417)).toBe(true); // adopted issue
+    expect(set.has(419)).toBe(true); // merged PR
+    expect(set.has(420)).toBe(true); // open PR
+    expect(set.has(99999)).toBe(false);
+  });
+});

--- a/scripts/build-progress-ledger.ts
+++ b/scripts/build-progress-ledger.ts
@@ -1,0 +1,181 @@
+/**
+ * Progress-Ledger 빌더 (브리프 신뢰 grounding — Phase A).
+ *
+ * CEO Brief 의 "어제 채택 진척" 표는 그동안 LLM 이 yesterday_brief 텍스트만 보고
+ * "🔄 진행 중" 같은 상태를 **상상으로 채워** 왔다(실제 PR/머지와 무관 → 날조).
+ * 이 스크립트는 어제 채택(score-strong/conditional)된 이슈가 **실제로** 머지 PR/오픈 PR
+ * 로 갔는지를 결정론적으로 판정해, LLM 이 발명할 여지 없이 그대로 렌더할 표를 만든다.
+ *
+ * 완료 신호: "머지/오픈 PR 본문이 그 이슈 #NNN 을 참조하는가" (auto-merge 가 PR body 에 기록).
+ *   - 머지 PR 참조        → MERGED   ✅
+ *   - 오픈 PR 참조        → OPEN_PR  🔄
+ *   - 참조 없음 + 이슈 closed → CLOSED_NO_PR ⚠️ (채택됐는데 구현 안 되고 닫힘)
+ *   - 참조 없음 + 이슈 open   → PENDING  ⏳
+ *
+ * 순수 export 함수 + main() CLI (process.argv[1] 가드). build-lane-state.ts 패턴 답습.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { extractIssueRefs } from "./build-lane-state";
+
+export type ProgressStatus = "MERGED" | "OPEN_PR" | "CLOSED_NO_PR" | "PENDING";
+
+/** 어제 채택된(게이트 통과) agent-council 이슈. */
+export interface AdoptedIssue {
+  number: number;
+  title: string;
+  /** lane(직군) 라벨 — pm/frontend/... */
+  agent: string;
+  /** "OPEN" | "CLOSED" (gh issue state) */
+  state?: string;
+}
+
+export interface PullRequest {
+  number: number;
+  title: string;
+  body?: string;
+  /** "merged" 면 머지된 PR, 그 외(open 등) */
+  merged?: boolean;
+}
+
+export interface ProgressEntry {
+  issue: number;
+  title: string;
+  agent: string;
+  pr: number | null;
+  status: ProgressStatus;
+}
+
+export interface BuildInput {
+  adopted: AdoptedIssue[];
+  mergedPRs: PullRequest[];
+  openPRs: PullRequest[];
+}
+
+/** PR 목록을 "참조 이슈번호 → PR번호" 맵으로 (가장 최근/큰 PR 우선). */
+function refToPr(prs: PullRequest[]): Map<number, number> {
+  const map = new Map<number, number>();
+  for (const pr of prs) {
+    for (const n of extractIssueRefs(`${pr.title ?? ""} ${pr.body ?? ""}`)) {
+      const existing = map.get(n);
+      if (existing === undefined || pr.number > existing) map.set(n, pr.number);
+    }
+  }
+  return map;
+}
+
+/** 진척 원장 빌드 (순수 함수). */
+export function buildProgressLedger(input: BuildInput): ProgressEntry[] {
+  const mergedMap = refToPr(input.mergedPRs);
+  const openMap = refToPr(input.openPRs);
+
+  return input.adopted.map((iss) => {
+    const mergedPr = mergedMap.get(iss.number);
+    if (mergedPr !== undefined) {
+      return { issue: iss.number, title: iss.title, agent: iss.agent, pr: mergedPr, status: "MERGED" };
+    }
+    const openPr = openMap.get(iss.number);
+    if (openPr !== undefined) {
+      return { issue: iss.number, title: iss.title, agent: iss.agent, pr: openPr, status: "OPEN_PR" };
+    }
+    const closed = (iss.state ?? "").toUpperCase() === "CLOSED";
+    return {
+      issue: iss.number,
+      title: iss.title,
+      agent: iss.agent,
+      pr: null,
+      status: closed ? "CLOSED_NO_PR" : "PENDING",
+    };
+  });
+}
+
+const STATUS_LABEL: Record<ProgressStatus, string> = {
+  MERGED: "✅ 머지됨",
+  OPEN_PR: "🔄 PR 리뷰 중",
+  CLOSED_NO_PR: "⚠️ 종료(미구현)",
+  PENDING: "⏳ 미착수",
+};
+
+function clip(s: string, n: number): string {
+  const t = (s || "").replace(/\n/g, " ").trim();
+  return t.length > n ? t.slice(0, n) + "…" : t;
+}
+
+/**
+ * "어제 채택 진척" 표를 마크다운으로 렌더 (LLM 은 이 표를 그대로 복사, 상태 발명 금지).
+ * 어제 채택이 없으면 안내 문구.
+ */
+export function renderProgressTable(entries: ProgressEntry[]): string {
+  if (!entries.length) {
+    return "| (어제 채택 항목 없음 — 진척 추적 없음) | - | - | - |";
+  }
+  const rows = entries.map((e) => {
+    const prCell = e.pr ? `PR #${e.pr}` : "-";
+    return `| #${e.issue} ${clip(e.title, 40)} | ${e.agent} | ${STATUS_LABEL[e.status]} | ${prCell} |`;
+  });
+  return rows.join("\n");
+}
+
+/** 상단 실적 한 줄: 어제 실제로 머지된 항목만. 자율성 체감 복구용. */
+export function renderShippedLine(entries: ProgressEntry[]): string {
+  const shipped = entries.filter((e) => e.status === "MERGED");
+  if (!shipped.length) return "🚢 어제 실제 머지: 없음";
+  const parts = shipped.map((e) => `PR #${e.pr}(${e.agent}: ${clip(e.title, 24)})`);
+  return `🚢 어제 실제 머지 ${shipped.length}건: ${parts.join(", ")}`;
+}
+
+/** 발행 전 검증용 — 브리프가 인용해도 되는 이슈/ PR 번호 화이트리스트. */
+export function allowedNumbers(entries: ProgressEntry[], todayNumbers: number[]): Set<number> {
+  const set = new Set<number>(todayNumbers);
+  for (const e of entries) {
+    set.add(e.issue);
+    if (e.pr) set.add(e.pr);
+  }
+  return set;
+}
+
+export function renderLedgerJson(entries: ProgressEntry[]): string {
+  return JSON.stringify(entries);
+}
+
+// ─────────────────────────────────────────────────────────────
+// CLI 엔트리
+//   build <adopted.json> <merged.json> <open.json> <out_table.md> <out_shipped.txt>
+//       → 진척 표(.md) + 실적 한 줄(.txt) 파일 생성, ledger JSON 을 stdout
+// ─────────────────────────────────────────────────────────────
+
+function readJson<T>(path: string | undefined, fallback: T): T {
+  if (!path) return fallback;
+  try {
+    const raw = readFileSync(path, "utf8").trim();
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function main(): void {
+  const argv = process.argv;
+  if (argv[2] !== "build") {
+    console.error(
+      "usage:\n  tsx scripts/build-progress-ledger.ts build <adopted.json> <merged.json> <open.json> <out_table.md> <out_shipped.txt>",
+    );
+    process.exit(1);
+  }
+  const input: BuildInput = {
+    adopted: readJson<AdoptedIssue[]>(argv[3], []),
+    mergedPRs: readJson<PullRequest[]>(argv[4], []),
+    openPRs: readJson<PullRequest[]>(argv[5], []),
+  };
+  const entries = buildProgressLedger(input);
+  const { writeFileSync } = require("node:fs") as typeof import("node:fs");
+  if (argv[6]) writeFileSync(argv[6], renderProgressTable(entries));
+  if (argv[7]) writeFileSync(argv[7], renderShippedLine(entries));
+  process.stdout.write(renderLedgerJson(entries));
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("build-progress-ledger")) {
+  main();
+}


### PR DESCRIPTION
## 문제 (라이브 검증)
CEO Brief의 "어제 채택 진척" 표가 **100% LLM 날조**였음. 브리프 #418은 06-05에 만료 close된 #353/#350/#349/#346(구현 PR 0건)을 "🔄 진행 중"으로 지어냈고, ceo_brief job은 실제 PR/머지 사실 데이터를 전혀 받지 않아 LLM이 상상으로 채움.

## 변경
- **`scripts/build-progress-ledger.ts`** (신규, 순수함수+vitest 10): 어제 idea 이슈 → 머지/오픈 PR 본문의 `#N` 참조로 `MERGED`/`OPEN_PR`/`CLOSED_NO_PR`/`PENDING` 결정론 판정. `build-lane-state.ts`의 `extractIssueRefs` 재사용.
- **ceo_brief job**: 진척 원장 step 추가 → 사전계산된 표를 프롬프트에 주입하고 LLM은 **그대로 복사·상태 발명 금지**. 상단에 "🚢 어제 실제 머지 N건" 실적 줄(자율성 체감 복구).
- **발행 전 #번호 검증**: 화이트리스트(오늘 신규 이슈 ∪ 어제 이슈/연결 PR) 밖 번호 인용 시 경고 푸터 + job summary.

## 라이브 dry-run 결과 (정직한 표)
| 이슈 | 상태 |
|---|---|
| #417 | ✅ 머지됨 (PR #419) |
| #409·410·412·413·415 | 🔄 PR 리뷰 중 (PR #420) |
| #411·414·416 | ⚠️ 종료(미구현) |

## 게이트
lint ✅ · typecheck ✅ · vitest 86 ✅ (신규 10). web 앱 무변경 → build:web CI 위임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)