### PR TITLE
feat(council): 톱다운 P4 — daily를 진척 리포트로 (아이디어 생성 종료)

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -1,12 +1,18 @@
 name: Daily Agent Council
 
+# ⚠️ 일일 바텀업 제안 비활성화 (2026-06-09 톱다운 개편 P4):
+#   매일 9직군이 산발적 아이디어를 던지던 cron 을 끈다. 이제 톱다운 프로젝트 구동
+#   (PROJECT_ROADMAP.md → select_project → project-kickoff 분해 → 격파)이며,
+#   매일 cron 은 project-progress.yml(활성 프로젝트 진척 리포트)로 대체됐다.
+#   이 워크플로는 수동(workflow_dispatch) 폴백으로만 남긴다. 자율 루프 복원 시 schedule 주석 해제.
+# on:
+#   schedule:
+#     - cron: "0 22 * * *"  # 매일 오전 7시 KST (UTC 22:00 전날) — 비활성
 on:
-  schedule:
-    - cron: "0 22 * * *"  # 매일 오전 7시 KST (UTC 22:00 전날)
   workflow_dispatch:
     inputs:
       agent:
-        description: "실행할 에이전트 (all / pm / frontend / backend / designer / qa / cto / marketer / security / prompt_engineer)"
+        description: "실행할 에이전트 (all / pm / frontend / backend / designer / qa / cto / marketer / security / prompt_engineer) — 수동 폴백"
         required: false
         default: "all"
 

--- a/.github/workflows/project-progress.yml
+++ b/.github/workflows/project-progress.yml
@@ -1,0 +1,94 @@
+name: Project Progress Report
+
+# 톱다운 워크플로 P4 — 매일 아침, 산발적 아이디어 생성 대신 *활성 프로젝트 진척*을 보고한다.
+#   활성 프로젝트 있음 → project:<id> task 의 머지/PR/미착수 집계 + "다음 할 일".
+#   활성 프로젝트 없음 → 백로그 surfacing(오너의 select_project 선택 대기).
+on:
+  schedule:
+    - cron: "0 22 * * *"  # 매일 오전 7시 KST (UTC 22:00 전날)
+  workflow_dispatch:
+
+concurrency:
+  group: project-progress
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve active project
+        id: active
+        run: |
+          set -uo pipefail
+          if [ ! -f PROJECT_ROADMAP.md ]; then
+            echo "has=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          npx -y tsx@4.19.2 scripts/project-roadmap.ts active PROJECT_ROADMAP.md > /tmp/active.json 2>/dev/null || echo "null" > /tmp/active.json
+          ID=$(jq -r '.id // empty' /tmp/active.json 2>/dev/null || echo "")
+          TITLE=$(jq -r '.title // ""' /tmp/active.json 2>/dev/null || echo "")
+          if [ -n "$ID" ]; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+            echo "id=$ID" >> "$GITHUB_OUTPUT"
+            echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          else
+            echo "has=false" >> "$GITHUB_OUTPUT"
+          fi
+          npx -y tsx@4.19.2 scripts/project-roadmap.ts summary PROJECT_ROADMAP.md > /tmp/summary.txt 2>/dev/null || echo "(로드맵 요약 실패)" > /tmp/summary.txt
+
+      - name: Build progress report (활성 프로젝트)
+        id: progress
+        if: steps.active.outputs.has == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PID: ${{ steps.active.outputs.id }}
+          PTITLE: ${{ steps.active.outputs.title }}
+        run: |
+          set -uo pipefail
+          # project:<id> task 이슈 (open+closed) — 라벨에서 축 추출
+          gh issue list --label "project:$PID" --state all --limit 100 \
+            --json number,title,state,labels --repo "${{ github.repository }}" 2>/dev/null \
+          | jq '[ .[] | {
+                number, title, state,
+                axis: ([.labels[].name]
+                  | if index("product-lead") then "PL"
+                    elif index("tech-debt") then "TD"
+                    elif index("backend") then "BA"
+                    elif index("experience") then "UX"
+                    else "task" end)
+              } ]' > /tmp/proj_issues.json 2>/dev/null || echo "[]" > /tmp/proj_issues.json
+          [ -s /tmp/proj_issues.json ] || echo "[]" > /tmp/proj_issues.json
+
+          gh pr list --state merged --limit 60 --json number,title,body \
+            --repo "${{ github.repository }}" > /tmp/p_merged.json 2>/dev/null || echo "[]" > /tmp/p_merged.json
+          gh pr list --state open --limit 60 --json number,title,body \
+            --repo "${{ github.repository }}" > /tmp/p_open.json 2>/dev/null || echo "[]" > /tmp/p_open.json
+
+          npx -y tsx@4.19.2 scripts/project-progress.ts report "$PID" "$PTITLE" \
+            /tmp/proj_issues.json /tmp/p_merged.json /tmp/p_open.json > /tmp/report.txt 2>/dev/null \
+            || echo "진척 리포트 생성 실패 — 수동 확인 요망 ($PID)" > /tmp/report.txt
+          { echo "### 🚧 $PID 진척"; cat /tmp/report.txt; } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack
+        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        env:
+          HAS: ${{ steps.active.outputs.has }}
+        run: |
+          set -uo pipefail
+          URL=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
+          if [ "$HAS" = "true" ] && [ -s /tmp/report.txt ]; then
+            TEXT=$(cat /tmp/report.txt)
+          else
+            SUM=$(cat /tmp/summary.txt 2>/dev/null || echo "(백로그 없음)")
+            TEXT=$(printf '🗺️ *활성 프로젝트 없음 — 백로그 대기*\n다음 중 하나를 슬랙에서 선택하세요 (예: "P1 시작"):\n%s' "$SUM")
+          fi
+          BODY=$(jq -n --arg t "$TEXT" '{text: $t}')
+          curl -sS -X POST -H 'Content-type: application/json' --data "$BODY" "$URL" || true

