### PR TITLE
[CEO Brief 2026-06-09] FOMO Index 신뢰성 강화 + 보안/성능/UX 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ OPENAI_API_KEY=""
 OPENAI_MODEL=""
 OPENAI_BASE_URL=""
 
+# ─── FOMO Club 보안 ──────────────────────────────────────────────────────────
+SESSION_HMAC_SECRET="change-me"           # 익명 세션 HMAC 서명 시크릿 (32자 이상 랜덤 문자열 권장)
+
 # ─── Tarot 앱 전용 ────────────────────────────────────────────────────────────
 TAROT_API_SECRET="change-me"              # 모바일↔API 공유 시크릿
 

--- a/apps/fomo-club/app/index.tsx
+++ b/apps/fomo-club/app/index.tsx
@@ -224,10 +224,12 @@ const styles = StyleSheet.create({
   brand: { color: FomoColors.whiteout, fontSize: 18, fontWeight: "600" },
   link: { color: FomoColors.muted, fontSize: 14 },
   stageLabel: { color: FomoColors.muted, fontSize: 12, marginBottom: Spacing.s12 },
-  indexRow: { alignItems: "center", marginTop: Spacing.s24, minHeight: 28 },
-  indexText: { color: FomoColors.whiteout, fontSize: 24, fontWeight: "600" },
-  muted: { color: FomoColors.muted, fontSize: 12, marginTop: 4 },
-  indexSummary: { color: FomoColors.whiteout, fontSize: 13, marginTop: Spacing.s4, opacity: 0.85 },
+  indexRow: { alignItems: "center", marginTop: Spacing.s24, minHeight: 36 },
+  // 숫자를 32pt·Bold로 — 3초 안에 FOMO Index 값이 눈에 들어오는 크기 (#412)
+  indexText: { color: FomoColors.whiteout, fontSize: 32, fontWeight: "700", letterSpacing: -0.5 },
+  muted: { color: FomoColors.muted, fontSize: 12, marginTop: 6 },
+  // 상태 설명을 16pt로 올려 인덱스와 계층 차이를 명확히 (#412)
+  indexSummary: { color: FomoColors.whiteout, fontSize: 16, fontWeight: "400", marginTop: Spacing.s8, lineHeight: 22 },
   summary: { color: FomoColors.whiteout, fontSize: 14, textAlign: "center", marginTop: Spacing.s8, maxWidth: 300 },
   mention: { color: FomoColors.whiteout, textAlign: "center", fontSize: 14, marginTop: Spacing.s16, lineHeight: 20 },
   voteBlock: { width: "100%", marginTop: Spacing.s40 },

--- a/apps/fomo-web/components/FomoFace.tsx
+++ b/apps/fomo-web/components/FomoFace.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import type { FomoFace as FomoFaceType } from "@fomo/core";
 
 /**
@@ -5,6 +6,7 @@ import type { FomoFace as FomoFaceType } from "@fomo/core";
  * 타마고치/동물의숲/ShowHex 류: 둥근 머리 + 작은 몸 + 발 + 윤곽선 + 볼터치.
  * 흰 본체 + 회색 윤곽 + 검정 눈, 감정색(glow)은 볼터치 + 외곽광으로(레퍼런스의 '흰 캐릭터 + 색 악센트' 문법).
  * 5표정은 눈·입 픽셀 오버레이로. 애니메이션은 idle float만(초안 — 고도화 전).
+ * React.memo + useMemo: face/glow/size가 동일하면 SVG 전체 재계산·리렌더 방지.
  */
 
 const COLS = 16;
@@ -77,59 +79,65 @@ const OUTLINE = "#6E6E82";
 const BODY = "#F2F2EA";
 const EYE = "#2A2A35";
 
-export function FomoFace({
-  face,
-  glow,
-  size = 168,
-}: {
-  face: FomoFaceType;
-  glow?: string | undefined;
-  size?: number;
-}) {
-  const e = EXPR[face];
-  const eyeSet = new Set(e.eyes);
-  const mouthSet = new Set(e.mouth);
-  const cheekSet = new Set(e.cheeks);
-  const cheek = glow ?? "#FF9AA2"; // glow 있으면 감정색, 없으면 옅은 분홍
+export const FomoFace = memo(
+  function FomoFace({
+    face,
+    glow,
+    size = 168,
+  }: {
+    face: FomoFaceType;
+    glow?: string | undefined;
+    size?: number;
+  }) {
+    const pixel = size / (COLS + 2); // 좌우 여백 1칸
+    const w = COLS * pixel;
+    const h = ROWS * pixel;
 
-  const pixel = size / (COLS + 2); // 좌우 여백 1칸
-  const w = COLS * pixel;
-  const h = ROWS * pixel;
+    // face·glow·size가 바뀔 때만 셀 배열 재계산
+    const cells = useMemo(() => {
+      const e = EXPR[face];
+      const eyeSet = new Set(e.eyes);
+      const mouthSet = new Set(e.mouth);
+      const cheekSet = new Set(e.cheeks);
+      const cheek = glow ?? "#FF9AA2"; // glow 있으면 감정색, 없으면 옅은 분홍
 
-  const cells: { x: number; y: number; fill: string }[] = [];
-  for (let r = 0; r < ROWS; r++) {
-    for (let c = 0; c < COLS; c++) {
-      const ch = BASE[r]![c];
-      if (ch === ".") continue;
-      const key = `${r},${c}`;
-      let fill: string;
-      if (eyeSet.has(key) || mouthSet.has(key)) fill = EYE;
-      else if (cheekSet.has(key)) fill = cheek;
-      else if (ch === "K") fill = OUTLINE;
-      else fill = BODY;
-      cells.push({ x: c, y: r, fill });
-    }
+      const result: { x: number; y: number; fill: string }[] = [];
+      for (let r = 0; r < ROWS; r++) {
+        for (let c = 0; c < COLS; c++) {
+          const ch = BASE[r]![c];
+          if (ch === ".") continue;
+          const key = `${r},${c}`;
+          let fill: string;
+          if (eyeSet.has(key) || mouthSet.has(key)) fill = EYE;
+          else if (cheekSet.has(key)) fill = cheek;
+          else if (ch === "K") fill = OUTLINE;
+          else fill = BODY;
+          result.push({ x: c, y: r, fill });
+        }
+      }
+      return result;
+    }, [face, glow]);
+
+    return (
+      <div
+        style={{
+          width: size,
+          height: size,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          // 감정/지수 색은 외곽광으로만
+          filter: glow ? `drop-shadow(0 0 ${pixel * 1.4}px ${glow}99)` : "none",
+          transition: "filter 420ms cubic-bezier(0.16,1,0.3,1)",
+          animation: "fomo-float 6s ease-in-out infinite",
+        }}
+      >
+        <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} shapeRendering="crispEdges" aria-hidden>
+          {cells.map(({ x, y, fill }) => (
+            <rect key={`${x},${y}`} x={x * pixel} y={y * pixel} width={pixel} height={pixel} fill={fill} />
+          ))}
+        </svg>
+      </div>
+    );
   }
-
-  return (
-    <div
-      style={{
-        width: size,
-        height: size,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        // 감정/지수 색은 외곽광으로만
-        filter: glow ? `drop-shadow(0 0 ${pixel * 1.4}px ${glow}99)` : "none",
-        transition: "filter 420ms cubic-bezier(0.16,1,0.3,1)",
-        animation: "fomo-float 6s ease-in-out infinite",
-      }}
-    >
-      <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} shapeRendering="crispEdges" aria-hidden>
-        {cells.map(({ x, y, fill }) => (
-          <rect key={`${x},${y}`} x={x * pixel} y={y * pixel} width={pixel} height={pixel} fill={fill} />
-        ))}
-      </svg>
-    </div>
-  );
-}
+);

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { memo, useState, useMemo } from "react";
 import {
   EMOTION_TYPES,
   EMOTION_LABELS,
@@ -17,6 +17,7 @@ import { FomoFace } from "@/components/FomoFace";
 import { RollingBanner } from "@/components/RollingBanner";
 import { EmotionCalendar } from "@/components/EmotionCalendar";
 import { SignupGate } from "@/components/SignupGate";
+import { FomoIndexSkeleton, TallySkeleton } from "@/components/SkeletonLoader";
 import { stateGlow } from "@/lib/fomoVisual";
 import type {
   FomoIndexResponse,
@@ -31,7 +32,7 @@ type Tab = "home" | "calendar";
  * 메인 홈 — 하단 탭 바로 메인/캘린더 분기.
  * 향후 M4(피드) 등 탭 추가 시 TABS 배열에만 항목 추가하면 됨.
  */
-export function HomeView({
+export const HomeView = memo(function HomeView({
   index,
   tally,
   banner,
@@ -40,6 +41,7 @@ export function HomeView({
   onReopenGate,
   loggedIn,
   onLoggedIn,
+  isLoading = false,
 }: {
   index: FomoIndexResponse | null;
   tally: TallyResponse | null;
@@ -49,13 +51,26 @@ export function HomeView({
   onReopenGate: () => void;
   loggedIn: boolean;
   onLoggedIn: () => void;
+  isLoading?: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("home");
 
-  const state = index ? scoreToState(index.score) : null;
-  const marketFace = index ? scoreToFace(index.score) : "curious";
+  const state = useMemo(() => (index ? scoreToState(index.score) : null), [index]);
+  const marketFace = useMemo(() => (index ? scoreToFace(index.score) : "curious"), [index]);
   const stage: "market" | "mine" = mine ? "mine" : "market";
-  const line = mine ? mineLine(mine) : state ? marketLine(state) : "";
+  const line = useMemo(
+    () => (mine ? mineLine(mine) : state ? marketLine(state) : ""),
+    [mine, state]
+  );
+  const glowColor = useMemo(
+    () =>
+      stage === "mine" && mine
+        ? EMOTION_COLORS[mine]
+        : index
+          ? stateGlow(index.score)
+          : undefined,
+    [stage, mine, index]
+  );
 
   return (
     <>
@@ -73,36 +88,36 @@ export function HomeView({
               <RollingBanner items={banner} />
             </div>
 
-            {/* 주인공: 포모 */}
-            <p className="mb-2 text-xs text-muted">{stage === "market" ? "오늘의 포모" : "나의 포모"}</p>
-            <FomoFace
-              face={stage === "market" ? marketFace : "calm"}
-              glow={
-                stage === "mine" && mine
-                  ? EMOTION_COLORS[mine]
-                  : index
-                    ? stateGlow(index.score)
-                    : undefined
-              }
-              size={84}
-            />
+            {/* 주인공: 포모 (로딩 중엔 스켈레톤) */}
+            {isLoading && !index ? (
+              <FomoIndexSkeleton />
+            ) : (
+              <>
+                <p className="mb-2 text-xs text-muted">{stage === "market" ? "오늘의 포모" : "나의 포모"}</p>
+                <FomoFace
+                  face={stage === "market" ? marketFace : "calm"}
+                  glow={glowColor}
+                  size={84}
+                />
 
-            {/* 보조: FOMO Index (픽셀) */}
-            <div className="mt-3 flex flex-col items-center">
-              {index ? (
-                <>
-                  <p className="font-pixel text-4xl leading-none text-whiteout">{index.score}</p>
-                  <p className="mt-1.5 font-pixel text-xs text-muted">
-                    FOMO INDEX · {index.state}
-                    {index.prevDayDelta
-                      ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}`
-                      : ""}
-                  </p>
-                </>
-              ) : (
-                <p className="font-pixel text-sm text-muted">FOMO INDEX · 집계 준비 중</p>
-              )}
-            </div>
+                {/* 보조: FOMO Index (픽셀) */}
+                <div className="mt-3 flex flex-col items-center">
+                  {index ? (
+                    <>
+                      <p className="font-pixel text-4xl leading-none text-whiteout">{index.score}</p>
+                      <p className="mt-1.5 font-pixel text-xs text-muted">
+                        FOMO INDEX · {index.state}
+                        {index.prevDayDelta
+                          ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}`
+                          : ""}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="font-pixel text-sm text-muted">FOMO INDEX · 집계 준비 중</p>
+                  )}
+                </div>
+              </>
+            )}
 
             {/* 포모의 담담한 한마디 */}
             {line && (
@@ -142,8 +157,12 @@ export function HomeView({
               </div>
             )}
 
-            {/* 집계 — 정직한 숫자 */}
-            {tally && (
+            {/* 집계 — 정직한 숫자 (로딩 중엔 스켈레톤) */}
+            {isLoading && !tally ? (
+              <section className="mt-7 w-full">
+                <TallySkeleton />
+              </section>
+            ) : tally && (
               <section className="mt-7 w-full">
                 <p className="text-xs text-muted">
                   오늘 <span className="font-pixel text-whiteout">{tally.total}</span>명이 마음을 남겼어요
@@ -212,7 +231,7 @@ export function HomeView({
       </nav>
     </>
   );
-}
+});
 
 function TabButton({
   active,

--- a/apps/fomo-web/components/SkeletonLoader.tsx
+++ b/apps/fomo-web/components/SkeletonLoader.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * 로딩/폴백 상태용 스켈레톤 UI.
+ * FOMO Index와 감정 투표 영역의 데이터 미비 시 빈 화면 대신 표시.
+ * 최소한의 형태로 — 과도한 시각적 복잡성은 오히려 혼란을 야기.
+ */
+
+function SkeletonBlock({ className }: { className?: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-surface ${className ?? ""}`}
+      aria-hidden
+    />
+  );
+}
+
+/** FOMO Index + 마스코트 영역 스켈레톤 */
+export function FomoIndexSkeleton() {
+  return (
+    <div className="flex flex-col items-center gap-3 py-4">
+      {/* 마스코트 자리 */}
+      <SkeletonBlock className="h-[84px] w-[84px] rounded-lg" />
+      {/* 숫자 자리 */}
+      <SkeletonBlock className="h-8 w-16" />
+      {/* 상태 라벨 자리 */}
+      <SkeletonBlock className="h-3 w-32" />
+      {/* 한마디 자리 */}
+      <SkeletonBlock className="h-4 w-48" />
+    </div>
+  );
+}
+
+/** 감정 투표 집계 영역 스켈레톤 */
+export function TallySkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-2 py-2">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <SkeletonBlock className="h-3 w-8" />
+          <SkeletonBlock className="h-2 flex-1" />
+          <SkeletonBlock className="h-3 w-6" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/api/fomo/emotions/today/route.ts
+++ b/apps/web/app/api/fomo/emotions/today/route.ts
@@ -10,6 +10,7 @@ export function OPTIONS() {
 
 // GET /api/fomo/emotions/today — 오늘 감정 투표 집계 (비율 + 총 N명).
 // 정직한 숫자: total은 항상 실제 집계값. 0이어도 그대로.
+// 데이터 미비 시 fallback:true + 중립값으로 안전하게 반환 (빈 화면 방지).
 export async function GET() {
   const date = kstDate();
   try {
@@ -18,9 +19,12 @@ export async function GET() {
     const ratios = Object.fromEntries(
       EMOTION_TYPES.map((e) => [e, total > 0 ? Math.round(((tally[e] ?? 0) / total) * 100) : 0])
     );
-    return corsJson({ date, total, counts, ratios });
+    // 투표 0건이면 fallback 플래그 명시 — 클라이언트가 "아직 집계 없음"을 구분 가능.
+    return corsJson({ date, total, counts, ratios, fallback: total === 0 });
   } catch (err) {
     console.warn("[fomo/emotions/today] error", err);
-    return corsJson({ error: "집계 조회 실패", code: "TALLY_ERROR" }, { status: 500 });
+    // DB 오류 시에도 안전한 중립 기본값 반환.
+    const zero = Object.fromEntries(EMOTION_TYPES.map((e) => [e, 0]));
+    return corsJson({ date, total: 0, counts: zero, ratios: zero, fallback: true });
   }
 }

--- a/apps/web/app/api/fomo/emotions/vote/route.ts
+++ b/apps/web/app/api/fomo/emotions/vote/route.ts
@@ -3,6 +3,7 @@ import { EMOTION_TYPES } from "@fomo/core";
 import { prisma } from "../../../../../lib/prisma";
 import { kstDate, todayTally, isEmotionType, corsJson, withCors } from "../../../../../lib/fomo";
 import { extractBearerToken, verifyToken } from "@/lib/tarot/jwt";
+import { verifySessionSig } from "../../../../../lib/sessionHmac";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,7 @@ export function OPTIONS() {
 
 interface VoteBody {
   sessionId?: string;
+  sessionSig?: string;
   emotion?: string;
   source?: string;
   userId?: string;
@@ -29,6 +31,15 @@ export async function POST(req: NextRequest) {
     if (!sessionId) {
       return corsJson({ error: "sessionId 필요", code: "MISSING_SESSION" }, { status: 400 });
     }
+
+    // HMAC 서명 검증 — 서명이 있으면 반드시 올바른 서명이어야 한다.
+    // 서명이 없는 경우 레거시 클라이언트(서명 미지원)로 간주하고 허용.
+    const sessionSig = body.sessionSig?.trim();
+    if (sessionSig && !verifySessionSig(sessionId, sessionSig)) {
+      console.warn("[fomo/emotions/vote] 세션 서명 불일치 — 위변조 의심", { sessionId: sessionId.slice(0, 8) + "…" });
+      return corsJson({ error: "세션 서명이 올바르지 않습니다", code: "INVALID_SESSION_SIG" }, { status: 403 });
+    }
+
     if (!isEmotionType(emotion)) {
       return corsJson(
         { error: `emotion은 ${EMOTION_TYPES.join("|")} 중 하나`, code: "BAD_EMOTION" },

--- a/apps/web/app/api/fomo/session/route.ts
+++ b/apps/web/app/api/fomo/session/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { corsJson, withCors } from "../../../../lib/fomo";
+import { signSessionId } from "../../../../lib/sessionHmac";
+
+export const dynamic = "force-dynamic";
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+/**
+ * POST /api/fomo/session — 익명 세션 HMAC 서명 발급.
+ * 클라이언트가 sessionId를 직접 생성한 뒤, 이 엔드포인트에서 서명을 발급받아 저장한다.
+ * 이후 투표 요청 시 서명을 함께 전송하면 서버가 위변조 여부를 검증한다.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as { sessionId?: string };
+    const sessionId = body.sessionId?.trim();
+
+    if (!sessionId || sessionId.length < 8 || sessionId.length > 128) {
+      return corsJson({ error: "유효하지 않은 sessionId", code: "INVALID_SESSION" }, { status: 400 });
+    }
+
+    const signature = signSessionId(sessionId);
+    return corsJson({ sessionId, signature });
+  } catch (err) {
+    console.warn("[fomo/session] 서명 발급 오류", err);
+    return corsJson({ error: "서명 발급 실패", code: "SIGN_ERROR" }, { status: 500 });
+  }
+}

--- a/apps/web/lib/sessionHmac.ts
+++ b/apps/web/lib/sessionHmac.ts
@@ -1,0 +1,26 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const SECRET = process.env.SESSION_HMAC_SECRET ?? "dev-hmac-secret-change-in-prod";
+
+/**
+ * sessionId → HMAC-SHA256 서명 생성.
+ * 클라이언트가 session/create 엔드포인트에서 발급받아 저장한다.
+ */
+export function signSessionId(sessionId: string): string {
+  return createHmac("sha256", SECRET).update(sessionId).digest("hex");
+}
+
+/**
+ * 서명 검증. timing-safe 비교로 타이밍 공격 방지.
+ * 서명 불일치 시 false를 반환하며, 호출부에서 로깅과 처리를 담당한다.
+ */
+export function verifySessionSig(sessionId: string, sig: string): boolean {
+  if (!sig) return false;
+  const expected = signSessionId(sessionId);
+  try {
+    return timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(sig, "hex"));
+  } catch {
+    // 길이 불일치 등 버퍼 오류 — 위변조로 간주
+    return false;
+  }
+}

--- a/packages/fomo-core/__tests__/calculate.test.ts
+++ b/packages/fomo-core/__tests__/calculate.test.ts
@@ -1,0 +1,169 @@
+/**
+ * computeFomoIndex 회귀 테스트 — 폴백 처리 및 데이터 정합성 검증.
+ * QA 이슈 #413: 데이터 소스 실패 시 안전한 폴백 + 스냅샷 정합성 보장.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { computeFomoIndex } from "../src/index-engine/calculate";
+import * as marketHeatModule from "../src/index-engine/marketHeat";
+import * as communityHeatModule from "../src/index-engine/communityHeat";
+import * as emotionHeatModule from "../src/index-engine/emotionHeat";
+import * as whaleHeatModule from "../src/index-engine/whaleHeat";
+
+// ─── 1. 기본 폴백 동작 ───────────────────────────────────────────────────────
+
+describe("데이터 소스가 정상일 때", () => {
+  it("모든 Heat를 합산하여 정확히 1건의 스냅샷을 반환한다", () => {
+    // Given: 모든 데이터 소스가 정상적으로 작동
+    // When: computeFomoIndex를 호출
+    const idx = computeFomoIndex(
+      {
+        market: { volumeChangePct: 50, turnoverChangePct: 40 },
+        community: { mentionChangePct: 30, bullishRatio: 0.6 },
+        emotion: { fomo: 5, greed: 3, fear: 2 },
+        whale: [{ weight: 3, label: "BTC 신고가" }],
+      },
+      "2026-06-10"
+    );
+
+    // Then: 정확히 4개 컴포넌트, 날짜 일치, score 범위 0~100
+    expect(idx.components).toHaveLength(4);
+    expect(idx.date).toBe("2026-06-10");
+    expect(idx.score).toBeGreaterThanOrEqual(0);
+    expect(idx.score).toBeLessThanOrEqual(100);
+    expect(idx.score).toBe(
+      idx.components.reduce((sum, c) => sum + c.score, 0)
+    );
+  });
+
+  it("components의 score 합이 최종 score와 일치한다", () => {
+    const idx = computeFomoIndex(
+      { emotion: { fomo: 10, greed: 5 }, whale: [{ weight: 4 }] },
+      "2026-06-10"
+    );
+    const sumFromComponents = idx.components.reduce((sum, c) => sum + c.score, 0);
+    expect(idx.score).toBe(sumFromComponents);
+  });
+});
+
+// ─── 2. 데이터 소스 실패 시 폴백 ─────────────────────────────────────────────
+
+describe("데이터 소스 일부 실패 시", () => {
+  it("누락된 데이터는 폴백 값으로 대체되어 FOMO Index를 정상 반환한다", () => {
+    // Given: 데이터 소스 일부가 실패(undefined)
+    // When: 일부 inputs만 전달
+    const idx = computeFomoIndex(
+      { emotion: { fear: 8, regret: 2 } },
+      "2026-06-10"
+    );
+
+    // Then: 누락된 Market/Community/Whale은 폴백 처리, score는 정상
+    expect(idx.score).toBeGreaterThanOrEqual(0);
+    expect(idx.score).toBeLessThanOrEqual(100);
+    expect(idx.components.find((c) => c.key === "market")?.meta?.confidence).toBe("fallback");
+    expect(idx.components.find((c) => c.key === "community")?.meta?.confidence).toBe("fallback");
+  });
+
+  it("전체 데이터 미비 시 중립 스냅샷(45점, 관심)을 반환한다", () => {
+    const idx = computeFomoIndex({}, "2026-06-10");
+    // Market(15) + Community(15) + Emotion(15) + Whale(0) = 45
+    expect(idx.score).toBe(45);
+    expect(idx.state).toBe("관심");
+  });
+
+  it("MarketHeat가 예외를 던져도 파이프라인이 중단되지 않는다", () => {
+    // Given: marketHeat 함수가 예외를 던지는 상황
+    const spy = vi.spyOn(marketHeatModule, "marketHeat").mockImplementationOnce(() => {
+      throw new Error("Market API 연결 실패");
+    });
+
+    // When: computeFomoIndex 호출
+    const idx = computeFomoIndex({ market: { volumeChangePct: 10 } }, "2026-06-10");
+
+    // Then: 오류 노출 없이 폴백 값(15)으로 대체
+    expect(idx.score).toBeGreaterThanOrEqual(0);
+    expect(idx.components.find((c) => c.key === "market")?.score).toBe(15);
+    spy.mockRestore();
+  });
+
+  it("CommunityHeat가 예외를 던져도 폴백 처리된다", () => {
+    const spy = vi.spyOn(communityHeatModule, "communityHeat").mockImplementationOnce(() => {
+      throw new Error("Reddit API 타임아웃");
+    });
+
+    const idx = computeFomoIndex({ community: { mentionChangePct: 20 } }, "2026-06-10");
+
+    expect(idx.score).toBeGreaterThanOrEqual(0);
+    expect(idx.components.find((c) => c.key === "community")?.score).toBe(15);
+    spy.mockRestore();
+  });
+
+  it("EmotionHeat가 예외를 던져도 폴백 처리된다", () => {
+    const spy = vi.spyOn(emotionHeatModule, "emotionHeat").mockImplementationOnce(() => {
+      throw new Error("DB 연결 오류");
+    });
+
+    const idx = computeFomoIndex({ emotion: { fomo: 5 } }, "2026-06-10");
+
+    expect(idx.score).toBeGreaterThanOrEqual(0);
+    expect(idx.components.find((c) => c.key === "emotion")?.score).toBe(15);
+    spy.mockRestore();
+  });
+
+  it("WhaleHeat가 예외를 던져도 폴백 처리된다", () => {
+    const spy = vi.spyOn(whaleHeatModule, "whaleHeat").mockImplementationOnce(() => {
+      throw new Error("CoinGecko API 오류");
+    });
+
+    const idx = computeFomoIndex({ whale: [{ weight: 5 }] }, "2026-06-10");
+
+    expect(idx.score).toBeGreaterThanOrEqual(0);
+    expect(idx.components.find((c) => c.key === "whale")?.score).toBe(0);
+    spy.mockRestore();
+  });
+});
+
+// ─── 3. 데이터 정합성 검증 ───────────────────────────────────────────────────
+
+describe("스냅샷 데이터 정합성", () => {
+  it("score는 항상 0~100 범위를 벗어나지 않는다", () => {
+    const extremeCases = [
+      computeFomoIndex({}, "2026-06-10"),
+      computeFomoIndex(
+        {
+          market: { volumeChangePct: 999, turnoverChangePct: 999 },
+          emotion: { fomo: 100, greed: 100 },
+          whale: [{ weight: 999 }],
+        },
+        "2026-06-10"
+      ),
+      computeFomoIndex(
+        {
+          market: { volumeChangePct: -999 },
+          emotion: { fear: 100, regret: 100 },
+        },
+        "2026-06-10"
+      ),
+    ];
+
+    for (const idx of extremeCases) {
+      expect(idx.score).toBeGreaterThanOrEqual(0);
+      expect(idx.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("state는 항상 유효한 FomoState 중 하나이다", () => {
+    const VALID_STATES = ["무관심", "관망", "관심", "FOMO", "광기"];
+    const idx = computeFomoIndex({ emotion: { fomo: 20 } }, "2026-06-10");
+    expect(VALID_STATES).toContain(idx.state);
+  });
+
+  it("사용자에게 오류 데이터(undefined/null score)는 노출되지 않는다", () => {
+    const idx = computeFomoIndex({}, "2026-06-10");
+    expect(idx.score).not.toBeNaN();
+    expect(idx.score).not.toBeUndefined();
+    expect(idx.score).not.toBeNull();
+    for (const c of idx.components) {
+      expect(c.score).not.toBeNaN();
+    }
+  });
+});

--- a/packages/fomo-core/src/index-engine/calculate.ts
+++ b/packages/fomo-core/src/index-engine/calculate.ts
@@ -1,9 +1,9 @@
 import type { FomoIndex, HeatComponent } from "../types";
 import { scoreToState } from "../state";
-import { marketHeat } from "./marketHeat";
-import { communityHeat } from "./communityHeat";
-import { emotionHeat } from "./emotionHeat";
-import { whaleHeat } from "./whaleHeat";
+import { marketHeat, MARKET_HEAT_MAX } from "./marketHeat";
+import { communityHeat, COMMUNITY_HEAT_MAX } from "./communityHeat";
+import { emotionHeat, EMOTION_HEAT_MAX } from "./emotionHeat";
+import { whaleHeat, WHALE_HEAT_MAX } from "./whaleHeat";
 import type { MarketSignals, CommunitySignals, EmotionTally, WhaleEvent } from "./types";
 
 export interface FomoIndexInputs {
@@ -13,17 +13,34 @@ export interface FomoIndexInputs {
   whale?: WhaleEvent[];
 }
 
+/** 데이터 소스 오류 시 사용하는 안전한 중립 기본값. */
+const FALLBACK_COMPONENTS: HeatComponent[] = [
+  { key: "market", score: MARKET_HEAT_MAX / 2, max: MARKET_HEAT_MAX, meta: { confidence: "fallback", sourcesTotal: 4, sourcesAvailable: 0 } },
+  { key: "community", score: COMMUNITY_HEAT_MAX / 2, max: COMMUNITY_HEAT_MAX, meta: { confidence: "fallback", sourcesTotal: 3, sourcesAvailable: 0 } },
+  { key: "emotion", score: EMOTION_HEAT_MAX / 2, max: EMOTION_HEAT_MAX, meta: { confidence: "fallback", sourcesTotal: 1, sourcesAvailable: 0 } },
+  { key: "whale", score: 0, max: WHALE_HEAT_MAX, meta: { confidence: "fallback", sourcesTotal: 1, sourcesAvailable: 0 } },
+];
+
+function safeHeat<T>(fn: (input: T | undefined) => HeatComponent, input: T | undefined, fallback: HeatComponent): HeatComponent {
+  try {
+    return fn(input);
+  } catch (err) {
+    console.warn(`[fomo-core] ${fallback.key}Heat 산출 오류 — 폴백 적용`, err);
+    return fallback;
+  }
+}
+
 /**
  * 4개 Heat를 합산하여 FOMO Index(0~100) + 상태를 산출한다.
  * Market 30 + Community 30 + Emotion 30 + Whale 10. docs/FOMO_INDEX.md.
- * 모든 입력 미비 시에도 중립 스냅샷을 반환한다(절대 에러 없음).
+ * 데이터 소스 오류 시 개별 Heat를 폴백 값으로 대체하고 파이프라인을 중단하지 않는다.
  */
 export function computeFomoIndex(inputs: FomoIndexInputs, date: string): FomoIndex {
   const components: HeatComponent[] = [
-    marketHeat(inputs.market),
-    communityHeat(inputs.community),
-    emotionHeat(inputs.emotion),
-    whaleHeat(inputs.whale),
+    safeHeat(marketHeat, inputs.market, FALLBACK_COMPONENTS[0]!),
+    safeHeat(communityHeat, inputs.community, FALLBACK_COMPONENTS[1]!),
+    safeHeat(emotionHeat, inputs.emotion, FALLBACK_COMPONENTS[2]!),
+    safeHeat((w) => whaleHeat(w), inputs.whale, FALLBACK_COMPONENTS[3]!),
   ];
   const score = components.reduce((acc, c) => acc + c.score, 0);
   return { date, score, state: scoreToState(score), components };

--- a/packages/fomo-core/src/index-engine/summary.ts
+++ b/packages/fomo-core/src/index-engine/summary.ts
@@ -1,7 +1,32 @@
-import type { FomoIndex } from "../types";
+import type { FomoIndex, HeatKey } from "../types";
 import { scoreToEmoji } from "../state";
 import type { EmotionTally } from "./types";
 import { EMOTION_LABELS } from "../types";
+
+const HEAT_LABELS: Record<HeatKey, string> = {
+  market: "시장",
+  community: "커뮤니티",
+  emotion: "감정",
+  whale: "고래",
+};
+
+/**
+ * FOMO Index 상위 2개 Heat 컴포넌트를 "라벨(비율%)" 형식으로 요약.
+ * components가 없으면 빈 문자열 반환.
+ */
+function topHeatContext(index: FomoIndex): string {
+  if (!index.components || index.components.length === 0) return "";
+  const sorted = [...index.components]
+    .filter((c) => c.score > 0)
+    .sort((a, b) => b.score / b.max - a.score / a.max)
+    .slice(0, 2);
+  if (sorted.length === 0) return "";
+  const parts = sorted.map((c) => {
+    const pct = Math.round((c.score / c.max) * 100);
+    return `${HEAT_LABELS[c.key]} ${pct}%`;
+  });
+  return `(${parts.join(", ")})`;
+}
 
 /**
  * FOMO Index 스냅샷 → AI Summary 1~2문장 (규칙 기반 폴백).
@@ -11,16 +36,38 @@ import { EMOTION_LABELS } from "../types";
 export function buildSummary(index: FomoIndex, tally: EmotionTally = {}): string {
   const emoji = scoreToEmoji(index.score);
   const moodLine = STATE_LINE[index.state];
+  const heatCtx = topHeatContext(index);
 
   const entries = (Object.entries(tally) as [keyof typeof EMOTION_LABELS, number][]).filter(
     ([, n]) => (n ?? 0) > 0
   );
+
   if (entries.length === 0) {
-    return `${emoji} 오늘 시장 감정은 '${index.state}' 부근입니다. ${moodLine}`;
+    return `${emoji} 오늘 시장은 '${index.state}'${heatCtx ? " " + heatCtx : ""}. ${moodLine}`;
   }
+
   const [topEmotion] = entries.sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))[0]!;
-  return `${emoji} 오늘 시장 감정은 '${index.state}'. 가장 많이 선택된 감정은 「${EMOTION_LABELS[topEmotion]}」이에요. ${moodLine}`;
+  return `${emoji} 오늘 시장은 '${index.state}'${heatCtx ? " " + heatCtx : ""}. 가장 많이 선택된 감정은 「${EMOTION_LABELS[topEmotion]}」이에요. ${moodLine}`;
 }
+
+/**
+ * FOMO Index 헤드라인 — 숫자 옆에서 현재 온도를 3초 안에 직관적으로 전달.
+ * 상위 2개 Heat 분포를 포함해 "왜 이 지수인지"를 담백하게 설명한다.
+ * 투자 조언·단정 금지. docs/FOMO_INDEX.md.
+ */
+export function buildHeadline(index: FomoIndex): string {
+  const heatCtx = topHeatContext(index);
+  const base = HEADLINE_LINE[index.state];
+  return heatCtx ? `${base} — ${heatCtx}` : base;
+}
+
+const HEADLINE_LINE: Record<FomoIndex["state"], string> = {
+  무관심: "오늘 시장은 침착",
+  관망: "잔잔하게 관망 중",
+  관심: "조금씩 달아오르는 중",
+  FOMO: "다들 들떠 있어요",
+  광기: "감정이 시장보다 앞서요",
+};
 
 const STATE_LINE: Record<FomoIndex["state"], string> = {
   무관심: "다들 잠잠한 하루예요.",


### PR DESCRIPTION
## 구현 항목

### ✅ #415 CTO — FOMO Index 파이프라인 에러 핸들링 강화
- `calculate.ts`: 각 Heat 호출을 `safeHeat()` 래퍼로 감싸 예외 시 폴백 처리
- 안전한 폴백 상수 `FALLBACK_COMPONENTS` 정의 (Market/Community/Emotion=15, Whale=0)
- `console.warn`으로 오류 로깅, 파이프라인 중단 없음

### ✅ #425 Backend — `/api/fomo/emotions/today` 폴백 로직
- 투표 0건 시 `fallback: true` 플래그 반환 — 클라이언트가 "아직 집계 없음" 구분 가능
- DB 오류 시에도 빈 화면 대신 중립 기본값(0건) + `fallback: true` 반환

### ✅ #428 Prompt Engineer — FOMO Index 헤드라인 품질 개선
- `buildSummary`: Heat 컴포넌트 상위 2개를 `(시장 67%, 감정 50%)` 형식으로 헤드라인 포함
- 신규 `buildHeadline(index)`: 상태+Heat 맥락을 담은 3초 직관 헤드라인
- 폴백: Heat가 없으면 기존 상태 라인만 반환

### ✅ #426 Security — 익명 세션 HMAC 위변조 방지
- `apps/web/lib/sessionHmac.ts`: `signSessionId` / `verifySessionSig` (timing-safe)
- `POST /api/fomo/session`: 클라이언트용 서명 발급 엔드포인트
- `/api/fomo/emotions/vote`: `sessionSig` 포함 시 HMAC 검증, 불일치 403 + 로깅
- 레거시 클라이언트(서명 미포함) 하위 호환성 유지
- `.env.example`에 `SESSION_HMAC_SECRET` 추가

### ✅ #409 PM — SkeletonLoader 컴포넌트 (로딩 상태 처리)
- `apps/fomo-web/components/SkeletonLoader.tsx`: `FomoIndexSkeleton` + `TallySkeleton`
- `HomeView`에 `isLoading` prop 추가, 데이터 미비 시 스켈레톤 표시

### ✅ #410 Frontend — FomoFace + HomeView 렌더링 최적화
- `FomoFace`: `React.memo` 래핑 + `useMemo`로 픽셀 셀 배열 계산 캐싱
- `HomeView`: `memo()` + `useMemo`로 `state/marketFace/line/glowColor` 캐싱

### ✅ #412 Designer — fomo-club FOMO Index 타이포그래피 위계 개선
- `indexText`: 24pt/600 → **32pt/700** (3초 안에 숫자 인식)
- `indexSummary`: 13pt/0.85op → **16pt/400** (명확한 위계)
- `indexRow` minHeight: 28 → 36

### ✅ #413 QA — computeFomoIndex 폴백·정합성 회귀 테스트
- `packages/fomo-core/__tests__/calculate.test.ts` 신규 (11개 테스트)
- 3개 카테고리: 정상 데이터 정합성 / 데이터 소스 실패 폴백 / 범위·상태 검증
- 각 Heat 예외 시 파이프라인 중단 없음 확인 (spy mock 활용)

---

## 킬리스트 (미구현)

| 항목 | 이유 |
|------|------|
| #374 애니메이션 효과 | 자동 폐기 카테고리 — 장식 폴리싱 금지 |
| #378 가짜 데이터 테스트 | 정직한 숫자 원칙 위반 |

---

## 검증

- [x] lint 통과 (기존 pre-existing TS5101 baseUrl deprecated 외 신규 오류 없음)
- [x] typecheck 통과 (apps/web, apps/fomo-web, packages/fomo-core 모두 오류 없음)
- [x] build:web 통과
- [x] test 통과 (578 tests, 56 files — 신규 11개 테스트 포함)

---

## 참조

이슈: #429 (CEO Brief 2026-06-09)
관련 이슈: #428, #426, #425, #415, #413, #412, #410, #409

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQQ4fYNtoGjLp7g8Au4B4H)_