### PR TITLE
fix(banner): 거시지수 1차 소스 Twelve Data 무료키 교체 (#480)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,12 @@ SLACK_SIGNING_SECRET=""                   # Slack App → Basic Information → 
 GITHUB_PAT=""                             # Fine-grained PAT (repo + workflow 스코프)
 GITHUB_REPO="mlender-ai/taro-stock-app"   # GitHub 레포 (owner/repo)
 
+# ─── FOMO 롤링 배너 거시지수 (#480) ──────────────────────────────────────────
+# Twelve Data 무료키(800req/day) — 배너 macro 1차 소스. Yahoo egress 차단 회피용.
+# 미설정 시 자동으로 Yahoo chart 폴백(현 동작 유지). Vercel env 에만 넣으면 자동 격상.
+# 발급: https://twelvedata.com → Sign up → Dashboard → API Key
+TWELVE_DATA_API_KEY=""
+
 # ─── AI Agent Chat (Phase 3) ─────────────────────────────────────────────────
 AI_API_URL=""                             # AI API 엔드포인트 (예: https://models.github.ai/inference/chat/completions)
 AI_API_KEY=""                             # AI API 키

--- a/apps/web/app/api/fomo/banner/route.ts
+++ b/apps/web/app/api/fomo/banner/route.ts
@@ -5,6 +5,7 @@ import {
   buildMacroItems,
   buildPulseItems,
   yahooChange,
+  twelveDataChange,
   bannerFallback,
   type BannerItem,
   type MacroQuote,
@@ -27,12 +28,14 @@ export const dynamic = "force-dynamic";
 const YAHOO_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 // 호스트 2개 폴백 — 한쪽이 스로틀(429/빈응답)이면 다른 쪽 시도.
 const YAHOO_HOSTS = ["https://query1.finance.yahoo.com", "https://query2.finance.yahoo.com"];
-const INDICES: { key: MacroQuote["key"]; label: string; symbol: string }[] = [
-  { key: "kospi", label: "코스피", symbol: "^KS11" },
-  { key: "kosdaq", label: "코스닥", symbol: "^KQ11" },
-  { key: "spx", label: "S&P500", symbol: "^GSPC" },
-  { key: "ndq", label: "나스닥", symbol: "^IXIC" },
-  { key: "sox", label: "필라델피아 반도체", symbol: "^SOX" },
+// symbol: Yahoo chart 심볼(폴백). td: Twelve Data `/quote` 심볼(1차 소스).
+// Twelve Data 무료키(800req/day)로 5개를 batch 1콜에 받으므로 부하·레이트리밋과 무관하게 안정적.
+const INDICES: { key: MacroQuote["key"]; label: string; symbol: string; td: string }[] = [
+  { key: "kospi", label: "코스피", symbol: "^KS11", td: "KS11" },
+  { key: "kosdaq", label: "코스닥", symbol: "^KQ11", td: "KQ11" },
+  { key: "spx", label: "S&P500", symbol: "^GSPC", td: "GSPC" },
+  { key: "ndq", label: "나스닥", symbol: "^IXIC", td: "IXIC" },
+  { key: "sox", label: "필라델피아 반도체", symbol: "^SOX", td: "SOX" },
 ];
 
 export function OPTIONS() {
@@ -65,17 +68,60 @@ async function fetchIndexCloses(symbol: string): Promise<(number | null)[] | nul
 }
 
 /**
- * Yahoo chart(최근 5일 일봉)에서 각 지수의 직전 대비 변화율을 모은다.
- * **순차 요청** — 동시(burst)로 5개를 때리면 Yahoo가 일부를 스로틀해 누락되므로
- * 하나씩 직렬로(호스트 폴백 포함) 받아 안정성을 확보한다(5분 캐시라 지연 무관).
+ * Twelve Data `/quote` batch — 5개 지수를 comma-separated 로 1콜에 받는다(무료 800req/day).
+ * 응답은 심볼 키 객체({ "KS11": {...}, ... }) 또는 단일 객체. 키 없으면 빈 맵.
+ * Vercel egress IP 차단·부하와 무관하게 안정적 → 1차 소스(#480). 키 없으면 호출 안 함.
+ */
+async function fetchMacroTwelveData(): Promise<Map<MacroQuote["key"], { change: number; close: number }>> {
+  const out = new Map<MacroQuote["key"], { change: number; close: number }>();
+  const apiKey = process.env.TWELVE_DATA_API_KEY;
+  if (!apiKey) return out;
+  try {
+    const symbols = INDICES.map((s) => s.td).join(",");
+    const url = `https://api.twelvedata.com/quote?symbol=${encodeURIComponent(symbols)}&apikey=${encodeURIComponent(apiKey)}`;
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(8_000),
+      // 5분 데이터 캐시 — 무료 일일쿼터·레이트리밋 보호.
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return out;
+    const payload = (await res.json()) as Record<string, unknown> & { status?: string };
+    // batch(>1심볼)는 심볼 키 객체, 단일은 quote 객체 자체.
+    const pick = (td: string): Parameters<typeof twelveDataChange>[0] => {
+      const byKey = (payload as Record<string, unknown>)[td];
+      if (byKey && typeof byKey === "object") return byKey as Parameters<typeof twelveDataChange>[0];
+      if (INDICES.length === 1) return payload as Parameters<typeof twelveDataChange>[0];
+      return null;
+    };
+    for (const s of INDICES) {
+      const parsed = twelveDataChange(pick(s.td));
+      if (parsed) out.set(s.key, parsed);
+    }
+  } catch (err) {
+    console.warn("[fomo/banner] twelvedata error", err);
+  }
+  return out;
+}
+
+/**
+ * 거시 지수 변화율 수집. 1차 Twelve Data(키 있을 때, batch 1콜) → 누락분만 Yahoo 폴백.
+ * Yahoo 는 **순차 요청** — 동시 burst 면 스로틀로 누락되므로 하나씩 직렬(호스트 폴백 포함).
+ * 키 미설정 시엔 기존 Yahoo 경로 그대로(graceful) → 오너가 Vercel env 설정 시 자동 격상.
  */
 async function fetchMacro(): Promise<MacroQuote[]> {
+  const td = await fetchMacroTwelveData();
   const quotes: MacroQuote[] = [];
   for (const s of INDICES) {
+    const hit = td.get(s.key);
+    if (hit) {
+      quotes.push({ ...s, change: hit.change, close: hit.close });
+      continue;
+    }
+    // Twelve Data 누락(키 없음 포함) → Yahoo 폴백.
     const closes = await fetchIndexCloses(s.symbol);
     const parsed = closes ? yahooChange(closes) : null;
     if (parsed) quotes.push({ ...s, change: parsed.change, close: parsed.close });
-    else console.warn(`[fomo/banner] yahoo miss ${s.symbol}`);
+    else console.warn(`[fomo/banner] macro miss ${s.symbol} (td+yahoo)`);
   }
   return quotes;
 }

--- a/packages/fomo-core/__tests__/banner.test.ts
+++ b/packages/fomo-core/__tests__/banner.test.ts
@@ -4,6 +4,7 @@ import {
   buildWhaleItems,
   buildMacroItems,
   yahooChange,
+  twelveDataChange,
   buildPulseItems,
   bannerFallback,
   parseStooqDailyChange,
@@ -87,6 +88,33 @@ describe("yahooChange", () => {
   it("유효 종가 2개 미만이면 null", () => {
     expect(yahooChange([null, 100])).toBeNull();
     expect(yahooChange([])).toBeNull();
+  });
+});
+
+describe("twelveDataChange", () => {
+  it("percent_change(문자열) 우선 신뢰 + close 파싱", () => {
+    const r = twelveDataChange({ close: "2611.45", previous_close: "2600.00", percent_change: "0.44" });
+    expect(r?.close).toBe(2611.45);
+    expect(r?.change).toBe(0.44);
+  });
+
+  it("percent_change 없으면 close/previous_close 로 계산", () => {
+    const r = twelveDataChange({ close: 4950, previous_close: 5000 });
+    expect(r?.close).toBe(4950);
+    expect(r && Math.round(r.change * 100) / 100).toBe(-1);
+  });
+
+  it("숫자 타입도 허용", () => {
+    const r = twelveDataChange({ close: 100, percent_change: 2.5 });
+    expect(r).toEqual({ close: 100, change: 2.5 });
+  });
+
+  it("status:error / null / close 결측 / prev 0 이면 null", () => {
+    expect(twelveDataChange({ status: "error", close: "100" })).toBeNull();
+    expect(twelveDataChange(null)).toBeNull();
+    expect(twelveDataChange(undefined)).toBeNull();
+    expect(twelveDataChange({ previous_close: "100" })).toBeNull();
+    expect(twelveDataChange({ close: 100, previous_close: 0 })).toBeNull();
   });
 });
 

--- a/packages/fomo-core/src/banner.ts
+++ b/packages/fomo-core/src/banner.ts
@@ -231,6 +231,39 @@ export function yahooChange(
   return { change: ((last - prev) / prev) * 100, close: last };
 }
 
+/**
+ * Twelve Data `/quote` 응답 1건에서 변화율(%)·최근 종가를 구한다.
+ * (Yahoo/Stooq가 Vercel egress IP를 레이트리밋·차단해 ^KS11 등이 상시 누락 →
+ *  무료키 기반 Twelve Data 로 1차 소스 교체. #480.)
+ * `percent_change`(문자열/숫자)를 우선 신뢰하고, 없으면 close/previous_close 로 계산.
+ * 값이 없거나 파싱 불가, 또는 status:"error" 면 null(→ 항목 생략 / Yahoo 폴백).
+ */
+export function twelveDataChange(
+  q:
+    | {
+        status?: string;
+        close?: string | number | null;
+        previous_close?: string | number | null;
+        percent_change?: string | number | null;
+      }
+    | null
+    | undefined
+): { change: number; close: number } | null {
+  if (!q || q.status === "error") return null;
+  const num = (v: unknown): number | null => {
+    if (v === null || v === undefined || v === "") return null;
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
+  const close = num(q.close);
+  if (close === null) return null;
+  const pctChange = num(q.percent_change);
+  if (pctChange !== null) return { change: pctChange, close };
+  const prev = num(q.previous_close);
+  if (prev === null || prev === 0) return null;
+  return { change: ((close - prev) / prev) * 100, close };
+}
+
 /** 미증시/반도체/국내 지수 → BannerItem[]. 실측 변화율만, 결측은 생략. */
 export function buildMacroItems(quotes: MacroQuote[]): BannerItem[] {
   const items: BannerItem[] = [];


### PR DESCRIPTION
## 무엇 / 왜
FOMO 롤링 배너의 거시지수(코스피·코스닥·S&P500·나스닥·반도체)가 부하·시점에 따라 상시 누락되던 버그(#480). 근인: Yahoo/Stooq가 Vercel egress IP를 레이트리밋·차단 → 특히 `^KS11`이 항상 누락.

## 어떻게
- **1차 소스 교체**: Twelve Data `/quote` batch(무료 800req/day, 5지수 **1콜**)로 변경 → 부하·egress 차단과 무관하게 안정.
- **graceful 폴백**: `TWELVE_DATA_API_KEY` 게이트. 키 있으면 TD batch, **누락분만** 지수별 Yahoo 폴백. **키 없으면 기존 Yahoo 동작 그대로** → 지금 머지해도 안전, 오너가 Vercel env 설정 시 자동 격상.
- **순수 빌더 재사용**: `MacroQuote`/`buildMacroItems`는 그대로. `fetchMacro`만 교체(이슈 구현 포인트 준수).
- 신규 순수 파서 `twelveDataChange()` + vitest 4케이스.
- `.env.example`에 `TWELVE_DATA_API_KEY` 반영.

## 검증
- `npm test` 621/621 통과 (banner 19케이스 포함)
- typecheck:fomo-core / typecheck:web / lint:web / build:web 전부 통과

## 오너 액션 (활성화)
Vercel → Project → Settings → Environment Variables 에 `TWELVE_DATA_API_KEY` 설정([twelvedata.com](https://twelvedata.com) 무료 가입 → API Key). 설정 전까지는 Yahoo 폴백으로 동작.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)