### PR TITLE
feat(brain): 지식 v3 — CEO 결정 자동추출 + 컴팩션 + PRD 지식주입

### DIFF
--- a/.github/workflows/knowledge-distill.yml
+++ b/.github/workflows/knowledge-distill.yml
@@ -54,8 +54,21 @@ jobs:
             echo "[]" > /tmp/kb_hits.json
           fi
 
-          # 3) 결정(자유 텍스트) — 현재 빈 배열(후속: 브리프/플랜doc 추출)
+          # 3) 결정 자동추출 — 기획문서(plan-doc) 이슈의 "✅ CEO 결정" 섹션 불릿
           echo "[]" > /tmp/kb_decisions.json
+          PLAN_NUMS=$(gh issue list --label "plan-doc" --state all --limit 10 \
+            --json number --jq '.[].number' --repo "${{ github.repository }}" 2>/dev/null || echo "")
+          : > /tmp/kb_dec_all.json
+          for N in $PLAN_NUMS; do
+            gh issue view "$N" --json body --jq .body --repo "${{ github.repository }}" 2>/dev/null > /tmp/kb_plan_body.md || continue
+            npx -y tsx@4.19.2 scripts/knowledge-base.ts decisions /tmp/kb_plan_body.md 2>/dev/null \
+              | jq --arg ref "issue#$N" '[ .[] | {text: ., ref: $ref} ]' >> /tmp/kb_dec_all.json || true
+          done
+          if [ -s /tmp/kb_dec_all.json ]; then
+            # build 는 {text, ref}[] 를 받는다 — issue# 출처 보존 (멱등은 ref+text 기준)
+            jq -s 'add // []' /tmp/kb_dec_all.json > /tmp/kb_decisions.json 2>/dev/null || echo "[]" > /tmp/kb_decisions.json
+          fi
+          [ -s /tmp/kb_decisions.json ] || echo "[]" > /tmp/kb_decisions.json
 
           # 4) 규칙(rule) 자동추출 — Standing Constraints(=CEO 확정 규칙)를 지식 rule 층으로
           if [ -f constraints/active.json ]; then

--- a/.github/workflows/project-kickoff.yml
+++ b/.github/workflows/project-kickoff.yml
@@ -96,6 +96,14 @@ jobs:
             CB=$(npx -y tsx@4.19.2 scripts/constraints.ts render-brief /tmp/ctx_c.json 2>/dev/null || echo "(조회 실패)")
           fi
           echo "constraints<<__CEOF__" >> "$GITHUB_OUTPUT"; echo "$CB" >> "$GITHUB_OUTPUT"; echo "__CEOF__" >> "$GITHUB_OUTPUT"
+          # K2 — 기획문서 작성 전, 관련 과거 지식(이미 출고/결정) 검색 재주입
+          KN="(지식 레이어 없음)"
+          if [ -f knowledge/distilled.md ]; then
+            PT=$(printf '%s' "$ACTIVE" | jq -r '.title // ""' 2>/dev/null || echo "")
+            PS=$(printf '%s' "$ACTIVE" | jq -r '.scope // ""' 2>/dev/null || echo "")
+            KN=$(npx -y tsx@4.19.2 scripts/knowledge-retrieve.ts retrieve knowledge/distilled.md "$PT $PS" 2>/dev/null || echo "(검색 실패)")
+          fi
+          echo "knowledge<<__KEOF__" >> "$GITHUB_OUTPUT"; echo "$KN" >> "$GITHUB_OUTPUT"; echo "__KEOF__" >> "$GITHUB_OUTPUT"
 
       - name: "기획문서(PRD) 작성 (기획 직군 LLM)"
         id: prd
@@ -129,6 +137,8 @@ jobs:
 
             ## Standing Constraints (자가점검 기준)
             ${{ steps.ctx.outputs.constraints }}
+
+            ${{ steps.ctx.outputs.knowledge }}
 
             위 프로젝트의 상세 기획문서(PRD)를 마크다운으로 작성하라.
 

--- a/scripts/__tests__/knowledge-base.test.ts
+++ b/scripts/__tests__/knowledge-base.test.ts
@@ -3,11 +3,52 @@ import {
   lessonsFromMergedPRs,
   lessonsFromDecisions,
   lessonsFromConstraints,
+  extractPlanDecisions,
+  compactLessons,
   parseDistilled,
   mergeLessons,
   renderDistilled,
   renderDailyNote,
 } from "../knowledge-base";
