### PR TITLE
feat(brain): K2 출처 있는 지식 검색 재주입

### DIFF
--- a/.github/workflows/implement-task.yml
+++ b/.github/workflows/implement-task.yml
@@ -70,6 +70,13 @@ jobs:
           PROJ=$(printf '%s' "$DATA" | jq -r '[.labels[].name] | map(select(startswith("project:"))) | (.[0] // "")')
           echo "proj=$PROJ" >> "$GITHUB_OUTPUT"
           printf '%s' "$DATA" | jq '{title, body}' > /tmp/self.json
+          # K2 — 관련 과거 지식 출처 검색 재주입 (기존 코드 재사용·중복 구현 방지)
+          KN="(지식 레이어 없음)"
+          if [ -f knowledge/distilled.md ]; then
+            QTITLE=$(printf '%s' "$DATA" | jq -r '.title')
+            KN=$(npx -y tsx@4.19.2 scripts/knowledge-retrieve.ts retrieve knowledge/distilled.md "$QTITLE $(head -c 300 /tmp/task_spec.md 2>/dev/null)" 2>/dev/null || echo "(검색 실패)")
+          fi
+          echo "knowledge<<__KEOF__" >> "$GITHUB_OUTPUT"; echo "$KN" >> "$GITHUB_OUTPUT"; echo "__KEOF__" >> "$GITHUB_OUTPUT"
 
       # ── 선행 게이트 (충돌 방지): 선행 task PR 이 머지(close) 되기 전엔 구현 차단 ──
       - name: Prerequisite gate
@@ -136,6 +143,8 @@ jobs:
             2. `npm run lint` 와 `npm run typecheck` 를 직접 실행해 통과할 때까지 수정. (가능하면 `npm run test` 도)
             3. 구현 요약 한 줄을 `/tmp/impl-title.txt` 에 기록.
             4. **commit/push/PR 생성은 하지 마세요.** 코드 변경만 작업 트리에 남기면 다음 단계가 처리합니다.
+
+            ${{ steps.task.outputs.knowledge }}
 
             ## 구현할 이슈 #${{ github.event.inputs.issue }}: ${{ steps.task.outputs.title }}
             ${{ steps.task.outputs.body }}

--- a/.github/workflows/project-decompose.yml
+++ b/.github/workflows/project-decompose.yml
@@ -59,6 +59,12 @@ jobs:
           INV=$(git ls-files 'apps/fomo-web/app/**' 'apps/fomo-web/components/**' 'apps/fomo-club/app/**' 'apps/fomo-club/components/**' 'packages/fomo-core/src/**' 'apps/web/app/api/fomo/**' 'apps/web/prisma/**' 2>/dev/null | grep -vE '__tests__|\.test\.|globals\.css' | sort | head -140)
           [ -z "$INV" ] && INV="(인벤토리 조회 실패)"
           echo "inventory<<__IEOF__" >> "$GITHUB_OUTPUT"; echo "$INV" >> "$GITHUB_OUTPUT"; echo "__IEOF__" >> "$GITHUB_OUTPUT"
+          # K2 — 관련 과거 지식 출처와 함께 검색 재주입 (중복 설계 방지)
+          KN="(지식 레이어 없음)"
+          if [ -f knowledge/distilled.md ]; then
+            KN=$(npx -y tsx@4.19.2 scripts/knowledge-retrieve.ts retrieve knowledge/distilled.md "$PTITLE $(head -c 300 /tmp/prd.txt 2>/dev/null)" 2>/dev/null || echo "(검색 실패)")
+          fi
+          echo "knowledge<<__KEOF__" >> "$GITHUB_OUTPUT"; echo "$KN" >> "$GITHUB_OUTPUT"; echo "__KEOF__" >> "$GITHUB_OUTPUT"
 
       - name: "직군 회의 — 기획문서 → 하위 task 분해 (LLM)"
         id: decompose
@@ -89,6 +95,8 @@ jobs:
 
             ## 이미 있는 파일/영역 (files 항목은 여기서 골라 구체적으로)
             ${{ steps.ctx.outputs.inventory }}
+
+            ${{ steps.ctx.outputs.knowledge }}
 
             위 PRD 를 충실히 반영한 직군별 하위 task 배열(JSON)만 출력하라. 4~8개. 각 task 는 details/files/acceptance 까지 구체적으로.
 

--- a/.github/workflows/propose-project.yml
+++ b/.github/workflows/propose-project.yml
@@ -47,9 +47,15 @@ jobs:
           DONE=$(gh pr list --state merged --limit 25 --json title \
             --repo "${{ github.repository }}" 2>/dev/null | jq -r '.[].title' 2>/dev/null | head -c 2500 || echo "")
 
