### PR TITLE
feat(council): 하위 task 상세화 — 작업내용·파일·완료 체크리스트

### DIFF
--- a/.github/workflows/project-decompose.yml
+++ b/.github/workflows/project-decompose.yml
@@ -55,6 +55,10 @@ jobs:
           fi
           PRD=$(cat /tmp/prd.txt)
           echo "prd<<__PEOF__" >> "$GITHUB_OUTPUT"; echo "$PRD" >> "$GITHUB_OUTPUT"; echo "__PEOF__" >> "$GITHUB_OUTPUT"
+          # 실제 파일 인벤토리 — 각 task 가 '어느 파일/영역'을 건드리는지 구체적으로 적게
+          INV=$(git ls-files 'apps/fomo-web/app/**' 'apps/fomo-web/components/**' 'apps/fomo-club/app/**' 'apps/fomo-club/components/**' 'packages/fomo-core/src/**' 'apps/web/app/api/fomo/**' 'apps/web/prisma/**' 2>/dev/null | grep -vE '__tests__|\.test\.|globals\.css' | sort | head -140)
+          [ -z "$INV" ] && INV="(인벤토리 조회 실패)"
+          echo "inventory<<__IEOF__" >> "$GITHUB_OUTPUT"; echo "$INV" >> "$GITHUB_OUTPUT"; echo "__IEOF__" >> "$GITHUB_OUTPUT"
 
       - name: "직군 회의 — 기획문서 → 하위 task 분해 (LLM)"
         id: decompose
@@ -67,19 +71,26 @@ jobs:
           system-prompt: |
             당신은 FOMO Club 제품팀이다. *승인된 기획문서(PRD)* 를 직군별 실행 task 로 분해한다.
             직군(axis 는 한글명 그대로): 기획 / 백엔드 / 프론트·UX / 품질.
+            ★ 각 task 는 **개발자가 바로 착수할 만큼 구체적**이어야 한다. 한 줄 제목만 던지지 마라.
             규칙:
             1. PRD 의 기능 요구사항·범위를 충실히 반영. PRD 에 없는 기능 추가 금지(비대화 금지).
             2. 각 task 는 단일 PR 크기. 의존성(dependsOn)을 seq 로 명시해 실행 순서를 만든다.
-            3. 가시적·미시적 잡일(여백 1px 등) 금지. 정직한 숫자·투자조언·타로 금지 준수.
-            4. 각 task 에 담당 직군 1개. 출력은 **오직 JSON 배열**. 코드펜스·설명 금지.
-            형식: [{"seq":1,"axis":"기획","title":"...","rationale":"PRD 의 어느 요구사항을 충족","dependsOn":[],"acceptance":"검증 가능한 완료 기준"}, ...]
+            3. **details**: 그 task 에서 실제로 할 일을 3~6개 구체 항목으로(무엇을 만들고 어떻게 — 함수/엔드포인트/컴포넌트/스키마 수준). 추상어 금지.
+            4. **files**: 아래 "이미 있는 파일/영역"을 참고해 *실제로 건드릴 파일·경로 후보*를 적는다(신규면 "신규:" 접두사). 추측 경로 금지.
+            5. **acceptance**: 검증 가능한 완료 체크리스트 2~4개(테스트·동작·수치).
+            6. 가시적·미시적 잡일(여백 1px 등) 금지. 정직한 숫자·투자조언·타로 금지 준수. 담당 직군 1개.
+            7. 출력은 **오직 JSON 배열**. 코드펜스·설명 금지.
+            형식: [{"seq":1,"axis":"백엔드","title":"한 줄 목표","rationale":"PRD 의 어느 요구사항을 충족","details":["구체 작업1","구체 작업2","..."],"files":"apps/web/app/api/fomo/..., packages/fomo-core/src/...","acceptance":["체크1","체크2"],"dependsOn":[1]}, ...]
           prompt: |
             ## 프로젝트: ${{ steps.ctx.outputs.pid }} · ${{ steps.ctx.outputs.ptitle }}
 
-            ## 승인된 기획문서 (PRD)
+            ## 승인된 기획문서 (PRD) — 이걸 충실히 분해하라
             ${{ steps.ctx.outputs.prd }}
 
-            위 PRD 를 충실히 반영한 직군별 하위 task 배열(JSON)만 출력하라. 4~8개 권장.
+            ## 이미 있는 파일/영역 (files 항목은 여기서 골라 구체적으로)
+            ${{ steps.ctx.outputs.inventory }}
+
+            위 PRD 를 충실히 반영한 직군별 하위 task 배열(JSON)만 출력하라. 4~8개. 각 task 는 details/files/acceptance 까지 구체적으로.
 
       - name: Create task issues
         id: create

