### PR TITLE
feat(council): 충돌 방지 — 구현 직렬화 + 선행 의존성 게이트

### DIFF
--- a/.github/workflows/implement-task.yml
+++ b/.github/workflows/implement-task.yml
@@ -16,8 +16,10 @@ on:
         description: "effort (비우면 vars.CLAUDE_EFFORT → medium)"
         required: false
 
+# 충돌 방지(2026-06): 모든 task 구현을 *직렬화*한다(공유 그룹). 동시에 여러 task 를 구현하면
+# 각자 main 에서 분기해 서로 모르는 설계를 만들어 충돌하므로, 한 번에 하나만 실행한다.
 concurrency:
-  group: implement-task-${{ github.event.inputs.issue }}
+  group: implement-task
   cancel-in-progress: false
 
 permissions:
@@ -64,10 +66,36 @@ jobs:
           echo "dup=$DUP" >> "$GITHUB_OUTPUT"
           printf '%s' "$DATA" | jq -r '.body' > /tmp/task_spec.md
           echo "body<<__EOF__" >> "$GITHUB_OUTPUT"; cat /tmp/task_spec.md >> "$GITHUB_OUTPUT"; echo "__EOF__" >> "$GITHUB_OUTPUT"
+          # 프로젝트 라벨(project:<id>) + self.json (게이트 입력)
+          PROJ=$(printf '%s' "$DATA" | jq -r '[.labels[].name] | map(select(startswith("project:"))) | (.[0] // "")')
+          echo "proj=$PROJ" >> "$GITHUB_OUTPUT"
+          printf '%s' "$DATA" | jq '{title, body}' > /tmp/self.json
+
+      # ── 선행 게이트 (충돌 방지): 선행 task PR 이 머지(close) 되기 전엔 구현 차단 ──
+      - name: Prerequisite gate
+        id: gate
+        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUM: ${{ github.event.inputs.issue }}
+          PROJ: ${{ steps.task.outputs.proj }}
+        run: |
+          set -uo pipefail
+          if [ -z "$PROJ" ]; then echo "passed=true" >> "$GITHUB_OUTPUT"; echo "프로젝트 라벨 없음 — 게이트 생략"; exit 0; fi
+          gh issue list --label "$PROJ,task" --state all --limit 60 \
+            --json number,title,state --repo "${{ github.repository }}" 2>/dev/null > /tmp/siblings.json || echo "[]" > /tmp/siblings.json
+          RES=$(npx -y tsx@4.19.2 scripts/task-deps.ts gate "$NUM" /tmp/self.json /tmp/siblings.json 2>/dev/null || echo '{"ok":true,"reason":"게이트 평가 실패 — 통과 처리"}')
+          OK=$(printf '%s' "$RES" | jq -r '.ok'); REASON=$(printf '%s' "$RES" | jq -r '.reason')
+          echo "passed=$OK" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          echo "🚦 게이트: ok=$OK — $REASON"
+          if [ "$OK" != "true" ]; then
+            gh issue comment "$NUM" --repo "${{ github.repository }}" --body "🚦 구현 보류 — $REASON" || true
+          fi
 
       - name: Resolve model
         id: model
-        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0'
+        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0' && steps.gate.outputs.passed == 'true'
         env:
           IN_MODEL: ${{ github.event.inputs.model }}
           IN_EFFORT: ${{ github.event.inputs.effort }}
@@ -79,7 +107,7 @@ jobs:
 
       - name: Implement with Claude Code
         id: implement
-        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0'
+        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0' && steps.gate.outputs.passed == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -113,7 +141,7 @@ jobs:
             ${{ steps.task.outputs.body }}
 
       - name: Create Branch and PR
-        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0'
+        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0' && steps.gate.outputs.passed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           NUM: ${{ github.event.inputs.issue }}
@@ -163,12 +191,16 @@ jobs:
           FOUND: ${{ steps.task.outputs.found }}
           DUP: ${{ steps.task.outputs.dup }}
           ITITLE: ${{ steps.task.outputs.title }}
