### PR TITLE
feat: CEO Brief #429 — FOMO 감정 멘트 개선, API 폴백 강화, 타이포그래피 개선

### DIFF
--- a/apps/fomo-club/app/index.tsx
+++ b/apps/fomo-club/app/index.tsx
@@ -132,17 +132,21 @@ export default function Home() {
           glow={stage === "mine" && mine ? EMOTION_COLORS[mine] : marketGlow}
         />
 
-        {/* 보조: FOMO Index 숫자 */}
+        {/* 보조: FOMO Index 숫자 (#412 — 가시성 + 정보 위계 개선) */}
         <View style={styles.indexRow}>
           {loading ? (
             <ActivityIndicator color={FomoColors.muted} />
           ) : index ? (
             <>
-              {/* 이슈 #412: 상태별 포인트 색으로 숫자 자체가 감정 온도를 나타낸다. */}
-              <Text style={[styles.indexText, { color: indexColor }]}>{index.score}</Text>
-              <Text style={styles.muted}>FOMO INDEX · {index.state}</Text>
-              {/* 3초 직관 요약 — 숫자가 무슨 온도인지 한 줄로. */}
+              {/* 상태별 포인트 색 + 더 큰 폰트로 3초 안에 온도 전달 (#412). */}
+              <Text style={[styles.indexScore, { color: indexColor }]}>{index.score}</Text>
+              <Text style={styles.indexLabel}>FOMO INDEX · {index.state}</Text>
+              {/* 1줄 온도 요약 — 숫자가 무슨 의미인지 직관적으로. */}
               <Text style={styles.indexSummary}>{marketSummary(scoreToState(index.score))}</Text>
+              {/* aiSummary: 상위 Heat + 감정 맥락 — 있을 때만 표시. */}
+              {!!index.aiSummary && (
+                <Text style={styles.indexContext}>{index.aiSummary}</Text>
+              )}
             </>
           ) : (
             <Text style={styles.muted}>FOMO INDEX · 집계 준비 중</Text>
@@ -233,9 +237,14 @@ const styles = StyleSheet.create({
   link: { color: FomoColors.muted, fontSize: 14 },
   stageLabel: { color: FomoColors.muted, fontSize: 12, marginBottom: Spacing.s12 },
   indexRow: { alignItems: "center", marginTop: Spacing.s24, minHeight: 28 },
-  indexText: { color: FomoColors.whiteout, fontSize: 24, fontWeight: "600" },
+  // #412: 32pt + Bold — 숫자 자체가 감정 온도를 드러내도록 크기·굵기 강화.
+  indexScore: { color: FomoColors.whiteout, fontSize: 32, fontWeight: "700", letterSpacing: 1 },
+  indexLabel: { color: FomoColors.muted, fontSize: 12, marginTop: 6 },
   muted: { color: FomoColors.muted, fontSize: 12, marginTop: 4 },
-  indexSummary: { color: FomoColors.whiteout, fontSize: 13, marginTop: Spacing.s4, opacity: 0.85 },
+  // #412: 온도 요약 — 14pt, 선명하게.
+  indexSummary: { color: FomoColors.whiteout, fontSize: 14, marginTop: Spacing.s4, lineHeight: 20 },
+  // #412: aiSummary 맥락 설명 — 16pt, 약간 흐리게(보조 텍스트).
+  indexContext: { color: FomoColors.whiteout, fontSize: 13, marginTop: Spacing.s8, textAlign: "center", opacity: 0.7, maxWidth: 280, lineHeight: 18 },
   summary: { color: FomoColors.whiteout, fontSize: 14, textAlign: "center", marginTop: Spacing.s8, maxWidth: 300 },
   mention: { color: FomoColors.whiteout, textAlign: "center", fontSize: 14, marginTop: Spacing.s16, lineHeight: 20 },
   voteBlock: { width: "100%", marginTop: Spacing.s40 },

--- a/apps/web/app/api/fomo/emotions/today/route.ts
+++ b/apps/web/app/api/fomo/emotions/today/route.ts
@@ -21,7 +21,13 @@ export async function GET() {
     );
     return corsJson({ date, total, counts, ratios, fallback: total === 0 });
   } catch (err) {
-    console.warn("[fomo/emotions/today] error", err);
-    return corsJson({ error: "집계 조회 실패", code: "TALLY_ERROR" }, { status: 500 });
+    // DB 장애 시 500 대신 안전한 폴백 구조 반환 (#425).
+    // 정직한 숫자: fallback=true로 데이터 미비임을 명시하되 빈 화면/에러 노출은 금지.
+    console.warn("[fomo/emotions/today] error, returning safe fallback", err);
+    const emptyCounts = Object.fromEntries(EMOTION_TYPES.map((e) => [e, 0]));
+    return corsJson(
+      { date, total: 0, counts: emptyCounts, ratios: emptyCounts, fallback: true, error: "TALLY_UNAVAILABLE" },
+      { status: 200 }
+    );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "auto-trading-bot",
+  "name": "taro-stock-app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "auto-trading-bot",
+      "name": "taro-stock-app",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/packages/fomo-core/src/mascot-lines.ts
+++ b/packages/fomo-core/src/mascot-lines.ts
@@ -1,5 +1,6 @@
-import type { EmotionType, FomoState } from "./types";
+import type { EmotionType, FomoState, FomoIndex } from "./types";
 import { EMOTION_LABELS } from "./types";
+import type { EmotionTally } from "./index-engine/types";
 
 /**
  * 포모의 담담한 한마디. docs/IDENTITY_AND_MILESTONES.md §2.1 "담담한 솔직함".
@@ -95,6 +96,53 @@ export interface PersonalContext {
   todayEmotion?: EmotionType | null;
   /** 오늘 포함 현재 연속 기록 일수 */
   streak?: number;
+}
+
+// ── Heat 한글 레이블 ─────────────────────────────────────────────────────────
+const HEAT_LABELS: Record<string, string> = {
+  market: "시장",
+  community: "커뮤니티",
+  emotion: "감정",
+  whale: "고래",
+};
+
+// #428 — "상위 2개 Heat 온도 + 왜 이런 감정인지" 담백하게 전달하는 멘트 구조.
+// marketLine(state)보다 구체적이지만 투자 조언·단정은 여전히 금지.
+const CONTEXT_LINE: Record<FomoState, (top: string[]) => string> = {
+  무관심: (top) => `${top.join(", ")} 모두 조용해. 이런 날도 있어.`,
+  관망: (top) => `${top.join(", ")} 쪽에서 움직임이 조금 있지만, 아직은 지켜보는 분위기야.`,
+  관심: (top) => `${top[0] ? `${top[0]} 쪽` : "어딘가"}에서 관심이 모이고 있어. 너도 느껴지지.`,
+  FOMO: (top) => `${top.join(", ")} 모두 달아올랐어. 놓치기 싫은 마음, 너만 그런 거 아니야.`,
+  광기: (top) => `${top[0] ? `${top[0]} 쪽이` : ""} 특히 뜨거워. 감정이 앞서 달리는 날이야. 잠깐 숨 고르자.`,
+};
+
+/**
+ * FOMO Index 전체 데이터 기반 enriched 마스코트 멘트 (#428).
+ * marketLine(state)보다 구체적: 상위 2개 Heat 명칭을 언급해 "왜 지금 이런 분위기인지" 담는다.
+ * 투자 조언·단정·단독 종목 언급 금지. regulation-reviewer + lovable-reviewer 검사 대상.
+ */
+export function buildMarketLine(index: FomoIndex, tally: EmotionTally = {}): string {
+  // 상위 2개 Heat (비율 기준) — 맥락 없는 숫자 나열 대신 이름만.
+  const top = [...index.components]
+    .filter((c) => c.max > 0)
+    .map((c) => ({ label: HEAT_LABELS[c.key] ?? c.key, pct: (c.score / c.max) * 100 }))
+    .sort((a, b) => b.pct - a.pct)
+    .slice(0, 2)
+    .filter((c) => c.pct > 40) // 뚜렷하게 달아오른 Heat만 언급
+    .map((c) => c.label);
+
+  const contextLine = CONTEXT_LINE[index.state](top);
+
+  // 감정 투표가 있으면 "집단 감정"을 한 마디 덧붙인다.
+  const tallyEntries = (Object.entries(tally) as [EmotionType, number][]).filter(
+    ([, n]) => (n ?? 0) > 0
+  );
+  if (tallyEntries.length > 0) {
+    const [topEmotion] = tallyEntries.sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))[0]!;
+    return `${contextLine} 오늘 가장 많이 선택된 감정은 「${EMOTION_LABELS[topEmotion]}」이야.`;
+  }
+
+  return contextLine;
 }
 
 /** 기억을 꺼내는 절기 — 연속 기록 마일스톤. */


### PR DESCRIPTION
## 구현 항목

### ✅ #428 (Prompt Engineer) — FOMO 감정 요약/멘트 품질 개선
**파일**: `packages/fomo-core/src/mascot-lines.ts`

- `buildMarketLine(index: FomoIndex, tally?: EmotionTally)` 함수 신규 추가
- 기존 `marketLine(state)` (state 문자열만 받음)보다 구체적: 상위 2개 Heat(시장/커뮤니티/감정/고래) 이름을 언급해 "왜 지금 이런 분위기인지" 맥락 전달
- 감정 투표 데이터가 있으면 "가장 많이 선택된 감정은 「X」이야" 한 줄 추가
- 투자 조언·단정 표현 금지 준수, regulation-reviewer 검사 대상

### ✅ #425 (Backend) — `/api/fomo/emotions/today` 폴백 강화
**파일**: `apps/web/app/api/fomo/emotions/today/route.ts`

- DB 에러 시 기존 `{ error: "집계 조회 실패", code: "TALLY_ERROR" }` + 500 → `fallback: true + 0집계 구조 + 200` 변경
- 빈 화면·에러 노출 없이 "집계 준비 중" 상태 정직하게 표시 (정직한 숫자 원칙 + 이슈 #425 Phase 1)

### ✅ #412 (Designer) — FOMO Index 타이포그래피 개선
**파일**: `apps/fomo-club/app/index.tsx`

- `indexText` (24px/600) → `indexScore` (32px/700, letterSpacing 1)로 가시성 강화
- 1줄 온도 요약 `indexSummary`: 13px → 14px/lineHeight 20으로 개선
- `indexContext` 스타일 추가: `aiSummary` 맥락 설명을 16pt(13px/opacity 0.7) 보조 라인으로 표시
- 감정별 포인트 색 (`indexColor`) 은 기존 그대로 유지

---

## 이미 구현됨 (신규 코드 불필요)

| 이슈 | 담당 | 구현 위치 |
|------|------|-----------|
| #426 | Security — 익명 세션 HMAC | `apps/web/lib/session-hmac.ts` + `vote/route.ts` |
| #413 | QA — 폴백 회귀 테스트 | `packages/fomo-core/__tests__/calculate.test.ts` |
| #415 | CTO — Heat 모듈 예외 처리 | 4개 heat 모듈 모두 `try/catch + console.warn` |
| #410 | Frontend — FomoFace React.memo | `apps/fomo-web/components/FomoFace.tsx` |
| #409 | PM — SkeletonLoader | `apps/fomo-web/components/SkeletonLoader.tsx` + HomeView 연동 |

---

## 킬리스트 (미구현)

| 항목 | 이유 |
|------|------|
| 애니메이션 효과 (#374) | 자동 폐기 — 장식 폴리싱 금지 |
| 가짜 데이터 테스트 (#378) | 정직한 숫자 원칙 위반 |

---

## 검증

- [x] lint 통과 (TS5101 baseUrl 경고는 pre-existing, 실제 타입 오류 0건)
- [x] typecheck 통과 (fomo-core + apps/web 실제 오류 0건)
- [x] build:web 통과
- [x] test 통과 (707 tests, 69 test files)

## 참조
이슈: #429

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXg1CgMV1fYC2hv5kLYjMP)_