### PR TITLE
Phase 3: 키워드 코멘트 LLM 1차 + 가드레일

### DIFF
--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@fomo/core";
 import { withCors, kstDate } from "../../../../lib/fomo";
 import { fetchAllNews } from "../../../../lib/fomo-news-sources";
+import { addKeywordCardComments } from "../../../../lib/fomo-keyword-comment";
 
 /**
  * 키워드 카드 API — "오늘 사람들 시선이 가장 쏠린 키워드" 실데이터 산출. KEYWORD_ENGINE_SPEC §4.6 / Phase 2.
@@ -77,12 +78,15 @@ async function computeLive(date: string): Promise<KeywordsPayload> {
   // 뉴스 추출 → 커뮤니티 참여도 가산(뉴스로 확인된 테마에만, §4.3 보수적) → 점수.
   const extracted = mergeCommunityEngagement(extractKeywords(items), communitySignals);
   const scored = scoreKeywords(extracted, { nowMs: Date.now() });
-  const cards = buildKeywordCards(scored);
+  const ruleCards = buildKeywordCards(scored);
 
   // 키워드 0건 = 보여줄 게 없음 → mock 명시적 폴백(가짜 점수 강제 생성 금지, §5).
-  if (cards.length === 0) {
+  if (ruleCards.length === 0) {
     return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback", live: true };
   }
+
+  // Phase 3: 코멘트를 LLM 1차로(가드레일 + 룰 폴백 강등). 점수 로직은 그대로 — 코멘트 텍스트만 교체.
+  const cards = await addKeywordCardComments(scored, ruleCards);
   return { date, cards, confidence: overallConfidence(scored), live: true };
 }
 

--- a/apps/web/lib/fomo-keyword-comment.ts
+++ b/apps/web/lib/fomo-keyword-comment.ts
@@ -1,0 +1,100 @@
+import {
+  applyLlmComment,
+  buildKeywordCommentPrompt,
+  parseKeywordComments,
+  type KeywordCard,
+  type LlmKeywordComment,
+  type ScoredKeyword,
+} from "@fomo/core";
+
+/**
+ * 키워드 카드 코멘트 — LLM 1차, 룰 폴백 강등. KEYWORD_ENGINE_SPEC §4.4 / Phase 3.
+ *
+ * fomo-comment.ts(기사 코멘트)와 동형: AI_API_URL + 키해소(AI_API_KEY→GITHUB_TOKEN) + 배치 1콜 + 인메모리 캐시.
+ * 검증·병합은 @fomo/core 의 순수 함수(applyLlmComment: 금칙어/균형추 가드 + 룰 폴백)에 위임한다.
+ *
+ * 강등 경로(모두 룰 폴백 = buildKeywordCard 결과 유지):
+ *   - AI 미설정 → LLM 시도 안 함.
+ *   - fetch 실패/레이트리밋/타임아웃 → 캐시에 없는 카드는 룰 그대로.
+ *   - 가드 위반(투자조언/예측/전문용어/균형추 누락) → applyLlmComment 가 그 카드만 룰로 되돌림.
+ *
+ * 정직성(§5): score 를 프롬프트에 넣어, 데이터가 잠잠하면(낮은 점수) LLM 도 과장하지 않게 유도.
+ */
+
+const AI_API_URL = process.env["AI_API_URL"] ?? "";
+// 코멘트는 5장 내외라 품질 우선 — 본 모델(AI_MODEL) 사용, 미설정 시 빠른 mini.
+const COMMENT_MODEL = process.env["AI_MODEL"] || "openai/gpt-4.1-mini";
+// 변주(자연스러움) 위해 약간 높게. AI_TEMPERATURE 가 있으면 재활용.
+const TEMPERATURE = Number.parseFloat(process.env["AI_TEMPERATURE"] ?? "") || 0.7;
+
+/** keyword|score → 검증 전 LLM 묶음 캐시. 같은 회차 재호출 비용 절감(라우트가 이미 30분 TTL). */
+const cache = new Map<string, LlmKeywordComment>();
+const CACHE_MAX = 500;
+
+function resolveAiKey(): string {
+  const configured = process.env["AI_API_KEY"] ?? "";
+  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
+    return process.env["GITHUB_TOKEN"] ?? "";
+  }
+  return configured;
+}
+
+interface LlmResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+const cacheKey = (kw: ScoredKeyword) => `${kw.keyword}|${kw.fomoScore}`;
+
+/**
+ * 룰 폴백 카드(cards)에 LLM 코멘트를 얹어 반환. cards 는 scored 와 같은 순서/길이(buildKeywordCards).
+ * 항상 입력 길이만큼 카드를 돌려준다(누락·빈 코멘트 없음 — 최소 룰 폴백).
+ */
+export async function addKeywordCardComments(
+  scored: readonly ScoredKeyword[],
+  cards: readonly KeywordCard[]
+): Promise<KeywordCard[]> {
+  const apiKey = resolveAiKey();
+
+  if (AI_API_URL && apiKey) {
+    const uncached = scored.filter((kw) => !cache.has(cacheKey(kw)));
+    if (uncached.length > 0) {
+      try {
+        const prompt = buildKeywordCommentPrompt(
+          uncached.map((kw) => ({
+            keyword: kw.keyword,
+            score: kw.fomoScore,
+            titles: kw.articles.map((a) => a.title),
+            related: kw.related,
+          }))
+        );
+        const res = await fetch(AI_API_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+          body: JSON.stringify({
+            model: COMMENT_MODEL,
+            temperature: TEMPERATURE,
+            messages: [{ role: "user", content: prompt }],
+          }),
+          signal: AbortSignal.timeout(25_000),
+        });
+        if (res.ok) {
+          const data = (await res.json()) as LlmResponse;
+          const parsed = parseKeywordComments(data.choices?.[0]?.message?.content ?? "");
+          const byKeyword = new Map(parsed.map((c) => [c.keyword, c]));
+          for (const kw of uncached) {
+            const c = byKeyword.get(kw.keyword);
+            if (c) cache.set(cacheKey(kw), c);
+          }
+          if (cache.size > CACHE_MAX) cache.clear();
+        } else {
+          console.warn("[fomo/keyword-comment] LLM", res.status);
+        }
+      } catch (err) {
+        console.warn("[fomo/keyword-comment] error", err);
+      }
+    }
+  }
+
+  // 병합: 가드 통과한 LLM 코멘트만 얹고, 없거나 위반이면 룰 폴백 카드 그대로(applyLlmComment 내부 검증).
+  return scored.map((kw, i) => applyLlmComment(cards[i]!, cache.get(cacheKey(kw))));
+}

