### PR TITLE
feat(fomo): 포모의 기억 — 나를 기억하는 캐릭터

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -12,6 +12,8 @@ import {
   isCalmDay,
   restorativeLine,
   calendarStats,
+  personalLine,
+  prevDay,
   type EmotionType,
 } from "@fomo/core";
 import { FomoFace } from "@/components/FomoFace";
@@ -60,11 +62,20 @@ export function HomeView({
   const state = index ? scoreToState(index.score) : null;
   const marketFace = index ? scoreToFace(index.score) : "curious";
   const stage: "market" | "mine" = mine ? "mine" : "market";
-  const line = mine ? mineLine(mine) : state ? marketLine(state) : "";
   // 연속 기록 — 캘린더와 같은 계산(calendarStats)·같은 문구로 홈에도 살짝 (전략: 리텐션 = BM의 전제)
   const streak = calendar
     ? calendarStats(calendar.month, calendar.days as Record<string, EmotionType>, calendar.today).streak
     : 0;
+  // 포모의 기억 — 어제의 감정·연속 기록을 기억하는 멘트가 있으면 우선, 없으면 기존 한마디 폴백
+  const memory =
+    mine && calendar
+      ? personalLine({
+          yesterdayEmotion: (calendar.days[prevDay(calendar.today)] ?? null) as EmotionType | null,
+          todayEmotion: mine,
+          streak,
+        })
+      : null;
+  const line = mine ? (memory ?? mineLine(mine)) : state ? marketLine(state) : "";
 
   return (
     <>

--- a/packages/fomo-core/__tests__/mascot-lines.test.ts
+++ b/packages/fomo-core/__tests__/mascot-lines.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { marketLine, marketSummary, mineLine, restorativeLine, isCalmDay } from "../src/mascot-lines";
+import { marketLine, marketSummary, mineLine, restorativeLine, isCalmDay, personalLine } from "../src/mascot-lines";
 import { EMOTION_TYPES } from "../src/types";
 
 const STATES = ["무관심", "관망", "관심", "FOMO", "광기"] as const;
@@ -60,5 +60,46 @@ describe("잔잔한 날 = 치유의 날 (M2 회복 콘텐츠)", () => {
       seen.add(restorativeLine(`2026-06-${String(d).padStart(2, "0")}`));
     }
     expect(seen.size).toBeGreaterThan(1);
+  });
+});
+
+describe("personalLine — 포모의 기억 (나를 기억하는 캐릭터)", () => {
+  it("연속 기록 마일스톤이 최우선", () => {
+    const l = personalLine({ yesterdayEmotion: "fear", todayEmotion: "fomo", streak: 7 });
+    expect(l).toBe("오늘로 7일째야. 네가 남긴 색들, 전부 기억하고 있어.");
+  });
+
+  it("감정 전환을 기억한다", () => {
+    const l = personalLine({ yesterdayEmotion: "fear", todayEmotion: "conviction", streak: 2 });
+    expect(l).toBe("어제의 너는 공포, 오늘은 확신. 그 변화, 내가 기억할게.");
+  });
+
+  it("같은 감정이 이어져도 기억한다", () => {
+    const l = personalLine({ yesterdayEmotion: "fomo", todayEmotion: "fomo", streak: 3 });
+    expect(l).toBe("어제도 오늘도 FOMO. 이어지는 마음도 그대로 적어뒀어.");
+  });
+
+  it("어제 기록이 없으면 null (폴백 — 거짓 기억 금지)", () => {
+    expect(personalLine({ yesterdayEmotion: null, todayEmotion: "fomo", streak: 1 })).toBeNull();
+    expect(personalLine({ todayEmotion: "fomo" })).toBeNull();
+    expect(personalLine({})).toBeNull();
+  });
+
+  it("마일스톤 아닌 streak 는 전환/이어짐 규칙으로", () => {
+    const l = personalLine({ yesterdayEmotion: "greed", todayEmotion: "greed", streak: 8 });
+    expect(l).toContain("어제도 오늘도");
+  });
+
+  it("금칙 표현(조언·단정·죄책감) 없음", () => {
+    const lines = [
+      personalLine({ yesterdayEmotion: "fear", todayEmotion: "fomo", streak: 7 }),
+      personalLine({ yesterdayEmotion: "fear", todayEmotion: "fomo", streak: 2 }),
+      personalLine({ yesterdayEmotion: "fomo", todayEmotion: "fomo", streak: 2 }),
+    ];
+    for (const l of lines) {
+      expect(l).toBeTruthy();
+      expect(l!).not.toMatch(FORBIDDEN);
+      expect(l!).not.toMatch(/하세요|해야|안 오면|죽어|미안하지/); // 조언·죄책감 어휘
+    }
   });
 });

--- a/packages/fomo-core/src/calendar.ts
+++ b/packages/fomo-core/src/calendar.ts
@@ -87,7 +87,7 @@ export interface CalendarStats {
 }
 
 /** "YYYY-MM-DD"에서 하루 전 문자열. 시간대 안전(UTC 분해). */
