### PR TITLE
Phase 5 step 1: 흔들림 점수 엔진 (순수)

### DIFF
--- a/docs/SHAKE_SCORE_SPEC.md
+++ b/docs/SHAKE_SCORE_SPEC.md
@@ -1,0 +1,67 @@
+# 흔들림 점수 스펙 (SHAKE_SCORE_SPEC)
+
+| | |
+|---|---|
+| **상태** | Phase 5 step 1 구현 완료(엔진). PRODUCT_VISION §8.1/§8.2 의 구체화. |
+| **선행 문서** | `docs/PRODUCT_VISION.md` §4.1·§8 / `docs/PRODUCT_TRUTH.md`(정직한 숫자) |
+| **구현** | `packages/fomo-core/src/shake-score/score.ts` (순수 함수) + `__tests__/shake-score.test.ts` |
+| **정의 축(오너 확정)** | **혼합형** — 시장 열기 × 내 스와이프 관심 반응. 콜드스타트는 숫자 숨김. |
+
+> 흔들림 점수는 **시장의 열기가 아니라, 그 열기에 대한 오늘 *나*의 반응**을 0~100으로 본다.
+> §4.1 "시장은 광기 84인데 너는 잘 안 흔들렸어"를 숫자로 만든다.
+
+---
+
+## 1. 입력 (이미 가진 로컬 신호)
+
+전부 익명·로컬(localStorage). fomo-web 어댑터가 join 해 엔진에 넘긴다.
+
+- `keywordHistory`(`fomo_keyword_history`): 본 카드 {keyword, **fomoScore**, ts}
+- `keywordInterest`(`fomo_keyword_interest`): 스와이프 {keywordId, **more/less**, ts}
+
+→ `ShakeInteraction { keyword, fomoScore(0~100), reaction?:"more"|"less", tsMs }`
+
+KST 일자 버킷팅은 엔진 내부(`Intl … Asia/Seoul`, 결정적).
+
+## 2. 공식
+
+각 engagement(반응 있는 카드)에 대해:
+```
+pull_i   = (fomoScore_i / 100) × (reaction==="more" ? 1.0 : 0.25)   // 시장 열기 × 내 반응
+marketPull = mean(pull_i)
+scatter    = min(1, (오늘 more로 추격한 서로 다른 '뜨거운'(fomoScore≥50) 테마 수) / 3)   // §4.4 시선 옮겨다님
+score      = round(100 × (0.75·marketPull + 0.25·scatter))
+```
+- **혼합**: 같은 시장 열기라도 따라가면(more) 높고 패스하면(less) 낮다. 차가운 테마는 추격해도 거의 안 오른다(분산에서도 제외 — 차가운 추격은 FOMO 가 아님).
+- **대조값** `marketHeat` = 오늘 본 카드(반응 무관) 평균 fomoScore → "시장 84 vs 너 32".
+- **가중치/임계는 튜닝 가능**(상수): W_PULL .75 / W_SCATTER .25 / LESS .25 / HOT 50 / SCATTER_SAT 3.
+
+## 3. 정직성 / 콜드스타트 (§8.2)
+
+| 조건 | confidence | 화면 |
+|---|---|---|
+| 오늘 engagement ≥ 7 | `ok` | 점수 노출 |
+| 3 ≤ engagement < 7 | `low` | 점수 + "긴가민가" 결 |
+| engagement < 3, 과거 기록 있음 | `insufficient` | **숫자 숨김** + "데이터 부족" |
+| engagement < 3, 첫날(과거 버킷 없음) | `onboarding` | **숫자 숨김** + "너를 알아가는 중" |
+
+- **가짜 숫자 금지**: 데이터 부족 시 `score=null`. 30일 기준선이 없으므로 "평소 대비" 단정 안 함.
+- **어제 대비 Δ**: 로컬에 어제 버킷이 충분(engagement≥3)할 때만 `today−yesterday`, 아니면 `null`.
+
+## 4. 출력
+
+```ts
+ShakeResult {
+  score: number | null
+  confidence: "ok" | "low" | "insufficient" | "onboarding"
+  marketHeat: number | null
+  deltaVsYesterday: number | null
+  components: { marketPull, scatter } | null
+  engagementCount, viewedCount: number
+  reason: string   // 정직성 노출/디버그
+}
+```
+
+## 5. 다음 단계 (이 엔진 위에)
+
+PRODUCT_VISION §9 Phase 5: step 2 "오늘의 너"(스와이프 끝 카드 — 점수+시장 대조) → step 3 판단 보조 무료 진단 → step 4 패턴 거울(PRO) → step 5 결제. **엔진은 세 화면 공통 토대.** 서버 집계(취향 프로파일)는 §7 행동 로그 보존 위에서 후속.

