### PR TITLE
fix(council): 킥오프 이슈 생성 — 라벨 사전 생성 + 에러 노출

### DIFF
--- a/.github/workflows/project-kickoff.yml
+++ b/.github/workflows/project-kickoff.yml
@@ -146,6 +146,10 @@ jobs:
           fi
           PTITLE=$(jq -r '.title // ""' /tmp/active.json 2>/dev/null || echo "")
           AXIS_LABEL () { case "$1" in PL) echo "product-lead";; TD) echo "tech-debt";; BA) echo "backend";; UX) echo "experience";; *) echo "agent-council";; esac; }
+          # gh issue create 는 *존재하지 않는 라벨*이면 실패한다 → 필요한 라벨을 idempotent 하게 미리 생성.
+          for L in "project:$PID" "agent-council" "task" "product-lead" "tech-debt" "backend" "experience"; do
+            gh label create "$L" --force --color ededed --description "topdown kickoff" >/dev/null 2>&1 || true
+          done
           CREATED=""
           for i in $(seq 0 $((COUNT-1))); do
             jq -c ".[$i]" /tmp/tasks.json > /tmp/task.json
@@ -154,8 +158,10 @@ jobs:
             npx -y tsx@4.19.2 scripts/kickoff-tasks.ts render "$PID" /tmp/task.json > /tmp/task_body.md 2>/dev/null || echo "(본문 생성 실패)" > /tmp/task_body.md
             LB=$(AXIS_LABEL "$AXIS")
             if N=$(gh issue create --title "$TITLE" --body-file /tmp/task_body.md \
-                  --label "project:$PID,agent-council,task,$LB" --repo "${{ github.repository }}" 2>/dev/null); then
+                  --label "project:$PID,agent-council,task,$LB" --repo "${{ github.repository }}"); then
               CREATED="$CREATED ${N##*/}"
+            else
+              echo "⚠️ 이슈 생성 실패: $TITLE"
             fi
           done
           PLAN=$(npx -y tsx@4.19.2 scripts/kickoff-tasks.ts parse "$PID" /tmp/decompose_raw.txt 2>/dev/null \


### PR DESCRIPTION
라이브 P1 킥오프에서 LLM 분해(8 task)는 정상이었으나 이슈 0건. 원인: `gh issue create`가 없는 라벨(project:P1·task·product-lead·experience)이면 실패하는데 `2>/dev/null`로 묻힘. → 라벨 idempotent 사전 생성(`gh label create --force`) + 에러 노출. YAML ✅.