### PR TITLE
fix(council): 자동 개발 게이트 — CEO 승인 기반으로 전환

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -1,9 +1,16 @@
 name: Auto Implement CEO Brief
 
+# ⚠️ 자동 개발 게이트 (2026-06-09 CEO 지시):
+#   기존엔 "Daily Agent Council" 성공 시 workflow_run 으로 *자동* 개발(PR 생성)됐다.
+#   → CEO가 브리프를 먼저 검토하고 승인할 때만 개발되도록 자동 트리거를 제거한다.
+#   개발 시작 경로: ① Slack 봇에 "개발해/구현 시작"(= [[ACTION:implement]] → workflow_dispatch)
+#                  ② GitHub Actions 수동 실행(workflow_dispatch).
+#   (이전 workflow_run 자동 트리거는 의도적으로 비활성화 — 자율 루프 재개 시 아래 주석 복구.)
+# on:
+#   workflow_run:
+#     workflows: ["Daily Agent Council"]
+#     types: [completed]
 on:
-  workflow_run:
-    workflows: ["Daily Agent Council"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       brief_date:
@@ -28,9 +35,8 @@ permissions:
 
 jobs:
   implement:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+    # 승인 기반: 수동/Slack 트리거(workflow_dispatch)에서만 실행. 자동 개발 금지.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 문제
"Daily Agent Council" 성공 시 `auto-implement.yml`이 **workflow_run으로 자동 개발**(PR 생성)했음 — 오늘자 PR #420이 CEO 검토 없이 그렇게 생성됨. CEO는 브리프/제안을 **먼저 꼼꼼히 검토하고 승인**할 때만 개발되길 원함.

## 변경
- `auto-implement.yml`: `workflow_run` 자동 트리거 비활성화(주석으로 보존), `workflow_dispatch`만 유지.
- 개발 시작 경로: ① Slack 봇 "개발해/구현 시작"(`[[ACTION:implement]]` → dispatch) ② Actions 수동 실행.
- 자율 루프 재개 시 주석 복구만.

## 효과
- 매일 council은 계속 제안 → 브리프 생성 → Slack 게시(여기까지 자동).
- 개발은 CEO 승인 시에만. idea-proposal 수동 트리거해도 자동 개발 안 됨.

YAML ✅ (트리거: workflow_dispatch only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)