--- a/packages/fomo-core/__tests__/keyword-comment.test.ts
+++ b/packages/fomo-core/__tests__/keyword-comment.test.ts
@@ -10,9 +10,15 @@ import {
   scoreKeywords,
   josa,
   hasBatchim,
+  applyLlmComment,
+  validateLlmComment,
+  parseKeywordComments,
+  buildKeywordCommentPrompt,
+  isCommentSafe,
   type KeywordSourceItem,
   type ScoredKeyword,
   type CommunitySourceSignal,
+  type LlmKeywordComment,
 } from "../src";
 
 const NOW = Date.parse("2026-06-13T12:00:00Z");
@@ -109,6 +115,86 @@ describe("코멘트 변주 (밴드 중복 해소)", () => {
     const base = scoreSample()[0]!;
     const card = buildKeywordCard({ ...base, keyword: "AI", fomoScore: 66, mentions: 23 });
     expect(card.comment.includes("23")).toBe(true);
+  });
+});
+
+describe("Phase 3 — LLM 코멘트 가드레일 (§4.4)", () => {
+  const good: LlmKeywordComment = {
+    keyword: "반도체",
+    comment: "너 지금 반도체 관심 왔구나. 너만 그런 거 아니야 — 시장도 과열됐어. 잠깐 뒤로 빠져서 지켜보는 건 어때?",
+    why: "오늘 엔비디아·삼성전자 얘기가 여기저기서 돌면서 다들 시선이 쏠렸어.",
+    remember: "제일 뜨거울 때 들어가면 늦는 경우가 많아. 안 급해도 돼.",
+  };
+
+  it("정상 LLM 코멘트는 통과하고 카드에 얹힌다", () => {
+    expect(validateLlmComment(good)).toBe(true);
+    const card = buildKeywordCard(scoreSample()[0]!);
+    const merged = applyLlmComment(card, good);
+    expect(merged.comment).toBe(good.comment);
+    expect(merged.depth.why).toBe(good.why);
+    expect(merged.depth.remember).toBe(good.remember);
+    // 점수·관련종목 등 사실 부분은 LLM 이 못 건드린다.
+    expect(merged.fomoScore).toBe(card.fomoScore);
+    expect(merged.related).toEqual(card.related);
+  });
+
+  it("투자조언 주입 → 폐기 → 룰 폴백으로 강등", () => {
+    const card = buildKeywordCard(scoreSample()[0]!);
+    const bad: LlmKeywordComment = { ...good, comment: "지금 반도체 매수해. 안 사면 후회해." };
+    expect(validateLlmComment(bad)).toBe(false);
+    // applyLlmComment 가 룰 카드 그대로 돌려준다(코멘트 교체 안 됨).
+    expect(applyLlmComment(card, bad)).toEqual(card);
+  });
+
+  it("미래 예측 주입 → 폐기", () => {
+    const bad: LlmKeywordComment = { ...good, comment: "이거 곧 오른다. 천천히 봐도 돼." };
+    expect(validateLlmComment(bad)).toBe(false);
+  });
+
+  it("전문용어 주입 → 폐기", () => {
+    const bad: LlmKeywordComment = { ...good, why: "골든크로스가 떠서 다들 들떴어. 안 급해도 돼." };
+    expect(validateLlmComment(bad)).toBe(false);
+  });
+
+  it("균형추(진정 결) 누락 → 폐기", () => {
+    const bad: LlmKeywordComment = {
+      ...good,
+      comment: "너 지금 반도체 관심 왔구나. 다들 여기 몰렸어.",
+      remember: "오늘 제일 뜨거운 키워드였어.",
+    };
+    expect(validateLlmComment(bad)).toBe(false);
+  });
+
+  it("빈 필드(LLM 누락) → 폐기 + applyLlmComment 룰 폴백", () => {
+    const card = buildKeywordCard(scoreSample()[0]!);
+    expect(validateLlmComment({ ...good, why: "" })).toBe(false);
+    expect(validateLlmComment(undefined)).toBe(false);
+    // undefined(LLM 미동작) → 룰 카드 그대로.
+    expect(applyLlmComment(card, undefined)).toEqual(card);
+  });
+
+  it("룰 폴백 템플릿 자체는 금칙어 가드를 통과한다(강등 카드도 안전)", () => {
+    for (const c of buildKeywordCards(scoreSample())) {
+      expect(isCommentSafe(`${c.comment} ${c.depth.why} ${c.depth.remember}`)).toBe(true);
+    }
+  });
+
+  it("parseKeywordComments — JSON 배열 + 코드펜스/잡텍스트 허용", () => {
+    const raw = '설명 텍스트\n```json\n[{"keyword":"코인","comment":"c","why":"w","remember":"r"}]\n``` 끝';
+    const out = parseKeywordComments(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ keyword: "코인", comment: "c", why: "w", remember: "r" });
+    expect(parseKeywordComments("not json")).toEqual([]);
+  });
+
+  it("buildKeywordCommentPrompt — 2인칭/균형추/JSON 지시 + 키워드 포함", () => {
+    const p = buildKeywordCommentPrompt([
+      { keyword: "반도체", score: 88, titles: ["엔비디아 급등"], related: ["삼성전자"] },
+    ]);
+    expect(p).toContain("반도체");
+    expect(p).toContain('2인칭 "너"');
+    expect(p).toContain("균형추");
+    expect(p).toMatch(/JSON 배열/);
   });
 });
 