+
+describe("extractPlanDecisions", () => {
+  const body = [
+    "## 🗺️ 상위 프로젝트: P2",
+    "본문",
+    "## ✅ CEO 결정 (승인 — 일부 수정 반영)",
+    "- 🚫 **포모 포인트의 사용처/유료화는 보류.** 향후 별도 논의.",
+    "- ✅ 이번엔 적립 로직만 설계·구현한다",
+    "- 짧음",
+    "## 기능 요구사항",
+    "- 이건 결정 아님",
+  ].join("\n");
+  it("CEO 결정 섹션의 불릿만 추출(마크업 정리, 다음 섹션 제외)", () => {
+    const d = extractPlanDecisions(body);
+    expect(d).toHaveLength(2);
+    expect(d[0]).toContain("포모 포인트의 사용처/유료화는 보류");
+    expect(d[0]).not.toContain("**");
+    expect(d.some((x) => x.includes("결정 아님"))).toBe(false);
+  });
+  it("섹션 없으면 빈 배열", () => {
+    expect(extractPlanDecisions("# 그냥 문서\n- 불릿")).toEqual([]);
+  });
+});
+
+describe("compactLessons", () => {
+  it("rule/decision 전부 보존, shipped 는 최신 N개", () => {
+    const lessons = [
+      { date: "2026-06-01", kind: "rule" as const, text: "규칙", ref: "c-1" },
+      { date: "2026-06-01", kind: "decision" as const, text: "결정", ref: "" },
+      { date: "2026-06-01", kind: "shipped" as const, text: "옛출고", ref: "PR#1" },
+      { date: "2026-06-09", kind: "shipped" as const, text: "신출고1", ref: "PR#2" },
+      { date: "2026-06-10", kind: "shipped" as const, text: "신출고2", ref: "PR#3" },
+    ];
+    const c = compactLessons(lessons, 2);
+    expect(c.filter((l) => l.kind !== "shipped")).toHaveLength(2);
+    const shipped = c.filter((l) => l.kind === "shipped");
+    expect(shipped.map((l) => l.ref)).toEqual(["PR#3", "PR#2"]); // 최신 2개만
+  });
+});
 
 describe("lessonsFromConstraints", () => {
   it("active constraint → rule 교훈 (ref=id, createdAt 우선)", () => {
@@ -69,6 +110,14 @@ describe("mergeLessons (멱등 누적)", () => {
     const ex = [{ date: "d", kind: "decision" as const, text: "포인트 보류", ref: "" }];
     expect(mergeLessons(ex, [{ date: "d2", kind: "decision", text: "포인트 보류", ref: "" }])).toHaveLength(1);
     expect(mergeLessons(ex, [{ date: "d2", kind: "decision", text: "다른 결정", ref: "" }])).toHaveLength(2);
+  });
+  it("decision 은 같은 ref(이슈)에 여러 결정 허용 — ref+text 멱등", () => {
+    const ex = [{ date: "d", kind: "decision" as const, text: "포인트 유료화 보류", ref: "issue#450" }];
+    const merged = mergeLessons(ex, [
+      { date: "d", kind: "decision", text: "적립 로직만 구현", ref: "issue#450" }, // 같은 이슈, 다른 결정 → 추가
+      { date: "d2", kind: "decision", text: "포인트 유료화 보류", ref: "issue#450" }, // 동일 → 스킵
+    ]);
+    expect(merged).toHaveLength(2);
   });
 });
 

--- a/scripts/knowledge-base.ts
+++ b/scripts/knowledge-base.ts
@@ -70,6 +70,45 @@ export function lessonsFromConstraints(constraints: ConstraintRule[], fallbackDa
     }));
 }
 