-function prevDay(date: string): string {
+export function prevDay(date: string): string {
   const { year, month, day } = parseDate(date);
   const dt = new Date(Date.UTC(year, month - 1, day - 1));
   return `${dt.getUTCFullYear()}-${pad2(dt.getUTCMonth() + 1)}-${pad2(dt.getUTCDate())}`;

--- a/packages/fomo-core/src/mascot-lines.ts
+++ b/packages/fomo-core/src/mascot-lines.ts
@@ -1,4 +1,5 @@
 import type { EmotionType, FomoState } from "./types";
+import { EMOTION_LABELS } from "./types";
 
 /**
  * 포모의 담담한 한마디. docs/IDENTITY_AND_MILESTONES.md §2.1 "담담한 솔직함".
@@ -79,4 +80,38 @@ export function restorativeLine(date: string): string {
   let sum = 0;
   for (let i = 0; i < date.length; i++) sum += date.charCodeAt(i);
   return RESTORATIVE_LINES[sum % RESTORATIVE_LINES.length]!;
+}
+
+/**
+ * 포모의 기억 — "나를 기억하는 캐릭터" (전략 노트 v1.0 §1.4).
+ * 다마고치(돌봄 의무·죄책감) ❌ — 돌봄의 방향을 뒤집어, 포모가 *나의 기록*을 기억한다.
+ * 실측 기록만 참조(정직한 숫자), 결정적 규칙 템플릿(형태가 곧 윤리 — LLM·자유문장 ❌).
+ * 해당 없으면 null → 호출부가 기존 mineLine/restorativeLine 으로 폴백.
+ */
+export interface PersonalContext {
+  /** 어제 남긴 감정 (기록 없으면 null) */
+  yesterdayEmotion?: EmotionType | null;
+  /** 오늘 남긴 감정 */
+  todayEmotion?: EmotionType | null;
+  /** 오늘 포함 현재 연속 기록 일수 */
+  streak?: number;
+}
+
+/** 기억을 꺼내는 절기 — 연속 기록 마일스톤. */
+const STREAK_MILESTONES: readonly number[] = [7, 14, 30, 50, 100];
+
+/** 우선순위: 마일스톤(희귀) > 감정 전환 > 같은 감정 이어짐 > null(폴백). */
+export function personalLine(ctx: PersonalContext): string | null {
+  const { yesterdayEmotion, todayEmotion, streak = 0 } = ctx;
+
+  if (streak > 0 && STREAK_MILESTONES.includes(streak)) {
+    return `오늘로 ${streak}일째야. 네가 남긴 색들, 전부 기억하고 있어.`;
+  }
+  if (yesterdayEmotion && todayEmotion && yesterdayEmotion !== todayEmotion) {
+    return `어제의 너는 ${EMOTION_LABELS[yesterdayEmotion]}, 오늘은 ${EMOTION_LABELS[todayEmotion]}. 그 변화, 내가 기억할게.`;
+  }
+  if (yesterdayEmotion && todayEmotion && yesterdayEmotion === todayEmotion) {
+    return `어제도 오늘도 ${EMOTION_LABELS[todayEmotion]}. 이어지는 마음도 그대로 적어뒀어.`;
+  }
+  return null;
 }


### PR DESCRIPTION
## 무엇 / 왜 (전략 노트 v1.0 §1.4)
"내가 키우는 캐릭터(다마고치)" ❌ → **"나를 기억하는 캐릭터(포모)"** ⭕. 돌봄의 방향을 뒤집어 죄책감 없이 애착만. 홈의 "나의 포모" 한마디가 내 기록을 기억한다:
- 마일스톤(7/14/30/50/100일): "오늘로 7일째야. 네가 남긴 색들, 전부 기억하고 있어."
- 감정 전환: "어제의 너는 공포, 오늘은 확신. 그 변화, 내가 기억할게."
- 이어짐: "어제도 오늘도 FOMO. 이어지는 마음도 그대로 적어뒀어."

## 어떻게
- `personalLine()` — mascot-lines 패턴의 **결정적 규칙 템플릿**(LLM·자유문장 ❌, 형태가 곧 윤리). 우선순위: 마일스톤(희귀) > 전환 > 이어짐 > **null 폴백**(기존 mineLine).
- 어제 기록이 없으면 null — **거짓 기억 금지**(honest-numbers).
- `prevDay()` export(calendar.ts) + HomeView 배선. 캘린더 API 데이터 재사용, API 신설 없음.
- I1(통찰 미러)과 합쳐 "기록할수록 포모가 나를 더 잘 앎" 리텐션 루프.

## 제약 자가점검
- 금칙어 테스트: 조언·단정·죄책감 어휘 0 ✅ (기존 FORBIDDEN 정규식 + 죄책감 어휘 추가 검사)
- effectsban: 기존 한마디 자리 텍스트 교체만 ✅

## 검증
- vitest 6케이스 신규, `npm test` 638/638 ✅
- typecheck:fomo-core / typecheck:fomo-web / build:fomo-web ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)