### PR TITLE
Phase 1: 키워드 추출 + 포모 점수 코어 엔진 (순수 함수)

### DIFF
--- a/docs/KEYWORD_ENGINE_SPEC.md
+++ b/docs/KEYWORD_ENGINE_SPEC.md
@@ -126,6 +126,13 @@ community       클러스터링          (군중 쏠림)        + 균형추 + de
 
 5구간 ↔ 색·표정 매핑은 `@fomo/core`의 `scoreToColor`/`scoreToEmoji` 재활용(`KeywordCardFeed.tsx:4`에서 이미 import 중). FOMO_INDEX.md의 5구간과 일관.
 
+#### Phase 2에서 반드시 해결할 것 (Phase 1 구현이 남긴 한계 — 선택 아님)
+
+Phase 1은 30일 기준선이 없어 `(c)톤강도·(d)커뮤니티열`만 재정규화(실효 가중 tone 0.571 / community 0.429)하고 confidence "low"로 산출한다. 그대로 머지하되, Phase 2에서 `(a)volume·(b)accel` 기준선을 스냅샷에 넣을 때 아래 둘을 **반드시** 함께 푼다.
+
+1. **(필수) community 정규화 ↔ '어제 대비' 서사 충돌.** 현재 `(d)`는 *당일* 키워드들 사이의 상대 참여도(`engagement / 당일 max`)다. "오늘의 너"의 핵심 훅(어제 64 → 오늘 45, PRODUCT_VISION §4.1)은 day-over-day delta 위에 선다. community가 당일 상대값이면 어제·오늘이 **다른 척도**라 delta가 거짓이 된다. Phase 2 스냅샷에 `(a)(b)` 기준선을 도입할 때 **community도 날짜 간 비교 가능한 절대 기준**(예: 30일 참여도 기준선 대비)으로 다듬어야 한다. **안 풀면 리텐션 훅이 깨진다.**
+2. **(확인) community 소유 왜곡 — 순위 역전.** 진짜 급등인데 뉴스전용(참여 0)이면 저평가되고(상한 ~57), 중립인데 커뮤니티만 시끄러우면 과대평가된다(+최대 ~43). 기준선이 들어와도 상대정규화 특성상 자동으로 안 풀릴 수 있으니 Phase 2에서 같이 점검한다.
+
 ### 4.4 코멘트 생성 — `keyword-cards/comment.ts` (신규)
 
 `comment`(카드 앞면) + `depth.why` + `depth.remember`를 생성. **LLM 1차, 룰 폴백 필수.**