+/**
+ * 기획문서(plan-doc) 본문의 "✅ CEO 결정" 섹션에서 결정 불릿을 추출.
+ * 사람이 승인/수정하며 적은 결정("포인트 유료화 보류" 등)이 지식 decision 층으로 적층된다.
+ * 섹션 헤더(## ✅ CEO 결정 …)부터 다음 헤더(##) 전까지의 "- " 불릿만, 마크업 정리.
+ */
+export function extractPlanDecisions(body: string): string[] {
+  const lines = (body || "").split("\n");
+  const out: string[] = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (/^#{2,3}\s*.*CEO\s*결정/.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection && /^#{1,3}\s/.test(line)) break; // 다음 섹션
+    if (inSection) {
+      const m = line.match(/^\s*-\s+(.*)$/);
+      if (m) {
+        const text = clean(m[1]!.replace(/\*\*/g, "").replace(/^[🚫✅⛔→>]+\s*/u, ""));
+        if (text.length >= 6) out.push(text.slice(0, 180));
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * 컴팩션 — 무한 누적 방지. rule/decision 은 전부 보존(가장 오래가는 지식),
+ * shipped 만 최신순으로 maxShipped 개 유지. (오래된 출고는 코드/inventory 가 이미 진실)
+ */
+export function compactLessons(lessons: Lesson[], maxShipped = 300): Lesson[] {
+  const keep = lessons.filter((l) => l.kind !== "shipped");
+  const shipped = lessons
+    .filter((l) => l.kind === "shipped")
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
+    .slice(0, maxShipped);
+  return [...keep, ...shipped];
+}
+
 const LINE_RE = /^- \[(\d{4}-\d{2}-\d{2})\]\s*\((shipped|decision|rule)\)\s*(.*?)(?:\s*\[출처:\s*([^\]]+)\])?\s*$/;
 
 /** knowledge/distilled.md 파싱 → Lesson[]. */
@@ -82,9 +121,18 @@ export function parseDistilled(md: string): Lesson[] {
   return out;
 }
 
-/** 멱등 누적 — ref 가 있으면 ref 로, 없으면 정규화 text 로 중복 판정. 신규만 추가. */
+/**
+ * 멱등 누적 — kind 별 중복 키. 신규만 추가.
+ *  - shipped/rule: ref 1개 = 교훈 1개 (PR 번호·constraint id 가 유일키)
+ *  - decision: 한 이슈(ref)에 결정이 여러 개 가능 → ref+text 로 판정 (같은 ref 붕괴 방지)
+ */
 export function mergeLessons(existing: Lesson[], incoming: Lesson[]): Lesson[] {
-  const keyOf = (l: Lesson) => (l.ref ? `ref:${l.ref.toLowerCase()}` : `txt:${l.text.toLowerCase()}`);
+  const keyOf = (l: Lesson) => {
+    const txt = l.text.toLowerCase();
+    if (!l.ref) return `txt:${txt}`;
+    if (l.kind === "decision") return `ref:${l.ref.toLowerCase()}|${txt}`;
+    return `ref:${l.ref.toLowerCase()}`;
+  };
   const seen = new Set(existing.map(keyOf));
   const merged = [...existing];
   for (const l of incoming) {
@@ -158,27 +206,37 @@ function readText(path: string | undefined): string {
  */
 function main(): void {
   const argv = process.argv;
+  if (argv[2] === "decisions") {
+    // decisions <plan_doc_body.md> → CEO 결정 불릿 JSON 배열 stdout
+    const body = readText(argv[3]);
+    process.stdout.write(JSON.stringify(extractPlanDecisions(body)));
+    return;
+  }
   if (argv[2] !== "build") {
-    console.error("usage: tsx scripts/knowledge-base.ts build <date> <merged.json> <hits.json> <decisions.json> <distilled.md> <out_daily.md>");
+    console.error("usage: tsx scripts/knowledge-base.ts <build|decisions> ...");
     process.exit(1);
   }
   const date = argv[3] ?? "";
   const merged = readJson<MergedPR[]>(argv[4], []);
   const hits = readJson<{ id: string; count: number }[]>(argv[5], []);
-  const decisions = readJson<string[]>(argv[6], []);
+  // decisions: string[] 또는 {text, ref}[] 둘 다 허용 — ref(issue#) 가 있으면 출처 보존
+  const decisionsRaw = readJson<Array<string | { text: string; ref?: string }>>(argv[6], []);
+  const decisionTexts = decisionsRaw.map((d) => (typeof d === "string" ? d : d.text ?? ""));
+  const decisionRefs = decisionsRaw.map((d) => (typeof d === "string" ? "" : d.ref ?? ""));
   const distilledPath = argv[7];
   const outDaily = argv[8];
   const constraints = readJson<ConstraintRule[]>(argv[9], []); // 선택 — active constraints 배열
 
-  const incoming = [
+  const dailyLessons = [
     ...lessonsFromMergedPRs(merged, date),
-    ...lessonsFromDecisions(decisions, date),
-    ...lessonsFromConstraints(constraints, date),
+    ...lessonsFromDecisions(decisionTexts, date, decisionRefs),
   ];
+  // 규칙(constraints)은 distilled 에만 — daily 노트가 매일 전체 규칙으로 도배되는 것 방지
+  const incoming = [...dailyLessons, ...lessonsFromConstraints(constraints, date)];
   const existing = parseDistilled(readText(distilledPath));
-  const mergedLessons = mergeLessons(existing, incoming);
+  const mergedLessons = compactLessons(mergeLessons(existing, incoming));
   if (distilledPath) writeFileSync(distilledPath, renderDistilled(mergedLessons));
-  if (outDaily) writeFileSync(outDaily, renderDailyNote(date, incoming, hits));
+  if (outDaily) writeFileSync(outDaily, renderDailyNote(date, dailyLessons, hits));
   process.stdout.write(String(mergedLessons.length - existing.length));
 }
 


### PR DESCRIPTION
지식 레이어 고도화 마감 라운드.

- CEO 결정 자동추출: plan-doc '✅ CEO 결정' 불릿 → decision 교훈(issue# 출처, kind별 멱등 — 같은 이슈 다결정 허용 버그 수정)
- 컴팩션: rule/decision 보존, shipped 최신 300개
- knowledge-distill: plan-doc 결정 {text,ref} 적층 배선, daily 노트 규칙 도배 방지
- project-kickoff(PRD)에 K2 지식 주입(마지막 빠진 지점)

vitest 159 ✅ · 백필 확인(rule 8+shipped 63) ✅