### PR TITLE
fix: fomo-index 파이프라인 죽은 prisma 경로 수정

### DIFF
--- a/scripts/fomo-index-pipeline.ts
+++ b/scripts/fomo-index-pipeline.ts
@@ -58,7 +58,8 @@ function kstDate(offsetDays = 0): string {
 async function loadPrisma() {
   if (!process.env.DATABASE_URL) return null;
   try {
-    const mod = await import("../apps/web/lib/tarot/prisma");
+    // Phase 0(#490)에서 lib/tarot/prisma → lib/prisma 로 이동(named export `prisma`).
+    const mod = await import("../apps/web/lib/prisma");
     return mod.prisma;
   } catch (err) {
     process.stderr.write(`prisma load 실패(드라이런 진행): ${String(err)}\n`);


### PR DESCRIPTION
## 문제
Phase 0(#490)에서 `apps/web/lib/tarot/prisma` 가 삭제되고 prisma 가 `apps/web/lib/prisma.ts`(named `prisma`)로 이동했는데, `scripts/fomo-index-pipeline.ts` 의 `loadPrisma()` 는 여전히 옛 경로를 import 한다. → import 가 항상 실패 → `catch` 로 빠져 **FOMO Index 가 조용히 드라이런(스냅샷 저장 안 됨)** 으로 돌고 있었다(무알림 데이터 누락).

## 수정
import 경로를 `../apps/web/lib/prisma` 로 교정(`emotionVote`/`fomoIndexSnapshot` 동일 클라이언트).

## 검증
- typecheck:web ✅
- `DATABASE_URL` 주입 dry-run: 기존 `prisma load 실패(드라이런 진행)` 메시지 **사라짐** → prisma 로드 후 실제 쿼리 시도(로컬 DB 없어 연결 실패는 예상; prod 의 실제 DATABASE_URL 에선 정상 저장).

🤖 Generated with [Claude Code](https://claude.com/claude-code)