### PR TITLE
feat(brain): K1 복리 지식 레이어 (Brain Trinity 적층)

### DIFF
--- a/.github/workflows/knowledge-distill.yml
+++ b/.github/workflows/knowledge-distill.yml
@@ -1,0 +1,86 @@
+name: Knowledge Distill (Brain K1)
+
+# 에이전트 두뇌 K1 — 매일 흩어진 기억(머지 PR·제약 hit)을 정제 지식으로 적층한다.
+#   knowledge/distilled.md (멱등 누적, K2 검색이 읽음) + knowledge/daily/<date>.md (그날 raw).
+#   "메모는 쌓이는데 다시 안 본다"를 막는 복리 지식 레이어.
+on:
+  schedule:
+    - cron: "30 22 * * *"  # 매일 오전 7:30 KST (진척 리포트 직후)
+  workflow_dispatch:
+
+concurrency:
+  group: knowledge-distill
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  distill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Gather + distill knowledge
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
+          SINCE=$(TZ=Asia/Seoul date -d '2 days ago' '+%Y-%m-%d' 2>/dev/null || TZ=Asia/Seoul date -v-2d '+%Y-%m-%d')
+
+          # 1) 최근 머지 PR (since 이후) → [{number,title}]
+          gh pr list --state merged --limit 60 --json number,title,mergedAt \
+            --repo "${{ github.repository }}" 2>/dev/null \
+            | jq --arg since "$SINCE" '[ .[] | select((.mergedAt|.[0:10]) >= $since) | {number, title} ]' \
+            > /tmp/kb_merged.json || echo "[]" > /tmp/kb_merged.json
+          [ -s /tmp/kb_merged.json ] || echo "[]" > /tmp/kb_merged.json
+
+          # 2) 오늘 제약 위반 hit ({id:count} → [{id,count}])
+          HITF="generated/constraint-hits/${TODAY}.json"
+          if [ -f "$HITF" ]; then
+            jq 'to_entries | map({id: .key, count: .value})' "$HITF" > /tmp/kb_hits.json 2>/dev/null || echo "[]" > /tmp/kb_hits.json
+          else
+            echo "[]" > /tmp/kb_hits.json
+          fi
+
+          # 3) 결정(현재는 자동 추출 보류 — 후속) — 빈 배열
+          echo "[]" > /tmp/kb_decisions.json
+
+          mkdir -p knowledge/daily
+          [ -f knowledge/distilled.md ] || printf '' > knowledge/distilled.md
+
+          NEW=$(npx -y tsx@4.19.2 scripts/knowledge-base.ts build \
+            "$TODAY" /tmp/kb_merged.json /tmp/kb_hits.json /tmp/kb_decisions.json \
+            knowledge/distilled.md "knowledge/daily/${TODAY}.md" 2>/dev/null || echo 0)
+          echo "NEW_LESSONS=$NEW" >> "$GITHUB_ENV"
+          echo "KDATE=$TODAY" >> "$GITHUB_ENV"
+          {
+            echo "### 🧠 Knowledge distill ($TODAY) — 신규 교훈 $NEW 건"
+            echo '```'; head -30 knowledge/distilled.md; echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit knowledge
+        run: |
+          set -uo pipefail
+          if git diff --quiet knowledge/; then
+            echo "지식 변경 없음 — 커밋 생략"; exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add knowledge/
+          git commit -m "chore(knowledge): ${KDATE} 지식 적층 (신규 교훈 ${NEW_LESSONS}건)"
+          git push origin HEAD:main
+
+      - name: Notify Slack
+        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        run: |
+          URL=$(printf '%s' "${{ vars.SLACK_WEBHOOK_URL }}" | tr -d '[:space:]')
+          TEXT="🧠 *지식 적층 (${KDATE})* — 정제 교훈 신규 ${NEW_LESSONS}건. knowledge/distilled.md 누적. (에이전트가 이걸 검색해 재제안·중복을 막습니다)"
+          BODY=$(jq -n --arg t "$TEXT" '{text: $t}')
+          curl -sS -X POST -H 'Content-type: application/json' --data "$BODY" "$URL" || true

--- a/scripts/__tests__/knowledge-base.test.ts
+++ b/scripts/__tests__/knowledge-base.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  lessonsFromMergedPRs,
+  lessonsFromDecisions,
+  parseDistilled,
+  mergeLessons,
+  renderDistilled,
+  renderDailyNote,
+} from "../knowledge-base";
+
+describe("lessonsFromMergedPRs", () => {
+  it("머지 PR → shipped 교훈 (Auto 접두사 제거 + ref)", () => {
+    const l = lessonsFromMergedPRs([{ number: 457, title: "[Auto] #457 — 챌린지 상태 DB ChallengeState" }], "2026-06-10");
+    expect(l[0]).toEqual({ date: "2026-06-10", kind: "shipped", text: "챌린지 상태 DB ChallengeState", ref: "PR#457" });
+  });
+  it("번호 없거나 제목 빈 PR 제외", () => {
+    expect(lessonsFromMergedPRs([{ number: 0, title: "x" }, { number: 5, title: "  " }], "d")).toEqual([]);
+  });
+});
+
+describe("parseDistilled / renderDistilled 라운드트립", () => {
+  it("렌더한 걸 다시 파싱하면 동일 교훈", () => {
+    const lessons = [
+      { date: "2026-06-10", kind: "shipped" as const, text: "챌린지 DB", ref: "PR#457" },
+      { date: "2026-06-09", kind: "decision" as const, text: "포인트 유료화 보류", ref: "issue#450" },
+    ];
+    const md = renderDistilled(lessons);
+    const back = parseDistilled(md);
+    expect(back).toHaveLength(2);
+    expect(back.find((l) => l.ref === "PR#457")!.text).toBe("챌린지 DB");
+    expect(back.find((l) => l.ref === "issue#450")!.kind).toBe("decision");
+  });
+  it("최신 날짜가 위로 정렬", () => {
+    const md = renderDistilled([
+      { date: "2026-06-08", kind: "shipped" as const, text: "a", ref: "PR#1" },
+      { date: "2026-06-10", kind: "shipped" as const, text: "b", ref: "PR#2" },
+    ]);
+    expect(md.indexOf("PR#2")).toBeLessThan(md.indexOf("PR#1"));
+  });
+});
+
+describe("mergeLessons (멱등 누적)", () => {
+  const existing = [{ date: "2026-06-09", kind: "shipped" as const, text: "기존", ref: "PR#100" }];
+  it("같은 ref 는 중복 적재 안 함", () => {
+    const merged = mergeLessons(existing, [{ date: "2026-06-10", kind: "shipped", text: "갱신본", ref: "PR#100" }]);
+    expect(merged).toHaveLength(1);
+  });
+  it("새 ref 는 추가", () => {
+    const merged = mergeLessons(existing, [{ date: "2026-06-10", kind: "shipped", text: "신규", ref: "PR#101" }]);
+    expect(merged).toHaveLength(2);
+  });
+  it("ref 없으면 text 로 중복 판정", () => {
+    const ex = [{ date: "d", kind: "decision" as const, text: "포인트 보류", ref: "" }];
+    expect(mergeLessons(ex, [{ date: "d2", kind: "decision", text: "포인트 보류", ref: "" }])).toHaveLength(1);
+    expect(mergeLessons(ex, [{ date: "d2", kind: "decision", text: "다른 결정", ref: "" }])).toHaveLength(2);
+  });
+});
+
+describe("renderDailyNote", () => {
+  it("출고·결정·제약 hit 섹션", () => {
+    const lessons = [
+      ...lessonsFromMergedPRs([{ number: 457, title: "[Auto] #457 — 챌린지 DB" }], "2026-06-10"),
+      ...lessonsFromDecisions(["포인트 유료화 보류"], "2026-06-10"),
+    ];
+    const note = renderDailyNote("2026-06-10", lessons, [{ id: "c-tarot-reject", count: 2 }]);
+    expect(note).toContain("2026-06-10 — 에이전트 두뇌 daily");
+    expect(note).toContain("챌린지 DB [PR#457]");
+    expect(note).toContain("포인트 유료화 보류");
+    expect(note).toContain("c-tarot-reject: 2회");
+  });
+  it("빈 입력은 (없음)", () => {
+    const note = renderDailyNote("2026-06-10", [], []);
+    expect(note).toContain("- (없음)");
+  });
+});

