### PR TITLE
feat(brain): 지식 레이어 고도화 — 규칙 자동추출 + 동의어·가중 검색

### DIFF
--- a/.github/workflows/knowledge-distill.yml
+++ b/.github/workflows/knowledge-distill.yml
@@ -54,15 +54,22 @@ jobs:
             echo "[]" > /tmp/kb_hits.json
           fi
 
-          # 3) 결정(현재는 자동 추출 보류 — 후속) — 빈 배열
+          # 3) 결정(자유 텍스트) — 현재 빈 배열(후속: 브리프/플랜doc 추출)
           echo "[]" > /tmp/kb_decisions.json
+
+          # 4) 규칙(rule) 자동추출 — Standing Constraints(=CEO 확정 규칙)를 지식 rule 층으로
+          if [ -f constraints/active.json ]; then
+            jq '.constraints | map({id, rule, createdAt})' constraints/active.json > /tmp/kb_constraints.json 2>/dev/null || echo "[]" > /tmp/kb_constraints.json
+          else
+            echo "[]" > /tmp/kb_constraints.json
+          fi
 
           mkdir -p knowledge/daily
           [ -f knowledge/distilled.md ] || printf '' > knowledge/distilled.md
 
           NEW=$(npx -y tsx@4.19.2 scripts/knowledge-base.ts build \
             "$TODAY" /tmp/kb_merged.json /tmp/kb_hits.json /tmp/kb_decisions.json \
-            knowledge/distilled.md "knowledge/daily/${TODAY}.md" 2>/dev/null || echo 0)
+            knowledge/distilled.md "knowledge/daily/${TODAY}.md" /tmp/kb_constraints.json 2>/dev/null || echo 0)
           echo "NEW_LESSONS=$NEW" >> "$GITHUB_ENV"
           echo "KDATE=$TODAY" >> "$GITHUB_ENV"
           {

--- a/scripts/__tests__/knowledge-base.test.ts
+++ b/scripts/__tests__/knowledge-base.test.ts
@@ -2,11 +2,27 @@ import { describe, it, expect } from "vitest";
 import {
   lessonsFromMergedPRs,
   lessonsFromDecisions,
+  lessonsFromConstraints,
   parseDistilled,
   mergeLessons,
   renderDistilled,
   renderDailyNote,
 } from "../knowledge-base";
+
+describe("lessonsFromConstraints", () => {
+  it("active constraint → rule 교훈 (ref=id, createdAt 우선)", () => {
+    const l = lessonsFromConstraints(
+      [{ id: "c-tarot-reject", rule: "타로 신규작업 거부", createdAt: "2026-06-09" }],
+      "2026-06-10",
+    );
+    expect(l[0]).toEqual({ date: "2026-06-09", kind: "rule", text: "타로 신규작업 거부", ref: "c-tarot-reject" });
+  });
+  it("id/rule 없으면 제외, createdAt 없으면 fallback", () => {
+    const l = lessonsFromConstraints([{ id: "", rule: "x" }, { id: "c1", rule: "규칙" }], "2026-06-10");
+    expect(l).toHaveLength(1);
+    expect(l[0]!.date).toBe("2026-06-10");
+  });
+});
 
 describe("lessonsFromMergedPRs", () => {
   it("머지 PR → shipped 교훈 (Auto 접두사 제거 + ref)", () => {

--- a/scripts/__tests__/knowledge-retrieve.test.ts
+++ b/scripts/__tests__/knowledge-retrieve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { tokenize, retrieve, renderInjection } from "../knowledge-retrieve";
+import { tokenize, expand, retrieve, renderInjection } from "../knowledge-retrieve";
 import type { Lesson } from "../knowledge-base";
 
 const lessons: Lesson[] = [
@@ -20,10 +20,31 @@ describe("tokenize", () => {
   });
 });
 
+describe("expand (동의어 확장)", () => {
+  it("동의어 그룹으로 토큰 확장", () => {
+    const e = expand(["알림"]);
+    expect(e.has("푸시")).toBe(true);
+    expect(e.has("notification")).toBe(true);
+  });
+});
+
 describe("retrieve", () => {
   it("쿼리와 겹치는 교훈을 점수순 반환", () => {
     const r = retrieve("감정 캘린더 스트릭 기능 추가", lessons);
     expect(r[0]!.lesson.ref).toBe("PR#300"); // 감정+캘린더 겹침 최다
+  });
+  it("동의어로 recall — '푸시 notification' 쿼리가 '알림' 교훈 회수", () => {
+    const ls = [{ date: "2026-06-10", kind: "shipped" as const, text: "감정 변화 알림 발송", ref: "PR#999" }];
+    const r = retrieve("푸시 notification 시스템", ls);
+    expect(r.length).toBe(1);
+    expect(r[0]!.lesson.ref).toBe("PR#999");
+  });
+  it("동점이면 최신 교훈 우선(최신성 가중)", () => {
+    const ls = [
+      { date: "2026-05-01", kind: "shipped" as const, text: "감정 캘린더", ref: "PR#1" },
+      { date: "2026-06-10", kind: "shipped" as const, text: "감정 캘린더", ref: "PR#2" },
+    ];
+    expect(retrieve("감정 캘린더", ls, 6, "2026-06-11")[0]!.lesson.ref).toBe("PR#2");
   });
   it("관련 없으면 빈 배열", () => {
     expect(retrieve("로그인 OAuth 토큰 갱신", lessons)).toEqual([]);

--- a/scripts/knowledge-base.ts
+++ b/scripts/knowledge-base.ts
@@ -49,6 +49,27 @@ export function lessonsFromDecisions(decisions: string[], date: string, refs: st
     .map((text, i) => ({ date, kind: "decision" as const, text, ref: refs[i] ?? "" }));
 }
 
+export interface ConstraintRule {
+  id: string;
+  rule: string;
+  createdAt?: string;
+}
+
+/**
+ * Standing Constraints(active.json) → rule 교훈. CEO 확정 규칙은 가장 오래가는 결정이므로
+ * 지식의 rule 층을 자동으로 채운다(지금까지 비어 있던 층). ref = constraint id, 멱등 누적.
+ */
+export function lessonsFromConstraints(constraints: ConstraintRule[], fallbackDate: string): Lesson[] {
+  return (constraints || [])
+    .filter((c) => c && c.id && clean(c.rule))
+    .map((c) => ({
+      date: c.createdAt || fallbackDate,
+      kind: "rule" as const,
+      text: clean(c.rule).slice(0, 180),
+      ref: c.id,
+    }));
+}
+
 const LINE_RE = /^- \[(\d{4}-\d{2}-\d{2})\]\s*\((shipped|decision|rule)\)\s*(.*?)(?:\s*\[출처:\s*([^\]]+)\])?\s*$/;
 
 /** knowledge/distilled.md 파싱 → Lesson[]. */
@@ -147,8 +168,13 @@ function main(): void {
   const decisions = readJson<string[]>(argv[6], []);
   const distilledPath = argv[7];
   const outDaily = argv[8];
+  const constraints = readJson<ConstraintRule[]>(argv[9], []); // 선택 — active constraints 배열
 
-  const incoming = [...lessonsFromMergedPRs(merged, date), ...lessonsFromDecisions(decisions, date)];
+  const incoming = [
+    ...lessonsFromMergedPRs(merged, date),
+    ...lessonsFromDecisions(decisions, date),
+    ...lessonsFromConstraints(constraints, date),
+  ];
   const existing = parseDistilled(readText(distilledPath));
   const mergedLessons = mergeLessons(existing, incoming);
   if (distilledPath) writeFileSync(distilledPath, renderDistilled(mergedLessons));

--- a/scripts/knowledge-retrieve.ts
+++ b/scripts/knowledge-retrieve.ts
@@ -16,10 +16,47 @@ const STOP = new Set([
   "및", "또는", "그리고", "에서", "으로", "추가", "구현", "개선", "제안", "기능", "시스템",
 ]);
 
+/**
+ * 도메인 동의어 — 키워드 완전일치만으로는 "알림"과 "푸시 notification" 을 못 잇는다.
+ * 각 그룹의 토큰은 검색 시 서로로 확장된다(결정론적, 임베딩 무의존, 소규모 코퍼스에 충분).
+ */
+const SYNONYMS: string[][] = [
+  ["알림", "푸시", "notification", "push"],
+  ["캘린더", "calendar", "달력"],
+  ["포인트", "리워드", "reward", "보상", "적립"],
+  ["시뮬레이터", "시뮬레이션", "simulator", "모의"],
+  ["커뮤니티", "피드", "feed", "레딧", "reddit", "네이버", "토론"],
+  ["감정", "이모션", "emotion", "기분"],
+  ["챌린지", "미션", "challenge", "퀘스트"],
+  ["마스코트", "포모", "표정", "mascot"],
+  ["인덱스", "지수", "index", "히트", "heat"],
+  ["통계", "집계", "stats", "aggregate"],
+  ["고래", "whale"],
+];
+const SYN_MAP: Map<string, Set<string>> = (() => {
+  const m = new Map<string, Set<string>>();
+  for (const group of SYNONYMS) {
+    const set = new Set(group);
+    for (const t of group) m.set(t, set);
+  }
+  return m;
+})();
+
 /** 한글/영문/숫자 토큰화 — 2자 이상, 스톱워드 제외, 소문자. */
 export function tokenize(s: string): string[] {
   const raw = (s || "").toLowerCase().match(/[a-z0-9]+|[가-힣]{2,}/g) ?? [];
   return raw.filter((t) => t.length >= 2 && !STOP.has(t));
+}
+
+/** 토큰 집합을 동의어로 확장. */
+export function expand(tokens: Iterable<string>): Set<string> {
+  const out = new Set<string>();
+  for (const t of tokens) {
+    out.add(t);
+    const syn = SYN_MAP.get(t);
+    if (syn) for (const s of syn) out.add(s);
+  }
+  return out;
 }
 
 export interface Scored {
@@ -27,16 +64,32 @@ export interface Scored {
   score: number;
 }
 
-/** 쿼리와 교훈의 키워드 겹침 점수로 상위 N 선택(score>0). */
-export function retrieve(query: string, lessons: Lesson[], topN = 6): Scored[] {
-  const q = new Set(tokenize(query));
+/** 일수 차이로 최신성 가중(0~오래될수록 감소). */
+function recencyBoost(date: string, now: string): number {
+  const d = Date.parse(date + "T00:00:00Z");
+  const n = Date.parse((now || date) + "T00:00:00Z");
+  if (!Number.isFinite(d) || !Number.isFinite(n)) return 0;
+  const days = Math.max(0, (n - d) / 86400000);
+  return days <= 7 ? 0.5 : days <= 30 ? 0.25 : 0; // 최근 1주 +0.5, 1달 +0.25
+}
+
+/**
+ * 쿼리-교훈 키워드 겹침 + 동의어 확장 + 최신성/출처 가중으로 상위 N 선택.
+ * now 미지정 시 가장 최신 교훈 날짜를 기준으로 한다(결정론 유지).
+ */
+export function retrieve(query: string, lessons: Lesson[], topN = 6, now?: string): Scored[] {
+  const q = expand(tokenize(query));
   if (q.size === 0) return [];
+  const ref = now ?? lessons.reduce((mx, l) => (l.date > mx ? l.date : mx), "");
   const scored: Scored[] = [];
   for (const l of lessons) {
-    const lt = new Set(tokenize(l.text));
-    let s = 0;
-    for (const t of lt) if (q.has(t)) s += 1;
-    if (s > 0) scored.push({ lesson: l, score: s });
+    const lt = expand(tokenize(l.text));
+    let overlap = 0;
+    for (const t of lt) if (q.has(t)) overlap += 1;
+    if (overlap > 0) {
+      const score = overlap + recencyBoost(l.date, ref) + (l.ref ? 0.1 : 0); // 출처 있으면 미세 가중
+      scored.push({ lesson: l, score });
+    }
   }
   scored.sort((a, b) => b.score - a.score || (a.lesson.date < b.lesson.date ? 1 : -1));
   return scored.slice(0, topN);


### PR DESCRIPTION
지식 레이어 고도화(제품 트랙 대신 진행).

## 1) 결정/규칙 자동추출 (비어있던 rule 층 채움)
- `lessonsFromConstraints`: Standing Constraints(=CEO 확정 규칙) → rule 교훈 자동 적층(ref=constraint id, 멱등). knowledge-distill 9번째 인자로 배선.
- 효과: 에이전트가 '정직한 숫자·타로 금지·예측 금지' 등 **CEO 규칙을 출처와 함께 기억** → 검색 재주입.

## 2) 검색 recall 고도화 (키워드 완전일치 탈피)
- 도메인 **동의어 확장**(알림↔푸시↔notification, 캘린더↔calendar, 포인트↔리워드↔적립, 커뮤니티↔피드↔레딧…) + **최신성 가중**(1주 +0.5/1달 +0.25) + 출처 가중.
- 효과: '푸시 notification' 쿼리가 '알림' 교훈 회수, 동점은 최신 우선.

## 게이트
YAML ✅ vitest +5(총 knowledge 21) ✅ lint·typecheck ✅. 라이브 dry-run: CEO 규칙 7건 rule 적층 확인.

> 임베딩 검색은 코퍼스가 작아(수십~수백 교훈) 비용 대비 효익 낮음 + 외부 키/엔드포인트 의존 → 결정론 동의어 방식으로 충분. 필요 시 후속.