+          GATE: ${{ steps.gate.outputs.passed }}
+          GREASON: ${{ steps.gate.outputs.reason }}
         run: |
           URL=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
           if [ "$FOUND" != "true" ]; then
             TEXT="⚠️ *구현 불가 (#${NUM})* — task 이슈가 없거나 닫힘/라벨 불일치."
           elif [ "${DUP:-0}" != "0" ]; then
             TEXT="ℹ️ *#${NUM}* 이미 구현 PR이 열려 있어 새로 만들지 않았습니다."
+          elif [ "${GATE:-true}" != "true" ]; then
+            TEXT="🚦 *#${NUM} 구현 보류 (선행 게이트)* — ${GREASON}"
           else
             TEXT="🚀 *구현 실행 — #${NUM} ${ITITLE}* — Claude Code 가 구현 후 PR을 올립니다(수 분). CI 후 리뷰/머지."
           fi

--- a/scripts/__tests__/task-deps.test.ts
+++ b/scripts/__tests__/task-deps.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseSeq, parseDeps, unmetPrereqs, gate } from "../task-deps";
+
+describe("parseSeq", () => {
+  it("제목에서 seq 추출", () => {
+    expect(parseSeq("[P2 3/6 · 백엔드] 포인트 API")).toBe(3);
+    expect(parseSeq("[P10 12/20 · 품질] x")).toBe(12);
+    expect(parseSeq("관련 없는 제목")).toBeNull();
+  });
+});
+
+describe("parseDeps", () => {
+  it("선행 단계 줄에서 seq 들 추출", () => {
+    expect(parseDeps("## 진행\n- **선행 단계**: 1단계, 2단계\n끝")).toEqual([1, 2]);
+    expect(parseDeps("- **선행 단계**: 없음 (먼저 시작 가능)")).toEqual([]);
+    expect(parseDeps("선행 정보 없음")).toEqual([]);
+  });
+});
+
+describe("unmetPrereqs / gate", () => {
+  const siblings = [
+    { number: 101, title: "[P2 1/4 · 백엔드] 스키마", state: "CLOSED" },
+    { number: 102, title: "[P2 2/4 · 백엔드] API", state: "OPEN" },
+    { number: 103, title: "[P2 3/4 · 프론트·UX] 화면", state: "OPEN" },
+  ];
+  it("선행이 OPEN 이면 미충족으로 잡는다", () => {
+    const u = unmetPrereqs(103, [1, 2], siblings);
+    expect(u.map((x) => x.number)).toEqual([102]); // 1단계(#101)는 CLOSED라 충족, 2단계(#102)는 OPEN
+  });
+  it("선행 전부 CLOSED 면 통과", () => {
+    const sib = [{ number: 101, title: "[P2 1/4 · 백엔드] 스키마", state: "CLOSED" }];
+    expect(gate(102, "[P2 2/4 · 백엔드] API", "- **선행 단계**: 1단계", sib).ok).toBe(true);
+  });
+  it("선행 OPEN 이면 게이트 차단 + 사유", () => {
+    const g = gate(103, "[P2 3/4 · 프론트·UX] 화면", "- **선행 단계**: 1단계, 2단계", siblings);
+    expect(g.ok).toBe(false);
+    expect(g.reason).toContain("#102");
+    expect(g.reason).toContain("순차");
+  });
+  it("선행 없음이면 항상 통과", () => {
+    expect(gate(101, "[P2 1/4 · 백엔드] 스키마", "- **선행 단계**: 없음", siblings).ok).toBe(true);
+  });
+  it("자기 자신은 선행에서 제외", () => {
+    expect(unmetPrereqs(102, [2], siblings)).toEqual([]);
+  });
+});

