### PR TITLE
feat(council): 기획문서(PRD) 게이트 — 선택→기획문서→승인→분해

### DIFF
--- a/.github/workflows/project-decompose.yml
+++ b/.github/workflows/project-decompose.yml
@@ -1,0 +1,137 @@
+name: Project Decompose
+
+# 톱다운 — 기획문서(PRD) 승인 후, PRD 를 직군별 하위 task 이슈로 분해한다.
+#   Slack [[ACTION:approve_plan]] {"id":"P2"} (또는 수동) → 이 워크플로.
+#   기획문서가 없으면(킥오프 먼저 안 함) 중단.
+on:
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: "분해할 프로젝트 id (예: P2) — 기획문서가 이미 있어야 함"
+        required: true
+
+concurrency:
+  group: project-decompose
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+jobs:
+  decompose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve project + plan-doc + dedup
+        id: ctx
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          PID="${{ github.event.inputs.project_id }}"
+          echo "pid=$PID" >> "$GITHUB_OUTPUT"
+          # 프로젝트 메타
+          PTITLE=$(npx -y tsx@4.19.2 scripts/project-roadmap.ts list PROJECT_ROADMAP.md 2>/dev/null \
+            | jq -r --arg id "$PID" '.[] | select(.id==$id) | .title' 2>/dev/null || echo "")
+          echo "ptitle=$PTITLE" >> "$GITHUB_OUTPUT"
+          # 이미 task 이슈 있으면 중단(중복 분해 방지)
+          TASKS=$(gh issue list --label "project:$PID,task" --state open --limit 50 \
+            --json number --jq 'length' --repo "${{ github.repository }}" 2>/dev/null || echo 0)
+          echo "tasks=$TASKS" >> "$GITHUB_OUTPUT"
+          # 기획문서(plan-doc) 본문 — 분해 입력
+          PLANNUM=$(gh issue list --label "project:$PID,plan-doc" --state all --limit 5 \
+            --json number,createdAt --jq 'sort_by(.createdAt) | last | .number' --repo "${{ github.repository }}" 2>/dev/null || echo "")
+          echo "plannum=$PLANNUM" >> "$GITHUB_OUTPUT"
+          if [ -n "$PLANNUM" ]; then
+            gh issue view "$PLANNUM" --json body --jq .body --repo "${{ github.repository }}" 2>/dev/null | head -c 6000 > /tmp/prd.txt || echo "" > /tmp/prd.txt
+          else
+            echo "" > /tmp/prd.txt
+          fi
+          PRD=$(cat /tmp/prd.txt)
+          echo "prd<<__PEOF__" >> "$GITHUB_OUTPUT"; echo "$PRD" >> "$GITHUB_OUTPUT"; echo "__PEOF__" >> "$GITHUB_OUTPUT"
+
+      - name: "직군 회의 — 기획문서 → 하위 task 분해 (LLM)"
+        id: decompose
+        if: steps.ctx.outputs.tasks == '0' && steps.ctx.outputs.plannum != ''
+        uses: actions/ai-inference@v1
+        continue-on-error: true
+        with:
+          model: openai/gpt-4o
+          max-tokens: 4096
+          system-prompt: |
+            당신은 FOMO Club 제품팀이다. *승인된 기획문서(PRD)* 를 직군별 실행 task 로 분해한다.
+            직군(axis 는 한글명 그대로): 기획 / 백엔드 / 프론트·UX / 품질.
+            규칙:
+            1. PRD 의 기능 요구사항·범위를 충실히 반영. PRD 에 없는 기능 추가 금지(비대화 금지).
+            2. 각 task 는 단일 PR 크기. 의존성(dependsOn)을 seq 로 명시해 실행 순서를 만든다.
+            3. 가시적·미시적 잡일(여백 1px 등) 금지. 정직한 숫자·투자조언·타로 금지 준수.
+            4. 각 task 에 담당 직군 1개. 출력은 **오직 JSON 배열**. 코드펜스·설명 금지.
+            형식: [{"seq":1,"axis":"기획","title":"...","rationale":"PRD 의 어느 요구사항을 충족","dependsOn":[],"acceptance":"검증 가능한 완료 기준"}, ...]
+          prompt: |
+            ## 프로젝트: ${{ steps.ctx.outputs.pid }} · ${{ steps.ctx.outputs.ptitle }}
+
+            ## 승인된 기획문서 (PRD)
+            ${{ steps.ctx.outputs.prd }}
+
+            위 PRD 를 충실히 반영한 직군별 하위 task 배열(JSON)만 출력하라. 4~8개 권장.
+
+      - name: Create task issues
+        id: create
+        if: steps.ctx.outputs.tasks == '0' && steps.decompose.outputs.response != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PID: ${{ steps.ctx.outputs.pid }}
+          PTITLE: ${{ steps.ctx.outputs.ptitle }}
+          RESP: ${{ steps.decompose.outputs.response }}
+        run: |
+          set -uo pipefail
+          printf '%s' "$RESP" > /tmp/decompose_raw.txt
+          npx -y tsx@4.19.2 scripts/kickoff-tasks.ts parse "$PID" /tmp/decompose_raw.txt > /tmp/tasks.json || echo "[]" > /tmp/tasks.json
+          COUNT=$(jq 'length' /tmp/tasks.json 2>/dev/null || echo 0)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" = "0" ]; then echo "분해 0건"; echo "plan=(분해 실패)" >> "$GITHUB_OUTPUT"; exit 0; fi
+          AXIS_LABEL () { case "$1" in 기획) echo "기획";; 품질) echo "품질";; 백엔드) echo "백엔드";; 프론트·UX) echo "프론트UX";; *) echo "agent-council";; esac; }
+          for L in "project:$PID" "agent-council" "task" "기획" "백엔드" "프론트UX" "품질"; do
+            gh label create "$L" --force --color ededed --description "topdown" >/dev/null 2>&1 || true
+          done
+          for i in $(seq 0 $((COUNT-1))); do
+            jq -c ".[$i]" /tmp/tasks.json > /tmp/task.json
+            AXIS=$(jq -r '.axis' /tmp/task.json); SEQ=$(jq -r '.seq' /tmp/task.json)
+            TITLE="[$PID $SEQ/$COUNT · $AXIS] $(jq -r '.title' /tmp/task.json)"
+            npx -y tsx@4.19.2 scripts/kickoff-tasks.ts render "$PID" "$PTITLE" "$COUNT" /tmp/task.json > /tmp/task_body.md 2>/dev/null || echo "(본문 생성 실패)" > /tmp/task_body.md
+            LB=$(AXIS_LABEL "$AXIS")
+            gh issue create --title "$TITLE" --body-file /tmp/task_body.md \
+              --label "project:$PID,agent-council,task,$LB" --repo "${{ github.repository }}" || echo "⚠️ 생성 실패: $TITLE"
+          done
+          PLAN=$(jq -r '(length) as $n | to_entries[] | "\(.value.seq)/\($n) [\(.value.axis)] \(.value.title)" + (if (.value.dependsOn|length)>0 then " ← \(.value.dependsOn|join(","))단계 후" else "" end)' /tmp/tasks.json 2>/dev/null || echo "")
+          echo "plan<<__PEOF__" >> "$GITHUB_OUTPUT"; echo "$PLAN" >> "$GITHUB_OUTPUT"; echo "__PEOF__" >> "$GITHUB_OUTPUT"
+          { echo "### 🧩 $PID 분해 이슈 $COUNT건"; echo '```'; echo "$PLAN"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack
+        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        env:
+          PID: ${{ steps.ctx.outputs.pid }}
+          PTITLE: ${{ steps.ctx.outputs.ptitle }}
+          TASKS: ${{ steps.ctx.outputs.tasks }}
+          PLANNUM: ${{ steps.ctx.outputs.plannum }}
+          COUNT: ${{ steps.create.outputs.count }}
+          PLAN: ${{ steps.create.outputs.plan }}
+        run: |
+          URL=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
+          if [ -z "${PLANNUM:-}" ]; then
+            TEXT="⚠️ *${PID} 분해 불가* — 기획문서가 없습니다. 먼저 \"${PID} 시작\"으로 기획문서를 만드세요."
+          elif [ "${TASKS:-0}" != "0" ]; then
+            TEXT="ℹ️ *${PID}* 이미 분해된 task 이슈가 있어 재분해하지 않았습니다."
+          elif [ -n "${COUNT:-}" ] && [ "${COUNT}" != "0" ]; then
+            TEXT="🧩 *기획 승인 → ${PID} · ${PTITLE} 분해 완료* (${COUNT}개 task):\n${PLAN}\n\n구현은 CEO 승인(\"개발해\") 시에만. 진척은 매일 리포트로."
+          else
+            TEXT="⚠️ *${PID} 분해 실패*(LLM) — 수동 확인 요망."
+          fi
+          BODY=$(jq -n --arg t "$TEXT" '{text: $t}')
+          curl -sS -X POST -H 'Content-type: application/json' --data "$BODY" "$URL" || true

--- a/.github/workflows/project-kickoff.yml
+++ b/.github/workflows/project-kickoff.yml
@@ -69,33 +69,36 @@ jobs:
           git commit -m "chore(roadmap): ${{ github.event.inputs.project_id }} 활성화 (project kickoff)"
           git push origin HEAD:main
 
-      # ── 4축(PL/TD/BA/UX) 회의로 활성 프로젝트를 project:<id> 이슈 세트로 분해 (P2) ──
-      - name: Prepare decomposition context
+      # ── 기획문서(PRD) 작성 — 선택 직후엔 이슈 분해가 아니라 *기획문서* 먼저 (사람 GO/NO-GO 판단용) ──
+      - name: Prepare PRD context
         id: ctx
         if: steps.select.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           PID="${{ github.event.inputs.project_id }}"
-          # 이미 이 프로젝트의 task 이슈가 있으면 재분해 skip(중복 세트 방지)
-          EXIST=$(gh issue list --label "project:$PID" --state open --limit 50 \
+          # 이미 이 프로젝트의 기획문서가 있으면 재작성 skip(중복 방지)
+          EXIST=$(gh issue list --label "project:$PID,plan-doc" --state open --limit 10 \
             --json number --jq 'length' --repo "${{ github.repository }}" 2>/dev/null || echo 0)
           echo "exist=$EXIST" >> "$GITHUB_OUTPUT"
           ACTIVE=$(cat /tmp/active.json 2>/dev/null || echo "null")
           echo "active_json<<__AEOF__" >> "$GITHUB_OUTPUT"; echo "$ACTIVE" >> "$GITHUB_OUTPUT"; echo "__AEOF__" >> "$GITHUB_OUTPUT"
-          NS=$(cat AGENT_NORTH_STAR.md 2>/dev/null | head -c 4000 || echo "")
-          echo "north_star<<__NEOF__" >> "$GITHUB_OUTPUT"; echo "$NS" >> "$GITHUB_OUTPUT"; echo "__NEOF__" >> "$GITHUB_OUTPUT"
+          echo "ptitle=$(printf '%s' "$ACTIVE" | jq -r '.title // ""' 2>/dev/null || echo "")" >> "$GITHUB_OUTPUT"
+          VISION=$(cat docs/FOMO_CLUB.md 2>/dev/null | head -c 3500 || echo "")
+          echo "vision<<__VEOF__" >> "$GITHUB_OUTPUT"; echo "$VISION" >> "$GITHUB_OUTPUT"; echo "__VEOF__" >> "$GITHUB_OUTPUT"
+          INV=$(git ls-files 'apps/fomo-web/app/**' 'apps/fomo-web/components/**' 'apps/fomo-club/app/**' 'apps/fomo-club/components/**' 'packages/fomo-core/src/**' 'apps/web/app/api/fomo/**' 2>/dev/null | grep -vE '__tests__|\.test\.|globals\.css|_layout' | sort | head -120)
+          echo "inventory<<__IEOF__" >> "$GITHUB_OUTPUT"; echo "$INV" >> "$GITHUB_OUTPUT"; echo "__IEOF__" >> "$GITHUB_OUTPUT"
           CB="(constraint 없음)"
           if [ -f constraints/active.json ]; then
             TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
-            npx -y tsx@4.19.2 scripts/constraints.ts active constraints/active.json "$TODAY" > /tmp/ctx_active_constraints.json 2>/dev/null || echo "[]" > /tmp/ctx_active_constraints.json
-            CB=$(npx -y tsx@4.19.2 scripts/constraints.ts render-brief /tmp/ctx_active_constraints.json 2>/dev/null || echo "(constraint 조회 실패)")
+            npx -y tsx@4.19.2 scripts/constraints.ts active constraints/active.json "$TODAY" > /tmp/ctx_c.json 2>/dev/null || echo "[]" > /tmp/ctx_c.json
+            CB=$(npx -y tsx@4.19.2 scripts/constraints.ts render-brief /tmp/ctx_c.json 2>/dev/null || echo "(조회 실패)")
           fi
           echo "constraints<<__CEOF__" >> "$GITHUB_OUTPUT"; echo "$CB" >> "$GITHUB_OUTPUT"; echo "__CEOF__" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
-      - name: "4축 회의 — 프로젝트 분해 (LLM)"
-        id: decompose
+      - name: "기획문서(PRD) 작성 (기획 직군 LLM)"
+        id: prd
         if: steps.select.outputs.ok == 'true' && steps.ctx.outputs.exist == '0' && steps.ctx.outputs.active_json != 'null'
         uses: actions/ai-inference@v1
         continue-on-error: true
@@ -103,74 +106,51 @@ jobs:
           model: openai/gpt-4o
           max-tokens: 4096
           system-prompt: |
-            당신은 FOMO Club 제품팀이다. 4개 직군이 한 자리에 모여 *선택된 하나의 프로젝트*를
-            실행 가능한 하위 개발 task 로 분해한다. (산발적 아이디어가 아니라 톱다운 프로젝트 격파.)
-            직군(axis 는 아래 한글명 그대로 사용):
-            - 기획: 제품 기획·유저 저니·우선순위 (무엇을 왜 어떤 순서로)
-            - 백엔드: 데이터·API·스키마·집계·아키텍처·보안
-            - 프론트·UX: 화면·렌더·정보위계·포모 표정/멘트·전환·플로우
-            - 품질: 안정성·성능·빌드·테스트·폴백 회귀·옵저버빌리티
-            규칙:
-            1. 기획이 회의를 리딩한다. 프로젝트의 success 기준을 충족하는 *최소한의* task 로 쪼갠다(비대화 금지).
-            2. 각 task 는 단일 PR 로 끝낼 크기. 크면 더 쪼갠다. 가시적·미시적 잡일(여백 1px 등) 금지 — 프로젝트 success 에 직결되는 것만.
-            3. 각 task 에 담당 직군(기획/백엔드/프론트·UX/품질) 1개 배정. 의존성(dependsOn)을 seq 로 명시해 실행 순서를 만든다.
-            4. 정직한 숫자·투자조언 금지·타로 금지 등 Standing Constraints 를 위반하지 않는다.
-            5. 출력은 **오직 JSON 배열** 한 개. 설명·코드펜스 금지. axis 는 반드시 위 4개 한글 직군명 중 하나.
-            형식: [{"seq":1,"axis":"기획","title":"...","rationale":"이 프로젝트 success 와 어떻게 연결되는지","dependsOn":[],"acceptance":"검증 가능한 완료 기준"}, ...]
+            당신은 FOMO Club 의 기획자다. 선택된 *하나의 프로젝트*에 대한 **상세 기획문서(PRD)** 를 쓴다.
+            CEO(사람)가 이 문서만 읽고 "개발을 시작할지 말지"를 판단한다. 그러니 구체적이고 정직해야 한다.
+            아래 섹션을 마크다운으로 작성(추상어 금지 — 화면/데이터/동작/숫자로):
+            ## 배경 · 문제 (지금 왜 이게 필요한가)
+            ## 목표 · 성공지표 (검증 가능한 수치)
+            ## 사용자 시나리오 (유저 스토리 2~3개)
+            ## 기능 요구사항 (구체적으로 — 어떤 화면/데이터/동작. 이미 있는 것 위에 무엇을 더하는지)
+            ## 범위 · 비범위 (이번에 하는 것 / 안 하는 것)
+            ## 정체성 정합 (담담한 솔직함·정직한 숫자·love mark 를 어떻게 지키나)
+            ## 정체성·제약 자가점검 (예측/투자 도구화·푸시 보류·커뮤니티 후속 등 Out-of-Scope 와 충돌하는 부분이 있으면 *솔직히* 명시. 없으면 "충돌 없음")
+            ## 리스크 · 오픈 퀘스천 (CEO 결정이 필요한 것)
           prompt: |
-            ## 선택된 활성 프로젝트 (이걸 분해하라)
+            ## 선택된 프로젝트
             ${{ steps.ctx.outputs.active_json }}
 
-            ## North Star (정체성·금지 — 위반 금지)
-            ${{ steps.ctx.outputs.north_star }}
+            ## 제품 비전 (FOMO Club)
+            ${{ steps.ctx.outputs.vision }}
 
-            ## Standing Constraints (절대 위반 금지)
+            ## 이미 구현된 것 (이 위에 얹어라 — 중복 금지)
+            ${{ steps.ctx.outputs.inventory }}
+
+            ## Standing Constraints (자가점검 기준)
             ${{ steps.ctx.outputs.constraints }}
 
-            위 프로젝트의 success 기준을 충족하는 정렬된 task 배열(JSON)만 출력하라. 4~8개 권장.
+            위 프로젝트의 상세 기획문서(PRD)를 마크다운으로 작성하라.
 
-      - name: Create project issues
-        id: create
-        if: steps.select.outputs.ok == 'true' && steps.ctx.outputs.exist == '0' && steps.decompose.outputs.response != ''
+      - name: Create plan-doc issue
+        id: plandoc
+        if: steps.select.outputs.ok == 'true' && steps.ctx.outputs.exist == '0' && steps.prd.outputs.response != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PID: ${{ github.event.inputs.project_id }}
-          RESP: ${{ steps.decompose.outputs.response }}
+          PTITLE: ${{ steps.ctx.outputs.ptitle }}
+          RESP: ${{ steps.prd.outputs.response }}
         run: |
           set -uo pipefail
-          printf '%s' "$RESP" > /tmp/decompose_raw.txt
-          npx -y tsx@4.19.2 scripts/kickoff-tasks.ts parse "$PID" /tmp/decompose_raw.txt > /tmp/tasks.json || echo "[]" > /tmp/tasks.json
-          COUNT=$(jq 'length' /tmp/tasks.json 2>/dev/null || echo 0)
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-          if [ "$COUNT" = "0" ]; then
-            echo "분해 task 0건 — 이슈 생성 없음"; echo "plan=(분해 실패 — task 0건)" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          PTITLE=$(jq -r '.title // ""' /tmp/active.json 2>/dev/null || echo "")
-          AXIS_LABEL () { case "$1" in 기획) echo "기획";; 품질) echo "품질";; 백엔드) echo "백엔드";; 프론트·UX) echo "프론트UX";; *) echo "agent-council";; esac; }
-          # gh issue create 는 *존재하지 않는 라벨*이면 실패한다 → 필요한 라벨을 idempotent 하게 미리 생성.
-          for L in "project:$PID" "agent-council" "task" "기획" "백엔드" "프론트UX" "품질"; do
-            gh label create "$L" --force --color ededed --description "topdown kickoff" >/dev/null 2>&1 || true
+          printf '%s' "$RESP" > /tmp/prd.md
+          npx -y tsx@4.19.2 scripts/plan-doc.ts issue "$PID" "$PTITLE" /tmp/prd.md > /tmp/plandoc_issue.md 2>/dev/null || cp /tmp/prd.md /tmp/plandoc_issue.md
+          for L in "project:$PID" "agent-council" "plan-doc" "기획"; do
+            gh label create "$L" --force --color 5319e7 --description "topdown" >/dev/null 2>&1 || true
           done
