### PR TITLE
feat(council): 톱다운 P2 — 프로젝트 킥오프 4축 분해

### DIFF
--- a/.github/workflows/project-kickoff.yml
+++ b/.github/workflows/project-kickoff.yml
@@ -17,6 +17,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  models: read
 
 jobs:
   kickoff:
@@ -68,8 +69,100 @@ jobs:
           git commit -m "chore(roadmap): ${{ github.event.inputs.project_id }} 활성화 (project kickoff)"
           git push origin HEAD:main
 
-      # ── P2 TODO: 4축(PL/TD/BA/UX) 회의로 활성 프로젝트를 project:<id> 이슈 세트로 분해 ──
-      # 현재(P1)는 선택·활성화·알림까지. 분해는 project-kickoff 후속 step 으로 추가된다.
+      # ── 4축(PL/TD/BA/UX) 회의로 활성 프로젝트를 project:<id> 이슈 세트로 분해 (P2) ──
+      - name: Prepare decomposition context
+        id: ctx
+        if: steps.select.outputs.ok == 'true'
+        run: |
+          set -uo pipefail
+          PID="${{ github.event.inputs.project_id }}"
+          # 이미 이 프로젝트의 task 이슈가 있으면 재분해 skip(중복 세트 방지)
+          EXIST=$(gh issue list --label "project:$PID" --state open --limit 50 \
+            --json number --jq 'length' --repo "${{ github.repository }}" 2>/dev/null || echo 0)
+          echo "exist=$EXIST" >> "$GITHUB_OUTPUT"
+          ACTIVE=$(cat /tmp/active.json 2>/dev/null || echo "null")
+          echo "active_json<<__AEOF__" >> "$GITHUB_OUTPUT"; echo "$ACTIVE" >> "$GITHUB_OUTPUT"; echo "__AEOF__" >> "$GITHUB_OUTPUT"
+          NS=$(cat AGENT_NORTH_STAR.md 2>/dev/null | head -c 4000 || echo "")
+          echo "north_star<<__NEOF__" >> "$GITHUB_OUTPUT"; echo "$NS" >> "$GITHUB_OUTPUT"; echo "__NEOF__" >> "$GITHUB_OUTPUT"
+          CB="(constraint 없음)"
+          if [ -f constraints/active.json ]; then
+            TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+            npx -y tsx@4.19.2 scripts/constraints.ts active constraints/active.json "$TODAY" > /tmp/ctx_active_constraints.json 2>/dev/null || echo "[]" > /tmp/ctx_active_constraints.json
+            CB=$(npx -y tsx@4.19.2 scripts/constraints.ts render-brief /tmp/ctx_active_constraints.json 2>/dev/null || echo "(constraint 조회 실패)")
+          fi
+          echo "constraints<<__CEOF__" >> "$GITHUB_OUTPUT"; echo "$CB" >> "$GITHUB_OUTPUT"; echo "__CEOF__" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: "4축 회의 — 프로젝트 분해 (LLM)"
+        id: decompose
+        if: steps.select.outputs.ok == 'true' && steps.ctx.outputs.exist == '0' && steps.ctx.outputs.active_json != 'null'
+        uses: actions/ai-inference@v1
+        continue-on-error: true
+        with:
+          model: openai/gpt-4o
+          max-tokens: 4096
+          system-prompt: |
+            당신은 FOMO Club 에이전트 카운슬이다. 4축이 한 자리에 모여 *선택된 하나의 프로젝트*를
+            실행 가능한 task 로 분해한다. (산발적 아이디어가 아니라 톱다운 프로젝트 격파.)
+            - PL(Product Lead): 제품 로드맵·기획·유저 저니·시퀀싱 (무엇을 왜 어떤 순서로)
+            - TD(Tech-Debt): 안정성·성능·빌드·테스트·옵저버빌리티
+            - BA(Backend·Architecture): 데이터·API·스키마·아키텍처·보안 하드닝
+            - UX(Experience): 화면·렌더·정보위계·포모 표정/멘트·플로우
+            규칙:
+            1. PL 이 회의를 리딩한다. 프로젝트의 success 기준을 충족하는 *최소한의* task 로 쪼갠다(비대화 금지).
+            2. 각 task 는 단일 PR 로 끝낼 크기. 크면 더 쪼갠다. 가시적·미시적 잡일(여백 1px 등) 금지 — 프로젝트 success 에 직결되는 것만.
+            3. 각 task 에 담당 축(PL/TD/BA/UX) 1개 배정. 의존성(dependsOn)을 seq 로 명시해 실행 순서를 만든다.
+            4. 정직한 숫자·투자조언 금지·타로 금지 등 Standing Constraints 를 위반하지 않는다.
+            5. 출력은 **오직 JSON 배열** 한 개. 설명·코드펜스 금지.
+            형식: [{"seq":1,"axis":"PL","title":"...","rationale":"프로젝트 success 와 어떻게 연결","dependsOn":[],"acceptance":"검증 가능한 완료 기준"}, ...]
+          prompt: |
+            ## 선택된 활성 프로젝트 (이걸 분해하라)
+            ${{ steps.ctx.outputs.active_json }}
+
+            ## North Star (정체성·금지 — 위반 금지)
+            ${{ steps.ctx.outputs.north_star }}
+
+            ## Standing Constraints (절대 위반 금지)
+            ${{ steps.ctx.outputs.constraints }}
+
+            위 프로젝트의 success 기준을 충족하는 정렬된 task 배열(JSON)만 출력하라. 4~8개 권장.
+
+      - name: Create project issues
+        id: create
+        if: steps.select.outputs.ok == 'true' && steps.ctx.outputs.exist == '0' && steps.decompose.outputs.response != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PID: ${{ github.event.inputs.project_id }}
+          RESP: ${{ steps.decompose.outputs.response }}
+        run: |
+          set -uo pipefail
+          printf '%s' "$RESP" > /tmp/decompose_raw.txt
+          npx -y tsx@4.19.2 scripts/kickoff-tasks.ts parse "$PID" /tmp/decompose_raw.txt > /tmp/tasks.json || echo "[]" > /tmp/tasks.json
+          COUNT=$(jq 'length' /tmp/tasks.json 2>/dev/null || echo 0)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" = "0" ]; then
+            echo "분해 task 0건 — 이슈 생성 없음"; echo "plan=(분해 실패 — task 0건)" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          PTITLE=$(jq -r '.title // ""' /tmp/active.json 2>/dev/null || echo "")
+          AXIS_LABEL () { case "$1" in PL) echo "product-lead";; TD) echo "tech-debt";; BA) echo "backend";; UX) echo "experience";; *) echo "agent-council";; esac; }
+          CREATED=""
+          for i in $(seq 0 $((COUNT-1))); do
+            jq -c ".[$i]" /tmp/tasks.json > /tmp/task.json
+            AXIS=$(jq -r '.axis' /tmp/task.json)
+            TITLE="[$PID · $AXIS] $(jq -r '.title' /tmp/task.json)"
+            npx -y tsx@4.19.2 scripts/kickoff-tasks.ts render "$PID" /tmp/task.json > /tmp/task_body.md 2>/dev/null || echo "(본문 생성 실패)" > /tmp/task_body.md
+            LB=$(AXIS_LABEL "$AXIS")
+            if N=$(gh issue create --title "$TITLE" --body-file /tmp/task_body.md \
+                  --label "project:$PID,agent-council,task,$LB" --repo "${{ github.repository }}" 2>/dev/null); then
+              CREATED="$CREATED ${N##*/}"
+            fi
+          done
+          PLAN=$(npx -y tsx@4.19.2 scripts/kickoff-tasks.ts parse "$PID" /tmp/decompose_raw.txt 2>/dev/null \
+            | jq -r '.[] | "\(.seq). [\(.axis)] \(.title)" + (if (.dependsOn|length)>0 then " (선행 \(.dependsOn|join(",")))" else "" end)' 2>/dev/null || echo "")
+          echo "plan<<__PEOF__" >> "$GITHUB_OUTPUT"; echo "$PLAN" >> "$GITHUB_OUTPUT"; echo "__PEOF__" >> "$GITHUB_OUTPUT"
+          echo "created=$CREATED" >> "$GITHUB_OUTPUT"
+          { echo "### 🧩 $PID 분해 이슈 생성: $COUNT건"; echo '```'; echo "$PLAN"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify Slack
         if: always() && vars.SLACK_WEBHOOK_URL != ''
@@ -77,12 +170,19 @@ jobs:
           OK: ${{ steps.select.outputs.ok }}
           MSG: ${{ steps.select.outputs.msg }}
           PID: ${{ github.event.inputs.project_id }}
+          EXIST: ${{ steps.ctx.outputs.exist }}
+          COUNT: ${{ steps.create.outputs.count }}
+          PLAN: ${{ steps.create.outputs.plan }}
         run: |
           URL=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
-          if [ "$OK" = "true" ]; then
-            TEXT="🗺️ *Project Kickoff — ${PID} 활성화*\n${MSG}\n\n다음: 4축 에이전트가 이 프로젝트를 이슈로 분해합니다(곧). 진척은 매일 아침 리포트로 옵니다."
-          else
+          if [ "$OK" != "true" ]; then
             TEXT="⚠️ *Project Kickoff 실패 (${PID})*\n${MSG}"
+          elif [ "${EXIST:-0}" != "0" ]; then
+            TEXT="🗺️ *Project Kickoff — ${PID}*\n${MSG}\n\nℹ️ 이미 이 프로젝트의 task 이슈가 있어 재분해하지 않았습니다. 기존 이슈를 이어서 진행하세요."
+          elif [ -n "${COUNT:-}" ] && [ "${COUNT}" != "0" ]; then
+            TEXT="🗺️ *Project Kickoff — ${PID} 활성화 + 분해 완료*\n${MSG}\n\n🧩 *${COUNT}개 task 이슈 생성* (project:${PID}):\n${PLAN}\n\n구현은 CEO 승인(\"개발해\") 시에만. 진척은 매일 아침 리포트로 옵니다."
+          else
+            TEXT="🗺️ *Project Kickoff — ${PID} 활성화*\n${MSG}\n\n⚠️ 분해 task 생성 0건(LLM 실패 가능) — 수동 확인 요망."
           fi
           BODY=$(jq -n --arg t "$TEXT" '{text: $t}')
           curl -sS -X POST -H 'Content-type: application/json' --data "$BODY" "$URL" || true

--- a/scripts/__tests__/kickoff-tasks.test.ts
+++ b/scripts/__tests__/kickoff-tasks.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseKickoffTasks,
+  renderIssueBody,
+  renderIssueTitle,
+  renderPlan,
+  AXES,
+} from "../kickoff-tasks";
+
+describe("parseKickoffTasks", () => {
+  const good = JSON.stringify([
+    { seq: 1, axis: "PL", title: "포모 홈 와이어 정의", rationale: "심장", dependsOn: [], acceptance: "와이어 확정" },
+    { seq: 2, axis: "UX", title: "감정 선택→반응 전환", rationale: "love mark", dependsOn: [1], acceptance: "전환 동작" },
+    { seq: 3, axis: "BA", title: "감정 집계 API", rationale: "데이터", dependsOn: [1], acceptance: "API 200" },
+  ]);
+
+  it("정상 JSON 을 seq 순 정렬 파싱", () => {
+    const t = parseKickoffTasks(good);
+    expect(t.map((x) => x.seq)).toEqual([1, 2, 3]);
+    expect(t[1]!.axis).toBe("UX");
+    expect(t[1]!.dependsOn).toEqual([1]);
+  });
+  it("코드펜스/잡텍스트로 둘러싸여도 배열 추출", () => {
+    const wrapped = "```json\n" + good + "\n``` 끝!";
+    expect(parseKickoffTasks(wrapped)).toHaveLength(3);
+  });
+  it("axis 화이트리스트 밖/제목 없음은 제외", () => {
+    const raw = JSON.stringify([
+      { seq: 1, axis: "PL", title: "ok" },
+      { seq: 2, axis: "MARKETING", title: "직군밖" },
+      { seq: 3, axis: "UX", title: "" },
+    ]);
+    const t = parseKickoffTasks(raw);
+    expect(t).toHaveLength(1);
+    expect(t[0]!.title).toBe("ok");
+  });
+  it("미존재/자기참조 의존성 제거", () => {
+    const raw = JSON.stringify([
+      { seq: 1, axis: "PL", title: "a", dependsOn: [1, 99] },
+      { seq: 2, axis: "TD", title: "b", dependsOn: [1] },
+    ]);
+    const t = parseKickoffTasks(raw);
+    expect(t[0]!.dependsOn).toEqual([]); // 자기(1)·미존재(99) 제거
+    expect(t[1]!.dependsOn).toEqual([1]);
+  });
+  it("seq 누락 시 자동 채번", () => {
+    const raw = JSON.stringify([{ axis: "PL", title: "a" }, { axis: "UX", title: "b" }]);
+    expect(parseKickoffTasks(raw).map((x) => x.seq)).toEqual([1, 2]);
+  });
+  it("빈/불량 입력은 빈 배열", () => {
+    expect(parseKickoffTasks("")).toEqual([]);
+    expect(parseKickoffTasks("not json")).toEqual([]);
+    expect(parseKickoffTasks("{}")).toEqual([]);
+  });
+  it("AXES 는 4축", () => {
+    expect([...AXES]).toEqual(["PL", "TD", "BA", "UX"]);
+  });
+});
+
+describe("render", () => {
+  const task = { seq: 2, axis: "UX" as const, title: "전환", rationale: "love mark", dependsOn: [1], acceptance: "동작" };
+  it("이슈 제목 = [P1 · UX] 전환", () => {
+    expect(renderIssueTitle(task, "P1")).toBe("[P1 · UX] 전환");
+  });
+  it("본문에 담당축·선행·완료판정 포함", () => {
+    const b = renderIssueBody(task, "P1", "단 하나의 순간");
+    expect(b).toContain("담당 축: UX");
+    expect(b).toContain("선행: #1(seq)");
+    expect(b).toContain("동작");
+    expect(b).toContain("project:P1");
+  });
+  it("renderPlan 요약", () => {
+    const plan = renderPlan(parseKickoffTasks(JSON.stringify([
+      { seq: 1, axis: "PL", title: "a" },
+      { seq: 2, axis: "BA", title: "b", dependsOn: [1] },
+    ])), "P1");
+    expect(plan).toContain("1. [PL] a");
+    expect(plan).toContain("2. [BA] b (선행 1)");
+  });
+});