+          # K2 — 이미 출고/결정된 지식(중복 제안 방지). 제품 도메인 광역 쿼리로 검색.
+          KN="(지식 레이어 없음)"
+          if [ -f knowledge/distilled.md ]; then
+            KN=$(npx -y tsx@4.19.2 scripts/knowledge-retrieve.ts retrieve knowledge/distilled.md "감정 포모 챌린지 캘린더 포인트 알림 시뮬레이터 피드 통계 고래 인덱스" 2>/dev/null || echo "(검색 실패)")
+          fi
           { echo "vision<<__E__"; echo "$VISION"; echo "__E__";
             echo "inventory<<__E__"; echo "$INV"; echo "__E__";
-            echo "done<<__E__"; echo "$DONE"; echo "__E__"; } >> "$GITHUB_OUTPUT"
+            echo "done<<__E__"; echo "$DONE"; echo "__E__";
+            echo "knowledge<<__E__"; echo "$KN"; echo "__E__"; } >> "$GITHUB_OUTPUT"
 
       - name: "CEO 프로젝트 제안 (LLM)"
         id: propose
@@ -81,6 +87,8 @@ jobs:
 
             ## 최근 머지 PR (추가 참고 — 중복 금지)
             ${{ steps.ctx.outputs.done }}
+
+            ${{ steps.ctx.outputs.knowledge }}
 
             마일스톤 목록은 무시하고, 위 비전과 "이미 구현된 것"을 근거로 *아직 없는* 가장 임팩트 있는
             새 프로젝트 2~4개를 발굴해 JSON 배열로만 제안하라. 각 후보는 직군별 첫 착수까지 구체적으로.