--- a/packages/fomo-core/__tests__/shake-score.test.ts
+++ b/packages/fomo-core/__tests__/shake-score.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { computeShakeScore, type ShakeInteraction } from "../src";
+
+// 고정 기준 시각(KST 정오). 86_400_000 ms = 1일.
+const NOW = Date.parse("2026-06-14T03:00:00Z"); // 12:00 KST
+const DAY = 86_400_000;
+const ago = (h: number) => NOW - h * 3_600_000;
+
+function mk(
+  keyword: string,
+  fomoScore: number,
+  reaction: ShakeInteraction["reaction"],
+  tsMs = ago(1)
+): ShakeInteraction {
+  return { keyword, fomoScore, ...(reaction ? { reaction } : {}), tsMs };
+}
+
+describe("computeShakeScore — 혼합형(시장 열기 × 내 반응)", () => {
+  it("뜨거운 테마를 따라가면(more) 점수가 높다", () => {
+    const r = computeShakeScore(
+      [mk("반도체", 90, "more"), mk("AI", 85, "more"), mk("코인", 80, "more")],
+      { nowMs: NOW }
+    );
+    expect(r.score).not.toBeNull();
+    expect(r.score!).toBeGreaterThan(60);
+    expect(r.confidence).toBe("low"); // 3~6 engagement
+    expect(r.components!.marketPull).toBeGreaterThan(0.7);
+  });
+
+  it("시장이 뜨거워도 패스하면(less) 점수가 낮다 — '안 흔들렸어'", () => {
+    const hot = computeShakeScore(
+      [mk("반도체", 90, "more"), mk("AI", 88, "more"), mk("코인", 85, "more")],
+      { nowMs: NOW }
+    );
+    const calm = computeShakeScore(
+      [mk("반도체", 90, "less"), mk("AI", 88, "less"), mk("코인", 85, "less")],
+      { nowMs: NOW }
+    );
+    expect(calm.score!).toBeLessThan(hot.score!);
+    // 같은 시장 열기 → marketHeat 동일, shake 는 반응 따라 갈림.
+    expect(calm.marketHeat).toBe(hot.marketHeat);
+    expect(calm.score!).toBeLessThan(calm.marketHeat!);
+  });
+
+  it("차가운 테마를 따라가도 점수는 낮다(혼합 — 시장 열기 반영)", () => {
+    const cold = computeShakeScore(
+      [mk("금리", 15, "more"), mk("2차전지", 20, "more"), mk("코인", 18, "more")],
+      { nowMs: NOW }
+    );
+    expect(cold.score!).toBeLessThan(35);
+  });
+
+  it("시장 대조(marketHeat)는 반응 무관 — 본 카드 전체 평균", () => {
+    const r = computeShakeScore(
+      [mk("반도체", 80, "more"), mk("AI", 60, "less"), mk("금리", 40, undefined)],
+      { nowMs: NOW }
+    );
+    expect(r.marketHeat).toBe(60); // (80+60+40)/3
+    expect(r.viewedCount).toBe(3);
+    expect(r.engagementCount).toBe(2); // 반응 있는 것만
+  });
+
+  it("시선 분산(scatter) — 여러 테마 추격이 점수를 올린다", () => {
+    const focused = computeShakeScore(
+      [mk("반도체", 70, "more"), mk("반도체", 70, "more"), mk("반도체", 70, "more")],
+      { nowMs: NOW }
+    );
+    const scattered = computeShakeScore(
+      [mk("반도체", 70, "more"), mk("AI", 70, "more"), mk("코인", 70, "more")],
+      { nowMs: NOW }
+    );
+    expect(scattered.components!.scatter).toBeGreaterThan(focused.components!.scatter);
+    expect(scattered.score!).toBeGreaterThanOrEqual(focused.score!);
+  });
+});
+
+describe("콜드스타트 / 정직성 (§8.2)", () => {
+  it("첫날 + engagement 부족 → onboarding, 숫자 숨김", () => {
+    const r = computeShakeScore([mk("반도체", 90, "more"), mk("AI", 80, "more")], { nowMs: NOW });
+    expect(r.score).toBeNull();
+    expect(r.confidence).toBe("onboarding");
+    expect(r.components).toBeNull();
+    expect(r.reason).toContain("첫날");
+  });
+
+  it("과거 기록은 있으나 오늘 반응 < 3 → insufficient, 숫자 숨김", () => {
+    const r = computeShakeScore(
+      [
+        mk("반도체", 90, "more", ago(30)), // 어제 이전(과거 버킷 존재)
+        mk("AI", 80, "more"), // 오늘 1개뿐
+      ],
+      { nowMs: NOW }
+    );
+    expect(r.score).toBeNull();
+    expect(r.confidence).toBe("insufficient");
+  });
+
+  it("engagement >= 7 → confidence ok", () => {
+    const many = Array.from({ length: 7 }, (_, i) => mk(`t${i}`, 70, "more"));
+    expect(computeShakeScore(many, { nowMs: NOW }).confidence).toBe("ok");
+  });
+
+  it("입력 전무 → 안전(null + insufficient, 에러 없음)", () => {
+    const r = computeShakeScore([], { nowMs: NOW });
+    expect(r.score).toBeNull();
+    expect(r.marketHeat).toBeNull();
+    expect(r.deltaVsYesterday).toBeNull();
+  });
+});
+
+describe("어제 대비 Δ (로컬 버킷 기반, 가짜 금지)", () => {
+  const yest = (kw: string, s: number, rx: ShakeInteraction["reaction"]) =>
+    mk(kw, s, rx, NOW - DAY);
+
+  it("어제도 충분하면 today.score - yesterday.score", () => {
+    const r = computeShakeScore(
+      [
+        // 어제: 차분(less 위주) → 낮음
+        yest("반도체", 80, "less"), yest("AI", 80, "less"), yest("코인", 80, "less"),
+        // 오늘: 추격(more) → 높음
+        mk("반도체", 80, "more"), mk("AI", 80, "more"), mk("코인", 80, "more"),
+      ],
+      { nowMs: NOW }
+    );
+    expect(r.deltaVsYesterday).not.toBeNull();
+    expect(r.deltaVsYesterday!).toBeGreaterThan(0);
+  });
+
+  it("어제 데이터 부족하면 Δ = null (단정 안 함)", () => {
+    const r = computeShakeScore(
+      [mk("반도체", 80, "more"), mk("AI", 80, "more"), mk("코인", 80, "more")],
+      { nowMs: NOW }
+    );
+    expect(r.deltaVsYesterday).toBeNull();
+    expect(r.reason).toContain("어제 데이터 없음");
+  });
+});

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./emotion-translation";
 export * from "./news-feed";
 export * from "./stock-cards";
 export * from "./keyword-cards";