--- a/scripts/__tests__/kickoff-tasks.test.ts
+++ b/scripts/__tests__/kickoff-tasks.test.ts
@@ -9,16 +9,20 @@ import {
 
 describe("parseKickoffTasks", () => {
   const good = JSON.stringify([
-    { seq: 1, axis: "기획", title: "포모 홈 와이어 정의", rationale: "심장", dependsOn: [], acceptance: "와이어 확정" },
-    { seq: 2, axis: "프론트·UX", title: "감정 선택→반응 전환", rationale: "love mark", dependsOn: [1], acceptance: "전환 동작" },
-    { seq: 3, axis: "백엔드", title: "감정 집계 API", rationale: "데이터", dependsOn: [1], acceptance: "API 200" },
+    { seq: 1, axis: "기획", title: "포모 홈 와이어 정의", rationale: "심장", details: ["화면 구성 정의", "상태 정의"], files: "docs/", acceptance: ["와이어 확정", "리뷰 통과"], dependsOn: [] },
+    { seq: 2, axis: "프론트·UX", title: "감정 선택→반응 전환", rationale: "love mark", details: ["전환 컴포넌트"], files: "apps/fomo-web/components/FomoFace.tsx", acceptance: "전환 동작", dependsOn: [1] },
+    { seq: 3, axis: "백엔드", title: "감정 집계 API", rationale: "데이터", dependsOn: [1] },
   ]);
 
-  it("정상 JSON 을 seq 순 정렬 파싱", () => {
+  it("정상 JSON 을 seq 순 정렬 파싱 + 풍부한 필드", () => {
     const t = parseKickoffTasks(good);
     expect(t.map((x) => x.seq)).toEqual([1, 2, 3]);
     expect(t[1]!.axis).toBe("프론트·UX");
     expect(t[1]!.dependsOn).toEqual([1]);
+    expect(t[0]!.details).toEqual(["화면 구성 정의", "상태 정의"]);
+    expect(t[0]!.acceptance).toEqual(["와이어 확정", "리뷰 통과"]);
+    expect(t[1]!.files).toBe("apps/fomo-web/components/FomoFace.tsx");
+    expect(t[1]!.acceptance).toEqual(["전환 동작"]); // 문자열도 배열로
   });
   it("코드펜스/잡텍스트로 둘러싸여도 배열 추출", () => {
     expect(parseKickoffTasks("```json\n" + good + "\n``` 끝!")).toHaveLength(3);
@@ -70,19 +74,20 @@ describe("parseKickoffTasks", () => {
 });
 
 describe("render", () => {
-  const task = { seq: 2, axis: "프론트·UX" as const, title: "전환", rationale: "love mark", dependsOn: [1], acceptance: "동작" };
+  const task = { seq: 2, axis: "프론트·UX" as const, title: "전환", rationale: "love mark", details: ["FomoFace 전환 추가", "멘트 교체"], files: "apps/fomo-web/components/FomoFace.tsx", acceptance: ["전환 동작", "멘트 노출"], dependsOn: [1] };
   it("이슈 제목 = [P1 2/5 · 프론트·UX] 전환", () => {
     expect(renderIssueTitle(task, "P1", 5)).toBe("[P1 2/5 · 프론트·UX] 전환");
   });
-  it("본문에 상위 프로젝트·단계·선행·완료판정 포함", () => {
+  it("본문에 작업 내용·파일·체크리스트 포함", () => {
     const b = renderIssueBody(task, "P1", "단 하나의 순간", 5);
     expect(b).toContain("상위 프로젝트: P1 · 단 하나의 순간");
     expect(b).toContain("진행 단계: 2 / 5");
-    expect(b).toContain("담당 직군");
-    expect(b).toContain("프론트·UX");
-    expect(b).toContain("선행 단계");
+    expect(b).toContain("작업 내용");
+    expect(b).toContain("- FomoFace 전환 추가");
+    expect(b).toContain("관련 파일");
+    expect(b).toContain("apps/fomo-web/components/FomoFace.tsx");
+    expect(b).toContain("- [ ] 전환 동작");
     expect(b).toContain("1단계");
-    expect(b).toContain("동작");
   });
   it("renderPlan 순서 요약", () => {
     const plan = renderPlan(parseKickoffTasks(JSON.stringify([

--- a/scripts/kickoff-tasks.ts
+++ b/scripts/kickoff-tasks.ts
@@ -36,11 +36,16 @@ export interface KickoffTask {
   seq: number;
   axis: Axis;
   title: string;
+  /** PRD 의 어느 요구사항을 충족하는가 */
   rationale: string;
+  /** 구체 작업 항목 (무엇을 어떻게 — 3~6개) */
+  details: string[];
+  /** 관련 파일/영역 후보 (실제 경로 — 어디를 건드리나) */
+  files: string;
+  /** 완료 체크리스트 (검증 가능 — 2~4개) */
+  acceptance: string[];
   /** 선행 task 의 seq 들 */
   dependsOn: number[];
-  /** 완료 판정 기준(검증 가능) */
-  acceptance: string;
 }
 
 /** 구 약어(PL/TD/BA/UX)도 너그럽게 한글 직군으로 흡수. */
@@ -68,6 +73,18 @@ function coerceAxis(v: unknown): Axis | null {
 function coerceDeps(v: unknown): number[] {
   if (!Array.isArray(v)) return [];
   return v.map((x) => Number(x)).filter((n) => Number.isInteger(n) && n > 0);
+}
+
+/** 문자열 배열로 강제 — 배열이면 항목 trim, 문자열이면 줄/세미콜론 분리. */
+function coerceStrArray(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => String(x).trim()).filter(Boolean);
+  if (typeof v === "string") {
+    return v
+      .split(/\n|;|·|(?:^|\s)[-*]\s/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
 }
 
 /**
@@ -107,8 +124,10 @@ export function parseKickoffTasks(raw: string): KickoffTask[] {
       axis,
       title,
       rationale: typeof o.rationale === "string" ? o.rationale.trim() : "",
+      details: coerceStrArray(o.details),
+      files: typeof o.files === "string" ? o.files.trim() : coerceStrArray(o.files).join(", "),
+      acceptance: coerceStrArray(o.acceptance),
       dependsOn: coerceDeps(o.dependsOn),
-      acceptance: typeof o.acceptance === "string" ? o.acceptance.trim() : "",
     });
     auto = seq + 1;
   }
@@ -128,6 +147,12 @@ export function renderIssueBody(
   const deps = task.dependsOn.length
     ? task.dependsOn.map((d) => `${d}단계`).join(", ")
     : "없음 (먼저 시작 가능)";
+  const details = task.details.length
+    ? task.details.map((d) => `- ${d}`).join("\n")
+    : "- (구체 작업 미기재 — 분해 보강 필요)";
+  const accept = task.acceptance.length
+    ? task.acceptance.map((a) => `- [ ] ${a}`).join("\n")
+    : "- [ ] (완료 기준 미기재 — 분해 보강 필요)";
   return [
     `## 🗺️ 상위 프로젝트: ${projectId} · ${projectTitle}`,
     `이 이슈는 위 프로젝트를 완성하기 위한 **하위 개발 이슈**다.`,
@@ -136,14 +161,20 @@ export function renderIssueBody(
     `- **담당 직군**: ${task.axis} — ${AXIS_DESC[task.axis]}`,
     `- **선행 단계**: ${deps}`,
     "",
-    "## 🎯 무엇을 하나",
+    "## 🎯 목표",
     task.title,
     "",
-    "## 왜 (이 프로젝트에 왜 필요한가)",
-    task.rationale || "(근거 미기재)",
+    "## 🔨 작업 내용 (구체)",
+    details,
     "",
-    "## ✅ 완료 판정 (검증 가능)",
-    task.acceptance || "(판정 기준 미기재)",
+    "## 📂 관련 파일 / 영역",
+    task.files || "(미기재 — 구현 전 탐색 필요)",
+    "",
+    "## ✅ 완료 체크리스트 (검증 가능)",
+    accept,
+    "",
+    "## 🔗 왜 (PRD·프로젝트 연결)",
+    task.rationale || "(근거 미기재)",
     "",
     "---",
     `_프로젝트 \`${projectId}\` 의 ${task.seq}/${total} 단계. CEO 승인(슬랙 "개발해"/수동) 시에만 구현된다._`,


### PR DESCRIPTION
피드백: 분해된 하위 이슈(#451 등)가 한 줄 제목뿐이라 판단이 안 됨.

- **kickoff-tasks.ts**: task 스키마에 `details[]`(구체 작업)·`files`(관련 파일/영역)·`acceptance[]`(완료 체크리스트) 추가. 본문을 '🎯목표 / 🔨작업 내용 / 📂관련 파일 / ✅완료 체크리스트 / 🔗왜' 로 렌더.
- **project-decompose.yml**: 실제 파일 인벤토리(fomo-web/club·fomo-core·api·prisma schema) 주입 + 프롬프트가 details/files/acceptance 까지 구체 출력하도록(추상어·추측 경로 금지).

게이트: YAML ✅ vitest 11 ✅ lint·typecheck ✅ · render dry-run 확인.