--- a/scripts/__tests__/knowledge-retrieve.test.ts
+++ b/scripts/__tests__/knowledge-retrieve.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { tokenize, retrieve, renderInjection } from "../knowledge-retrieve";
+import type { Lesson } from "../knowledge-base";
+
+const lessons: Lesson[] = [
+  { date: "2026-06-10", kind: "shipped", text: "챌린지 상태 DB ChallengeState + 적립", ref: "PR#457" },
+  { date: "2026-06-09", kind: "shipped", text: "감정 캘린더 EmotionCalendar 구현", ref: "PR#300" },
+  { date: "2026-06-08", kind: "shipped", text: "네이버 종목토론실 커뮤니티 소스 연동", ref: "PR#408" },
+  { date: "2026-06-07", kind: "decision", text: "포인트 유료화 보류 — 적립만", ref: "issue#450" },
+];
+
+describe("tokenize", () => {
+  it("한글/영문 2자+ 토큰, 스톱워드 제외", () => {
+    const t = tokenize("감정 캘린더 EmotionCalendar 구현 및 추가");
+    expect(t).toContain("감정");
+    expect(t).toContain("캘린더");
+    expect(t).toContain("emotioncalendar");
+    expect(t).not.toContain("구현"); // 스톱워드
+    expect(t).not.toContain("및");
+  });
+});
+
+describe("retrieve", () => {
+  it("쿼리와 겹치는 교훈을 점수순 반환", () => {
+    const r = retrieve("감정 캘린더 스트릭 기능 추가", lessons);
+    expect(r[0]!.lesson.ref).toBe("PR#300"); // 감정+캘린더 겹침 최다
+  });
+  it("관련 없으면 빈 배열", () => {
+    expect(retrieve("로그인 OAuth 토큰 갱신", lessons)).toEqual([]);
+  });
+  it("빈 쿼리는 빈 배열", () => {
+    expect(retrieve("", lessons)).toEqual([]);
+  });
+  it("topN 제한", () => {
+    expect(retrieve("챌린지 감정 포인트 커뮤니티", lessons, 2).length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("renderInjection", () => {
+  it("관련 지식 + 출처 렌더", () => {
+    const block = renderInjection(retrieve("감정 캘린더", lessons));
+    expect(block).toContain("관련 과거 지식");
+    expect(block).toContain("감정 캘린더 EmotionCalendar");
+    expect(block).toContain("[출처: PR#300]");
+    expect(block).toContain("재제안·중복 설계 금지");
+  });
+  it("관련 없으면 신규 영역 안내", () => {
+    expect(renderInjection([])).toContain("신규 영역");
+  });
+});

--- a/scripts/knowledge-retrieve.ts
+++ b/scripts/knowledge-retrieve.ts
@@ -1,0 +1,78 @@
+/**
+ * 출처 있는 지식 검색 재주입 (에이전트 두뇌 K2).
+ *
+ * K1 이 적층한 knowledge/distilled.md 에서 쿼리(프로젝트 제목·범위·제안 텍스트)와 관련된
+ * 교훈을 키워드 겹침으로 골라, 출처와 함께 프롬프트 주입 블록으로 렌더한다.
+ * "이미 #470에서 결정 — 재제안·중복 금지 [출처]" 를 에이전트에게 보여 환각·중복을 막는다.
+ *
+ * 외부 의존/임베딩 없이 결정론적(키워드 겹침). 순수 export 함수 + main() CLI.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseDistilled, type Lesson } from "./knowledge-base";
+
+const STOP = new Set([
+  "the", "and", "for", "with", "feat", "fix", "chore", "council", "fomo", "p1", "p2", "p3", "p4",
+  "및", "또는", "그리고", "에서", "으로", "추가", "구현", "개선", "제안", "기능", "시스템",
+]);
+
+/** 한글/영문/숫자 토큰화 — 2자 이상, 스톱워드 제외, 소문자. */
+export function tokenize(s: string): string[] {
+  const raw = (s || "").toLowerCase().match(/[a-z0-9]+|[가-힣]{2,}/g) ?? [];
+  return raw.filter((t) => t.length >= 2 && !STOP.has(t));
+}
+
+export interface Scored {
+  lesson: Lesson;
+  score: number;
+}
+
+/** 쿼리와 교훈의 키워드 겹침 점수로 상위 N 선택(score>0). */
+export function retrieve(query: string, lessons: Lesson[], topN = 6): Scored[] {
+  const q = new Set(tokenize(query));
+  if (q.size === 0) return [];
+  const scored: Scored[] = [];
+  for (const l of lessons) {
+    const lt = new Set(tokenize(l.text));
+    let s = 0;
+    for (const t of lt) if (q.has(t)) s += 1;
+    if (s > 0) scored.push({ lesson: l, score: s });
+  }
+  scored.sort((a, b) => b.score - a.score || (a.lesson.date < b.lesson.date ? 1 : -1));
+  return scored.slice(0, topN);
+}
+
+/** 프롬프트 주입 블록. 관련 지식 없으면 안내. */
+export function renderInjection(scored: Scored[]): string {
+  if (!scored.length) {
+    return "## 🧠 관련 과거 지식\n(관련된 과거 출고·결정 없음 — 신규 영역)";
+  }
+  const lines = scored.map((s) => `- ${s.lesson.text}${s.lesson.ref ? ` [출처: ${s.lesson.ref}]` : ""}`);
+  return [
+    "## 🧠 관련 과거 지식 (출처) — 이미 출고/결정된 것: 재제안·중복 설계 금지",
+    "> 아래와 겹치는 기능은 *이미 있다*. 그 위에 무엇을 새로 더하는지 명확히 하라.",
+    ...lines,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────
+function main(): void {
+  const argv = process.argv;
+  if (argv[2] !== "retrieve") {
+    console.error("usage: tsx scripts/knowledge-retrieve.ts retrieve <distilled.md> <query...>");
+    process.exit(1);
+  }
+  let md = "";
+  try {
+    md = readFileSync(argv[3] ?? "", "utf8");
+  } catch {
+    md = "";
+  }
+  const query = argv.slice(4).join(" ");
+  process.stdout.write(renderInjection(retrieve(query, parseDistilled(md))));
+}
+
+const invokedPath = process.argv[1] ?? "";
+if (invokedPath.includes("knowledge-retrieve")) {
+  main();
+}


### PR DESCRIPTION
K1 지식 레이어를 propose/decompose/implement 프롬프트에 **출처와 함께** 검색 주입 → 환각·중복 차단.

- **scripts/knowledge-retrieve.ts** (순수+vitest 7): 키워드 겹침 결정론 검색, '이미 출고/결정 [출처:PR#N] 재제안 금지' 블록.
- **propose-project**: 광역 검색 → 이미 출고된 것 주입(감정 캘린더류 중복 제안 방지).
- **project-decompose**: PRD 쿼리 → 중복 모델/설계 방지(#467/#469 재발 차단).
- **implement-task**: task 쿼리 → 기존 코드 재사용.

게이트: YAML×3 ✅ vitest 7 ✅ lint·typecheck ✅. (knowledge/distilled.md 없으면 '신규 영역'으로 graceful)