+export * from "./shake-score";
 export * from "./voices";
 export * from "./index-engine/types";
 export * from "./index-engine/marketHeat";

--- a/packages/fomo-core/src/shake-score/index.ts
+++ b/packages/fomo-core/src/shake-score/index.ts
@@ -1,0 +1,1 @@
+export * from "./score";

--- a/packages/fomo-core/src/shake-score/score.ts
+++ b/packages/fomo-core/src/shake-score/score.ts
@@ -1,0 +1,150 @@
+/**
+ * 흔들림 점수(Shake Score) 엔진 — PRODUCT_VISION §8.1 / Phase 5 step 1.
+ *
+ * "시장의 열기가 아니라, 그 열기에 대한 *오늘 나의 반응*"을 0~100으로. 순수 함수(네트워크/저장 없음).
+ *
+ * 정의 축(오너 확정): **혼합형** — 시장 열기(카드 fomoScore) × 내 스와이프 관심 반응(more/less).
+ *   같은 시장 열기라도 내가 따라가면(more) 높고, 패스하면(less) 낮다. 시장이 광기여도 안 따라가면 낮음.
+ * 정직성(§8.2 콜드스타트): 오늘 engagement 가 적으면(< MIN) 가짜 숫자 대신 null + "알아가는 중".
+ *   30일 기준선이 없으므로 "평소 대비"는 단정하지 않고, 로컬 로그에 실재하는 어제 버킷만 Δ로 쓴다.
+ *
+ * 입력은 fomo-web 어댑터가 localStorage(keywordHistory + keywordInterest)를 join 해 넘긴다.
+ */
+
+export type ShakeReaction = "more" | "less";
+
+/** 카드 1건 상호작용. reaction 없으면 '봤지만 스와이프 반응 없음'(marketHeat 에만 기여). */
+export interface ShakeInteraction {
+  keyword: string;
+  /** 그 카드의 시장 fomoScore 0~100(군중 쏠림 — 시세 아님). */
+  fomoScore: number;
+  /** 스와이프 반응. 있으면 engagement 으로 카운트. */
+  reaction?: ShakeReaction;
+  /** epoch ms (KST 일자 버킷팅용). */
+  tsMs: number;
+}
+
+export type ShakeConfidence = "ok" | "low" | "insufficient" | "onboarding";
+
+export interface ShakeResult {
+  /** 0~100. 콜드스타트(데이터 부족)면 null — 가짜 숫자 금지. */
+  score: number | null;
+  confidence: ShakeConfidence;
+  /** 오늘 본 카드(반응 무관) 평균 fomoScore — "시장 84 vs 너 32" 대조용. 없으면 null. */
+  marketHeat: number | null;
+  /** 어제 버킷이 충분하면 today.score - yesterday.score, 없으면 null(가짜 안 만듦). */
+  deltaVsYesterday: number | null;
+  /** 점수 근거(디버그/튜닝/정직성 노출). score 가 null 이면 null. */
+  components: { marketPull: number; scatter: number } | null;
+  /** 오늘 스와이프 반응(engagement) 수. */
+  engagementCount: number;
+  /** 오늘 본 카드 수(반응 무관). */
+  viewedCount: number;
+  reason: string;
+}
+
+/** 점수 산출 최소 engagement(이 미만은 콜드스타트). */
+const MIN_ENGAGE = 3;
+/** confidence "ok" 도달 engagement. */
+const OK_ENGAGE = 7;
+/** 가중치(튜닝 가능). marketPull = 혼합 본체, scatter = §4.4 시선 옮겨다님. */
+const W_PULL = 0.75;
+const W_SCATTER = 0.25;
+/** less(패스) 반응의 노출 가중 — 봤지만 거의 저항. more=1.0. */
+const LESS_WEIGHT = 0.25;
+/** scatter 포화: 하루 서로 다른 *뜨거운* 테마 N개 추격하면 분산 1.0. */
+const SCATTER_SAT = 3;
+/** scatter 에 셀 '뜨거운' 테마 기준 — 혼합형: 차가운 테마 추격은 FOMO 가 아니라 분산에서 제외. */
+const HOT_THRESHOLD = 50;
+
+/** Asia/Seoul 기준 YYYY-MM-DD (결정적 — ms 입력만으로). */
+function kstDayKey(ms: number): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(new Date(ms));
+}
+
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
+const mean = (xs: readonly number[]) => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length);
+
+/** 한 일자 버킷의 점수 본체(콜드스타트 판단 전 raw 계산). engaged 가 비면 null. */
+function scoreBucket(dayInteractions: readonly ShakeInteraction[]): {
+  score: number;
+  marketPull: number;
+  scatter: number;
+  engagementCount: number;
+} | null {
+  const engaged = dayInteractions.filter((i) => i.reaction);
+  if (engaged.length === 0) return null;
+
+  // 혼합: 시장 열기(fomoScore/100) × 내 반응(more=1, less=0.25).
+  const pulls = engaged.map(
+    (i) => clamp01(i.fomoScore / 100) * (i.reaction === "more" ? 1 : LESS_WEIGHT)
+  );
+  const marketPull = mean(pulls);
+
+  // 분산: 오늘 'more'로 추격한 서로 다른 *뜨거운* 테마 수(혼합 — 차가운 추격은 FOMO 아님).
+  const moreThemes = new Set(
+    engaged.filter((i) => i.reaction === "more" && i.fomoScore >= HOT_THRESHOLD).map((i) => i.keyword)
+  );
+  const scatter = clamp01(moreThemes.size / SCATTER_SAT);
+
+  const score = Math.round(100 * (W_PULL * marketPull + W_SCATTER * scatter));
+  return { score, marketPull, scatter, engagementCount: engaged.length };
+}
+
+/**
+ * 오늘의 흔들림 점수 산출. interactions 는 최근 로컬 로그 전체(여러 날 섞여 있어도 됨 — 내부에서 KST 일자 버킷팅).
+ */
+export function computeShakeScore(
+  interactions: readonly ShakeInteraction[],
+  opts: { nowMs: number }
+): ShakeResult {
+  const todayKey = kstDayKey(opts.nowMs);
+  const yKey = kstDayKey(opts.nowMs - 86_400_000);
+
+  const today = interactions.filter((i) => kstDayKey(i.tsMs) === todayKey);
+  const yesterday = interactions.filter((i) => kstDayKey(i.tsMs) === yKey);
+  const priorDays = new Set(
+    interactions.map((i) => kstDayKey(i.tsMs)).filter((k) => k !== todayKey)
+  );
+
+  const viewedCount = today.length;
+  const engagementCount = today.filter((i) => i.reaction).length;
+  const marketHeat = today.length === 0 ? null : Math.round(mean(today.map((i) => i.fomoScore)));
+
+  // 콜드스타트(§8.2): 오늘 engagement 부족 → 숫자 숨김.
+  if (engagementCount < MIN_ENGAGE) {
+    const onboarding = priorDays.size === 0; // 비교할 어제(과거)가 아예 없음 = 첫날.
+    return {
+      score: null,
+      confidence: onboarding ? "onboarding" : "insufficient",
+      marketHeat,
+      deltaVsYesterday: null,
+      components: null,
+      engagementCount,
+      viewedCount,
+      reason: onboarding
+        ? `첫날 — 비교할 어제가 없어 너를 알아가는 중(오늘 ${engagementCount}개 반응)`
+        : `오늘 반응 ${engagementCount}개(<${MIN_ENGAGE}) — 데이터 부족, 점수 보류`,
+    };
+  }
+
+  const t = scoreBucket(today)!;
+
+  // 어제 Δ: 어제도 충분한 engagement 가 있을 때만(없으면 가짜 안 만듦).
+  const y = scoreBucket(yesterday);
+  const deltaVsYesterday =
+    y && y.engagementCount >= MIN_ENGAGE ? t.score - y.score : null;
+
+  return {
+    score: t.score,
+    confidence: engagementCount >= OK_ENGAGE ? "ok" : "low",
+    marketHeat,
+    deltaVsYesterday,
+    components: { marketPull: t.marketPull, scatter: t.scatter },
+    engagementCount,
+    viewedCount,
+    reason:
+      `추격 ${(t.marketPull * 100).toFixed(0)} · 분산 ${(t.scatter * 100).toFixed(0)}` +
+      (deltaVsYesterday === null ? " · 어제 데이터 없음" : ` · 어제 대비 ${deltaVsYesterday > 0 ? "+" : ""}${deltaVsYesterday}`),
+  };
+}