-          CREATED=""
-          for i in $(seq 0 $((COUNT-1))); do
-            jq -c ".[$i]" /tmp/tasks.json > /tmp/task.json
-            AXIS=$(jq -r '.axis' /tmp/task.json)
-            SEQ=$(jq -r '.seq' /tmp/task.json)
-            TITLE="[$PID $SEQ/$COUNT · $AXIS] $(jq -r '.title' /tmp/task.json)"
-            npx -y tsx@4.19.2 scripts/kickoff-tasks.ts render "$PID" "$PTITLE" "$COUNT" /tmp/task.json > /tmp/task_body.md 2>/dev/null || echo "(본문 생성 실패)" > /tmp/task_body.md
-            LB=$(AXIS_LABEL "$AXIS")
-            if N=$(gh issue create --title "$TITLE" --body-file /tmp/task_body.md \
-                  --label "project:$PID,agent-council,task,$LB" --repo "${{ github.repository }}"); then
-              CREATED="$CREATED ${N##*/}"
-            else
-              echo "⚠️ 이슈 생성 실패: $TITLE"
-            fi
-          done
-          PLAN=$(npx -y tsx@4.19.2 scripts/kickoff-tasks.ts parse "$PID" /tmp/decompose_raw.txt 2>/dev/null \
-            | jq -r '(length) as $n | to_entries[] | "\(.value.seq)/\($n) [\(.value.axis)] \(.value.title)" + (if (.value.dependsOn|length)>0 then " ← \(.value.dependsOn|join(","))단계 후" else "" end)' 2>/dev/null || echo "")
-          echo "plan<<__PEOF__" >> "$GITHUB_OUTPUT"; echo "$PLAN" >> "$GITHUB_OUTPUT"; echo "__PEOF__" >> "$GITHUB_OUTPUT"
-          echo "created=$CREATED" >> "$GITHUB_OUTPUT"
-          { echo "### 🧩 $PID 분해 이슈 생성: $COUNT건"; echo '```'; echo "$PLAN"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          URL=$(gh issue create --title "📋 [기획문서] $PID · $PTITLE" --body-file /tmp/plandoc_issue.md \
+            --label "project:$PID,agent-council,plan-doc,기획" --repo "${{ github.repository }}" 2>/dev/null || echo "")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          { echo "### 📋 $PID 기획문서"; echo "$URL"; } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify Slack
         if: always() && vars.SLACK_WEBHOOK_URL != ''
@@ -178,19 +158,19 @@ jobs:
           OK: ${{ steps.select.outputs.ok }}
           MSG: ${{ steps.select.outputs.msg }}
           PID: ${{ github.event.inputs.project_id }}
+          PTITLE: ${{ steps.ctx.outputs.ptitle }}
           EXIST: ${{ steps.ctx.outputs.exist }}
-          COUNT: ${{ steps.create.outputs.count }}
-          PLAN: ${{ steps.create.outputs.plan }}
+          URL: ${{ steps.plandoc.outputs.url }}
         run: |
-          URL=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
+          URL_HOOK=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
           if [ "$OK" != "true" ]; then
             TEXT="⚠️ *Project Kickoff 실패 (${PID})*\n${MSG}"
           elif [ "${EXIST:-0}" != "0" ]; then
-            TEXT="🗺️ *Project Kickoff — ${PID}*\n${MSG}\n\nℹ️ 이미 이 프로젝트의 task 이슈가 있어 재분해하지 않았습니다. 기존 이슈를 이어서 진행하세요."
-          elif [ -n "${COUNT:-}" ] && [ "${COUNT}" != "0" ]; then
-            TEXT="🗺️ *Project Kickoff — ${PID} 활성화 + 분해 완료*\n${MSG}\n\n🧩 *${COUNT}개 task 이슈 생성* (project:${PID}):\n${PLAN}\n\n구현은 CEO 승인(\"개발해\") 시에만. 진척은 매일 아침 리포트로 옵니다."
+            TEXT="🗺️ *${PID} 활성화* — ${MSG}\n\nℹ️ 이미 기획문서가 있습니다. 검토 후 \"${PID} 기획 승인\"으로 분해를 시작하세요."
+          elif [ -n "${URL:-}" ]; then
+            TEXT="📋 *기획문서 작성됨 — ${PID} · ${PTITLE}*\n${URL}\n\n읽어보시고 진행하려면 *\"${PID} 기획 승인\"*, 고칠 점은 이슈에 코멘트 주세요.\n_승인 전까지 직군 이슈 분해는 시작되지 않습니다._"
           else
-            TEXT="🗺️ *Project Kickoff — ${PID} 활성화*\n${MSG}\n\n⚠️ 분해 task 생성 0건(LLM 실패 가능) — 수동 확인 요망."
+            TEXT="🗺️ *${PID} 활성화* — ${MSG}\n\n⚠️ 기획문서 생성 실패(LLM) — 수동 확인 요망."
           fi
           BODY=$(jq -n --arg t "$TEXT" '{text: $t}')
-          curl -sS -X POST -H 'Content-type: application/json' --data "$BODY" "$URL" || true
+          curl -sS -X POST -H 'Content-type: application/json' --data "$BODY" "$URL_HOOK" || true

--- a/apps/web/__tests__/slack-actions.test.ts
+++ b/apps/web/__tests__/slack-actions.test.ts
@@ -126,4 +126,10 @@ describe("select_project 액션 (톱다운 프로젝트 선택)", () => {
     expect(r.actions).toEqual([{ name: "propose_projects", payload: {} }]);
     expect(KNOWN_ACTIONS.has("propose_projects")).toBe(true);
   });
+  it("approve_plan id 파싱 + KNOWN/HIGH_IMPACT", () => {
+    const r = parseActions('P2 기획 승인합니다 [[ACTION:approve_plan]] {"id":"P2"}');
+    expect(r.actions).toEqual([{ name: "approve_plan", payload: { id: "P2" } }]);
+    expect(KNOWN_ACTIONS.has("approve_plan")).toBe(true);
+    expect(HIGH_IMPACT_ACTIONS.has("approve_plan")).toBe(true);
+  });
 });

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -315,7 +315,8 @@ ${runList || "(없음)"}
 - 사용 가능한 액션:
   \`[[ACTION:run_council]]\` — Agent Council(idea-proposal) 즉시 실행 ("의회 돌려", "제안 받아")
   \`[[ACTION:propose_projects]]\` — CEO 에이전트가 제품 분석 → 프로젝트 후보 리스트 제안 ("프로젝트 제안해", "뭐부터 할지 제안해", "프로젝트 뽑아줘"). 사람이 검토 후 선택.
-  \`[[ACTION:select_project]] {"id":"P1"}\` — 제안된 후보 중 활성 프로젝트 선택 ("P1 시작", "P2 프로젝트 하자"). 선택 시 직군(기획/백엔드/프론트·UX/품질)이 하위 이슈로 분해.
+  \`[[ACTION:select_project]] {"id":"P1"}\` — 후보 중 활성 프로젝트 선택 ("P1 시작", "P2 프로젝트 하자"). 선택 시 **기획문서(PRD)** 를 먼저 작성(아직 분해 안 함).
+  \`[[ACTION:approve_plan]] {"id":"P2"}\` — 기획문서 검토 후 승인 ("P2 기획 승인", "이 기획으로 개발 진행"). 승인 시 직군(기획/백엔드/프론트·UX/품질)별 하위 이슈로 분해.
   \`[[ACTION:implement]] {"date":"YYYY-MM-DD"}\` — auto-implement 트리거 (date 생략 시 오늘) ("구현 시작", "개발 진행")
   \`[[ACTION:merge]] {"pr":291}\` — 특정 PR squash 머지 ("이 PR 머지해", 번호 명시)
   \`[[ACTION:merge_all]]\` — 열린 PR 중 **이상 없는 것 전부** 머지 ("PR 전부 머지", "남은 PR 머지", "이상없으면 다 머지"). 번호 불필요 — 초안·CI미통과·충돌은 자동 제외.
@@ -343,10 +344,11 @@ ${runList || "(없음)"}
 - 둘 다 지시하면("머지하고 이슈도 닫아") merge_all + close_all 두 토큰을 각각 단독 줄로 출력한다.
 - **절대 "닫을 이슈가 없다/PR 번호가 올바르지 않다"고 지어내지 마라** — 벌크 토큰을 내면 시스템이 실제 열린 PR/이슈를 조회해 처리한다. close_all 은 이미 닫힌 게 아니면 반드시 무언가 닫는다.
 
-**톱다운 프로젝트 흐름 (2단계)**:
-- ① "프로젝트 제안해", "뭐부터 할지 정리해", "프로젝트 뽑아줘" → \`[[ACTION:propose_projects]]\` (CEO가 제품 분석해 후보 리스트 제안). 사람이 제품 이해도를 검토.
-- ② "P1 시작", "P2 프로젝트 하자", "이 프로젝트로 가자" → \`[[ACTION:select_project]] {"id":"P<번호>"}\` (후보 중 1개 활성화 → 직군별 하위 이슈 분해).
-- 이건 매일 잔 아이디어를 받는 run_council 과 다르다. 톱다운: 제안 → 선택 → 분해 → 격파.
+**톱다운 프로젝트 흐름 (3단계 — 단계마다 사람이 게이트)**:
+- ① "프로젝트 제안해", "뭐부터 할지 정리해" → \`[[ACTION:propose_projects]]\` (CEO가 제품 분석해 후보 리스트 제안).
+- ② "P2 시작", "P2 프로젝트 하자" → \`[[ACTION:select_project]] {"id":"P2"}\` (활성화 + **기획문서(PRD)** 작성. 아직 분해 안 함).
+- ③ 기획문서 검토 후 "P2 기획 승인", "이 기획으로 진행" → \`[[ACTION:approve_plan]] {"id":"P2"}\` (PRD 기준 직군별 하위 이슈 분해).
+- 이건 매일 잔 아이디어 run_council 과 다르다. 톱다운: 제안 → 선택 → 기획문서 → 승인 → 분해 → 격파.
 
 - **순수 조회·요약·상태 확인·의견 질문**("브리핑 알려줘", "PR 뭐 있어", "상태 어때")에는 토큰을 내지 않는다.
 - merge/merge_all/close_completed/add_constraint 는 비가역·고영향 — CEO가 그 동작을 명시했을 때만. 정말 애매하면 토큰 없이 "구현을 시작할까요?"라고 한 번만 되묻는다(단, '개발/구현/진행' 동사가 있으면 되묻지 말고 바로 implement).
@@ -429,7 +431,13 @@ async function executeAction(
         const id = typeof action.payload.id === "string" ? action.payload.id.trim().toUpperCase() : "";
         if (!/^P\d+$/.test(id)) return "⚠️ select_project: 프로젝트 id(예: P1)가 올바르지 않아 실행하지 않았습니다.";
         await triggerWorkflow("project-kickoff.yml", { project_id: id });
-        return `🗺️ *프로젝트 ${id} 킥오프* — PROJECT_ROADMAP.md 를 active 로 갱신하고, 4축 에이전트가 이 프로젝트를 이슈로 분해합니다. 진척은 매일 아침 리포트로 옵니다.`;
+        return `🗺️ *프로젝트 ${id} 킥오프* — 활성화하고 **기획문서(PRD)** 를 먼저 작성합니다. 잠시 후 "📋 [기획문서] ${id}" 이슈가 올라오면 검토 후 *"${id} 기획 승인"* 하세요. (승인 전엔 직군 이슈 분해 안 함)`;
+      }
+      case "approve_plan": {
+        const id = typeof action.payload.id === "string" ? action.payload.id.trim().toUpperCase() : "";
+        if (!/^P\d+$/.test(id)) return "⚠️ approve_plan: 프로젝트 id(예: P2)가 올바르지 않아 실행하지 않았습니다.";
+        await triggerWorkflow("project-decompose.yml", { project_id: id });
+        return `✅ *${id} 기획 승인 → 분해 시작* — 기획문서(PRD)를 기준으로 직군별(기획/백엔드/프론트·UX/품질) 하위 이슈를 만듭니다. 구현은 이후 "개발해" 승인 시에만.`;
       }
       case "implement": {
         const raw = action.payload.date;

--- a/apps/web/lib/slack/actions.ts
+++ b/apps/web/lib/slack/actions.ts
@@ -16,6 +16,7 @@ export type ActionName =
   | "run_council"
   | "propose_projects"
   | "select_project"
+  | "approve_plan"
   | "implement"
   | "merge"
   | "merge_all"
@@ -30,6 +31,7 @@ export const KNOWN_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
   "run_council",
   "propose_projects",
   "select_project",
+  "approve_plan",
   "implement",
   "merge",
   "merge_all",
@@ -50,6 +52,7 @@ export const HIGH_IMPACT_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
   "close_all",
   "add_constraint",
   "select_project",
+  "approve_plan",
 ]);
 
 export interface ParsedAction {

--- a/scripts/__tests__/plan-doc.test.ts
+++ b/scripts/__tests__/plan-doc.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { planDocReady, renderPlanDocIssue, renderPlanDocSlack } from "../plan-doc";
+
+const prd = `## 배경
+사용자가 매일 올 이유가 약하다.
+## 목표
+데일리 챌린지로 재방문 +10%.
+## 기능 요구사항
+- 챌린지 카드, 포인트, 완료 화면.`;
+
+describe("planDocReady", () => {
+  it("충분한 분량이면 true", () => {
+    expect(planDocReady(prd)).toBe(true);
+  });
+  it("빈/짧은 건 false", () => {
+    expect(planDocReady("")).toBe(false);
+    expect(planDocReady("짧음")).toBe(false);
+  });
+});
+
+describe("renderPlanDocIssue", () => {
+  it("상위 프로젝트·승인 안내·PRD 본문 포함", () => {
+    const b = renderPlanDocIssue("P2", "게임화 데일리 챌린지", prd);
+    expect(b).toContain("상위 프로젝트: P2 · 게임화 데일리 챌린지");
+    expect(b).toContain("P2 기획 승인");
+    expect(b).toContain("데일리 챌린지로 재방문");
+    expect(b).toContain("보류/수정");
+  });
+  it("PRD 비면 경고 문구", () => {
+    expect(renderPlanDocIssue("P2", "x", "")).toContain("비었거나 너무 짧");
+  });
+});
+
+describe("renderPlanDocSlack", () => {
+  it("승인 안내 한 줄", () => {
+    const s = renderPlanDocSlack("P2", "챌린지", "http://x");
+    expect(s).toContain("기획문서 작성됨");
+    expect(s).toContain("P2 기획 승인");
+    expect(s).toContain("http://x");
+  });
+});

--- a/scripts/plan-doc.ts
+++ b/scripts/plan-doc.ts
@@ -1,0 +1,62 @@
+/**
+ * 기획문서(PRD) 래퍼 (톱다운 워크플로 — 선택 → 기획문서 → 승인 → 분해).
+ *
+ * project-kickoff 가 활성 프로젝트의 *상세 기획문서*를 기획 직군(LLM)으로 작성하면,
+ * 이 순수 모듈이 검토 안내 헤더로 감싸 이슈 본문을 만든다. 사람이 읽고 GO/NO-GO 를 판단한다.
+ * (PRD 본문 자체는 LLM 산문 — 파싱하지 않는다. 여기선 래핑/유효성만.)
+ *
+ * 순수 export 함수 + main() CLI.
+ *   issue <project_id> <project_title> <prd.md>  → 검토용 기획문서 이슈 본문을 stdout
+ */
+
+import { readFileSync } from "node:fs";
+
+/** PRD 본문이 쓸만한 분량인지(빈/너무 짧은 LLM 실패 가드). */
+export function planDocReady(prd: string): boolean {
+  return (prd || "").replace(/\s/g, "").length >= 40;
+}
+
+/** 검토용 기획문서 이슈 본문. */
+export function renderPlanDocIssue(projectId: string, projectTitle: string, prd: string): string {
+  const body = planDocReady(prd)
+    ? prd.trim()
+    : "_⚠️ 기획문서 생성이 비었거나 너무 짧습니다(LLM 실패 가능) — 다시 시도하거나 수동 작성하세요._";
+  return [
+    `## 🗺️ 상위 프로젝트: ${projectId} · ${projectTitle}`,
+    `> 이 문서는 **개발 착수 전 검토용 기획문서(PRD)** 입니다. 읽고 시작 여부를 판단하세요.`,
+    `> ✅ 진행: 슬랙에 **"${projectId} 기획 승인"** (또는 "이 기획으로 개발 진행") → 직군별(기획/백엔드/프론트·UX/품질) 하위 이슈로 분해.`,
+    `> ✋ 보류/수정: 이 이슈에 코멘트로 피드백 — 분해는 시작되지 않습니다.`,
+    "",
+    "---",
+    "",
+    body,
+  ].join("\n");
+}
+
+/** Slack 통지용 한 줄. */
+export function renderPlanDocSlack(projectId: string, projectTitle: string, issueUrl: string): string {
+  return [
+    `📋 *기획문서 작성됨 — ${projectId} · ${projectTitle}*`,
+    issueUrl,
+    `읽어보시고 진행하려면 *"${projectId} 기획 승인"*, 고칠 점이 있으면 이슈에 코멘트 주세요.`,
+    `_승인 전까지 직군 이슈 분해는 시작되지 않습니다._`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────
+function main(): void {
+  const argv = process.argv;
+  if (argv[2] !== "issue") {
+    console.error("usage: tsx scripts/plan-doc.ts issue <project_id> <project_title> <prd.md>");
+    process.exit(1);
+  }
+  const pid = argv[3] ?? "P?";
+  const title = argv[4] ?? "";
+  const prd = readFileSync(argv[5] ?? "/dev/stdin", "utf8");
+  process.stdout.write(renderPlanDocIssue(pid, title, prd));
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("plan-doc")) {
+  main();
+}


### PR DESCRIPTION
사용자 피드백: P2 수락 시 곧장 직군 이슈가 아니라, **먼저 상세 기획문서**를 내고 사람이 그걸 보고 GO/NO-GO 판단.

## 흐름 (3단계 게이트)
```
① 제안   propose_projects → 후보 리스트
② 선택   "P2 시작" → 활성화 + 📋 기획문서(PRD) 이슈  ← 분해 아직 안 함
③ 승인   "P2 기획 승인" → PRD 기준 직군별 하위 이슈 분해
```

## 변경
- **project-kickoff.yml**: 선택 후 직군 분해 → **기획문서(PRD) 작성**(기획 직군 LLM: 배경/목표·지표/시나리오/기능요구/범위/정체성정합/제약 자가점검/리스크). 실제 구현 인벤토리 주입.
- **project-decompose.yml** (신설): "기획 승인"(approve_plan) → PRD 본문을 입력으로 직군별 task 분해. PRD 에 없는 기능 추가 금지.
- **scripts/plan-doc.ts** (순수+vitest 5): PRD 검토 이슈 래퍼.
- **Slack**: `approve_plan` 액션 + 안내 3단계화.

게이트: YAML×2 ✅ vitest 33 ✅ lint·typecheck·build:web ✅.