### PR TITLE
Phase 2: 키워드 카드 실데이터 + API + UI 연결

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
-import { MOCK_KEYWORD_CARDS, scoreToColor, scoreToEmoji, type KeywordCard } from "@fomo/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { scoreToColor, scoreToEmoji, type KeywordCard, type KeywordConfidence } from "@fomo/core";
 import { KeywordDepthPage } from "@/components/KeywordDepthPage";
+import { fetchKeywords } from "@/lib/fomoApi";
 import { recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
 
@@ -47,10 +48,80 @@ function CardFace({ card, progress }: { card: KeywordCard; progress?: string }) 
   );
 }
 
-export function KeywordCardFeed({
-  cards = MOCK_KEYWORD_CARDS,
+/** confidence 정직 한마디(§5). high 면 노출 안 함. */
+function ConfidenceNote({ confidence }: { confidence: KeywordConfidence }) {
+  if (confidence === "high") return null;
+  const text =
+    confidence === "fallback"
+      ? "오늘은 시장이 너무 조용해서 보여줄 게 별로 없어. 그것도 정상이야."
+      : "오늘은 데이터가 좀 적어서 포모도 긴가민가해 🤔";
+  return (
+    <p className="mb-2 px-2 text-center text-[11px] leading-5 text-muted">{text}</p>
+  );
+}
+
+/** 스와이프 스켈레톤(로딩) — 무한 로딩 대신 카드 형태만 비워 보여준다. */
+function DeckSkeleton() {
+  return (
+    <div className="w-full">
+      <div className="mx-auto h-[56vh] w-full animate-pulse rounded-2xl border border-hairline bg-surface" />
+      <p className="mt-4 text-center text-xs text-muted">오늘 뭐에 쏠렸는지 보는 중…</p>
+    </div>
+  );
+}
+
+/** 담담한 빈 상태(수집 실패/데이터 없음) — 무한 로딩 금지. */
+function DeckEmpty() {
+  return (
+    <div className="mt-16 flex flex-col items-center gap-3 px-8 text-center">
+      <p className="text-sm leading-6 text-whiteout">
+        오늘은 보여줄 게 잠깐 비었어.
+        <br />
+        조용한 날도 있는 거야. 이따 다시 와줘.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * 데이터 로딩 래퍼 — /api/fomo/keywords 실데이터를 받아 덱에 넘긴다.
+ * 로딩=스켈레톤, 실패=담담한 빈 상태(무한 로딩 금지). confidence 는 덱 상단 한마디로.
+ */
+export function KeywordCardFeed() {
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "error" }
+    | { kind: "ready"; cards: readonly KeywordCard[]; confidence: KeywordConfidence }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    fetchKeywords()
+      .then((res) => {
+        if (!alive) return;
+        if (!res.cards || res.cards.length === 0) setState({ kind: "error" });
+        else setState({ kind: "ready", cards: res.cards, confidence: res.confidence });
+      })
+      .catch((err) => {
+        console.warn("[KeywordCardFeed] fetch failed", err);
+        if (alive) setState({ kind: "error" });
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (state.kind === "loading") return <DeckSkeleton />;
+  if (state.kind === "error") return <DeckEmpty />;
+  return <KeywordDeck cards={state.cards} confidence={state.confidence} />;
+}
+
+function KeywordDeck({
+  cards,
+  confidence,
 }: {
-  cards?: readonly KeywordCard[];
+  cards: readonly KeywordCard[];
+  confidence: KeywordConfidence;
 }) {
   // 마운트 시점의 "이미 본" 집합 — 본 카드는 덱에서 제외(다시 와도 다음 카드부터).
   const viewedIds = useState(() => new Set(getHistory().map((h) => h.id)))[0];
@@ -159,6 +230,7 @@ export function KeywordCardFeed({
 
   return (
     <div className="w-full">
+      <ConfidenceNote confidence={confidence} />
       <p className="mb-2 px-1 text-center text-xs text-muted">
         오른쪽=<span style={{ color: UP }}>관심</span> · 왼쪽=덜 관심 · 탭하면 자세히
       </p>

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -1,6 +1,14 @@
 // FOMO API 클라이언트. API는 apps/web(@trading/web)의 /api/fomo/*에 있다.
 // NEXT_PUBLIC_FOMO_API_BASE로 오버라이드(로컬: http://127.0.0.1:3200), 기본은 배포된 prod.
-import type { BannerItem, FeedCards, MarketScore, MoodSignal, ScoredArticle } from "@fomo/core";
+import type {
+  BannerItem,
+  FeedCards,
+  KeywordCard,
+  KeywordConfidence,
+  MarketScore,
+  MoodSignal,
+  ScoredArticle,
+} from "@fomo/core";
 import { getToken, setToken } from "@/lib/auth";
 
 export type { BannerItem } from "@fomo/core";
@@ -70,6 +78,16 @@ export interface NewsResponse {
   lang: "en" | "ko";
 }
 export const fetchNews = () => get<NewsResponse>("/api/fomo/news");
+
+/** 키워드 카드 — "오늘 쏠린 키워드" 실데이터(KEYWORD_ENGINE_SPEC §4.6). confidence 로 정직성 노출. */
+export type { KeywordCard, KeywordConfidence } from "@fomo/core";
+export interface KeywordsResponse {
+  date: string;
+  cards: KeywordCard[];
+  confidence: KeywordConfidence;
+  live: boolean;
+}
+export const fetchKeywords = () => get<KeywordsResponse>("/api/fomo/keywords");
 
 export const fetchCalendar = (sessionId: string, month?: string) =>
   get<CalendarResponse>(

--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import {
+  extractKeywords,
+  mergeCommunityEngagement,
+  scoreKeywords,
+  buildKeywordCards,
+  overallConfidence,
+  fetchCommunity,
+  MOCK_KEYWORD_CARDS,
+  type KeywordCard,
+  type KeywordConfidence,
+  type KeywordSourceItem,
+} from "@fomo/core";
+import { withCors, kstDate } from "../../../../lib/fomo";
+import { fetchAllNews } from "../../../../lib/fomo-news-sources";
+
+/**
+ * 키워드 카드 API — "오늘 사람들 시선이 가장 쏠린 키워드" 실데이터 산출. KEYWORD_ENGINE_SPEC §4.6 / Phase 2.
+ *
+ * 파이프라인: 뉴스 RSS + 커뮤니티(Promise.allSettled 병렬) → extract → community 가산 → score → 룰 폴백 코멘트.
+ * 코멘트는 Phase 2 라 LLM 없이 룰 폴백 템플릿만(LLM 은 Phase 3).
+ *
+ * 응답 정직성(§5): confidence 를 반드시 동봉. 30일 기준선이 아직 없어 라이브는 'low'(가짜 high 금지).
+ * 라이브 산출이 키워드 0건이면 mock 을 *명시적 폴백*(confidence:"fallback")으로 반환 — 진짜처럼 위장하지 않는다.
+ *
+ * 스냅샷-우선(§4.6 1단계: 오늘 스냅샷 있으면 그대로)은 Phase 4(cron + DDL 승인)에서 이 앞에 붙는다.
+ * 지금은 스냅샷 테이블에 의존하지 않고 라이브 산출을 메인 경로로 둔다(prisma db push 미실행).
+ */
+export const dynamic = "force-dynamic";
+// 외부 소스(뉴스 RSS·커뮤니티 HTML) 수집이 수초 걸릴 수 있어 데드라인 넉넉히.
+export const maxDuration = 30;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+interface KeywordsPayload {
+  date: string;
+  cards: readonly KeywordCard[];
+  confidence: KeywordConfidence;
+  live: boolean;
+}
+
+// ── 라이브 결과 메모리 캐시(TTL) + in-flight dedup ──────────────────────────
+// snapshot-first 정신(§4.6): 한 사용자의 새로고침/동시 접속이 외부 소스를 반복 폭격하지 않게,
+// 라이브 산출 결과를 서버 인스턴스 단위로 짧게 캐시하고 동시 요청은 진행 중 Promise 를 공유한다.
+// (Phase 4 의 일일 DB 스냅샷이 들어오면 이 메모리 캐시는 백업 역할로 내려간다.)
+const TTL_MS = 30 * 60 * 1000;
+let cache: { at: number; payload: KeywordsPayload } | null = null;
+let inflight: Promise<KeywordsPayload> | null = null;
+
+/** 뉴스/커뮤니티 실수집 → 키워드 카드 산출. 실패해도 throw 없이 mock 폴백을 돌려준다. */
+async function computeLive(date: string): Promise<KeywordsPayload> {
+  const [newsResult, communityResult] = await Promise.allSettled([fetchAllNews(), fetchCommunity()]);
+
+  const items: KeywordSourceItem[] = [];
+  if (newsResult.status === "fulfilled") {
+    for (const a of newsResult.value) {
+      items.push({
+        title: a.title,
+        ...(a.summary ? { summary: a.summary } : {}),
+        publishedAt: a.publishedAt,
+        source: a.source,
+        lang: a.lang,
+      });
+    }
+  } else {
+    console.warn("[fomo/keywords] news error", newsResult.reason);
+  }
+
+  const communitySignals =
+    communityResult.status === "fulfilled" ? communityResult.value.sources : [];
+  if (communityResult.status === "rejected") {
+    console.warn("[fomo/keywords] community error", communityResult.reason);
+  }
+
+  // 뉴스 추출 → 커뮤니티 참여도 가산(뉴스로 확인된 테마에만, §4.3 보수적) → 점수.
+  const extracted = mergeCommunityEngagement(extractKeywords(items), communitySignals);
+  const scored = scoreKeywords(extracted, { nowMs: Date.now() });
+  const cards = buildKeywordCards(scored);
+
+  // 키워드 0건 = 보여줄 게 없음 → mock 명시적 폴백(가짜 점수 강제 생성 금지, §5).
+  if (cards.length === 0) {
+    return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback", live: true };
+  }
+  return { date, cards, confidence: overallConfidence(scored), live: true };
+}
+
+/** TTL 캐시 + dedup 래퍼. */
+async function getPayload(date: string): Promise<KeywordsPayload> {
+  if (cache && Date.now() - cache.at < TTL_MS && cache.payload.date === date) {
+    return cache.payload;
+  }
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    try {
+      const payload = await computeLive(date);
+      cache = { at: Date.now(), payload };
+      return payload;
+    } catch (err) {
+      // 라이브 경로 자체가 깨져도 빈 화면 금지 — mock 명시적 폴백.
+      console.warn("[fomo/keywords] live compute failed — mock fallback", err);
+      return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback" as const, live: false };
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+export async function GET() {
+  const date = kstDate();
+  const payload = await getPayload(date);
+  return withCors(
+    NextResponse.json(payload, {
+      // 엣지 캐시 — 외부 소스 레이트리밋 보호(피드/배너와 동일 정책).
+      headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=1200" },
+    })
+  );
+}

--- a/packages/fomo-core/__tests__/keyword-comment.test.ts
+++ b/packages/fomo-core/__tests__/keyword-comment.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildKeywordCards,
+  overallConfidence,
+  CALM_MARKERS,
+  communityEngagementByTheme,
+  mergeCommunityEngagement,
+  extractKeywords,
+  scoreKeywords,
+  type KeywordSourceItem,
+  type ScoredKeyword,
+  type CommunitySourceSignal,
+} from "../src";
+
+const NOW = Date.parse("2026-06-13T12:00:00Z");
+
+const SAMPLE: KeywordSourceItem[] = [
+  { title: "엔비디아 신고가 급등, HBM 수요 폭발", publishedAt: "2026-06-13T11:00:00Z", source: "한국경제" },
+  { title: "삼성전자 반도체 랠리 지속", publishedAt: "2026-06-13T11:00:00Z", source: "매일경제" },
+  { title: "비트코인 다시 상승, 코인판 들썩", publishedAt: "2026-06-13T11:00:00Z", source: "블록미디어" },
+  { title: "연준 FOMC 앞두고 금리 관망", publishedAt: "2026-06-13T11:00:00Z", source: "연합뉴스" },
+];
+
+function scoreSample(): ScoredKeyword[] {
+  return scoreKeywords(extractKeywords(SAMPLE), { nowMs: NOW });
+}
+
+/** 코멘트 가드(§2): 예측·투자조언·전문용어·거래부추김 금칙어. */
+const FORBIDDEN = /사라|팔아라|매수|매도|목표가|오를 것|내릴 것|상승할|하락할|지금 안 사면|PER|밸류에이션|추천/;
+
+describe("buildKeywordCards (룰 폴백 코멘트)", () => {
+  it("모든 카드 코멘트에 균형추(진정) 마커가 최소 1개", () => {
+    const cards = buildKeywordCards(scoreSample());
+    expect(cards.length).toBeGreaterThan(0);
+    for (const c of cards) {
+      const hasCalm = CALM_MARKERS.some((m) => c.comment.includes(m) || c.depth.remember.includes(m));
+      expect(hasCalm, `카드 ${c.keyword} 균형추 누락`).toBe(true);
+    }
+  });
+
+  it("모든 카드(코멘트+depth)에 금칙어가 없다", () => {
+    const cards = buildKeywordCards(scoreSample());
+    for (const c of cards) {
+      const blob = `${c.comment} ${c.depth.why} ${c.depth.remember}`;
+      expect(FORBIDDEN.test(blob), `카드 ${c.keyword} 금칙어`).toBe(false);
+    }
+  });
+
+  it("점수 전 구간(0~100)에서도 균형추 유지 + 금칙어 0", () => {
+    const base = scoreSample()[0]!;
+    for (const score of [5, 30, 50, 70, 95]) {
+      const card = buildKeywordCards([{ ...base, fomoScore: score }])[0]!;
+      const blob = `${card.comment} ${card.depth.remember}`;
+      expect(CALM_MARKERS.some((m) => blob.includes(m))).toBe(true);
+      expect(FORBIDDEN.test(`${card.comment} ${card.depth.why} ${card.depth.remember}`)).toBe(false);
+    }
+  });
+
+  it("관련 종목/이모지가 카드로 전달된다", () => {
+    const cards = buildKeywordCards(scoreSample());
+    const semi = cards.find((c) => c.keyword === "반도체")!;
+    expect(semi.related).toContain("삼성전자");
+    expect(semi.emoji).toBe("🔥");
+  });
+});
+
+describe("overallConfidence (정직성)", () => {
+  it("키워드 0건 → fallback", () => {
+    expect(overallConfidence([])).toBe("fallback");
+  });
+  it("Phase 2 라이브(전부 low) → low", () => {
+    expect(overallConfidence(scoreSample())).toBe("low");
+  });
+});
+
+describe("communityEngagementByTheme / merge (§4.3 커뮤니티 귀속)", () => {
+  const signals: CommunitySourceSignal[] = [
+    { source: "naver/005930", postCount: 40, totalUpvotes: 40, totalComments: 0, bullishRatio: 0.6, fetchedAt: "" }, // 삼성전자 → 반도체
+    { source: "reddit/cryptocurrency", postCount: 25, totalUpvotes: 200, totalComments: 80, bullishRatio: 0.7, fetchedAt: "" }, // → 코인
+    { source: "naver/035720", postCount: 30, totalUpvotes: 30, totalComments: 0, bullishRatio: 0.5, fetchedAt: "" }, // 카카오 → 매핑 없음
+  ];
+
+  it("소스 라벨 → 테마 매핑, 매핑 없는 소스는 제외", () => {
+    const map = communityEngagementByTheme(signals);
+    expect(map.get("반도체")?.engagement).toBe(40);
+    expect(map.get("코인")?.engagement).toBe(280); // 200+80
+    expect(map.has("2차전지")).toBe(false);
+    // 카카오(매핑 없음)는 어떤 테마에도 안 들어간다
+    expect([...map.keys()]).toEqual(expect.arrayContaining(["반도체", "코인"]));
+    expect(map.size).toBe(2);
+  });
+
+  it("뉴스로 확인된 테마에만 참여도 가산(커뮤니티-단독 테마 신설 안 함)", () => {
+    const extracted = extractKeywords(SAMPLE); // 반도체·코인·금리·AI (뉴스 근거)
+    const merged = mergeCommunityEngagement(extracted, signals);
+    const semi = merged.find((k) => k.keyword === "반도체")!;
+    const coin = merged.find((k) => k.keyword === "코인")!;
+    expect(semi.engagement).toBe(40); // 뉴스 0 + 커뮤니티 40
+    expect(coin.engagement).toBe(280);
+    // 커뮤니티 시그널이 새 테마를 만들지 않는다(키 수 동일)
+    expect(merged.length).toBe(extracted.length);
+  });
+
+  it("빈 시그널 → 추출 그대로(에러 없음)", () => {
+    const extracted = extractKeywords(SAMPLE);
+    expect(mergeCommunityEngagement(extracted, [])).toEqual(extracted);
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/comment.ts
+++ b/packages/fomo-core/src/keyword-cards/comment.ts
@@ -1,0 +1,148 @@
+import type { KeywordCard } from "./types";
+import type { ScoredKeyword, KeywordConfidence } from "./score";
+
+/**
+ * 코멘트 생성 — 룰 폴백 템플릿. KEYWORD_ENGINE_SPEC §4.4.
+ *
+ * 순수 함수. Phase 2 는 LLM 없이 점수 구간별 템플릿만 쓴다(LLM 은 Phase 3).
+ * mock.ts 의 톤을 폴백 기준으로 삼는다: 친구 반말 + 담담함 + 반드시 균형추(진정)로 닫기.
+ *
+ * 절대 규칙(§2): 예측·투자조언·전문용어·거래부추김 0, 모든 카드에 균형추 필수.
+ * 가드 테스트(keyword-comment.test.ts)가 금칙어/균형추를 검증한다.
+ */
+
+/** 진정(균형추) 마커 — 모든 코멘트·remember 에 최소 1개 포함되어야 한다(가드 테스트). */
+export const CALM_MARKERS: readonly string[] = [
+  "기회는 또 와",
+  "안 급해도 돼",
+  "급할 거 없어",
+  "천천히",
+  "조심",
+  "아쉬워할 필요 없어",
+  "무서워할 것",
+  "나쁜 게 아니야",
+];
+
+interface BandTemplate {
+  /** 구간 하한(이상). state.ts BANDS 와 동일 경계. */
+  min: number;
+  comment: (kw: string) => string;
+  whyTitle: string;
+  rememberTitle: string;
+  remember: (kw: string) => string;
+}
+
+// 점수 구간별 템플릿(state.ts 5구간과 정합). 높을수록 진정 톤을 강하게(§4.4 규칙5).
+const BANDS: readonly BandTemplate[] = [
+  {
+    min: 81,
+    comment: (k) =>
+      `오늘 다들 ${k} 얘기뿐이야. 너만 못 탄 것 같지? 그 마음 알아. ` +
+      `근데 이미 한참 달아오른 걸 따라 들어가는 건 늘 조심하는 게 좋아.`,
+    whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
+    rememberTitle: "근데 이건 기억해",
+    remember: () => "다들 좋다고 몰릴 때가 보통 제일 비쌀 때야. 오늘 못 탔다고 아쉬워할 필요 없어. 기회는 또 와.",
+  },
+  {
+    min: 61,
+    comment: (k) =>
+      `${k} 얘기가 다시 뜨거워졌어. 다들 이쪽으로 시선이 쏠리는 날이야. ` +
+      `휩쓸리기 쉬운 주제니까 한 박자 천천히 봐도 돼.`,
+    whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
+    rememberTitle: "근데 이건 기억해",
+    remember: () => "분위기로 달아오른 건 분위기로 식기도 해. '나만 놓쳤다'는 마음이 들 때일수록 천천히.",
+  },
+  {
+    min: 41,
+    comment: (k) =>
+      `오늘은 ${k}로 시선이 좀 모이는 날이야. 크게 들뜨진 않았어. ` +
+      `조용히 지켜보는 분위기니까 너도 급할 거 없어.`,
+    whyTitle: "오늘 왜 여기에 시선이 모였어?",
+    rememberTitle: "근데 이건 기억해",
+    remember: () => "이런 날은 섣불리 움직이기보다 지켜보는 사람이 많아. 안 급해도 돼.",
+  },
+  {
+    min: 21,
+    comment: (k) =>
+      `${k}는 오늘 좀 가라앉았어. 한때 들썩였던 곳이라 지금은 식은 느낌이야. ` +
+      `빠졌다고 무서워할 것도, 싸졌다고 급할 것도 없어.`,
+    whyTitle: "오늘은 왜 잠잠했어?",
+    rememberTitle: "근데 이건 기억해",
+    remember: () => "크게 올랐던 자리는 식을 때도 크게 식어. 오를 때 못 탔다고 아쉬워하지 않아도 되는 이유야.",
+  },
+  {
+    min: 0,
+    comment: (k) =>
+      `${k}는 오늘 거의 조용했어. 다들 관심이 다른 데 가 있는 날이야. ` +
+      `조용한 건 나쁜 게 아니야. 너도 안 급해도 돼.`,
+    whyTitle: "오늘은 왜 잠잠했어?",
+    rememberTitle: "근데 이건 기억해",
+    remember: () => "관심이 없다고 뭔가 잘못된 건 아니야. 시선은 매일 다른 곳으로 옮겨다니거든.",
+  },
+];
+
+function bandFor(score: number): BandTemplate {
+  for (const b of BANDS) if (score >= b.min) return b;
+  return BANDS[BANDS.length - 1]!;
+}
+
+/** 관련 종목 자연어 나열(시세 아님). "삼성전자·SK하이닉스 같은" 식. */
+function relatedPhrase(related: readonly string[]): string {
+  if (related.length === 0) return "관련 종목들";
+  if (related.length === 1) return `${related[0]} 같은 곳`;
+  return `${related.slice(0, 2).join("·")} 같은 곳`;
+}
+
+/**
+ * depth.why — 오늘 데이터를 담담히. 예측 없이 "무슨 일이 있었나"만.
+ * 실제 mention 수를 정직하게 노출(가짜 단정 금지).
+ */
+function buildWhy(kw: ScoredKeyword): string {
+  const phrase = relatedPhrase(kw.related);
+  if (kw.mentions === 0) {
+    return `오늘은 ${kw.keyword} 쪽에 새 소식이 거의 없어서 사람들 시선이 머물지 않았어. 새 소식이 없으면 이렇게 잠잠하기도 해.`;
+  }
+  return (
+    `오늘 ${kw.keyword} 관련 얘기가 여기저기서 ${kw.mentions}건쯤 돌았어. ` +
+    `${phrase}이 같이 묶여 오르내리니까 '나도 봐야 하나' 하는 사람이 늘어난 거야.`
+  );
+}
+
+/** ScoredKeyword → KeywordCard(룰 폴백 코멘트 포함). */
+export function buildKeywordCard(kw: ScoredKeyword): KeywordCard {
+  const band = bandFor(kw.fomoScore);
+  return {
+    id: kw.keyword,
+    keyword: kw.keyword,
+    emoji: kw.emoji,
+    fomoScore: kw.fomoScore,
+    comment: band.comment(kw.keyword),
+    related: kw.related,
+    depth: {
+      whyTitle: band.whyTitle,
+      why: buildWhy(kw),
+      rememberTitle: band.rememberTitle,
+      remember: band.remember(kw.keyword),
+    },
+  };
+}
+
+export function buildKeywordCards(scored: readonly ScoredKeyword[]): KeywordCard[] {
+  return scored.map(buildKeywordCard);
+}
+
+/**
+ * 전체 산출 신뢰도(응답 confidence, §4.6·§5). 정직성 노출.
+ * - 키워드 0건 → "fallback"(보여줄 게 없음 → 라우트가 mock 으로 대체).
+ * - 키워드 있음 → Phase 2 는 30일 기준선이 없어 'high' 도달 불가. 카드별 confidence 중 최선을 따른다.
+ *   (Phase 1·2 는 전부 'low' — (a)volume·(b)accel 부재. 기준선은 Phase 4 에서.)
+ */
+export function overallConfidence(scored: readonly ScoredKeyword[]): KeywordConfidence {
+  if (scored.length === 0) return "fallback";
+  const order: KeywordConfidence[] = ["high", "medium", "low", "fallback"];
+  let best: KeywordConfidence = "fallback";
+  for (const k of scored) {
+    if (order.indexOf(k.confidence) < order.indexOf(best)) best = k.confidence;
+  }
+  return best;
+}

--- a/packages/fomo-core/src/keyword-cards/community.ts
+++ b/packages/fomo-core/src/keyword-cards/community.ts
@@ -1,0 +1,74 @@
+import type { CommunitySourceSignal } from "../index-engine/community";
+import type { ExtractedKeyword } from "./extract";
+
+/**
+ * 커뮤니티 참여도 → 키워드(테마) 귀속. KEYWORD_ENGINE_SPEC §4.1·§4.3.
+ *
+ * 순수 함수(네트워크 0). 입력: fetchCommunity 의 집계 시그널(소스별 postCount/upvote/댓글).
+ * 기존 페처(reddit/naver)는 글을 *소스 단위로 집계*해 개별 제목을 버린다 → 제목 매칭 불가.
+ * 그래서 소스 라벨(서브레딧/종목코드)을 테마로 매핑해 참여도를 귀속한다(재활용, 페처 미변경).
+ *
+ * ⚠️ §4.3 한계(Phase 2에서 정직하게 노출, 완전 해결은 Phase 4 기준선):
+ *   - 커뮤니티 참여도엔 날짜 간 비교 가능한 절대 기준선이 없다(당일 상대값) → '어제 대비' 서사 불가.
+ *   - 그래서 이 단계의 귀속은 *뉴스로 이미 확인된 테마만 가산*한다(보수적):
+ *     뉴스 근거 없이 커뮤니티만 시끄러운 테마를 카드로 만들지 않아 '커뮤니티 소유 왜곡'(§4.3 #2)을
+ *     기준선 없이 과대평가하는 위험을 피한다. 진짜 커뮤니티-단독 급등을 놓치는 트레이드오프는
+ *     Phase 4(절대 기준선)에서 해소한다.
+ */
+
+/**
+ * 커뮤니티 소스 라벨 → 테마 키워드 매핑.
+ * - naver/{종목코드}: 페처 DEFAULT_NAVER_CODES 의 대표 종목. (카카오·NAVER 는 5테마에 안 들어가 제외.)
+ * - reddit/{서브레딧}: 주제 특정 서브레딧만 매핑(일반 투자 서브레딧은 테마 귀속 불가 → 제외).
+ * 매핑 없는 소스는 조용히 버린다(정직: 임의 귀속 금지).
+ */
+const SOURCE_THEME: Record<string, string> = {
+  "naver/005930": "반도체", // 삼성전자
+  "naver/000660": "반도체", // SK하이닉스
+  "naver/247540": "2차전지", // 에코프로비엠
+  "reddit/cryptocurrency": "코인",
+};
+
+/** 한 시그널의 참여도(좋아요+댓글). 둘 다 0이면 글 수로 보정(naver 종토는 글당 반응 미파싱). */
+function engagementOf(s: CommunitySourceSignal): number {
+  const reactions = Math.max(0, s.totalUpvotes) + Math.max(0, s.totalComments);
+  return reactions > 0 ? reactions : Math.max(0, s.postCount);
+}
+
+export interface CommunityThemeWeight {
+  engagement: number;
+  postCount: number;
+}
+
+/** 커뮤니티 시그널 → 테마별 참여도 합. 매핑 안 되는 소스는 제외. */
+export function communityEngagementByTheme(
+  signals: readonly CommunitySourceSignal[],
+): Map<string, CommunityThemeWeight> {
+  const out = new Map<string, CommunityThemeWeight>();
+  for (const s of signals) {
+    const theme = SOURCE_THEME[s.source];
+    if (!theme) continue;
+    const prev = out.get(theme) ?? { engagement: 0, postCount: 0 };
+    out.set(theme, {
+      engagement: prev.engagement + engagementOf(s),
+      postCount: prev.postCount + Math.max(0, s.postCount),
+    });
+  }
+  return out;
+}
+
+/**
+ * 추출된(뉴스 근거) 키워드에 커뮤니티 참여도를 가산.
+ * 보수적: 이미 뉴스로 확인된 테마에만 가산(커뮤니티-단독 테마는 만들지 않음, 위 ⚠️ 참고).
+ */
+export function mergeCommunityEngagement(
+  extracted: readonly ExtractedKeyword[],
+  signals: readonly CommunitySourceSignal[],
+): ExtractedKeyword[] {
+  const byTheme = communityEngagementByTheme(signals);
+  return extracted.map((kw) => {
+    const add = byTheme.get(kw.keyword);
+    if (!add) return kw;
+    return { ...kw, engagement: kw.engagement + add.engagement };
+  });
+}

--- a/packages/fomo-core/src/keyword-cards/extract.ts
+++ b/packages/fomo-core/src/keyword-cards/extract.ts
@@ -25,6 +25,8 @@ interface ThemeDef {
   emoji: string;
   /** 매칭 용어 — EN+KO. 한 글이 복수 테마에 매칭될 수 있다. */
   terms: readonly string[];
+  /** 관련 종목/테마 미니 리스트(시세 아님 — "다들 이런 것들 봤어"). KeywordCard.related 소스. */
+  related: readonly string[];
 }
 
 /**
@@ -35,28 +37,35 @@ export const THEME_DICTIONARY: Record<string, ThemeDef> = {
   반도체: {
     emoji: "🔥",
     terms: ["반도체", "HBM", "엔비디아", "SK하이닉스", "삼성전자", "TSMC", "메모리", "파운드리", "semiconductor", "chip", "nvidia"],
+    related: ["삼성전자", "SK하이닉스", "엔비디아"],
   },
   AI: {
     emoji: "🤖",
     terms: ["AI", "인공지능", "오픈AI", "챗GPT", "ChatGPT", "LLM", "GPT", "openai", "엔비디아"],
+    related: ["엔비디아", "마이크로소프트", "팔란티어"],
   },
   코인: {
     emoji: "₿",
     terms: ["비트코인", "이더리움", "코인", "암호화폐", "가상자산", "crypto", "bitcoin", "btc", "ethereum", "eth", "ETF"],
+    related: ["비트코인", "이더리움"],
   },
   금리: {
     emoji: "💵",
     terms: ["금리", "연준", "FOMC", "기준금리", "채권", "인플레", "물가", "rate", "fed", "fomc"],
+    related: ["은행주", "채권"],
   },
   "2차전지": {
     emoji: "🔋",
     terms: ["2차전지", "2차 전지", "배터리", "에코프로", "LG에너지", "전기차", "battery"],
+    related: ["에코프로비엠", "LG에너지솔루션"],
   },
 };
 
 export interface ExtractedKeyword {
   keyword: string;
   emoji: string;
+  /** 관련 종목/테마 미니 리스트(시세 아님). 테마 사전 고정값. */
+  related: readonly string[];
   /** 이 테마에 매칭된 원본 글. */
   articles: KeywordSourceItem[];
   /** 매칭 글 수(언급량). */
@@ -99,6 +108,7 @@ export function extractKeywords(items: KeywordSourceItem[]): ExtractedKeyword[] 
     out.push({
       keyword,
       emoji: THEME_DICTIONARY[keyword]!.emoji,
+      related: THEME_DICTIONARY[keyword]!.related,
       articles,
       mentions: articles.length,
       engagement: articles.reduce((s, a) => s + (a.engagement ?? 0), 0),

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -2,3 +2,5 @@ export * from "./types";
 export * from "./mock";
 export * from "./extract";
 export * from "./score";
+export * from "./community";
+export * from "./comment";


### PR DESCRIPTION
KEYWORD_ENGINE_SPEC §6 Phase 2. 키워드 카드를 mock에서 실데이터 라이브 산출로 전환.

## 한 일 (이 범위만)
- **`/api/fomo/keywords`** (apps/web 신규): `feed/route.ts` 패턴. 뉴스 RSS(`fetchAllNews`) + 커뮤니티(`fetchCommunity`)를 `Promise.allSettled` 병렬 수집 → `extractKeywords` → 커뮤니티 참여도 가산 → `scoreKeywords` → 룰 폴백 코멘트. 응답에 `confidence`·`live` 동봉. 절대 빈값 없음.
  - **캐시**: 라이브 결과 모듈 스코프 메모리 캐시(TTL 30분) + in-flight Promise dedup → 한 사용자 새로고침/동시 접속이 외부 소스를 반복 폭격하지 않음. (Phase 4 일일 DB 스냅샷이 들어오면 이 캐시는 백업으로 내려감.)
  - **정직성**: 30일 기준선 부재 → 라이브는 `low`(가짜 high 금지). 키워드 0건/실패 → mock을 **명시적 fallback**(`confidence:"fallback"`)으로 노출, 진짜처럼 위장 안 함.
- **`keyword-cards/comment.ts`** (신규): 점수 5구간별 룰 폴백 코멘트 + depth(why/remember). 모든 카드 균형추 필수. mock.ts 톤 기준. LLM은 Phase 3.
- **`keyword-cards/community.ts`** (신규): `fetchCommunity`의 집계 시그널(소스별 참여도)을 소스 라벨(naver/종목코드, reddit/서브레딧)로 테마에 귀속. 뉴스로 확인된 테마에만 **보수적 가산**.
- 테마 사전에 `related`(관련 종목) 추가. `fomoApi.fetchKeywords()` 추가.
- **`KeywordCardFeed`**: `MOCK_KEYWORD_CARDS` 직접 import 제거 → fetch. 로딩=스켈레톤, 실패=담담한 빈 상태(무한 로딩 금지), `confidence!=="high"`면 정직한 한마디(§5).
- 가드 테스트(`keyword-comment.test.ts`): 균형추 누락 / 금칙어(예측·투자조언·전문용어) / 커뮤니티 귀속 / confidence.

## §4.3 미해결 2개 점검 결과
대표 코퍼스(실제 RSS/커뮤니티 형태) 라이브 산출 시:

| 키워드 | score | mentions | community eng |
|---|---|---|---|
| ₿ 코인 | **83** | 2 | 540 (reddit) |
| 🔥 반도체 | 56 | 3 | 90 (naver) |
| 🤖 AI | 46 | 3 | 0 |
| 💵 금리 | 36 | 1 | 0 |
| 🔋 2차전지 | 12 | 1 | 0 |

- **#2 커뮤니티 소유 왜곡 확인됨**: 코인은 뉴스 언급(2)이 반도체(3)보다 적은데도 점수가 더 높다. Reddit 참여도(540)가 Naver 글수(90)를 압도 → cross-source engagement가 같은 척도가 아님(reddit upvote ≫ naver postCount). 상대 정규화(`engagement/max`)라 자동 해소 안 됨. **완전 해결은 Phase 4**(절대 기준선)로, 지금은 `confidence:"low"`로 정직하게 노출.
- **#1 day-over-day 충돌**: 커뮤니티가 당일 상대값이라 어제·오늘 척도가 달라 delta가 거짓이 됨 — Phase 4 스냅샷 절대 기준선과 함께 해소. 이번엔 점검·문서화까지.
- 보수적 선택: 커뮤니티 시그널이 **새 테마를 만들지 않음**(뉴스 미확인 테마는 카드 신설 X) → 기준선 없이 커뮤니티-단독 노이즈를 과대평가하는 위험 차단.

## 검증
- `npm run test` 549 passed (신규 17 포함)
- `typecheck:fomo-core / web / fomo-web` 통과
- `build:web` / `build:fomo-web` 통과 (`/api/fomo/keywords` 등록 확인)

## 안 한 것
LLM 코멘트(Phase 3), 스냅샷 cron·prod DDL(Phase 4, `prisma db push` 미실행), 흔들림 점수·개인화(Phase 5).

> ⚠️ 이 컨테이너는 외부 egress가 전부 403(네트워크 정책)이라 **오늘자 실피드는 받지 못함** — 위 표는 실제 RSS/커뮤니티와 동일한 형태의 대표 코퍼스 산출. 라이브 경로는 0건일 때 정직한 fallback으로 degrade함을 확인.

https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC)_