### PR DESCRIPTION
PRODUCT_VISION §9 Phase 5의 **step 1 — 흔들림 점수 엔진**. §8.1/§8.2를 구체화한 순수 함수 + 테스트. **UI는 다음 단계**(세 화면 공통 토대라 엔진부터).

## 정의 (오너 확정)
- **축**: 혼합형 — 시장 열기(카드 fomoScore) × 내 스와이프 관심 반응(more/less). "시장이 광기여도 안 따라가면 낮다"(§4.1).
- **콜드스타트**: 데이터 부족 시 숫자 숨김(가짜 숫자 금지).

## 공식
```
pull_i     = (fomoScore/100) × (more?1 : less?0.25)
marketPull = mean(pull_i)
scatter    = min(1, 추격한 '뜨거운'(≥50) 서로 다른 테마 수 / 3)   // §4.4
score      = round(100 × (0.75·marketPull + 0.25·scatter))
marketHeat = 오늘 본 카드 평균 fomoScore (대조: "시장 84 vs 너 32")
```
입력은 이미 가진 로컬 신호(`keywordHistory.fomoScore` × `keywordInterest.more/less`). 가중치·임계는 튜닝 가능 상수.

## 정직성 (§8.2)
| engagement | confidence | 화면 |
|---|---|---|
| ≥7 | ok | 점수 |
| 3~6 | low | 점수+긴가민가 |
| <3, 과거O | insufficient | 숫자 숨김 |
| <3, 첫날 | onboarding | 숫자 숨김·온보딩 |

어제 대비 Δ는 로컬 어제 버킷이 충분할 때만(없으면 null). 30일 기준선 없어 "평소 대비" 단정 안 함.

## 검증
- typecheck ✅ / vitest **577**(+11) ✅ / build:web ✅
- 실시나리오: 광기인데 다 패스 → **시장 86 vs 너 16**, 추격(many) → **85(ok)**, 한 테마 차분 → 61, 오늘 1개 → **숨김(insufficient)**.

## 안 한 것 (다음 step)
- UI("오늘의 너" 스와이프 끝 카드, step 2), 판단 보조/패턴 거울/결제(step 3~5), 서버 집계.

## ⚠️ 참고
PRODUCT_VISION §9의 Phase 5 착수 게이트(D7 재방문 검증)는 아직 미충족(Phase 4 미머지·db push 보류). 본 엔진은 게이트와 무관한 순수 토대라 선구현. 머지는 직접.

🤖 Generated with [Claude Code](https://claude.com/claude-code)