--- a/scripts/knowledge-base.ts
+++ b/scripts/knowledge-base.ts
@@ -1,0 +1,162 @@
+/**
+ * 복리 지식 레이어 — "제2의 뇌" Brain Trinity (에이전트 두뇌 K1).
+ *
+ * 흩어진 기억(머지 PR·CEO 결정·제약 hit·outcome)을 raw → distilled(정제된 교훈) 로 적층한다.
+ * distilled 는 K2(검색 재주입)가 읽어 "이미 구현됨/결정됨 — 재제안·중복 금지"를 출처와 함께 주입한다.
+ * 매일 자동 누적(스크린샷의 daily 자동 생성·갱신). 순수 export 함수 + main() CLI.
+ *
+ * 핵심: distilled 는 *PR/이슈 번호(ref)* 로 멱등 누적 → 같은 사실이 중복 적재되지 않는다.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+export type LessonKind = "shipped" | "decision" | "rule";
+
+export interface Lesson {
+  date: string;
+  kind: LessonKind;
+  text: string;
+  /** 출처 — "PR#457" | "issue#470" | "" */
+  ref: string;
+}
+
+export interface MergedPR {
+  number: number;
+  title: string;
+}
+
+function clean(s: string): string {
+  return (s || "").replace(/\s+/g, " ").trim();
+}
+
+/** 머지 PR → "구현됨" 교훈 (재구현 방지의 핵심 신호). [Auto] 접두사 제거. */
+export function lessonsFromMergedPRs(prs: MergedPR[], date: string): Lesson[] {
+  return prs
+    .filter((p) => p && p.number > 0 && clean(p.title))
+    .map((p) => ({
+      date,
+      kind: "shipped" as const,
+      text: clean(p.title).replace(/^\[Auto\]\s*#?\d*\s*—?\s*/i, ""),
+      ref: `PR#${p.number}`,
+    }));
+}
+
+/** CEO 결정/규칙 텍스트 → decision 교훈. */
+export function lessonsFromDecisions(decisions: string[], date: string, refs: string[] = []): Lesson[] {
+  return decisions
+    .map((d, i) => clean(d))
+    .filter(Boolean)
+    .map((text, i) => ({ date, kind: "decision" as const, text, ref: refs[i] ?? "" }));
+}
+
+const LINE_RE = /^- \[(\d{4}-\d{2}-\d{2})\]\s*\((shipped|decision|rule)\)\s*(.*?)(?:\s*\[출처:\s*([^\]]+)\])?\s*$/;
+
+/** knowledge/distilled.md 파싱 → Lesson[]. */
+export function parseDistilled(md: string): Lesson[] {
+  const out: Lesson[] = [];
+  for (const line of (md || "").split("\n")) {
+    const m = line.match(LINE_RE);
+    if (m) out.push({ date: m[1]!, kind: m[2] as LessonKind, text: clean(m[3]!), ref: (m[4] ?? "").trim() });
+  }
+  return out;
+}
+
+/** 멱등 누적 — ref 가 있으면 ref 로, 없으면 정규화 text 로 중복 판정. 신규만 추가. */
+export function mergeLessons(existing: Lesson[], incoming: Lesson[]): Lesson[] {
+  const keyOf = (l: Lesson) => (l.ref ? `ref:${l.ref.toLowerCase()}` : `txt:${l.text.toLowerCase()}`);
+  const seen = new Set(existing.map(keyOf));
+  const merged = [...existing];
+  for (const l of incoming) {
+    const k = keyOf(l);
+    if (!seen.has(k)) {
+      seen.add(k);
+      merged.push(l);
+    }
+  }
+  return merged;
+}
+
+/** distilled.md 렌더 (날짜 내림차순). */
+export function renderDistilled(lessons: Lesson[]): string {
+  const sorted = [...lessons].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+  const lines = sorted.map(
+    (l) => `- [${l.date}] (${l.kind}) ${l.text}${l.ref ? ` [출처: ${l.ref}]` : ""}`,
+  );
+  return [
+    "# 🧠 정제된 지식 (distilled) — 에이전트 재주입용 단일 진실",
+    "",
+    "> 자동 누적. 이미 구현/결정된 사실 — 재제안·중복 설계 금지. K2 검색이 이 파일을 읽어 프롬프트에 출처와 함께 주입한다.",
+    "",
+    ...lines,
+    "",
+  ].join("\n");
+}
+
+/** 그날의 raw 적층 노트(daily). */
+export function renderDailyNote(date: string, lessons: Lesson[], hits: { id: string; count: number }[]): string {
+  const shipped = lessons.filter((l) => l.kind === "shipped");
+  const decisions = lessons.filter((l) => l.kind !== "shipped");
+  return [
+    `# 🗓️ ${date} — 에이전트 두뇌 daily`,
+    "",
+    "## ✅ 오늘 출고(머지)",
+    shipped.length ? shipped.map((l) => `- ${l.text} [${l.ref}]`).join("\n") : "- (없음)",
+    "",
+    "## 🧭 결정/규칙",
+    decisions.length ? decisions.map((l) => `- ${l.text}${l.ref ? ` [${l.ref}]` : ""}`).join("\n") : "- (없음)",
+    "",
+    "## ⛔ 제약 위반 hit (오늘)",
+    hits.length ? hits.map((h) => `- ${h.id}: ${h.count}회`).join("\n") : "- (없음)",
+    "",
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────
+function readJson<T>(path: string | undefined, fb: T): T {
+  if (!path) return fb;
+  try {
+    const raw = readFileSync(path, "utf8").trim();
+    return raw ? (JSON.parse(raw) as T) : fb;
+  } catch {
+    return fb;
+  }
+}
+function readText(path: string | undefined): string {
+  if (!path) return "";
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * CLI:
+ *   build <date> <merged.json> <hits.json> <decisions.json> <distilled.md> <out_daily.md>
+ *     → distilled.md 를 갱신(머지 누적) 쓰고, out_daily.md 에 daily 노트 작성. stdout 에 신규 교훈 수.
+ */
+function main(): void {
+  const argv = process.argv;
+  if (argv[2] !== "build") {
+    console.error("usage: tsx scripts/knowledge-base.ts build <date> <merged.json> <hits.json> <decisions.json> <distilled.md> <out_daily.md>");
+    process.exit(1);
+  }
+  const date = argv[3] ?? "";
+  const merged = readJson<MergedPR[]>(argv[4], []);
+  const hits = readJson<{ id: string; count: number }[]>(argv[5], []);
+  const decisions = readJson<string[]>(argv[6], []);
+  const distilledPath = argv[7];
+  const outDaily = argv[8];
+
+  const incoming = [...lessonsFromMergedPRs(merged, date), ...lessonsFromDecisions(decisions, date)];
+  const existing = parseDistilled(readText(distilledPath));
+  const mergedLessons = mergeLessons(existing, incoming);
+  if (distilledPath) writeFileSync(distilledPath, renderDistilled(mergedLessons));
+  if (outDaily) writeFileSync(outDaily, renderDailyNote(date, incoming, hits));
+  process.stdout.write(String(mergedLessons.length - existing.length));
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("knowledge-base")) {
+  main();
+}


### PR DESCRIPTION
아티클 인사이트(하네스+복리 지식이 모트, 제2의 뇌 daily 자동 적층) 1단계.

## 문제
지식이 7곳에 흩어져 복리로 안 쌓임 → 중복 설계(#467/#469)·환각(감정 캘린더 중복 제안). "메모는 쌓이는데 다시 안 본다"가 에이전트에 그대로.

## 변경
- **scripts/knowledge-base.ts** (순수+vitest 9): 머지 PR/결정 → 교훈, ref(PR#/issue#) **멱등 누적**(중복 적재 방지), distilled.md 라운드트립, daily 노트.
- **knowledge-distill.yml** (매일 7:30 KST): 머지 PR·제약 hit → `knowledge/distilled.md` 누적 + `knowledge/daily/<date>.md` → 커밋.

## 라이브 검증
실제 머지 PR 23건 → 출처와 함께 정제 적층 확인. 이게 K2 검색이 읽어 재제안·중복을 막는 단일 진실.

게이트: YAML ✅ vitest 9 ✅ lint·typecheck ✅. (scripts+workflow만 — web 무관)

다음: K2(이 지식을 propose/kickoff/decompose 프롬프트에 출처와 함께 주입).