--- a/scripts/task-deps.ts
+++ b/scripts/task-deps.ts
@@ -1,0 +1,95 @@
+/**
+ * Task 의존성 게이트 (충돌 방지 — 순차 구현).
+ *
+ * 병렬 구현의 충돌 교훈: 의존성 있는 task 를 동시에 구현하면 각자 main 에서 분기해
+ * 서로 모르는 설계를 만든다(중복 모델 등). → 선행 task 가 *머지(close)* 되기 전엔 구현을 막는다.
+ *
+ * 이슈 제목 `[P2 3/6 · 직군] ...` 에서 seq, 본문 `- **선행 단계**: 1단계, 2단계` 에서 deps 를 파싱하고,
+ * 형제 project:<id> task 이슈들의 상태로 *미충족 선행*을 계산한다. 순수 함수 + vitest.
+ */
+
+import { readFileSync } from "node:fs";
+
+export interface SiblingTask {
+  number: number;
+  title: string;
+  /** "OPEN" | "CLOSED" */
+  state: string;
+}
+
+/** 제목 `[P2 3/6 · 백엔드] ...` → seq(3). 못 찾으면 null. */
+export function parseSeq(title: string): number | null {
+  const m = (title || "").match(/\[[^\]]*?\s(\d+)\/\d+\s*·/);
+  return m ? Number(m[1]) : null;
+}
+
+/** 본문의 `선행 단계: 1단계, 2단계` → [1,2]. "없음" 이면 []. */
+export function parseDeps(body: string): number[] {
+  if (!body) return [];
+  const line = body.split("\n").find((l) => l.includes("선행 단계"));
+  if (!line || /없음/.test(line)) return [];
+  const out = new Set<number>();
+  for (const m of line.matchAll(/(\d+)\s*단계/g)) out.add(Number(m[1]));
+  return Array.from(out);
+}
+
+/**
+ * 미충족 선행 task = deps(seq) 에 해당하는 형제 이슈 중 아직 OPEN(머지/완료 안 됨) 인 것.
+ * 자기 자신은 제외. seq 를 못 읽는 형제는 무시.
+ */
+export function unmetPrereqs(
+  selfNumber: number,
+  deps: number[],
+  siblings: SiblingTask[],
+): SiblingTask[] {
+  if (!deps.length) return [];
+  const depSet = new Set(deps);
+  return siblings.filter((s) => {
+    if (s.number === selfNumber) return false;
+    const seq = parseSeq(s.title);
+    return seq !== null && depSet.has(seq) && s.state.toUpperCase() === "OPEN";
+  });
+}
+
+/** 게이트 판정: 구현해도 되는가 + 사람이 읽을 사유. */
+export interface GateResult {
+  ok: boolean;
+  reason: string;
+}
+
+export function gate(
+  selfNumber: number,
+  selfTitle: string,
+  selfBody: string,
+  siblings: SiblingTask[],
+): GateResult {
+  const deps = parseDeps(selfBody);
+  const unmet = unmetPrereqs(selfNumber, deps, siblings);
+  if (unmet.length === 0) {
+    return { ok: true, reason: deps.length ? `선행 ${deps.join(",")}단계 모두 완료(머지)됨 — 구현 가능.` : "선행 없음 — 구현 가능." };
+  }
+  const list = unmet.map((u) => `#${u.number}(${parseSeq(u.title)}단계)`).join(", ");
+  return {
+    ok: false,
+    reason: `선행 task 미완료: ${list}. 선행 PR을 먼저 머지한 뒤 구현하세요(충돌 방지 — 순차 구현).`,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+function main(): void {
+  const argv = process.argv;
+  if (argv[2] !== "gate") {
+    console.error("usage: tsx scripts/task-deps.ts gate <self_number> <self.json> <siblings.json>");
+    process.exit(1);
+  }
+  const selfNumber = Number(argv[3]);
+  const self = JSON.parse(readFileSync(argv[4]!, "utf8")) as { title: string; body: string };
+  const siblings = JSON.parse(readFileSync(argv[5]!, "utf8")) as SiblingTask[];
+  const r = gate(selfNumber, self.title, self.body, siblings);
+  process.stdout.write(JSON.stringify(r));
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("task-deps")) {
+  main();
+}


### PR DESCRIPTION
오늘 병렬 구현 충돌(백엔드 3개가 서로 다른 모델 생성)의 구조적 재발 방지.

- **직렬화**: implement-task concurrency 를 공유 그룹으로 → 동시 1개만 구현.
- **선행 게이트**: task 의 '선행 단계'(seq)에 해당하는 형제 task 가 아직 OPEN(미머지)이면 구현 차단(이슈 코멘트+Slack). 선행 PR 머지 후에만 다음 구현 → 항상 앞 코드 위에 쌓임.
- **scripts/task-deps.ts** (순수+vitest 7).

게이트: YAML ✅ vitest 7 ✅ lint·typecheck ✅ · CLI dry-run(선행 OPEN 차단) 확인.