### PR TITLE
[CEO Brief #429] fomo-club today.tsx — 마스코트-옆-지수 레이아웃 (#412 누락분)

### DIFF
--- a/apps/fomo-club/app/(tabs)/today.tsx
+++ b/apps/fomo-club/app/(tabs)/today.tsx
@@ -52,21 +52,23 @@ export default function Today() {
           </View>
         )}
 
-        <Text style={styles.faceLabel}>오늘의 포모</Text>
-        <FomoFace face={index ? scoreToFace(index.score) : "curious"} size={96} glow={color} />
-
-        <View style={styles.indexBox}>
-          {index ? (
-            <>
-              <Text style={[styles.score, { color }]}>{index.score}</Text>
-              <Text style={styles.indexMeta}>
-                FOMO INDEX · {index.state}
-                {index.prevDayDelta ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}` : ""}
-              </Text>
-            </>
-          ) : (
-            <Text style={styles.indexMeta}>불러오는 중…</Text>
-          )}
+        {/* #412: 마스코트 + FOMO Index 나란히 — 감정과 지수의 직접 연결 */}
+        <View style={styles.heroRow}>
+          <FomoFace face={index ? scoreToFace(index.score) : "curious"} size={88} glow={color} />
+          <View style={styles.indexBlock}>
+            <Text style={styles.faceLabel}>오늘의 포모</Text>
+            {index ? (
+              <>
+                <Text style={[styles.score, { color }]}>{index.score}</Text>
+                <Text style={styles.indexMeta}>
+                  FOMO INDEX · {index.state}
+                  {index.prevDayDelta ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}` : ""}
+                </Text>
+              </>
+            ) : (
+              <Text style={styles.indexMeta}>불러오는 중…</Text>
+            )}
+          </View>
         </View>
 
         {state && <Text style={styles.line}>{marketLine(state)}</Text>}
@@ -91,10 +93,11 @@ const styles = StyleSheet.create({
   logo: { color: FomoColors.whiteout, fontSize: 16, fontWeight: "700" },
   sub: { color: FomoColors.muted, fontSize: 12 },
   block: { width: "100%", marginVertical: Spacing.s16 },
-  faceLabel: { color: FomoColors.muted, fontSize: 12, marginBottom: Spacing.s8 },
-  indexBox: { alignItems: "center", marginTop: Spacing.s12 },
+  faceLabel: { color: FomoColors.muted, fontSize: 12, marginBottom: 4 },
+  heroRow: { flexDirection: "row", alignItems: "center", gap: Spacing.s24, marginTop: Spacing.s16 },
+  indexBlock: { alignItems: "flex-start" },
   score: { fontSize: 40, fontWeight: "800", lineHeight: 44 },
-  indexMeta: { color: FomoColors.muted, fontSize: 12, marginTop: 6 },
+  indexMeta: { color: FomoColors.muted, fontSize: 12, marginTop: 4 },
   line: { color: FomoColors.whiteout, fontSize: 14, lineHeight: 20, textAlign: "center", marginTop: Spacing.s12, maxWidth: 300 },
   disclaimer: { color: FomoColors.muted, fontSize: 11, lineHeight: 20, textAlign: "center", marginTop: Spacing.s24 },
   bold: { color: FomoColors.whiteout },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "auto-trading-bot",
+  "name": "taro-stock-app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "auto-trading-bot",
+      "name": "taro-stock-app",
       "workspaces": [
         "apps/*",
         "packages/*"


### PR DESCRIPTION
## 구현 항목

### CEO Brief #429 (2026-06-09) — 이전 세션 구현 현황

| # | 이슈 | 담당 | 상태 |
|---|------|------|------|
| 1 | #428 FOMO 감정 요약/멘트 품질 개선 | Prompt Engineer | ✅ commit 7fbe907 (summary.ts 상위 2 Heat %) |
| 2 | #426 익명 세션 HMAC 위변조 방지 | Security | ✅ commit 7fbe907 (session-hmac.ts + vote route) |
| 3 | #425 emotions/today API 폴백 | Backend | ✅ commit 7fbe907 (fallback:true 플래그) |
| 4 | #415 Heat 파이프라인 예외 처리 | CTO | ✅ commit 7fbe907 (safeHeat + try/catch) |
| 5 | #413 폴백 회귀 테스트 | QA | ✅ commit 7fbe907 (calculate.test.ts 16개) |
| 6 | #412 UX/UI — 마스코트-옆-지수 | Designer | ⚠️ 부분 구현 → **이번 PR에서 완성** |
| 7 | #410 FomoFace React.memo | Frontend | ✅ commit 7fbe907 (memo + useMemo) |
| 8 | #409 스켈레톤 로딩 | PM | ✅ commit 7fbe907 (SkeletonLoader.tsx) |

### 이번 PR — #412 누락분 완성

commit `7fbe907`에서 `apps/fomo-club/app/index.tsx`(구 홈 화면)에 색상을 적용했으나,
commit `9f5a848`에서 신설된 `apps/fomo-club/app/(tabs)/today.tsx`(현 홈 화면)에는
마스코트-옆-지수 레이아웃이 적용되지 않았음.

**변경 내용:**
- `heroRow`: FomoFace + FOMO Index 수평 배치 (감정과 지수의 직접 연결)
- `indexBlock`: 숫자/상태/전일 델타를 마스코트 오른쪽 좌정렬
- `faceLabel("오늘의 포모")`을 지수 블록 상단으로 이동

## 킬리스트 (미구현)

| 항목 | 이슈 | 이유 |
|------|------|------|
| 애니메이션 효과 | #374 | 자동 폐기 — 장식 폴리싱 금지 |
| 가짜 데이터 테스트 | #378 | 정직한 숫자 원칙 위반 |

## 검증

- [x] lint 통과 (pre-existing env errors 제외)
- [x] typecheck 통과 (apps/web clean)
- [x] build:web 통과
- [x] test 통과 (727 tests, 70 files)

## 참조

이슈: #429 (CEO Brief 2026-06-09)
원 구현 커밋: 7fbe907 (PR #482)

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzJRuRBLnRzgsvfkbifbj2)_