--- a/packages/fomo-core/src/keyword-cards/comment.ts
+++ b/packages/fomo-core/src/keyword-cards/comment.ts
@@ -194,6 +194,144 @@ export function buildKeywordCards(scored: readonly ScoredKeyword[]): KeywordCard
   return scored.map(buildKeywordCard);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 3 — LLM 코멘트 + 가드레일 (KEYWORD_ENGINE_SPEC §4.4)
+//
+// 순수부: 프롬프트 빌더 + 응답 파서 + 가드(금칙어·균형추) + 룰 폴백 병합.
+// 네트워크(LLM 호출)는 apps/web/lib/fomo-keyword-comment.ts 가 담당하고, 검증·병합은 여기로 모은다.
+// LLM 실패·레이트리밋·가드 위반 시 자동으로 위 룰 폴백(buildKeywordCard)으로 강등한다.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** LLM 이 키워드별로 돌려주는 코멘트 묶음(앞면 comment + depth.why/remember). */
+export interface LlmKeywordComment {
+  keyword: string;
+  comment: string;
+  why: string;
+  remember: string;
+}
+
+/**
+ * 금칙어 가드(§2·§4.4 규칙 2·3). 위반 시 그 LLM 출력은 폐기 → 룰 폴백.
+ * - 투자조언/매수매도/종목추천: 행동 지시·추천.
+ * - 예측/미래 단정: "오른다/내린다/급등" 등 방향 단정.
+ * - 전문용어: 차트·기술 지표 용어(중학생도 알아듣게 하라는 규칙 위반).
+ * 주의: 룰 폴백 템플릿("따라 들어가는 건 조심" 등 과거·현재 설명)은 통과해야 하므로
+ *   "들어가라/세요" 같은 명령형만 잡고 "들어가는/들어가면" 서술형은 건드리지 않는다.
+ * 펀더멘탈(EPS·PER)은 §5 '따뜻하게 풀어줄' 대상이라 금칙에서 제외.
+ */
+export const COMMENT_FORBIDDEN: RegExp =
+  /사라|팔아라|사세요|파세요|매수|매도|손절|익절|불타기|물타기|풀매수|추천|담아라|담으세요|들어가라|들어가세요|진입하|베팅|올인|줍줍|오른다|오를\s*(?:거|것|듯|전망|예정)|내린다|내릴\s*(?:거|것|듯)|상승할|하락할|급등할|폭등|폭락|반등할|텐배거|떡상|떡락|불장|가즈아|목표가|지금\s*안\s*사면|오더블럭|골든크로스|데드크로스|RSI|MACD|볼린저|이평선|지지선|저항선|과매수|과매도|손익비|레버리지|공매도|보조지표|피보나치|이격도/;
+
+/**
+ * 균형추(진정 결) 감지 — §4.4 규칙 4: 모든 코멘트는 진정 결로 닫혀야 한다.
+ * 룰 폴백용 CALM_MARKERS 보다 넓게(LLM 의 자연스러운 표현까지 포착). 누락 시 폐기.
+ */
+const CALM_TONE =
+  /급(?:해|할|하지|한|히)|기회는\s*또|천천히|조심|아쉬워|무서워할|쉬어가|쉬어도|괜찮|조급|서두르지|놓쳐도|늦었다고|뒤로\s*빠져|물러나|지켜보|한\s*박자|천천히\s*봐도/;
+
+/** LLM 출력이 가드를 통과하는가(금칙어 없음 + 균형추 있음). */
+export function isCommentSafe(text: string): boolean {
+  if (!text) return false;
+  return !COMMENT_FORBIDDEN.test(text);
+}
+
+/** comment + remember 묶음에 진정 결이 1개 이상 있는가. */
+export function hasCalmTone(text: string): boolean {
+  return CALM_TONE.test(text);
+}
+
+/**
+ * LLM 코멘트 묶음 검증(§4.4). 하나라도 어기면 false → 호출부가 룰 폴백으로 강등.
+ * - comment/why/remember 모두 비어있지 않을 것.
+ * - 어느 필드에도 금칙어 없을 것.
+ * - comment+remember 에 균형추(진정 결) 있을 것.
+ */
+export function validateLlmComment(c: LlmKeywordComment | undefined | null): c is LlmKeywordComment {
+  if (!c) return false;
+  const { comment, why, remember } = c;
+  if (!comment?.trim() || !why?.trim() || !remember?.trim()) return false;
+  const blob = `${comment} ${why} ${remember}`;
+  if (!isCommentSafe(blob)) return false;
+  return hasCalmTone(`${comment} ${remember}`);
+}
+
+/**
+ * 룰 폴백 카드에 검증된 LLM 코멘트를 얹는다. LLM 이 없거나 가드 위반이면 룰 카드 그대로(자동 강등).
+ * 점수·관련 종목·이모지 등 카드의 사실 부분은 LLM 이 건드리지 않는다(코멘트 텍스트만 교체).
+ */
+export function applyLlmComment(card: KeywordCard, llm: LlmKeywordComment | undefined): KeywordCard {
+  if (!validateLlmComment(llm)) return card;
+  return {
+    ...card,
+    comment: llm.comment.trim(),
+    depth: {
+      ...card.depth,
+      why: llm.why.trim(),
+      remember: llm.remember.trim(),
+    },
+  };
+}
+
+/** §4.4 가드레일 프롬프트(운영자 톤 스펙 반영). 배치: 여러 키워드를 한 콜로. */
+export function buildKeywordCommentPrompt(
+  items: readonly { keyword: string; score: number; titles: readonly string[]; related: readonly string[] }[]
+): string {
+  const payload = items.map((it) => ({
+    keyword: it.keyword,
+    score: it.score,
+    titles: it.titles.slice(0, 5),
+    related: it.related.slice(0, 3),
+  }));
+  return [
+    "너는 'FOMO Club'의 마스코트 포모다. 새벽 1시에 차트 보며 똑같이 불안해하는 친구다.",
+    "아래 키워드 각각에 대해, 그 키워드에 관심이 온 사용자에게 한마디 건넨다.",
+    "",
+    "톤(반드시):",
+    '- 사용자에게 2인칭 "너"로 말한다. 친구 반말, 따뜻하고 담담하게. 위에서 가르치지 마라.',
+    "- 포모를 살짝 건드리되 즉시 진정시킨다. 결: \"너 지금 이거 관심 왔구나. 왜 왔는지 설명해줄게.",
+    '  근데 너만 그런 거 아니야 — 시장도 과열됐어. 잠깐 뒤로 빠져서 지켜보는 건 어때?" (베끼지 말고 이 결을 따를 것)',
+    "",
+    "규칙(어기면 그 키워드 출력은 폐기된다):",
+    "1) 과거·현재 사실만 설명. 미래 단정·예측 절대 금지(오른다/내린다/급등/반등할 금지).",
+    "2) 매수·매도·추천·종목 권유 금지(사라/팔아라/매수/들어가라 금지).",
+    "3) 전문용어 금지. 꼭 나오면 친구가 풀어주듯 쉽게(예: \"오더블럭? 큰손들이 사 모은 가격대야\").",
+    "4) 반드시 균형추(진정)로 닫는다: \"안 급해도 돼 / 기회는 또 와 / 잠깐 지켜보자\" 결.",
+    "5) 점수가 높을수록(60+) 진정 톤을 더 강하게. 낮으면(40-) \"조용한 건 나쁜 게 아니야\" 결.",
+    "",
+    'comment 는 2~3줄, why 는 왜 쏠렸는지 용어 없이, remember 는 균형추 한마디.',
+    '출력은 JSON 배열만(그 외 텍스트 0): [{"keyword","comment","why","remember"}]',
+    "",
+    JSON.stringify(payload),
+  ].join("\n");
+}
+
+/** LLM 응답(JSON 배열) 파서 — parseFomoComments 와 동형, 4필드. 코드펜스/잡텍스트 허용. */
+export function parseKeywordComments(content: string): LlmKeywordComment[] {
+  if (!content) return [];
+  const start = content.indexOf("[");
+  const end = content.lastIndexOf("]");
+  if (start === -1 || end <= start) return [];
+  let arr: unknown;
+  try {
+    arr = JSON.parse(content.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(arr)) return [];
+  const out: LlmKeywordComment[] = [];
+  for (const r of arr) {
+    if (r && typeof r === "object") {
+      const o = r as Record<string, unknown>;
+      const keyword = typeof o.keyword === "string" ? o.keyword.trim() : "";
+      const comment = typeof o.comment === "string" ? o.comment.trim() : "";
+      const why = typeof o.why === "string" ? o.why.trim() : "";
+      const remember = typeof o.remember === "string" ? o.remember.trim() : "";
+      if (keyword && comment) out.push({ keyword, comment, why, remember });
+    }
+  }
+  return out;
+}
+
 /**
  * 전체 산출 신뢰도(응답 confidence, §4.6·§5). 정직성 노출.
  * - 키워드 0건 → "fallback"(보여줄 게 없음 → 라우트가 mock 으로 대체).


### PR DESCRIPTION
KEYWORD_ENGINE_SPEC §6 Phase 3. 점수 공식(wa 0.500)은 **불변** — 코멘트 텍스트만 룰 폴백 → LLM 1차로 올린다.

## 범위
- **순수부** `keyword-cards/comment.ts`: 프롬프트 빌더 + 응답 파서 + 가드 + 룰 폴백 병합(네트워크 없음).
- **네트워크** `apps/web/lib/fomo-keyword-comment.ts`: AI_API_URL/KEY/MODEL/TEMPERATURE 재활용, 배치 1콜.
- `keywords/route.ts`: 룰 카드 생성 후 LLM 코멘트 얹기(점수·관련종목 등 사실 부분은 LLM 이 못 건드림).

## 가드레일 (§4.4)
- **금칙어**: 투자조언/매수매도/종목추천/미래예측/전문용어 정규식. 위반 시 그 카드 출력 폐기 → 룰 폴백.
- **균형추**: comment+remember 에 진정 결 없으면 폐기.
- **자동 강등**: LLM 미설정·실패·레이트리밋·타임아웃·가드 위반 → 기존 룰 변주 템플릿 그대로.

## 코멘트 톤 (운영자 스펙)
2인칭 "너". 포모 유발→즉시 진정. 과거·현재 설명만(미래 단정 금지). 전문용어는 친구가 풀어주듯. 점수 높을수록 진정 톤 강하게.

## 검증
- typecheck ✅ / vitest 566 ✅(가드 폐기·룰 폴백·파서·프롬프트 +10건) / build:web ✅
- **실데이터**: 뉴스 240건 → 5키워드 전부 LLM 생성, 서로 다르고 자연스럽고 2인칭·균형추 전부 포함, 점수 구간(88↔25)별 진정 톤 차등 확인.

## 안 한 것 (범위 밖)
- 스냅샷 cron·prod DDL(Phase 4), 흔들림 점수·개인화·검색(Phase 5~6).

머지는 직접.

🤖 Generated with [Claude Code](https://claude.com/claude-code)