### PR TITLE
feat(fomo): 자기 통찰 미러 — "나의 패턴" 거울 카드 (깨달음의 순간 v0)

### DIFF
--- a/apps/fomo-web/components/EmotionCalendar.tsx
+++ b/apps/fomo-web/components/EmotionCalendar.tsx
@@ -4,6 +4,8 @@ import { useMemo } from "react";
 import {
   buildCalendar,
   calendarStats,
+  insightStats,
+  mirrorLines,
   EMOTION_COLORS,
   EMOTION_LABELS,
   scoreToState,
@@ -29,6 +31,11 @@ export function EmotionCalendar({ data }: { data: CalendarResponse }) {
   const stats = useMemo(
     () => calendarStats(data.month, days, data.today),
     [data.month, days, data.today]
+  );
+  // 자기 통찰 미러 — 사실만 비춘다(조언 금지). 기록 3일 미만이면 빈 배열(미노출).
+  const mirrors = useMemo(
+    () => mirrorLines(insightStats(days, data.market, data.month)),
+    [days, data.market, data.month]
   );
 
   const [year, month] = data.month.split("-");
@@ -134,6 +141,21 @@ export function EmotionCalendar({ data }: { data: CalendarResponse }) {
           시장 달아오름
         </span>
       </div>
+
+      {/* 나의 패턴 — 쌓인 기록을 사실 그대로 비추는 거울 (전략 §1.3 "깨달음의 순간" v0).
+          조언은 하지 않는다 — "아!"는 보는 사람의 몫. */}
+      {mirrors.length > 0 && (
+        <div className="mt-5 w-full rounded-xl border border-hairline bg-surface px-4 py-3">
+          <p className="text-xs text-muted">나의 패턴</p>
+          <div className="mt-1.5 flex flex-col gap-1.5">
+            {mirrors.map((m) => (
+              <p key={m} className="text-sm leading-5 text-whiteout">
+                {m}
+              </p>
+            ))}
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/packages/fomo-core/__tests__/insights.test.ts
+++ b/packages/fomo-core/__tests__/insights.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { insightStats, mirrorLines, MIRROR_MIN_DAYS, HOT_MARKET_SCORE } from "../src/insights";
+import type { EmotionType } from "../src/types";
+
+// 5월 꼬리(이전 달)는 월 집계엔 제외, 연속 기록엔 포함되는 픽스처
+const days: Record<string, EmotionType> = {
+  "2026-05-31": "conviction",
+  "2026-06-01": "fomo",
+  "2026-06-02": "fomo",
+  "2026-06-03": "fear",
+  "2026-06-05": "greed",
+  "2026-06-06": "fomo",
+};
+const market: Record<string, number> = {
+  "2026-06-01": 75, // hot + 나도 fomo → 동조
+  "2026-06-02": 40, // not hot
+  "2026-06-03": 80, // hot + fear → 동조 아님
+  "2026-06-05": HOT_MARKET_SCORE, // hot 경계값 + greed → 동조
+  "2026-06-06": 55, // not hot
+};
+
+describe("insightStats", () => {
+  const s = insightStats(days, market, "2026-06");
+
+  it("이번 달 기록 일수·감정별 분포 (이전 달 제외)", () => {
+    expect(s.daysLogged).toBe(5);
+    expect(s.emotionCounts.fomo).toBe(3);
+    expect(s.emotionCounts.fear).toBe(1);
+    expect(s.emotionCounts.greed).toBe(1);
+    expect(s.emotionCounts.conviction).toBe(0); // 5/31은 월 밖
+  });
+
+  it("시장 핫일(61+) 중 기록일·동조일 — 분모는 기록 남긴 날만", () => {
+    expect(s.hotMarketLogged).toBe(3); // 6/1, 6/3, 6/5
+    expect(s.hotBoth).toBe(2); // 6/1(fomo), 6/5(greed)
+  });
+
+  it("최장 연속 기록은 월 경계를 넘어 잇는다", () => {
+    // 5/31~6/3 = 4일 연속, 6/5~6/6 = 2일
+    expect(s.longestStreak).toBe(4);
+  });
+
+  it("빈 입력은 전부 0", () => {
+    const z = insightStats({}, {}, "2026-06");
+    expect(z.daysLogged).toBe(0);
+    expect(z.longestStreak).toBe(0);
+  });
+});
+
+describe("mirrorLines", () => {
+  it(`기록 ${MIRROR_MIN_DAYS}일 미만이면 빈 배열 (정직한 숫자 — 비추지 않음)`, () => {
+    const s = insightStats({ "2026-06-01": "fomo", "2026-06-02": "fear" }, {}, "2026-06");
+    expect(mirrorLines(s)).toEqual([]);
+  });
+
+  it("거울 문장 — 수치가 실측과 일치", () => {
+    const lines = mirrorLines(insightStats(days, market, "2026-06"));
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe("이번 달 너는 FOMO 3일 · 공포 1일이었어.");
+    expect(lines[1]).toBe("시장이 달아올랐던 3일 중 2일, 너도 같이 뜨거웠어.");
+    expect(lines[2]).toBe("가장 길게 이어진 기록, 4일이야.");
+  });
+
+  it("동조 0회도 사실 그대로 비춘다", () => {
+    const d: Record<string, EmotionType> = {
+      "2026-06-01": "fear",
+      "2026-06-02": "fear",
+      "2026-06-03": "conviction",
+    };
+    const m = { "2026-06-01": 70, "2026-06-02": 90 };
+    const lines = mirrorLines(insightStats(d, m, "2026-06"));
+    expect(lines.some((l) => l.includes("한 번도 같이 달아오르지 않았어"))).toBe(true);
+  });
+
+  it("조언·예측 어휘 금지 (c-emotion-viz)", () => {
+    const lines = mirrorLines(insightStats(days, market, "2026-06"));
+    for (const l of lines) {
+      expect(l).not.toMatch(/하세요|해야|추천|매수|매도|오를|내릴|참아|멈춰/);
+    }
+  });
+
+  it("감정이 1종뿐이면 단일 문장", () => {
+    const d: Record<string, EmotionType> = {
+      "2026-06-01": "fomo",
+      "2026-06-03": "fomo",
+      "2026-06-05": "fomo",
+    };
+    const lines = mirrorLines(insightStats(d, {}, "2026-06"));
+    expect(lines[0]).toBe("이번 달 너는 FOMO 3일이었어.");
+  });
+});

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./types";
 export * from "./state";
 export * from "./mascot-lines";
 export * from "./calendar";
+export * from "./insights";
 export * from "./banner";
 export * from "./voices";
 export * from "./index-engine/types";

--- a/packages/fomo-core/src/insights.ts
+++ b/packages/fomo-core/src/insights.ts
@@ -1,0 +1,125 @@
+import type { EmotionType } from "./types";
+import { EMOTION_TYPES, EMOTION_LABELS } from "./types";
+import { parseDate } from "./calendar";
+
+/**
+ * 자기 통찰 미러 (전략 노트 v1.0 §1.3 "깨달음의 순간" v0).
+ *
+ * 쌓인 감정 기록을 *사실 그대로* 비추는 거울 문장을 만든다.
+ * 절대 원칙: 조언·예측·평가 금지(c-emotion-viz) — "다음엔 ~하세요" 류 어휘 0.
+ * 앱은 거울만 들고, "아!"는 사용자 몫이다.
+ * 정직한 숫자(c-honest-numbers): 실측 집계만, 기록 3일 미만이면 아무것도 비추지 않는다.
+ */
+
+/** 시장이 "달아오른" 기준 — 캘린더 핫 링과 동일(61 = FOMO 구간 시작). 단일 의미 유지. */
+export const HOT_MARKET_SCORE = 61;
+
+/** "나도 뜨거웠다"로 치는 감정 — FOMO·탐욕. */
+const HOT_EMOTIONS: readonly EmotionType[] = ["fomo", "greed"];
+
+export interface InsightStats {
+  /** 이번 달(month) 안에서 감정을 남긴 날 수 */
+  daysLogged: number;
+  /** 이번 달 감정별 일수 */
+  emotionCounts: Record<EmotionType, number>;
+  /** 시장이 달아올랐던 날(지수 61+) 중 *내가 기록도 남긴* 날 수 — 분모는 정직하게 */
+  hotMarketLogged: number;
+  /** 그중 나도 뜨거웠던(FOMO·탐욕) 날 수 */
+  hotBoth: number;
+  /** 제공된 기록 전체에서 가장 길게 이어진 연속 기록 일수(월 경계 무관) */
+  longestStreak: number;
+}
+
+/** "YYYY-MM-DD" → 그날의 일련 번호(UTC days). 연속성 판정용. */
+function dayNumber(date: string): number {
+  const { year, month, day } = parseDate(date);
+  return Math.round(Date.UTC(year, month - 1, day) / 86_400_000);
+}
+
+/**
+ * 기록(days)·시장 점수(market)에서 통찰 통계를 계산한다.
+ * month("YYYY-MM")는 월 집계 범위, 캘린더 API 응답(이전 달 포함 가능)을 그대로 받는다.
+ */
+export function insightStats(
+  days: Record<string, EmotionType>,
+  market: Record<string, number>,
+  month: string
+): InsightStats {
+  const prefix = `${month}-`;
+  const emotionCounts = Object.fromEntries(EMOTION_TYPES.map((e) => [e, 0])) as Record<
+    EmotionType,
+    number
+  >;
+  let daysLogged = 0;
+  let hotMarketLogged = 0;
+  let hotBoth = 0;
+
+  for (const [date, emotion] of Object.entries(days)) {
+    if (!emotion) continue;
+    if (date.startsWith(prefix)) {
+      daysLogged++;
+      if (emotion in emotionCounts) emotionCounts[emotion]++;
+      const score = market[date];
+      if (typeof score === "number" && score >= HOT_MARKET_SCORE) {
+        hotMarketLogged++;
+        if (HOT_EMOTIONS.includes(emotion)) hotBoth++;
+      }
+    }
+  }
+
+  // 최장 연속 기록 — 전체 기록 기준(월 경계를 넘어도 이어지면 잇는다)
+  const nums = Object.keys(days)
+    .filter((d) => days[d])
+    .map(dayNumber)
+    .sort((a, b) => a - b);
+  let longestStreak = 0;
+  let run = 0;
+  let prev: number | null = null;
+  for (const n of nums) {
+    run = prev !== null && n === prev + 1 ? run + 1 : 1;
+    if (run > longestStreak) longestStreak = run;
+    prev = n;
+  }
+
+  return { daysLogged, emotionCounts, hotMarketLogged, hotBoth, longestStreak };
+}
+
+/** 거울을 들 최소 기록 일수 — 이 미만이면 빈 배열(카드 미노출). */
+export const MIRROR_MIN_DAYS = 3;
+
+/**
+ * 통계 → 거울 문장 최대 3개. 사실 서술만, 조언·평가 어휘 없음.
+ *  1) 이번 달 감정 분포(상위 1~2개)
+ *  2) 시장이 달아오른 날과 나의 동조(0회면 "한 번도 같이 달아오르지 않았어"도 사실)
+ *  3) 최장 연속 기록(2일 이상일 때만)
+ */
+export function mirrorLines(stats: InsightStats): string[] {
+  if (stats.daysLogged < MIRROR_MIN_DAYS) return [];
+  const lines: string[] = [];
+
+  const top = EMOTION_TYPES.map((e) => ({ e, n: stats.emotionCounts[e] }))
+    .filter((x) => x.n > 0)
+    .sort((a, b) => b.n - a.n)
+    .slice(0, 2);
+  if (top.length === 2) {
+    lines.push(
+      `이번 달 너는 ${EMOTION_LABELS[top[0]!.e]} ${top[0]!.n}일 · ${EMOTION_LABELS[top[1]!.e]} ${top[1]!.n}일이었어.`
+    );
+  } else if (top.length === 1) {
+    lines.push(`이번 달 너는 ${EMOTION_LABELS[top[0]!.e]} ${top[0]!.n}일이었어.`);
+  }
+
+  if (stats.hotMarketLogged >= 2) {
+    lines.push(
+      stats.hotBoth > 0
+        ? `시장이 달아올랐던 ${stats.hotMarketLogged}일 중 ${stats.hotBoth}일, 너도 같이 뜨거웠어.`
+        : `시장이 달아올랐던 ${stats.hotMarketLogged}일, 너는 한 번도 같이 달아오르지 않았어.`
+    );
+  }
+
+  if (stats.longestStreak >= 2) {
+    lines.push(`가장 길게 이어진 기록, ${stats.longestStreak}일이야.`);
+  }
+
+  return lines.slice(0, 3);
+}


### PR DESCRIPTION
## 무엇 / 왜 (전략 노트 v1.0 §1.3 — BM의 첫 벽돌)
BM("자기 통찰 구독")이 작동하려면 쌓인 감정 데이터를 보고 사용자가 **스스로** 깨달아야 한다. 앱이 "이렇게 하세요"라고 하면 투자 조언(규제)+가짜 — 그래서 **거울만 든다**.

기록(캘린더) 탭 하단에 "나의 패턴" 카드:
- "이번 달 너는 FOMO 3일 · 공포 1일이었어" (감정 분포)
- "시장이 달아올랐던 3일 중 2일, 너도 같이 뜨거웠어" (시장 vs 나 동조 — 가장 깊은 통찰)
- "가장 길게 이어진 기록, 4일이야" (최장 연속)

## 어떻게
- `packages/fomo-core/src/insights.ts` 신규 — `insightStats()`/`mirrorLines()` 순수함수 + vitest 9케이스.
- 시장 "달아오름" 기준 61점 = 기존 캘린더 핫 링과 동일(단일 의미). 동조 분모는 **내가 기록 남긴 핫일만**(정직한 분모).
- API 신설 없음 — 캘린더 API가 이미 주는 `days`+`market`을 클라이언트에서 계산.
- 최장 streak는 월 경계 넘어 연속이면 잇는다(기존 calendarStats 철학 동일).

## 제약 자가점검
- c-emotion-viz: 조언·예측 어휘 0 — **금칙어 테스트로 강제**(하세요/추천/매수/매도/오를/참아…) ✅
- c-honest-numbers: 기록 3일 미만 미노출, 동조 0회도 "한 번도 같이 달아오르지 않았어" 사실 그대로 ✅
- effectsban/minimalux: 기존 카드 스타일 재사용, 텍스트만 ✅

## 검증
- vitest 9/9 (수치 실측 일치·금칙어·경계값 61·빈 입력) + `npm test` 641/641 ✅
- typecheck:fomo-core / typecheck:fomo-web / build:fomo-web ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)