--- a/scripts/__tests__/project-progress.test.ts
+++ b/scripts/__tests__/project-progress.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { rollup, renderProgressReport } from "../project-progress";
+import { buildProgressLedger } from "../build-progress-ledger";
+
+const issues = [
+  { number: 10, title: "포모 홈 와이어", axis: "PL", state: "CLOSED" },
+  { number: 11, title: "전환 love mark", axis: "UX", state: "OPEN" },
+  { number: 12, title: "감정 집계 API", axis: "BA", state: "OPEN" },
+  { number: 13, title: "폴백 회귀 테스트", axis: "TD", state: "OPEN" },
+];
+const merged = [{ number: 50, title: "[Auto] 와이어", body: "resolves #10", merged: true }];
+const open = [{ number: 51, title: "[Auto] 전환", body: "관련 #11", merged: false }];
+
+const entries = buildProgressLedger({
+  adopted: issues.map((i) => ({ number: i.number, title: i.title, agent: i.axis, state: i.state })),
+  mergedPRs: merged,
+  openPRs: open,
+});
+
+describe("rollup", () => {
+  it("머지/PR중/미착수 카운트 + 완료율", () => {
+    const r = rollup(entries);
+    expect(r.total).toBe(4);
+    expect(r.merged).toBe(1); // #10
+    expect(r.openPr).toBe(1); // #11
+    expect(r.pending).toBe(2); // #12, #13
+    expect(r.donePct).toBe(25);
+  });
+  it("빈 배열은 0%", () => {
+    expect(rollup([]).donePct).toBe(0);
+  });
+});
+
+describe("renderProgressReport", () => {
+  it("진척 헤드라인 + 다음 할 일 노출", () => {
+    const txt = renderProgressReport("P1", "단 하나의 순간", entries);
+    expect(txt).toContain("1/4 완료 (25%)");
+    expect(txt).toContain("다음 할 일");
+    expect(txt).toContain("#12 감정 집계 API");
+    expect(txt).toContain("#11 전환 love mark");
+  });
+  it("task 없으면 분해 안내", () => {
+    expect(renderProgressReport("P2", "습관", [])).toContain("분해된 task 이슈가 없");
+  });
+  it("전부 머지면 완료 축하 + 다음 프로젝트 안내", () => {
+    const allDone = buildProgressLedger({
+      adopted: [{ number: 1, title: "a", agent: "PL", state: "CLOSED" }],
+      mergedPRs: [{ number: 9, title: "m", body: "#1", merged: true }],
+      openPRs: [],
+    });
+    const txt = renderProgressReport("P1", "x", allDone);
+    expect(txt).toContain("100%");
+    expect(txt).toContain("모든 task 머지 완료");
+  });
+});

