### PR TITLE
Phase 4: 키워드 스냅샷 cron + 스냅샷-우선 라우트

### DIFF
--- a/.github/workflows/keyword-cards-pipeline.yml
+++ b/.github/workflows/keyword-cards-pipeline.yml
@@ -1,0 +1,64 @@
+name: Keyword Cards Pipeline
+
+# 키워드 카드 일일 스냅샷 (KEYWORD_ENGINE_SPEC §4.8 / Phase 4)
+# 한국장 마감 후 + 미국장 마감 후 등에 뉴스/커뮤니티 → 키워드 추출·점수·LLM 코멘트 → KeywordCardSnapshot 저장.
+# 이것은 *제품 데이터 파이프라인*이다(에이전트 자율 루프 아님) — 정지 대상이 아니다.
+#
+# 전제: prod 에 KeywordCardSnapshot 테이블이 있어야 저장된다(운영 규약상 `prisma db push` 직접 승인 후 활성).
+# 테이블 전이라도 워크플로는 산출 로그까지는 돌고, 저장 단계에서 실패로 가시화된다(누락을 숨기지 않음).
+
+on:
+  schedule:
+    # KST = UTC+9. 미국장 마감 후(06:30 KST = 21:30 UTC) + 한국장 마감 후(15:40 KST = 06:40 UTC) + 정오(03:00 UTC)
+    - cron: "30 21 * * 1-5" # 미국장 마감 후
+    - cron: "40 6 * * 1-5"  # 한국장 마감 후
+    - cron: "0 3 * * *"     # 정오 스냅샷
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Prisma generate
+        run: npm run prisma:generate
+
+      - name: Generate keyword card snapshot
+        id: generate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          AI_API_URL: ${{ secrets.AI_API_URL }}
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
+          AI_MODEL: ${{ secrets.AI_MODEL }}
+          AI_TEMPERATURE: ${{ secrets.AI_TEMPERATURE }}
+        run: npm run keywords:generate
+
+      # 운영 관측 — 실패/저하를 Slack 에 가시화(정직한 숫자: 스냅샷 누락을 숨기지 않음).
+      - name: Report health to Slack
+        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          OUTCOME: ${{ steps.generate.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          URL="$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')"
+          if [ "$OUTCOME" != "success" ]; then
+            MSG=$(printf '%s\n%s' "🔴 *키워드 카드 파이프라인 실패* — 오늘 스냅샷 미생성 (정직한 숫자: 데이터 누락)" ">${RUN_URL}")
+            jq -n --arg t "$MSG" '{text:$t}' > /tmp/kw_health.json
+          elif [ -f keyword-cards-health.json ]; then
+            jq '{text: ("🃏 키워드 카드 \(.date) — \(.count)개 (confidence: \(.confidence))")}' keyword-cards-health.json > /tmp/kw_health.json
+          else
+            jq -n --arg t "⚠️ 키워드 카드 — 건강 리포트 파일 없음(드라이런/스킵). ${RUN_URL}" '{text:$t}' > /tmp/kw_health.json
+          fi
+          curl -s -X POST "$URL" -H "Content-Type: application/json" -d @/tmp/kw_health.json || true

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -51,13 +51,6 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             </div>
           </section>
 
-          <div className="mt-8 rounded-xl border border-dashed border-hairline px-4 py-4">
-            <p className="font-pixel text-[11px] text-muted">곧 추가될 거야</p>
-            <p className="mt-1.5 text-sm leading-6 text-muted">
-              이 테마 더 깊이 보기 · 관심 종목 모아보기
-            </p>
-          </div>
-
           <p className="mt-8 text-center text-[11px] leading-5 text-muted">
             지난 흐름을 친구처럼 풀어준 거예요. 투자 조언이 아니에요.
           </p>

--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -1,34 +1,24 @@
 import { NextResponse } from "next/server";
-import {
-  extractKeywords,
-  mergeCommunityEngagement,
-  scoreKeywords,
-  buildKeywordCards,
-  overallConfidence,
-  fetchCommunity,
-  MOCK_KEYWORD_CARDS,
-  type KeywordCard,
-  type KeywordConfidence,
-  type KeywordSourceItem,
-} from "@fomo/core";
+import type { KeywordCard, KeywordConfidence } from "@fomo/core";
 import { withCors, kstDate } from "../../../../lib/fomo";
-import { fetchAllNews } from "../../../../lib/fomo-news-sources";
-import { addKeywordCardComments } from "../../../../lib/fomo-keyword-comment";
+import { computeKeywordCards } from "../../../../lib/keyword-pipeline";
+import { readKeywordSnapshot } from "../../../../lib/keyword-snapshot";
 
 /**
- * 키워드 카드 API — "오늘 사람들 시선이 가장 쏠린 키워드" 실데이터 산출. KEYWORD_ENGINE_SPEC §4.6 / Phase 2.
+ * 키워드 카드 API — "오늘 사람들 시선이 가장 쏠린 키워드" 실데이터 산출. KEYWORD_ENGINE_SPEC §4.6.
  *
- * 파이프라인: 뉴스 RSS + 커뮤니티(Promise.allSettled 병렬) → extract → community 가산 → score → 룰 폴백 코멘트.
- * 코멘트는 Phase 2 라 LLM 없이 룰 폴백 템플릿만(LLM 은 Phase 3).
+ * 응답 경로(§4.6 — 절대 빈값 없음):
+ *   1) 오늘 KeywordCardSnapshot 있으면 그대로 반환(live:false) — Phase 4 cron 이 미리 채운 것.
+ *   2) 없으면(스냅샷 전/테이블 미생성) 라이브 산출(live:true). 산출·검증·코멘트는 computeKeywordCards 공유.
+ *   3) 라이브도 실패하면 mock 명시적 폴백(confidence:"fallback").
  *
  * 응답 정직성(§5): confidence 를 반드시 동봉. 30일 기준선이 아직 없어 라이브는 'low'(가짜 high 금지).
- * 라이브 산출이 키워드 0건이면 mock 을 *명시적 폴백*(confidence:"fallback")으로 반환 — 진짜처럼 위장하지 않는다.
  *
- * 스냅샷-우선(§4.6 1단계: 오늘 스냅샷 있으면 그대로)은 Phase 4(cron + DDL 승인)에서 이 앞에 붙는다.
- * 지금은 스냅샷 테이블에 의존하지 않고 라이브 산출을 메인 경로로 둔다(prisma db push 미실행).
+ * db push 게이트: KeywordCardSnapshot 테이블이 아직 prod 에 없을 수 있어, 스냅샷 조회는 실패해도
+ *   조용히 라이브로 폴백한다(readKeywordSnapshot 내부 try/catch). 테이블이 생기면 1)이 자동 활성화.
  */
 export const dynamic = "force-dynamic";
-// 외부 소스(뉴스 RSS·커뮤니티 HTML) 수집이 수초 걸릴 수 있어 데드라인 넉넉히.
+// 외부 소스(뉴스 RSS·커뮤니티 HTML) + LLM 코멘트가 수초 걸릴 수 있어 데드라인 넉넉히.
 export const maxDuration = 30;
 
 export function OPTIONS() {
@@ -45,67 +35,41 @@ interface KeywordsPayload {
 // ── 라이브 결과 메모리 캐시(TTL) + in-flight dedup ──────────────────────────
 // snapshot-first 정신(§4.6): 한 사용자의 새로고침/동시 접속이 외부 소스를 반복 폭격하지 않게,
 // 라이브 산출 결과를 서버 인스턴스 단위로 짧게 캐시하고 동시 요청은 진행 중 Promise 를 공유한다.
-// (Phase 4 의 일일 DB 스냅샷이 들어오면 이 메모리 캐시는 백업 역할로 내려간다.)
+// (Phase 4 의 일일 DB 스냅샷이 메인이면 이 메모리 캐시는 스냅샷 미스 시 백업.)
 const TTL_MS = 30 * 60 * 1000;
 let cache: { at: number; payload: KeywordsPayload } | null = null;
 let inflight: Promise<KeywordsPayload> | null = null;
 
-/** 뉴스/커뮤니티 실수집 → 키워드 카드 산출. 실패해도 throw 없이 mock 폴백을 돌려준다. */
+/** 라이브 산출(공유 파이프라인). 실패해도 throw 없이 mock 폴백. */
 async function computeLive(date: string): Promise<KeywordsPayload> {
-  const [newsResult, communityResult] = await Promise.allSettled([fetchAllNews(), fetchCommunity()]);
-
-  const items: KeywordSourceItem[] = [];
-  if (newsResult.status === "fulfilled") {
-    for (const a of newsResult.value) {
-      items.push({
-        title: a.title,
-        ...(a.summary ? { summary: a.summary } : {}),
-        publishedAt: a.publishedAt,
-        source: a.source,
-        lang: a.lang,
-      });
-    }
-  } else {
-    console.warn("[fomo/keywords] news error", newsResult.reason);
+  try {
+    const { cards, confidence } = await computeKeywordCards();
+    return { date, cards, confidence, live: true };
+  } catch (err) {
+    console.warn("[fomo/keywords] live compute failed — mock fallback", err);
+    const { MOCK_KEYWORD_CARDS } = await import("@fomo/core");
+    return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback", live: false };
   }
-
-  const communitySignals =
-    communityResult.status === "fulfilled" ? communityResult.value.sources : [];
-  if (communityResult.status === "rejected") {
-    console.warn("[fomo/keywords] community error", communityResult.reason);
-  }
-
-  // 뉴스 추출 → 커뮤니티 참여도 가산(뉴스로 확인된 테마에만, §4.3 보수적) → 점수.
-  const extracted = mergeCommunityEngagement(extractKeywords(items), communitySignals);
-  const scored = scoreKeywords(extracted, { nowMs: Date.now() });
-  const ruleCards = buildKeywordCards(scored);
-
-  // 키워드 0건 = 보여줄 게 없음 → mock 명시적 폴백(가짜 점수 강제 생성 금지, §5).
-  if (ruleCards.length === 0) {
-    return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback", live: true };
-  }
-
-  // Phase 3: 코멘트를 LLM 1차로(가드레일 + 룰 폴백 강등). 점수 로직은 그대로 — 코멘트 텍스트만 교체.
-  const cards = await addKeywordCardComments(scored, ruleCards);
-  return { date, cards, confidence: overallConfidence(scored), live: true };
 }
 
-/** TTL 캐시 + dedup 래퍼. */
+/** 스냅샷-우선 → 캐시 → 라이브 dedup. */
 async function getPayload(date: string): Promise<KeywordsPayload> {
+  // 1) 오늘 스냅샷(테이블 없으면 null) — cron 이 채운 안정 데이터를 외부 호출 없이 즉시 반환.
+  const snap = await readKeywordSnapshot(date);
+  if (snap) return { date, cards: snap.cards, confidence: snap.confidence, live: false };
+
+  // 2) 메모리 캐시.
   if (cache && Date.now() - cache.at < TTL_MS && cache.payload.date === date) {
     return cache.payload;
   }
   if (inflight) return inflight;
 
+  // 3) 라이브 산출(dedup).
   inflight = (async () => {
     try {
       const payload = await computeLive(date);
       cache = { at: Date.now(), payload };
       return payload;
-    } catch (err) {
-      // 라이브 경로 자체가 깨져도 빈 화면 금지 — mock 명시적 폴백.
-      console.warn("[fomo/keywords] live compute failed — mock fallback", err);
-      return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback" as const, live: false };
     } finally {
       inflight = null;
     }

--- a/apps/web/lib/keyword-pipeline.ts
+++ b/apps/web/lib/keyword-pipeline.ts
@@ -1,0 +1,68 @@
+import {
+  extractKeywords,
+  mergeCommunityEngagement,
+  scoreKeywords,
+  buildKeywordCards,
+  overallConfidence,
+  fetchCommunity,
+  MOCK_KEYWORD_CARDS,
+  type KeywordCard,
+  type KeywordConfidence,
+  type KeywordSourceItem,
+} from "@fomo/core";
+import { fetchAllNews } from "./fomo-news-sources";
+import { addKeywordCardComments } from "./fomo-keyword-comment";
+
+/**
+ * 키워드 카드 산출 파이프라인(공유). KEYWORD_ENGINE_SPEC §4 / Phase 2~3.
+ *
+ * 라우트(/api/fomo/keywords)와 cron 스냅샷 스크립트(scripts/keywords-generate.ts)가 **동일** 경로를 쓰게
+ * 여기로 모은다 — 라이브와 스냅샷이 달라지지 않도록(정합성).
+ *
+ * 파이프라인: 뉴스 RSS + 커뮤니티(병렬) → extract → community 가산 → score → 룰 카드 → LLM 코멘트(가드+폴백).
+ * 키워드 0건이면 mock 명시적 폴백(confidence:"fallback") — 가짜 점수 강제 생성 금지(§5).
+ * 실패해도 throw 없이 폴백을 돌려준다(빈 화면 금지).
+ */
+
+export interface KeywordPayloadCore {
+  cards: readonly KeywordCard[];
+  confidence: KeywordConfidence;
+}
+
+export async function computeKeywordCards(): Promise<KeywordPayloadCore> {
+  const [newsResult, communityResult] = await Promise.allSettled([fetchAllNews(), fetchCommunity()]);
+
+  const items: KeywordSourceItem[] = [];
+  if (newsResult.status === "fulfilled") {
+    for (const a of newsResult.value) {
+      items.push({
+        title: a.title,
+        ...(a.summary ? { summary: a.summary } : {}),
+        publishedAt: a.publishedAt,
+        source: a.source,
+        lang: a.lang,
+      });
+    }
+  } else {
+    console.warn("[keyword-pipeline] news error", newsResult.reason);
+  }
+
+  const communitySignals =
+    communityResult.status === "fulfilled" ? communityResult.value.sources : [];
+  if (communityResult.status === "rejected") {
+    console.warn("[keyword-pipeline] community error", communityResult.reason);
+  }
+
+  const extracted = mergeCommunityEngagement(extractKeywords(items), communitySignals);
+  const scored = scoreKeywords(extracted, { nowMs: Date.now() });
+  const ruleCards = buildKeywordCards(scored);
+
+  // 키워드 0건 = 보여줄 게 없음 → mock 명시적 폴백(§5).
+  if (ruleCards.length === 0) {
+    return { cards: MOCK_KEYWORD_CARDS, confidence: "fallback" };
+  }
+
+  // Phase 3: 코멘트를 LLM 1차로(가드레일 + 룰 폴백 강등). 점수 로직은 그대로.
+  const cards = await addKeywordCardComments(scored, ruleCards);
+  return { cards, confidence: overallConfidence(scored) };
+}

--- a/apps/web/lib/keyword-snapshot.ts
+++ b/apps/web/lib/keyword-snapshot.ts
@@ -1,0 +1,51 @@
+import type { KeywordCard, KeywordConfidence } from "@fomo/core";
+import { prisma } from "./prisma";
+
+/**
+ * KeywordCardSnapshot 읽기/쓰기. KEYWORD_ENGINE_SPEC §4.5 / Phase 4.
+ *
+ * 라우트(읽기)와 cron 스크립트(쓰기)가 공유. cards 는 KeywordCard[] 를 Json 으로 저장.
+ *
+ * db push 게이트: 테이블이 아직 prod 에 없을 수 있다(운영 규약 — DDL 직접 승인).
+ *   그 동안에도 라우트가 죽지 않게, 읽기는 실패하면 null 을 돌려 라이브로 폴백한다.
+ */
+
+export interface KeywordSnapshot {
+  cards: readonly KeywordCard[];
+  confidence: KeywordConfidence;
+}
+
+/** 오늘(KST) 스냅샷. 없거나 테이블 미생성(db push 전)이면 null → 라우트가 라이브로 폴백. */
+export async function readKeywordSnapshot(date: string): Promise<KeywordSnapshot | null> {
+  try {
+    const row = await prisma.keywordCardSnapshot.findUnique({ where: { date } });
+    if (!row) return null;
+    return {
+      cards: row.cards as unknown as KeywordCard[],
+      confidence: row.confidence as KeywordConfidence,
+    };
+  } catch (err) {
+    // 테이블 미생성(P2021) 등 — 조용히 라이브 폴백. 빈 화면 금지.
+    console.warn("[keyword-snapshot] read skipped (table missing?)", (err as Error)?.message);
+    return null;
+  }
+}
+
+/** 스냅샷 upsert(날짜 unique). cron 전용. 실패 시 throw — 스크립트가 비정상 종료로 가시화. */
+export async function writeKeywordSnapshot(
+  date: string,
+  snapshot: KeywordSnapshot
+): Promise<void> {
+  await prisma.keywordCardSnapshot.upsert({
+    where: { date },
+    create: {
+      date,
+      cards: snapshot.cards as unknown as object,
+      confidence: snapshot.confidence,
+    },
+    update: {
+      cards: snapshot.cards as unknown as object,
+      confidence: snapshot.confidence,
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "research:issues": "tsx scripts/research-agent-issues.ts",
     "research:newsletter": "tsx scripts/research-newsletter.ts",
     "fomo:index": "tsx scripts/fomo-index-pipeline.ts",
+    "keywords:generate": "tsx scripts/keywords-generate.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/scripts/keywords-generate.ts
+++ b/scripts/keywords-generate.ts
@@ -1,0 +1,47 @@
+/**
+ * 키워드 카드 일일 스냅샷 생성. KEYWORD_ENGINE_SPEC §4.8 / Phase 4.
+ *
+ * 라우트와 동일한 공유 파이프라인(computeKeywordCards)으로 산출 → KeywordCardSnapshot upsert.
+ * cron(keyword-cards-pipeline.yml)이 하루 1~3회 실행 → 사용자 접속 없이도 매일 스냅샷이 채워진다.
+ *
+ * DATABASE_URL 없으면 계산만 하고 로그(드라이런). 절대 에러로 죽지 않는다(라이브 산출까지는).
+ * 저장 단계 실패만 비정상 종료로 가시화(정직한 숫자: 스냅샷 누락을 숨기지 않음).
+ *
+ * 환경변수: DATABASE_URL(저장), AI_API_URL/KEY/MODEL/TEMPERATURE(코멘트 LLM — 미설정 시 룰 폴백).
+ */
+import { writeFileSync } from "node:fs";
+import { computeKeywordCards } from "../apps/web/lib/keyword-pipeline";
+import { writeKeywordSnapshot } from "../apps/web/lib/keyword-snapshot";
+import { kstDate } from "../apps/web/lib/fomo";
+
+async function main() {
+  const date = kstDate();
+
+  const { cards, confidence } = await computeKeywordCards();
+  console.log(`[keywords:generate] ${date} — ${cards.length}개 카드, confidence=${confidence}`);
+  for (const c of cards) {
+    console.log(`  ${c.emoji} ${c.keyword} (${c.fomoScore})`);
+  }
+
+  // 운영 관측용 건강 리포트(워크플로 Slack 알림이 읽음).
+  writeFileSync(
+    "keyword-cards-health.json",
+    JSON.stringify({ date, count: cards.length, confidence }, null, 2)
+  );
+
+  if (!process.env.DATABASE_URL) {
+    console.log("[keywords:generate] DATABASE_URL 없음 — 드라이런(저장 안 함).");
+    return;
+  }
+
+  // db push 게이트: 테이블이 아직 없으면 여기서 throw → 워크플로 실패로 가시화(누락을 숨기지 않음).
+  await writeKeywordSnapshot(date, { cards, confidence });
+  console.log(`[keywords:generate] 스냅샷 저장 완료: ${date}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[keywords:generate] 실패", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
KEYWORD_ENGINE_SPEC §6 Phase 4. **prod DDL(`prisma db push`)은 게이트 — 미실행.** 머지 후 직접 승인 필요(아래 ⚠️).

## 범위
- **공유 파이프라인** `lib/keyword-pipeline.ts`: `computeKeywordCards` — 라우트와 cron 스크립트가 **동일** 산출 경로 사용(라이브=스냅샷 정합).
- **스냅샷 I/O** `lib/keyword-snapshot.ts`: `KeywordCardSnapshot` 읽기/쓰기. 읽기는 테이블 미생성 시 `null`→라이브 폴백.
- **스냅샷-우선 라우트** `keywords/route.ts`: 1) 오늘 스냅샷 → 2) 라이브 → 3) mock. 빈값 없음.
- **cron** `scripts/keywords-generate.ts` + `npm run keywords:generate` + `.github/workflows/keyword-cards-pipeline.yml`(하루 3회, 제품 데이터 파이프라인 — 에이전트 루프 아님).
- **UI** `KeywordDepthPage`: '곧 추가될 거야'(Phase 5 기능 티저) 제거. depth.why/remember 는 이미 실데이터.

## ⚠️ 머지 후 게이트 (직접 승인)
스냅샷 저장/조회가 실제로 동작하려면 prod 에 테이블이 있어야 합니다:
```
DATABASE_URL=... npx prisma db push   # KeywordCardSnapshot 생성 (운영 규약: DDL 직접 승인)
```
- **이 PR 전이라도 라우트는 안 죽습니다** — 테이블 없으면 조용히 라이브로 폴백(검증 완료).
- db push 후 → cron 이 채운 스냅샷이 자동으로 1순위가 됩니다.
- GitHub Actions secrets 에 `DATABASE_URL`(+ AI_*) 필요.

## 검증
- typecheck ✅ / vitest 566 ✅ / build:web ✅
- **cron 산출**(dry-run): 실데이터 5키워드 — 🔥반도체88 🤖AI48 💵금리41 ₿코인40 🔋2차전지25, confidence low, 저장 스킵 정상.
- **라우트 폴백**: 로컬 DB 미가동(=테이블 없음 상태) → `read skipped (table missing?)` → `live:true` 5카드 반환, 크래시 없음.

## 안 한 것 (범위 밖)
- `prisma db push`(게이트), 흔들림 점수·개인화·검색(Phase 5~6).

머지는 직접.

🤖 Generated with [Claude Code](https://claude.com/claude-code)