### PR TITLE
fix(council): constraint 체크리스트 오탐 제거 (#427 회귀)

### DIFF
--- a/scripts/__tests__/constraints.test.ts
+++ b/scripts/__tests__/constraints.test.ts
@@ -211,6 +211,13 @@ describe("checkViolations", () => {
     const v = checkViolations("투자 조언은 금지지만, 이번엔 투자 조언 문구를 본문에 넣자", [advice], "marketing");
     expect(v).toHaveLength(1);
   });
+  it("체크리스트 자기검증(#427 회귀): 금칙어 나열 + 미포함 확인은 위반 아님", () => {
+    const txt = '### 금융 규제 점검\n- 금칙어("매수/매도/수익보장/확정 예측/투자 조언") 미포함 확인: ✅\n- 단정 예측 표현 회피 확인: ✅';
+    expect(checkViolations(txt, [advice], "marketing")).toEqual([]);
+  });
+  it("리스트 마커(금칙어) 뒤 나열된 금지어는 회피로 간주", () => {
+    expect(checkViolations('금칙어: 매수 추천, 투자 조언 등 노출 안 함', [advice], "marketing")).toEqual([]);
+  });
 });
 
 describe("hits 집계", () => {

--- a/scripts/constraints.ts
+++ b/scripts/constraints.ts
@@ -315,17 +315,25 @@ export interface Violation {
  * #416(포모 멘트 카피, FOMO 정합) 이 "투자 조언" 단어를 회피 목적으로 언급했다가 오탐 킬된 사고를 막는다.
  */
 // 한국어 부정/회피 술어는 거의 항상 금지 명사 *뒤*에 온다("투자 조언이 아님", "매수 추천 금지",
-// "~을 하지 않"). 그래서 키워드 직후 좁은 창(10자)만 본다 — before 창을 쓰면 앞 절의 "금지"가
-// 끌려와 같은 문장의 다른 occurrence 를 오판(부정 누수)한다.
+// "투자 조언 미포함 확인", "~을 하지 않"). 그래서 키워드 직후 좁은 창(12자)을 본다.
+// "미포함/미사용/포함하지/없음" 같은 체크리스트 자기검증 표현이 좋은 제안을 죽이던 오탐(#427) 포함.
 const NEGATION_TOKENS = [
-  "금지", "아님", "아닌", "않", "없이", "없는", "없다", "회피", "지양", "방지",
+  "금지", "아님", "아닌", "않", "없이", "없는", "없다", "없음", "회피", "지양", "방지",
   "말아야", "말고", "제외", "배제", "안 함", "안함", "안 하",
+  "미포함", "미사용", "포함하지", "포함 안", "사용하지", "제거", "불가", "불허", "위반 없",
 ];
 
-/** 키워드 직후 좁은 창에 부정/회피 술어가 있으면 true (회피·면책 문장). */
+// 금지어를 *나열*하는 체크리스트/면책 헤더 — 키워드 *앞*에 오며, 뒤따르는 금지어는 회피 대상이다.
+// (예: `금칙어("매수/매도/투자 조언") 미포함`). generic "금지"(앞 절 누수 위험) 는 제외하고
+// 명확한 복합 마커만 본다 — 같은 문장의 실제 위반 occurrence 를 오판하지 않게.
+const LIST_MARKER_TOKENS = ["금칙어", "금지어", "금지 어휘", "금칙 어휘", "금지 표현"];
+
+/** 키워드 주변(직후 12자 또는 직전 30자 리스트마커)에 부정/회피 문맥이 있으면 true. */
 export function isNegatedOccurrence(text: string, idx: number, klen: number): boolean {
-  const after = text.slice(idx + klen, idx + klen + 10);
-  return NEGATION_TOKENS.some((t) => after.includes(t));
+  const after = text.slice(idx + klen, idx + klen + 12);
+  if (NEGATION_TOKENS.some((t) => after.includes(t))) return true;
+  const before = text.slice(Math.max(0, idx - 30), idx);
+  return LIST_MARKER_TOKENS.some((t) => before.includes(t));
 }
 
 /**


### PR DESCRIPTION
## 문제 (라이브 검증 중 발견)
개선 적용 후 council 재트리거 → #427 Marketer 제안(포모 멘트/UX 라이팅, FOMO 정합)이 또 "투자 조언"으로 킬됨. 본문: `금칙어("매수/매도/수익보장/확정 예측/투자 조언") 미포함 확인: ✅` — 금지어를 나열해 **미포함을 자기검증**하는 체크리스트인데, Phase B 가드가 "미포함"을 부정어로 인식 못 함.

## 변경
- `NEGATION_TOKENS` 확장: 미포함/미사용/포함하지/없음/제거/불가/불허/위반 없 (체크리스트 자기검증 표현).
- `LIST_MARKER_TOKENS`(금칙어/금지어/금지 어휘) 추가: 금지어 나열 헤더 뒤 키워드는 직전 30자에서 회피로 간주. generic "금지"는 앞 절 누수 위험이라 제외(기존 회귀 보존).
- vitest +2, 실제 #427 본문으로 위반 0 확인.

게이트: vitest 30 ✅ · lint ✅ · typecheck ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)