--- a/scripts/project-progress.ts
+++ b/scripts/project-progress.ts
@@ -1,0 +1,111 @@
+/**
+ * 프로젝트 진척 롤업/리포트 (톱다운 워크플로 P4).
+ *
+ * 활성 프로젝트의 `project:<id>` task 이슈들이 실제로 머지/PR/미착수 중 무엇인지를
+ * build-progress-ledger 의 결정론 판정(MERGED/OPEN_PR/PENDING/CLOSED_NO_PR)으로 굴려
+ * "N/M 완료" 진척 + 다음 할 일을 만든다. 매일 cron 이 이걸 Slack 으로 보고한다(아이디어 생성 아님).
+ *
+ * 순수 export 함수 + main() CLI.
+ *   report <project_id> <project_title> <issues.json> <merged.json> <open.json>
+ *     → Slack 리포트 텍스트를 stdout
+ */
+
+import { readFileSync } from "node:fs";
+import { buildProgressLedger, type ProgressEntry, type AdoptedIssue, type PullRequest } from "./build-progress-ledger";
+
+export interface ProjectRollup {
+  total: number;
+  merged: number;
+  openPr: number;
+  pending: number;
+  closedNoPr: number;
+  donePct: number;
+}
+
+export function rollup(entries: ProgressEntry[]): ProjectRollup {
+  const total = entries.length;
+  const merged = entries.filter((e) => e.status === "MERGED").length;
+  const openPr = entries.filter((e) => e.status === "OPEN_PR").length;
+  const pending = entries.filter((e) => e.status === "PENDING").length;
+  const closedNoPr = entries.filter((e) => e.status === "CLOSED_NO_PR").length;
+  const donePct = total > 0 ? Math.round((merged / total) * 100) : 0;
+  return { total, merged, openPr, pending, closedNoPr, donePct };
+}
+
+const STATUS_ICON: Record<ProgressEntry["status"], string> = {
+  MERGED: "✅",
+  OPEN_PR: "🔄",
+  PENDING: "⏳",
+  CLOSED_NO_PR: "⚠️",
+};
+
+/** 활성 프로젝트 진척 Slack 리포트. */
+export function renderProgressReport(
+  projectId: string,
+  projectTitle: string,
+  entries: ProgressEntry[],
+): string {
+  const r = rollup(entries);
+  if (r.total === 0) {
+    return `🗺️ *${projectId} · ${projectTitle}* — 아직 분해된 task 이슈가 없습니다. \`project-kickoff\` 로 분해하세요.`;
+  }
+  const lines: string[] = [];
+  lines.push(`🚧 *프로젝트 진척 — ${projectId} · ${projectTitle}*`);
+  lines.push(`*${r.merged}/${r.total} 완료 (${r.donePct}%)*  ·  🔄 PR중 ${r.openPr} · ⏳ 미착수 ${r.pending}${r.closedNoPr ? ` · ⚠️ 종료(미구현) ${r.closedNoPr}` : ""}`);
+  lines.push("");
+  // 남은 일(미착수·PR중) 우선 노출 — "오늘 할 일"
+  const remaining = entries.filter((e) => e.status === "PENDING" || e.status === "OPEN_PR");
+  if (remaining.length) {
+    lines.push("*다음 할 일:*");
+    for (const e of remaining.slice(0, 8)) {
+      lines.push(`${STATUS_ICON[e.status]} #${e.issue} ${e.title}${e.pr ? ` (PR #${e.pr})` : ""}`);
+    }
+  }
+  if (r.merged === r.total) {
+    lines.push("");
+    lines.push("🎉 *모든 task 머지 완료* — 프로젝트 done 처리 + 다음 프로젝트 선택을 검토하세요.");
+  }
+  lines.push("");
+  lines.push("_구현은 CEO 승인(슬랙 \"개발해\") 시에만. 산발적 일일 제안은 없습니다._");
+  return lines.join("\n");
+}
+
+/** 이슈 라벨에서 축(PL/TD/BA/UX) 라벨을 사람이 읽는 축으로(없으면 task). */
+function issueToAdopted(i: { number: number; title: string; state?: string; axis?: string }): AdoptedIssue {
+  return { number: i.number, title: i.title, agent: i.axis ?? "task", state: i.state };
+}
+
+// ─────────────────────────────────────────────────────────────
+function readJson<T>(path: string | undefined, fallback: T): T {
+  if (!path) return fallback;
+  try {
+    const raw = readFileSync(path, "utf8").trim();
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function main(): void {
+  const argv = process.argv;
+  if (argv[2] !== "report") {
+    console.error("usage: tsx scripts/project-progress.ts report <id> <title> <issues.json> <merged.json> <open.json>");
+    process.exit(1);
+  }
+  const id = argv[3] ?? "P?";
+  const title = argv[4] ?? "";
+  const issues = readJson<Array<{ number: number; title: string; state?: string; axis?: string }>>(argv[5], []);
+  const merged = readJson<PullRequest[]>(argv[6], []);
+  const open = readJson<PullRequest[]>(argv[7], []);
+  const entries = buildProgressLedger({
+    adopted: issues.map(issueToAdopted),
+    mergedPRs: merged,
+    openPRs: open,
+  });
+  process.stdout.write(renderProgressReport(id, title, entries));
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("project-progress")) {
+  main();
+}


### PR DESCRIPTION
바텀업 → 톱다운 전환 **마지막 단계**. 매일 아이디어 생성을 끄고, 매일 = **활성 프로젝트 진척 리포트**로.

## 변경
- **idea-proposal.yml**: `schedule` cron 비활성화(주석 보존), `workflow_dispatch` 폴백만 유지. → 매일 9직군 산발 제안 **종료**.
- **project-progress.yml** (신설, 매일 7시 KST + 수동): 활성 프로젝트의 `project:<id>` task 를 머지/PR중/미착수로 집계 → "**N/M 완료 + 다음 할 일**" Slack 보고. 활성 프로젝트 없으면 **백로그 surfacing**("P1 시작" 선택 대기).
- **scripts/project-progress.ts** (순수+vitest 5): build-progress-ledger 재사용 롤업/리포트.

## 게이트
YAML ✅(progress OK · idea-proposal=dispatch only) · vitest 114 ✅ · lint ✅ · typecheck ✅ · report dry-run("1/2 완료 50% + 다음 할 일") 확인.

## 톱다운 개편 완료 (P1~P4)
PROJECT_ROADMAP(P1) → Slack select_project(P1) → project-kickoff 4축 분해(P2) → 4축 로스터(P3) → 매일 진척 리포트(P4). 매일 잔 아이디어 종료, 프로젝트 단위 격파 + CEO 승인 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)