--- a/packages/fomo-core/__tests__/keyword-engine.test.ts
+++ b/packages/fomo-core/__tests__/keyword-engine.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractKeywords,
+  scoreKeywords,
+  THEME_DICTIONARY,
+  type KeywordSourceItem,
+} from "../src";
+
+const NOW = Date.parse("2026-06-13T12:00:00Z");
+const recent = "2026-06-13T11:00:00Z";
+
+// 샘플 mock 글 묶음 — 뉴스 + 커뮤니티(engagement).
+const SAMPLE: KeywordSourceItem[] = [
+  { title: "엔비디아 신고가 급등, HBM 수요 폭발", publishedAt: recent, source: "한국경제" },
+  { title: "삼성전자 반도체 랠리 지속", publishedAt: recent, source: "매일경제" },
+  { title: "SK하이닉스 사상 최고가 돌파", publishedAt: recent, source: "연합뉴스" },
+  { title: "반도체 커뮤니티: 다들 엔비디아 얘기뿐", publishedAt: recent, engagement: 320, source: "reddit" },
+  { title: "비트코인 다시 상승, 코인판 들썩", publishedAt: recent, engagement: 90, source: "reddit" },
+  { title: "이더리움 ETF 기대감", publishedAt: recent, source: "블록미디어" },
+  { title: "연준 FOMC 앞두고 금리 관망", publishedAt: recent, source: "연합뉴스" },
+  { title: "오늘 날씨가 맑습니다", publishedAt: recent, source: "기상청" }, // 매칭 0
+];
+
+describe("extractKeywords (사전 기반)", () => {
+  it("테마 버킷 추출 + mention 0 테마 제외 + 복수 테마 매칭", () => {
+    const ex = extractKeywords(SAMPLE);
+    const keys = ex.map((e) => e.keyword);
+    expect(keys).toContain("반도체");
+    expect(keys).toContain("코인");
+    expect(keys).toContain("금리");
+    // 2차전지는 SAMPLE에 없음 → 제외(정직)
+    expect(keys).not.toContain("2차전지");
+    // 반도체가 가장 많이 언급(4건) → 첫 번째
+    expect(ex[0]!.keyword).toBe("반도체");
+    expect(ex[0]!.mentions).toBe(4);
+    // 엔비디아 글은 반도체+AI 둘 다 매칭(복수 테마)
+    expect(keys).toContain("AI");
+  });
+
+  it("engagement 합산 + emoji 고정 매핑", () => {
+    const ex = extractKeywords(SAMPLE);
+    const semi = ex.find((e) => e.keyword === "반도체")!;
+    expect(semi.engagement).toBe(320);
+    expect(semi.emoji).toBe(THEME_DICTIONARY["반도체"]!.emoji);
+  });
+
+  it("빈 입력 → 빈 배열(에러 없음)", () => {
+    expect(extractKeywords([])).toEqual([]);
+  });
+
+  it("출력 타입에 미래 시점 필드 자리(firstDetectedAt/consecutiveDays)는 비어 있다", () => {
+    const ex = extractKeywords(SAMPLE);
+    expect(ex[0]!.firstDetectedAt).toBeUndefined();
+    expect(ex[0]!.consecutiveDays).toBeUndefined();
+  });
+});
+
+describe("scoreKeywords (군중 쏠림 0~100)", () => {
+  it("실제 점수가 산출되고 0~100 범위·내림차순", () => {
+    const scored = scoreKeywords(extractKeywords(SAMPLE), { nowMs: NOW });
+    expect(scored.length).toBeGreaterThan(0);
+    for (const s of scored) {
+      expect(s.fomoScore).toBeGreaterThanOrEqual(0);
+      expect(s.fomoScore).toBeLessThanOrEqual(100);
+    }
+    // 점수 내림차순
+    for (let i = 1; i < scored.length; i++) {
+      expect(scored[i - 1]!.fomoScore).toBeGreaterThanOrEqual(scored[i]!.fomoScore);
+    }
+  });
+
+  it("surge 키워드(신고가·급등)가 많은 반도체가 잔잔한 금리보다 높다", () => {
+    const scored = scoreKeywords(extractKeywords(SAMPLE), { nowMs: NOW });
+    const semi = scored.find((s) => s.keyword === "반도체")!;
+    const rate = scored.find((s) => s.keyword === "금리")!;
+    expect(semi.fomoScore).toBeGreaterThan(rate.fomoScore);
+  });
+
+  it("30일 기준선 없으면 confidence 'low' + (a)volume·(b)accel은 null (가짜 기준선 금지)", () => {
+    const scored = scoreKeywords(extractKeywords(SAMPLE), { nowMs: NOW });
+    for (const s of scored) {
+      expect(s.confidence).toBe("low");
+      expect(s.signals.volume).toBeNull();
+      expect(s.signals.accel).toBeNull();
+      // 산출에 쓰인 신호는 실제 집계 기반(tone·community)
+      expect(s.signals.tone).toBeGreaterThanOrEqual(0);
+      expect(s.signals.tone).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("빈 입력 → 빈 배열(에러 없음, 폴백)", () => {
+    expect(scoreKeywords([], { nowMs: NOW })).toEqual([]);
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/extract.ts
+++ b/packages/fomo-core/src/keyword-cards/extract.ts
@@ -1,0 +1,109 @@
+import type { NewsLang } from "../news-feed/types";
+
+/**
+ * 키워드/테마 추출 — 사전 기반 1차. KEYWORD_ENGINE_SPEC §4.2.
+ *
+ * 순수 함수(네트워크·DB 0). 입력: 점수 매기기 전 뉴스/커뮤니티 글 배열.
+ * 출력: 테마별 버킷 { keyword, articles, mentions, engagement, emoji }.
+ * LLM 클러스터링 X(예측 불가·디버깅 난해) — 사전 매칭으로 정직·재현 가능하게. v2에서 임베딩 확장.
+ */
+
+/** 추출 입력 — 뉴스 기사 또는 커뮤니티 글. fetch 는 Phase 2 라우트 담당. */
+export interface KeywordSourceItem {
+  title: string;
+  summary?: string;
+  /** 발행/작성 시각 ISO. 최신성·가속 계산용(없으면 무시). */
+  publishedAt?: string;
+  /** 커뮤니티 참여도(upvote+댓글 합). 뉴스는 0/생략. */
+  engagement?: number;
+  source?: string;
+  lang?: NewsLang;
+}
+
+interface ThemeDef {
+  /** 고정 이모지(분위기). §4.2 */
+  emoji: string;
+  /** 매칭 용어 — EN+KO. 한 글이 복수 테마에 매칭될 수 있다. */
+  terms: readonly string[];
+}
+
+/**
+ * 테마 사전(MVP). 코인+주식 테마만(PRODUCT_TRUTH §4 Now). 부동산·환율은 Later.
+ * 용어 추가/조정은 운영 중 데이터 보며 튜닝. 오추출 1건이 신뢰를 깨므로 보수적으로.
+ */
+export const THEME_DICTIONARY: Record<string, ThemeDef> = {
+  반도체: {
+    emoji: "🔥",
+    terms: ["반도체", "HBM", "엔비디아", "SK하이닉스", "삼성전자", "TSMC", "메모리", "파운드리", "semiconductor", "chip", "nvidia"],
+  },
+  AI: {
+    emoji: "🤖",
+    terms: ["AI", "인공지능", "오픈AI", "챗GPT", "ChatGPT", "LLM", "GPT", "openai", "엔비디아"],
+  },
+  코인: {
+    emoji: "₿",
+    terms: ["비트코인", "이더리움", "코인", "암호화폐", "가상자산", "crypto", "bitcoin", "btc", "ethereum", "eth", "ETF"],
+  },
+  금리: {
+    emoji: "💵",
+    terms: ["금리", "연준", "FOMC", "기준금리", "채권", "인플레", "물가", "rate", "fed", "fomc"],
+  },
+  "2차전지": {
+    emoji: "🔋",
+    terms: ["2차전지", "2차 전지", "배터리", "에코프로", "LG에너지", "전기차", "battery"],
+  },
+};
+
+export interface ExtractedKeyword {
+  keyword: string;
+  emoji: string;
+  /** 이 테마에 매칭된 원본 글. */
+  articles: KeywordSourceItem[];
+  /** 매칭 글 수(언급량). */
+  mentions: number;
+  /** 참여도 합(커뮤니티 upvote+댓글). */
+  engagement: number;
+  // ── 미래 확장 자리(Phase 2+, PRODUCT_VISION §7) — 지금은 미산출. 타입을 닫지 않기 위해 선점. ──
+  /** 쏠림 첫 감지일(YYYY-MM-DD). 일일 스냅샷 누적 시 채운다(타이밍 판단 보조용). */
+  firstDetectedAt?: string;
+  /** 연속 감지일 수. 스냅샷 누적 시 채운다. */
+  consecutiveDays?: number;
+}
+
+/** 한 글이 어떤 테마에 매칭되는지 — 사전 용어 substring(대소문자 무시). */
+function matchedThemes(item: KeywordSourceItem): string[] {
+  const blob = `${item.title} ${item.summary ?? ""}`.toLowerCase();
+  const hits: string[] = [];
+  for (const [keyword, def] of Object.entries(THEME_DICTIONARY)) {
+    if (def.terms.some((t) => blob.includes(t.toLowerCase()))) hits.push(keyword);
+  }
+  return hits;
+}
+
+/**
+ * 글 배열 → 테마 버킷. mention 0 테마는 제외(정직: 안 쏠렸으면 안 보여준다, §4.2 step 3).
+ * 정렬: 언급량 내림차순(동률이면 참여도) — 점수는 score.ts가 매긴다.
+ */
+export function extractKeywords(items: KeywordSourceItem[]): ExtractedKeyword[] {
+  const buckets = new Map<string, KeywordSourceItem[]>();
+  for (const item of items) {
+    for (const keyword of matchedThemes(item)) {
+      const arr = buckets.get(keyword) ?? [];
+      arr.push(item);
+      buckets.set(keyword, arr);
+    }
+  }
+
+  const out: ExtractedKeyword[] = [];
+  for (const [keyword, articles] of buckets) {
+    out.push({
+      keyword,
+      emoji: THEME_DICTIONARY[keyword]!.emoji,
+      articles,
+      mentions: articles.length,
+      engagement: articles.reduce((s, a) => s + (a.engagement ?? 0), 0),
+    });
+  }
+  out.sort((a, b) => b.mentions - a.mentions || b.engagement - a.engagement);
+  return out;
+}

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -1,2 +1,4 @@
 export * from "./types";
 export * from "./mock";
+export * from "./extract";
+export * from "./score";

--- a/packages/fomo-core/src/keyword-cards/score.ts
+++ b/packages/fomo-core/src/keyword-cards/score.ts
@@ -1,0 +1,101 @@
+import { scoreArticleFomo } from "../news-feed/score";
+import type { RawArticle } from "../news-feed/types";
+import type { ExtractedKeyword } from "./extract";
+
+/**
+ * 포모 점수 — 키워드의 군중 쏠림 정도(0~100). KEYWORD_ENGINE_SPEC §4.3.
+ *
+ * 시세가 아니라 "다들 여기 보는 정도". 순수 함수.
+ * §4.3 4신호 가중 평균: (a)언급볼륨 0.35 (b)언급가속 0.30 (c)톤강도 0.20 (d)커뮤니티열 0.15.
+ * (c)는 news-feed/score.ts(기사 단위 surge/rise/damp 점수기)를 재활용해 키워드 평균으로 집계.
+ *
+ * ⚠️ 정직성(§4.3 단서): (a)(b)는 30일 기준선/시계열이 있어야 산출 가능.
+ *   Phase 1엔 누적 스냅샷이 없으므로 (a)(b)는 산출하지 않고(null) confidence "low"로 표기,
+ *   (c)(d)만 재정규화해 점수를 낸다. 가짜 기준선은 절대 만들지 않는다.
+ *   (a)(b)와 high/medium confidence는 Phase 2+(스냅샷 누적) 도입.
+ */
+
+export type KeywordConfidence = "high" | "medium" | "low" | "fallback";
+
+export interface KeywordSignals {
+  /** (c) 톤 강도 0~1 — 키워드 기사들의 FOMO 점수 평균(surge 키워드↑). */
+  tone: number;
+  /** (d) 커뮤니티 열 0~1 — 오늘 키워드들 중 상대 참여도(engagement-weighted). */
+  community: number;
+  /** (a) 언급 볼륨 0~1 — 30일 기준선 대비. 미보유 시 null(Phase 2+). */
+  volume: number | null;
+  /** (b) 언급 가속 0~1 — 최근 6h vs 직전 6h. 시계열 미보유 시 null(Phase 2+). */
+  accel: number | null;
+}
+
+export interface ScoredKeyword extends ExtractedKeyword {
+  /** 0~100 — 군중 쏠림(시세 아님). */
+  fomoScore: number;
+  confidence: KeywordConfidence;
+  signals: KeywordSignals;
+  /** 산출 근거(디버그/튜닝). */
+  reason: string;
+}
+
+// §4.3 가중치.
+const W = { volume: 0.35, accel: 0.3, tone: 0.2, community: 0.15 } as const;
+
+function clamp01(n: number): number {
+  return Math.max(0, Math.min(1, n));
+}
+function clamp100(n: number): number {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+/** (c) 톤 강도 — 키워드 기사들의 기사단위 FOMO 점수 평균 / 100. news-feed 점수기 재활용. */
+function toneSignal(kw: ExtractedKeyword, nowMs: number): number {
+  if (kw.articles.length === 0) return 0;
+  let sum = 0;
+  for (const a of kw.articles) {
+    const article: RawArticle = {
+      id: "",
+      title: a.title,
+      url: "",
+      source: a.source ?? "",
+      publishedAt: a.publishedAt ?? "",
+      lang: a.lang ?? "ko",
+      ...(a.summary ? { summary: a.summary } : {}),
+    };
+    sum += scoreArticleFomo(article, nowMs).score;
+  }
+  return clamp01(sum / kw.articles.length / 100);
+}
+
+export interface ScoreOptions {
+  /** 현재 시각(ms) — 최신성·테스트 주입용. */
+  nowMs: number;
+}
+
+/**
+ * 추출된 키워드 → 포모 점수. 점수 내림차순 정렬.
+ * Phase 1: (c)(d)만으로 산출 + confidence "low"(30일 기준선 부재). (a)(b)는 null.
+ */
+export function scoreKeywords(keywords: ExtractedKeyword[], opts: ScoreOptions): ScoredKeyword[] {
+  // (d) 커뮤니티 열은 오늘 키워드들 사이의 상대 참여도 — 가짜 기준선 없이 자체 정규화.
+  const maxEngagement = Math.max(1, ...keywords.map((k) => k.engagement));
+
+  const scored = keywords.map((kw): ScoredKeyword => {
+    const tone = toneSignal(kw, opts.nowMs);
+    const community = clamp01(kw.engagement / maxEngagement);
+
+    // 30일 기준선 없음 → (a)(b) 미산출, (c)(d)만 재정규화.
+    const wSum = W.tone + W.community;
+    const fomoScore = clamp100(((W.tone * tone + W.community * community) / wSum) * 100);
+
+    return {
+      ...kw,
+      fomoScore,
+      confidence: "low",
+      signals: { tone, community, volume: null, accel: null },
+      reason: `tone=${tone.toFixed(2)} community=${community.toFixed(2)} | (a)volume·(b)accel 미산출(30일 기준선 부재) → confidence low`,
+    };
+  });
+
+  scored.sort((a, b) => b.fomoScore - a.fomoScore);
+  return scored;
+}


### PR DESCRIPTION
## 무엇을 (KEYWORD_ENGINE_SPEC §6 Phase 1 — 추출 + 점수 코어 엔진)

`packages/fomo-core/src/keyword-cards/`에 **순수 함수 2개** 추가. 네트워크·DB·API·LLM 0(그건 Phase 2~3).

1. **`extract.ts`** (§4.2 사전 기반 1차) — 뉴스·커뮤니티 글 배열 → 테마 버킷 `{ keyword, emoji, articles, mentions, engagement }[]`.
   - 테마 사전: 반도체🔥/AI🤖/코인₿/금리💵/2차전지🔋 (EN+KO 용어). 한 글이 복수 테마 매칭 가능, mention 0 테마는 제외(정직).
   - LLM 클러스터링 X(재현·디버깅 위해 사전 기반). v2 임베딩은 설계만.
   - 출력 타입에 `firstDetectedAt?`·`consecutiveDays?` **미래 자리 선점**(PRODUCT_VISION §7 흔들림 점수용) — 지금은 미산출, 타입만 안 닫음.
2. **`score.ts`** (§4.3) — 키워드 → 군중 쏠림 점수 0~100(시세 아님).
   - (c)톤강도 = **기존 `news-feed/score.ts`(surge/rise/damp) 재활용**한 기사 점수 평균, (d)커뮤니티열 = 상대 참여도.
   - ⚠️ (a)언급볼륨·(b)언급가속은 30일 기준선/시계열 필요 → Phase 1엔 누적 스냅샷 없음 → **null + confidence "low"**. 가짜 기준선 절대 안 만듦(§4.3 단서). high/medium·(a)(b)는 Phase 2+.
3. `index.ts` export 추가. **`mock.ts` 유지**(Phase 2에서 교체).

## 범위 밖(안 함)
화면 연결·API 라우트·실제 fetch·LLM 코멘트 = Phase 2~3. 스키마·DB·시점 추적 저장 = Phase 2 이후.

## Acceptance (Phase 1)
- ✅ mock 기사 → 실제 산출 점수: **🔥 반도체 91 · 🤖 AI 87 · ₿ 코인 53 · 💵 금리 36** (8건 입력, '날씨' 글은 매칭 0으로 제외)
- ✅ `npm run typecheck` 전체 통과
- ✅ vitest 전체 540 통과(키워드 엔진 8 신규)
- ✅ 30일 기준선 부재 → 전 키워드 confidence "low", (a)volume·(b)accel = null

## 변경 파일
- `packages/fomo-core/src/keyword-cards/extract.ts` (신규)
- `packages/fomo-core/src/keyword-cards/score.ts` (신규)
- `packages/fomo-core/src/keyword-cards/index.ts` (export 추가)
- `packages/fomo-core/__tests__/keyword-engine.test.ts` (신규)


## Known limitations — resolve in Phase 2 (필수)

Phase 1은 30일 기준선이 없어 `(c)톤강도·(d)커뮤니티열`만 재정규화 + confidence "low"로 산출한다. 그대로 머지하되, Phase 2에서 `(a)volume·(b)accel` 기준선을 스냅샷에 넣을 때 아래 둘을 **반드시** 함께 해결한다. (KEYWORD_ENGINE_SPEC §4.3에도 기록함.)

1. **(필수) community 정규화 ↔ '어제 대비' 서사 충돌.** `(d)`가 *당일* 상대 참여도(`engagement / 당일 max`)라 어제·오늘이 다른 척도 → "오늘의 너" 핵심 훅(어제 64 → 오늘 45, PRODUCT_VISION §4.1)의 day-over-day delta가 거짓이 된다. Phase 2 기준선 도입 시 community도 **날짜 간 비교 가능한 절대 기준**으로 다듬어야 함. 안 풀면 리텐션 훅이 깨진다.
2. **(확인) community 소유 왜곡 — 순위 역전.** 급등이지만 뉴스전용(참여 0)이면 저평가(상한 ~57), 중립이지만 커뮤니티만 시끄러우면 과대평가(+최대 ~43). 상대정규화 특성상 기준선 도입만으로 자동 해소 안 될 수 있으니 Phase 2에서 함께 점검.