--- a/scripts/kickoff-tasks.ts
+++ b/scripts/kickoff-tasks.ts
@@ -1,0 +1,150 @@
+/**
+ * 프로젝트 킥오프 분해 — task 세트 파서/검증/렌더 (톱다운 워크플로 P2).
+ *
+ * project-kickoff.yml 의 "4축 회의"(LLM) 가 활성 프로젝트를 정렬된 task 배열로 분해해
+ * JSON 으로 뱉으면, 이 순수 모듈이 검증·정렬·이슈 본문 렌더를 담당한다.
+ * 4축: PL(Product Lead) / TD(Tech-Debt) / BA(Backend·Architecture) / UX(Experience).
+ *
+ * 순수 export 함수 + main() CLI (process.argv[1] 가드).
+ *   parse <project_id> <tasks.json>  → 검증·정렬된 task JSON 배열을 stdout (불량 항목 제외)
+ *   render <project_id> <task.json>  → 단일 task 의 이슈 본문(마크다운)을 stdout
+ */
+
+import { readFileSync } from "node:fs";
+
+export const AXES = ["PL", "TD", "BA", "UX"] as const;
+export type Axis = (typeof AXES)[number];
+
+/** 4축 → GitHub 라벨(통합 후 lane 라벨) 매핑. */
+export const AXIS_LABEL: Record<Axis, string> = {
+  PL: "product-lead",
+  TD: "tech-debt",
+  BA: "backend",
+  UX: "experience",
+};
+
+export interface KickoffTask {
+  seq: number;
+  axis: Axis;
+  title: string;
+  rationale: string;
+  /** 선행 task 의 seq 들 */
+  dependsOn: number[];
+  /** 완료 판정 기준(검증 가능) */
+  acceptance: string;
+}
+
+function coerceAxis(v: unknown): Axis | null {
+  if (typeof v !== "string") return null;
+  const up = v.trim().toUpperCase();
+  return (AXES as readonly string[]).includes(up) ? (up as Axis) : null;
+}
+
+function coerceDeps(v: unknown): number[] {
+  if (!Array.isArray(v)) return [];
+  return v.map((x) => Number(x)).filter((n) => Number.isInteger(n) && n > 0);
+}
+
+/**
+ * LLM 원문(JSON 문자열 또는 객체)을 검증된 task 배열로.
+ * - 코드펜스/잡텍스트 둘러싸여도 첫 '['~마지막 ']' 추출.
+ * - axis 화이트리스트 밖, title 없음 → 제외(조용히 드롭, 부분 성공 허용).
+ * - seq 오름차순 정렬, 자기 자신/미존재 의존성 제거.
+ */
+export function parseKickoffTasks(raw: string): KickoffTask[] {
+  let text = (raw || "").trim();
+  if (!text) return [];
+  if (!text.startsWith("[")) {
+    const s = text.indexOf("[");
+    const e = text.lastIndexOf("]");
+    if (s === -1 || e === -1 || e <= s) return [];
+    text = text.slice(s, e + 1);
+  }
+  let arr: unknown;
+  try {
+    arr = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(arr)) return [];
+
+  const tasks: KickoffTask[] = [];
+  let auto = 1;
+  for (const item of arr) {
+    if (typeof item !== "object" || item === null) continue;
+    const o = item as Record<string, unknown>;
+    const axis = coerceAxis(o.axis);
+    const title = typeof o.title === "string" ? o.title.trim() : "";
+    if (!axis || !title) continue;
+    const seq = Number.isInteger(Number(o.seq)) && Number(o.seq) > 0 ? Number(o.seq) : auto;
+    tasks.push({
+      seq,
+      axis,
+      title,
+      rationale: typeof o.rationale === "string" ? o.rationale.trim() : "",
+      dependsOn: coerceDeps(o.dependsOn),
+      acceptance: typeof o.acceptance === "string" ? o.acceptance.trim() : "",
+    });
+    auto = seq + 1;
+  }
+  tasks.sort((a, b) => a.seq - b.seq);
+  // 존재하는 seq 집합 기준으로 의존성 정리(자기참조·미존재 제거)
+  const seqs = new Set(tasks.map((t) => t.seq));
+  for (const t of tasks) t.dependsOn = t.dependsOn.filter((d) => d !== t.seq && seqs.has(d));
+  return tasks;
+}
+
+/** 단일 task 의 GitHub 이슈 본문(마크다운). */
+export function renderIssueBody(task: KickoffTask, projectId: string, projectTitle: string): string {
+  const deps = task.dependsOn.length ? task.dependsOn.map((d) => `#${d}(seq)`).join(", ") : "없음";
+  return [
+    `> 🗺️ **프로젝트 ${projectId} · ${projectTitle}** 의 분해 task (킥오프 자동 생성).`,
+    "",
+    `### 담당 축: ${task.axis} (${AXIS_LABEL[task.axis]})`,
+    `### 순서(seq): ${task.seq}  ·  선행: ${deps}`,
+    "",
+    "### 왜 (프로젝트 정합)",
+    task.rationale || "(근거 미기재)",
+    "",
+    "### 완료 판정 (검증 가능)",
+    task.acceptance || "(판정 기준 미기재)",
+    "",
+    "---",
+    `_이 이슈는 \`project:${projectId}\` 세트의 일부다. CEO 승인(슬랙 \"개발해\"/수동) 시에만 구현된다._`,
+  ].join("\n");
+}
+
+/** 이슈 제목. */
+export function renderIssueTitle(task: KickoffTask, projectId: string): string {
+  return `[${projectId} · ${task.axis}] ${task.title}`;
+}
+
+/** 분해 요약(Slack/리포트). */
+export function renderPlan(tasks: KickoffTask[], projectId: string): string {
+  if (!tasks.length) return `(${projectId} 분해 task 없음)`;
+  return tasks
+    .map((t) => `${t.seq}. [${t.axis}] ${t.title}${t.dependsOn.length ? ` (선행 ${t.dependsOn.join(",")})` : ""}`)
+    .join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────
+function main(): void {
+  const argv = process.argv;
+  const cmd = argv[2];
+  if (cmd === "parse") {
+    const raw = readFileSync(argv[4] ?? "/dev/stdin", "utf8");
+    process.stdout.write(JSON.stringify(parseKickoffTasks(raw)));
+  } else if (cmd === "render") {
+    const pid = argv[3] ?? "P?";
+    const task = JSON.parse(readFileSync(argv[4] ?? "/dev/stdin", "utf8")) as KickoffTask;
+    process.stdout.write(renderIssueBody(task, pid, ""));
+  } else {
+    console.error("usage: tsx scripts/kickoff-tasks.ts <parse|render> <project_id> <file.json>");
+    process.exit(1);
+  }
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("kickoff-tasks")) {
+  main();
+}


### PR DESCRIPTION
바텀업 → 톱다운 전환 **2단계**. P1(백로그+선택) 위에 **프로젝트 분해**를 얹는다.

## 변경
- **scripts/kickoff-tasks.ts** (순수+vitest 10): LLM 분해 출력 파서/검증/렌더. 코드펜스·잡텍스트 허용, axis 화이트리스트(PL/TD/BA/UX)·title 검증, seq 정렬, 자기/미존재 의존성 제거, 부분 성공 허용.
- **project-kickoff.yml**: 활성화(P1) 후 →
  1. **컨텍스트 prep**: 활성 프로젝트 + North Star + Standing Constraints. 이미 `project:<id>` 이슈 있으면 **재분해 skip**(중복 세트 방지).
  2. **4축 회의(LLM)**: PL이 리딩, 프로젝트 success 기준 충족하는 최소 task 로 분해. 미시 잡일 금지, 의존성·완료판정 명시, constraints 위반 금지. (gpt-4o, continue-on-error)
  3. **이슈 생성**: `[<id> · <축>] 제목` + `project:<id>`/`task`/축 라벨. 본문에 담당축·선행·완료판정.
  4. **Slack 통지**: 분해 플랜 요약. 구현은 CEO 승인 시에만.
  - `models: read` 권한 추가.

## 게이트
YAML ✅ · vitest 18(kickoff 10 + roadmap 8) ✅ · lint ✅ · typecheck ✅ · parse dry-run(잡텍스트·불량 제거) 확인.

## 다음
P3: 에이전트 9→4 통합(PL/TD/BA/UX). P4: daily cron → 진척 리포트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)