### PR TITLE
fix(slack): 액션 토큰 중복 dispatch 방지

### DIFF
--- a/.github/workflows/propose-project.yml
+++ b/.github/workflows/propose-project.yml
@@ -7,7 +7,9 @@ on:
 
 concurrency:
   group: propose-project
-  cancel-in-progress: false
+  # 멱등(roadmap 재생성 + 검토 이슈). 중복 dispatch 시 앞 run 을 취소해
+  # 동시 main push race 를 막는다(2026-06-11 사고). 결과는 항상 1개.
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/apps/web/__tests__/slack-actions.test.ts
+++ b/apps/web/__tests__/slack-actions.test.ts
@@ -48,6 +48,20 @@ describe("parseActions", () => {
     expect(r.actions.map((a) => a.name)).toEqual(["merge_all", "close_all"]);
   });
 
+  // 2026-06-11 사고: LLM 이 같은 토큰을 2번 출력 → 워크플로 2번 dispatch → main push race
+  it("같은 액션 중복 출력은 한 번만 (멱등)", () => {
+    const r = parseActions("프로젝트 제안할게요.\n[[ACTION:propose_projects]]\n[[ACTION:propose_projects]]");
+    expect(r.actions).toEqual([{ name: "propose_projects", payload: {} }]);
+  });
+
+  it("같은 이름이라도 페이로드가 다르면 둘 다 유지", () => {
+    const r = parseActions('[[ACTION:merge]] {"pr":1}\n[[ACTION:merge]] {"pr":2}');
+    expect(r.actions).toEqual([
+      { name: "merge", payload: { pr: 1 } },
+      { name: "merge", payload: { pr: 2 } },
+    ]);
+  });
+
   it("merge_all·close_completed·close_all 은 고영향으로 분류", () => {
     expect(HIGH_IMPACT_ACTIONS.has("merge_all")).toBe(true);
     expect(HIGH_IMPACT_ACTIONS.has("close_completed")).toBe(true);

--- a/apps/web/lib/slack/actions.ts
+++ b/apps/web/lib/slack/actions.ts
@@ -87,27 +87,38 @@ export function parseActions(reply: string): ParseResult {
   const actions: ParsedAction[] = [];
   let cleaned = reply;
 
+  // 같은 (name, payload) 조합은 한 번만 실행한다.
+  // LLM 이 동일 토큰을 중복 출력하면 워크플로가 2번 dispatch 되어 main push race 가
+  // 발생한다(2026-06-11 propose_projects 중복 사고). 여기서 멱등하게 막는다.
+  const seen = new Set<string>();
+  const pushUnique = (action: ParsedAction): void => {
+    const key = `${action.name}:${JSON.stringify(action.payload)}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    actions.push(action);
+  };
+
   // 1) 범용 [[ACTION:name]] {json}?
   const actionRe = /\[\[ACTION:(\w+)\]\]\s*(\{[^\n]*\})?/g;
   let m: RegExpExecArray | null;
   while ((m = actionRe.exec(reply)) !== null) {
     const name = m[1];
     if (name && KNOWN_ACTIONS.has(name)) {
-      actions.push({ name: name as ActionName, payload: safeJson(m[2]) });
+      pushUnique({ name: name as ActionName, payload: safeJson(m[2]) });
     }
   }
   cleaned = cleaned.replace(actionRe, "").trim();
 
   // 2) 하위호환: [[TRIGGER_IMPLEMENT]]
   if (/\[\[TRIGGER_IMPLEMENT\]\]/.test(cleaned)) {
-    actions.push({ name: "implement", payload: {} });
+    pushUnique({ name: "implement", payload: {} });
     cleaned = cleaned.replace(/\[\[TRIGGER_IMPLEMENT\]\]/g, "").trim();
   }
 
   // 3) 하위호환: [[ADD_CONSTRAINT]]{json}
   const addC = cleaned.match(/\[\[ADD_CONSTRAINT\]\]\s*(\{[^\n]*\})/);
   if (addC && addC[1]) {
-    actions.push({ name: "add_constraint", payload: safeJson(addC[1]) });
+    pushUnique({ name: "add_constraint", payload: safeJson(addC[1]) });
     cleaned = cleaned.replace(/\[\[ADD_CONSTRAINT\]\]\s*\{[^\n]*\}/g, "").trim();
   }
 


### PR DESCRIPTION
## 배경
오늘(2026-06-11) "프로젝트 제안해" 슬랙 멘션에서 봇이 `[[ACTION:propose_projects]]` 토큰을 **2번** 출력 → `propose-project.yml`이 거의 동시에 2개 dispatch → 둘 다 `main`에 roadmap을 push하다 race condition으로 1개 실패([run](https://github.com/mlender-ai/taro-stock-app/actions/runs/27336925525)). 이슈 [#486](https://github.com/mlender-ai/taro-stock-app/issues/486)은 정상 생성됐으나, `merge`/`implement` 같은 고영향 액션에서 중복되면 위험.

## 수정
1. **1차 방어 — `parseActions` 멱등화**: 같은 `(name, payload)` 조합은 한 번만 실행. 페이로드가 다르면 둘 다 유지(`merge pr:1`/`pr:2` 정상 케이스 보존).
2. **2차 방어 — concurrency 가드**: `propose-project.yml` `cancel-in-progress: true`. 멱등 워크플로라 중복 시 앞 run 취소해도 결과는 항상 1개.
3. 회귀 테스트 2건 추가.

## 검증
- `slack-actions` 24건 통과(중복 dedup·다른 페이로드 케이스 포함)
- lint·typecheck·build:web 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)