### PR TITLE
키워드 카드: 언급 횟수 제거 + 실제 핵심 뉴스 소스 표시

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -32,6 +32,36 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             <p className="mt-2 text-sm leading-6 text-muted">{card.depth.why}</p>
           </section>
 
+          {card.sources.length > 0 && (
+            <section className="mt-6">
+              <p className="font-pixel text-sm text-whiteout">오늘 이런 뉴스가 돌았어</p>
+              <ul className="mt-2 space-y-2">
+                {card.sources.map((s, i) =>
+                  s.url ? (
+                    <li key={i}>
+                      <a
+                        href={s.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="block rounded-lg border border-hairline bg-surface px-3 py-2 transition-colors hover:border-whiteout/30"
+                      >
+                        <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
+                        {s.source && (
+                          <span className="mt-0.5 block text-[11px] text-muted">{s.source} · 원문 보기 →</span>
+                        )}
+                      </a>
+                    </li>
+                  ) : (
+                    <li key={i} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                      <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
+                      {s.source && <span className="mt-0.5 block text-[11px] text-muted">{s.source}</span>}
+                    </li>
+                  )
+                )}
+              </ul>
+            </section>
+          )}
+
           <section className="mt-6">
             <p className="font-pixel text-sm text-whiteout">{card.depth.rememberTitle}</p>
             <p className="mt-2 text-sm leading-6 text-muted">{card.depth.remember}</p>

--- a/apps/web/lib/keyword-pipeline.ts
+++ b/apps/web/lib/keyword-pipeline.ts
@@ -38,6 +38,7 @@ export async function computeKeywordCards(): Promise<KeywordPayloadCore> {
       items.push({
         title: a.title,
         ...(a.summary ? { summary: a.summary } : {}),
+        ...(a.url ? { url: a.url } : {}),
         publishedAt: a.publishedAt,
         source: a.source,
         lang: a.lang,

--- a/packages/fomo-core/__tests__/keyword-comment.test.ts
+++ b/packages/fomo-core/__tests__/keyword-comment.test.ts
@@ -111,10 +111,46 @@ describe("코멘트 변주 (밴드 중복 해소)", () => {
     const b = buildKeywordCard({ ...base, keyword: "금리", emoji: "💵", fomoScore: 30, mentions: 7 });
     expect(a.comment).not.toBe(b.comment);
   });
-  it("코멘트에 mention 수가 반영된다", () => {
+  it("언급 횟수(N번/N건)는 유저 텍스트에 노출하지 않는다 (운영자 피드백)", () => {
     const base = scoreSample()[0]!;
-    const card = buildKeywordCard({ ...base, keyword: "AI", fomoScore: 66, mentions: 23 });
-    expect(card.comment.includes("23")).toBe(true);
+    // mention 수가 커도 코멘트/why 에 숫자+번/건 패턴이 안 나와야 한다.
+    for (const score of [5, 35, 55, 75, 95]) {
+      const card = buildKeywordCard({ ...base, keyword: "AI", emoji: "🤖", fomoScore: score, mentions: 23 });
+      const blob = `${card.comment} ${card.depth.why} ${card.depth.remember}`;
+      expect(blob, `밴드 ${score} 언급수 노출`).not.toMatch(/\d+\s*(번|건)/);
+    }
+  });
+});
+
+describe("핵심 뉴스 소스 (실제 근거 노출, 추상 브리핑 대체)", () => {
+  const withArticles: ScoredKeyword = {
+    ...scoreSample().find((k) => k.keyword === "반도체")!,
+    articles: [
+      { title: "엔비디아 신고가 급등", source: "한국경제", url: "https://x/1", publishedAt: "2026-06-13T11:00:00Z" },
+      { title: "삼성전자 반도체 랠리", source: "매일경제", url: "https://x/2", publishedAt: "2026-06-13T12:00:00Z" },
+      { title: "삼성전자 반도체 랠리", source: "중복", publishedAt: "2026-06-13T09:00:00Z" }, // 제목 중복 → 제외
+      { title: "HBM 수요 폭발", source: "전자신문", publishedAt: "2026-06-13T08:00:00Z" },
+      { title: "네번째", source: "x", publishedAt: "2026-06-13T07:00:00Z" }, // MAX_SOURCES 초과 → 제외
+    ],
+  };
+
+  it("카드에 실제 기사 제목/출처/링크가 상위 N건(최신순, 중복 제거) 담긴다", () => {
+    const card = buildKeywordCard(withArticles);
+    expect(card.sources.length).toBe(3);
+    expect(card.sources[0]).toEqual({ title: "삼성전자 반도체 랠리", source: "매일경제", url: "https://x/2" }); // 최신
+    expect(card.sources.map((s) => s.title)).not.toContain("네번째"); // N 초과 제외
+    // 같은 제목 중복은 한 번만.
+    expect(card.sources.filter((s) => s.title === "삼성전자 반도체 랠리").length).toBe(1);
+  });
+
+  it("기사가 없으면 sources 빈 배열(에러 없음)", () => {
+    const card = buildKeywordCard({ ...withArticles, articles: [] });
+    expect(card.sources).toEqual([]);
+  });
+
+  it("LLM 프롬프트는 횟수 언급을 금지한다", () => {
+    const p = buildKeywordCommentPrompt([{ keyword: "반도체", score: 88, titles: ["엔비디아 급등"], related: ["삼성전자"] }]);
+    expect(p).toMatch(/횟수/);
   });
 });
 

--- a/packages/fomo-core/src/keyword-cards/comment.ts
+++ b/packages/fomo-core/src/keyword-cards/comment.ts
@@ -1,4 +1,5 @@
-import type { KeywordCard } from "./types";
+import type { KeywordCard, KeywordCardSource } from "./types";
+import type { KeywordSourceItem } from "./extract";
 import type { ScoredKeyword, KeywordConfidence } from "./score";
 import { josa } from "./josa";
 
@@ -9,9 +10,11 @@ import { josa } from "./josa";
  * mock.ts 의 톤을 폴백 기준으로 삼는다: 친구 반말 + 담담함 + 반드시 균형추(진정)로 닫기.
  *
  * 변주: 같은 밴드라도 똑같은 문장이 반복되지 않게 밴드별 템플릿 2~3개 풀 + 키워드 해시로
- *   **결정적** 선택(랜덤 X → 새로고침/캐시에도 안 바뀜) + 코멘트에 mention 수 반영.
+ *   **결정적** 선택(랜덤 X → 새로고침/캐시에도 안 바뀜).
  * 조사: josa() 로 받침 처리("코인는"→"코인은").
  *
+ * 정직성(운영자 피드백 2026-06-14): "N번 돌았어" 같은 *언급 횟수*는 백엔드 신호일 뿐
+ *   유저에게 의미 없어 코멘트/why 에 노출하지 않는다. 대신 실제 핵심 뉴스(card.sources)로 근거를 보여준다.
  * 절대 규칙(§2): 예측·투자조언·전문용어·거래부추김 0, 모든 변주에 균형추 필수.
  * 가드 테스트(keyword-comment.test.ts)가 금칙어/균형추를 전 변주에서 검증한다.
  */
@@ -38,7 +41,7 @@ function pick<T>(arr: readonly T[], key: string): T {
   return arr[h % arr.length]!;
 }
 
-type CommentFn = (kw: string, mention: number) => string;
+type CommentFn = (kw: string) => string;
 
 interface BandTemplate {
   /** 구간 하한(이상). state.ts BANDS 와 동일 경계. */
@@ -58,11 +61,11 @@ const BANDS: readonly BandTemplate[] = [
   {
     min: 81,
     comments: [
-      (k, m) =>
-        `오늘 ${k} 얘기가 ${m}번이나 돌았어. 너만 못 탄 것 같지? 그 마음 알아. ` +
+      (k) =>
+        `오늘 다들 ${k} 얘기뿐이야. 너만 못 탄 것 같지? 그 마음 알아. ` +
         `근데 이미 한참 달아오른 거 따라 들어가는 건 늘 조심하는 게 좋아.`,
-      (k, m) =>
-        `${eun(k)} 오늘 제일 시끄러운 키워드야 — ${m}번 넘게 얘기됐어. ` +
+      (k) =>
+        `${eun(k)} 오늘 제일 시끄러운 키워드야. ` +
         `다 놓친 기분 들지? 그래도 따라가는 건 천천히, 늦었다고 조급해 말고.`,
     ],
     whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
@@ -75,11 +78,11 @@ const BANDS: readonly BandTemplate[] = [
   {
     min: 61,
     comments: [
-      (k, m) =>
-        `${k} 얘기가 다시 뜨거워졌어. 오늘만 ${m}번쯤 돌았더라. ` +
+      (k) =>
+        `${k} 얘기가 다시 뜨거워졌어. ` +
         `휩쓸리기 쉬운 주제니까 한 박자 천천히 봐도 돼.`,
-      (k, m) =>
-        `오늘 ${k} 쪽으로 시선이 꽤 쏠렸어(${m}번). 다들 보니까 나도 봐야 하나 싶지? ` +
+      (k) =>
+        `오늘 ${k} 쪽으로 시선이 꽤 쏠렸어. 다들 보니까 나도 봐야 하나 싶지? ` +
         `그 마음일수록 조심해서 천천히.`,
     ],
     whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
@@ -92,11 +95,11 @@ const BANDS: readonly BandTemplate[] = [
   {
     min: 41,
     comments: [
-      (k, m) =>
-        `오늘은 ${k} 쪽으로 시선이 조금씩 모이는 날이야(${m}번). ` +
+      (k) =>
+        `오늘은 ${k} 쪽으로 시선이 조금씩 모이는 날이야. ` +
         `크게 들뜨진 않았어. 급할 거 없어.`,
-      (k, m) =>
-        `${k} 얘기가 ${m}번 정도 보이네. 후끈하진 않고 슬슬 관심 붙는 정도야. ` +
+      (k) =>
+        `${k} 얘기가 슬슬 보이네. 후끈하진 않고 관심 붙는 정도야. ` +
         `천천히 봐도 돼.`,
     ],
     whyTitle: "오늘 왜 여기에 시선이 모였어?",
@@ -109,11 +112,11 @@ const BANDS: readonly BandTemplate[] = [
   {
     min: 21,
     comments: [
-      (k, m) =>
-        `${eun(k)} 오늘 좀 잠잠했어. ${m}번 정도 언급됐는데 크게 들썩이진 않았어. ` +
+      (k) =>
+        `${eun(k)} 오늘 좀 잠잠했어. 크게 들썩이진 않았어. ` +
         `무서워할 것도, 급할 것도 없어.`,
-      (k, m) =>
-        `오늘 ${k} 얘기는 ${m}번쯤, 조용한 편이야. 한 박자 쉬어가는 날이지. ` +
+      (k) =>
+        `오늘 ${k} 얘기는 조용한 편이야. 한 박자 쉬어가는 날이지. ` +
         `안 급해도 돼.`,
     ],
     whyTitle: "오늘은 왜 잠잠했어?",
@@ -126,11 +129,11 @@ const BANDS: readonly BandTemplate[] = [
   {
     min: 0,
     comments: [
-      (k, m) =>
-        `${eun(k)} 오늘 거의 조용했어(${m}번). 다들 관심이 다른 데 가 있어. ` +
+      (k) =>
+        `${eun(k)} 오늘 거의 조용했어. 다들 관심이 다른 데 가 있어. ` +
         `조용한 건 나쁜 게 아니야.`,
-      (k, m) =>
-        `오늘 ${k} 얘기는 ${m}번뿐, 거의 안 보였어. 이런 날도 있는 거야. ` +
+      (k) =>
+        `오늘 ${k} 얘기는 거의 안 보였어. 이런 날도 있는 거야. ` +
         `너도 안 급해도 돼.`,
     ],
     whyTitle: "오늘은 왜 잠잠했어?",
@@ -156,7 +159,7 @@ function relatedPhrase(related: readonly string[]): string {
 
 /**
  * depth.why — 오늘 데이터를 담담히. 예측 없이 "무슨 일이 있었나"만.
- * 실제 mention 수를 정직하게 노출(가짜 단정 금지).
+ * 언급 횟수 같은 백엔드 수치는 노출하지 않는다(운영자 피드백) — 근거는 card.sources(실제 뉴스)가 보여준다.
  */
 function buildWhy(kw: ScoredKeyword): string {
   const phrase = relatedPhrase(kw.related);
@@ -164,16 +167,41 @@ function buildWhy(kw: ScoredKeyword): string {
     return `오늘은 ${kw.keyword} 쪽에 새 소식이 거의 없어서 사람들 시선이 머물지 않았어. 새 소식이 없으면 이렇게 잠잠하기도 해.`;
   }
   return (
-    `오늘 ${kw.keyword} 관련 얘기가 여기저기서 ${kw.mentions}건쯤 돌았어. ` +
-    `${phrase}이 같이 묶여 오르내리니까 '나도 봐야 하나' 하는 사람이 늘어난 거야.`
+    `오늘 ${kw.keyword} 관련 소식이 여기저기서 돌았어. ` +
+    `${phrase}이 같이 묶여 오르내리니까 '나도 봐야 하나' 하는 사람이 늘어난 거야. 아래 실제 뉴스가 그 근거야.`
   );
+}
+
+/**
+ * card.sources — 이 키워드를 뽑게 한 실제 핵심 뉴스(상위 N). 최신 우선, 제목 중복 제거.
+ * 추상 브리핑 대신 "무슨 기사 때문인지"를 직접 보여준다(운영자 피드백 2026-06-14).
+ */
+const MAX_SOURCES = 3;
+function buildSources(articles: readonly KeywordSourceItem[]): KeywordCardSource[] {
+  const sorted = [...articles].sort((a, b) =>
+    (b.publishedAt ?? "").localeCompare(a.publishedAt ?? "")
+  );
+  const seen = new Set<string>();
+  const out: KeywordCardSource[] = [];
+  for (const a of sorted) {
+    const title = a.title?.trim();
+    if (!title || seen.has(title)) continue;
+    seen.add(title);
+    out.push({
+      title,
+      ...(a.source ? { source: a.source } : {}),
+      ...(a.url ? { url: a.url } : {}),
+    });
+    if (out.length >= MAX_SOURCES) break;
+  }
+  return out;
 }
 
 /** ScoredKeyword → KeywordCard(룰 폴백 코멘트 포함, 키워드 해시로 변주 결정). */
 export function buildKeywordCard(kw: ScoredKeyword): KeywordCard {
   const band = bandFor(kw.fomoScore);
-  const comment = pick(band.comments, kw.keyword)(kw.keyword, kw.mentions);
-  const remember = pick(band.remembers, kw.keyword)(kw.keyword, kw.mentions);
+  const comment = pick(band.comments, kw.keyword)(kw.keyword);
+  const remember = pick(band.remembers, kw.keyword)(kw.keyword);
   return {
     id: kw.keyword,
     keyword: kw.keyword,
@@ -181,6 +209,7 @@ export function buildKeywordCard(kw: ScoredKeyword): KeywordCard {
     fomoScore: kw.fomoScore,
     comment,
     related: kw.related,
+    sources: buildSources(kw.articles),
     depth: {
       whyTitle: band.whyTitle,
       why: buildWhy(kw),
@@ -297,8 +326,9 @@ export function buildKeywordCommentPrompt(
     "3) 전문용어 금지. 꼭 나오면 친구가 풀어주듯 쉽게(예: \"오더블럭? 큰손들이 사 모은 가격대야\").",
     "4) 반드시 균형추(진정)로 닫는다: \"안 급해도 돼 / 기회는 또 와 / 잠깐 지켜보자\" 결.",
     "5) 점수가 높을수록(60+) 진정 톤을 더 강하게. 낮으면(40-) \"조용한 건 나쁜 게 아니야\" 결.",
+    "6) '몇 번 언급됐다 / N건 돌았다' 같은 *횟수 수치* 금지(유저에게 의미 없음). 대신 실제 기사 흐름을 자연스럽게 녹여라.",
     "",
-    'comment 는 2~3줄, why 는 왜 쏠렸는지 용어 없이, remember 는 균형추 한마디.',
+    'comment 는 2~3줄, why 는 왜 쏠렸는지 실제 기사 내용을 근거로 용어 없이, remember 는 균형추 한마디.',
     '출력은 JSON 배열만(그 외 텍스트 0): [{"keyword","comment","why","remember"}]',
     "",
     JSON.stringify(payload),

--- a/packages/fomo-core/src/keyword-cards/extract.ts
+++ b/packages/fomo-core/src/keyword-cards/extract.ts
@@ -12,6 +12,8 @@ import type { NewsLang } from "../news-feed/types";
 export interface KeywordSourceItem {
   title: string;
   summary?: string;
+  /** 원문 링크(있으면 카드 소스에서 클릭 가능). */
+  url?: string;
   /** 발행/작성 시각 ISO. 최신성·가속 계산용(없으면 무시). */
   publishedAt?: string;
   /** 커뮤니티 참여도(upvote+댓글 합). 뉴스는 0/생략. */

--- a/packages/fomo-core/src/keyword-cards/mock.ts
+++ b/packages/fomo-core/src/keyword-cards/mock.ts
@@ -14,11 +14,15 @@ export const MOCK_KEYWORD_CARDS: readonly KeywordCard[] = [
       "오늘 다들 반도체 얘기뿐이야. 너만 못 탄 것 같지? 그 마음 알아. " +
       "근데 이미 한참 오른 거 따라 들어가는 건 늘 조심하는 게 좋아.",
     related: ["삼성전자", "SK하이닉스", "엔비디아"],
+    sources: [
+      { title: "엔비디아 신고가… HBM 수요 폭발에 삼성·SK 동반 강세", source: "한국경제" },
+      { title: "외국인, 반도체 대형주 집중 매수", source: "매일경제" },
+    ],
     depth: {
       whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
       why:
-        "반도체 값이 다시 오를 것 같다는 얘기가 돌면서 관련 회사들이 같이 들썩였어. " +
-        "삼성전자·SK하이닉스 같은 큰 회사들이 한꺼번에 오르니까 '나도 타야 하나' 하는 사람이 확 몰린 거야.",
+        "반도체 수요가 살아난다는 얘기가 돌면서 관련 회사들이 같이 들썩였어. " +
+        "삼성전자·SK하이닉스 같은 큰 회사들이 한꺼번에 들썩이니까 '나도 타야 하나' 하는 사람이 확 몰린 거야. 아래 실제 뉴스가 그 근거야.",
       rememberTitle: "근데 이건 기억해",
       remember:
         "다들 좋다고 몰릴 때가 보통 제일 비쌀 때야. 뉴스 보고 들어가면 늦는 경우가 많거든. " +
@@ -34,6 +38,10 @@ export const MOCK_KEYWORD_CARDS: readonly KeywordCard[] = [
       "AI 얘기가 또 뜨거워졌어. 다들 이쪽으로 시선이 쏠리는 날이야. " +
       "휩쓸리기 쉬운 주제니까 한 박자 천천히 봐도 돼.",
     related: ["엔비디아", "마이크로소프트", "팔란티어"],
+    sources: [
+      { title: "오픈AI 새 모델 공개에 AI 관련주 일제히 강세", source: "연합뉴스" },
+      { title: "'AI 수혜' 기대에 팔란티어 급등", source: "이데일리" },
+    ],
     depth: {
       whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
       why:
@@ -53,6 +61,10 @@ export const MOCK_KEYWORD_CARDS: readonly KeywordCard[] = [
       "코인판이 다시 달아올랐어. '나만 안 탔나' 싶은 사람들이 오늘 진짜 많아. " +
       "딱 이럴 때가 제일 휩쓸리기 쉬워. 따라가는 건 늦춰도 괜찮아.",
     related: ["비트코인", "이더리움"],
+    sources: [
+      { title: "비트코인 다시 들썩… 코인판 거래량 급증", source: "블록미디어" },
+      { title: "이더리움 현물 ETF 기대감에 매수세", source: "코인데스크코리아" },
+    ],
     depth: {
       whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
       why:
@@ -72,6 +84,10 @@ export const MOCK_KEYWORD_CARDS: readonly KeywordCard[] = [
       "오늘은 금리 얘기로 다들 눈치 보는 날이야. 크게 들뜨진 않았어. " +
       "조용히 지켜보는 분위기니까 너도 급할 거 없어.",
     related: ["은행주", "채권"],
+    sources: [
+      { title: "연준 FOMC 앞두고 금리 관망세", source: "연합뉴스" },
+      { title: "금리 향방에 은행·채권 시장 촉각", source: "한국경제" },
+    ],
     depth: {
       whyTitle: "오늘 왜 여기에 다들 쏠렸어?",
       why:
@@ -91,6 +107,10 @@ export const MOCK_KEYWORD_CARDS: readonly KeywordCard[] = [
       "2차전지는 오늘 좀 가라앉았어. 한때 엄청 뜨거웠던 곳이라 지금은 식은 느낌이야. " +
       "빠졌다고 무서워할 것도, 싸졌다고 급할 것도 없어.",
     related: ["에코프로비엠", "LG에너지솔루션"],
+    sources: [
+      { title: "전기차 둔화 우려 재부각… 2차전지주 약세", source: "이데일리" },
+      { title: "배터리 업종, 관심 식으며 거래 한산", source: "머니투데이" },
+    ],
     depth: {
       whyTitle: "오늘은 왜 잠잠했어?",
       why:
@@ -110,6 +130,10 @@ export const MOCK_KEYWORD_CARDS: readonly KeywordCard[] = [
       "바이오는 오늘 거의 조용했어. 다들 관심이 다른 데 가 있는 날이야. " +
       "조용한 건 나쁜 게 아니야. 너도 안 급해도 돼.",
     related: ["삼성바이오로직스", "셀트리온"],
+    sources: [
+      { title: "바이오, 특별한 모멘텀 없이 관망", source: "약업신문" },
+      { title: "제약·바이오 거래 한산… 시선 분산", source: "데일리팜" },
+    ],
     depth: {
       whyTitle: "오늘은 왜 잠잠했어?",
       why:

--- a/packages/fomo-core/src/keyword-cards/types.ts
+++ b/packages/fomo-core/src/keyword-cards/types.ts
@@ -9,12 +9,22 @@
 export interface KeywordDepth {
   /** "오늘 왜 여기에 다들 쏠렸어?" 류 제목. */
   whyTitle: string;
-  /** 뉴스 종합을 친구 말투로(어떤 일+어떤 종목 묶였나, 용어 없이). */
+  /** 뉴스 종합을 친구 말투로(어떤 일+어떤 종목 묶였나, 용어 없이). 언급 횟수 같은 백엔드 수치는 노출 안 함. */
   why: string;
   /** "근데 이건 기억해" 류 제목(균형추). */
   rememberTitle: string;
   /** 포모 완화 — "따라가는 건 조심" 결. */
   remember: string;
+}
+
+/** 이 키워드를 뽑게 한 실제 뉴스 한 건(출처 표시용 — 추상 브리핑 대신 근거를 보여준다). */
+export interface KeywordCardSource {
+  /** 실제 기사 제목. */
+  title: string;
+  /** 매체명(예: "한국경제"). */
+  source?: string;
+  /** 원문 링크(있으면 클릭 가능). */
+  url?: string;
 }
 
 export interface KeywordCard {
@@ -29,5 +39,7 @@ export interface KeywordCard {
   comment: string;
   /** 관련 종목/테마 미니 리스트(시세 아님, "다들 이런 것들 봤어"). */
   related: readonly string[];
+  /** 이 키워드를 뽑게 한 실제 핵심 뉴스(헤드라인+출처). 추상 브리핑이 아니라 근거. */
+  sources: readonly KeywordCardSource[];
   depth: KeywordDepth;
 }


### PR DESCRIPTION
운영자 피드백(2026-06-14): ①"21번 돌았어" 같은 **언급 횟수는 백엔드 신호 → 유저 노출 제거**, ②추상적 브리핑 대신 **키워드를 뽑게 한 실제 핵심 뉴스(헤드라인+출처+링크)를 근거로 표시**.

## 변경
- **타입**: `KeywordCard.sources`(`{title, source?, url?}`) 추가. `KeywordSourceItem.url` 스루.
- **comment.ts**: 룰 템플릿·`buildWhy`에서 언급 수치(`${m}`/`N건`) 전부 제거. `buildSources`(상위 3, 최신순·제목 중복 제거). LLM 프롬프트에 "횟수 수치 금지" 규칙 추가.
- **keyword-pipeline.ts**: 뉴스 `url` 매핑.
- **mock.ts**: 6장 예시 소스 추가 + '오를 것 같다' 예측투 완화.
- **KeywordDepthPage**: "오늘 이런 뉴스가 돌았어" 섹션 — 헤드라인+출처, url 있으면 원문 링크(↗).
- **tests**: '언급수 반영' → '횟수 비노출' 테스트 교체 + 소스 추출 테스트.

## 검증
- typecheck ✅ / vitest **569** ✅ / build:web ✅ / build:fomo-web ✅
- **실데이터**: 5키워드 comment/why 에 횟수 0건, sources 에 실제 한경·매경 헤드라인 + 원문 링크 채워짐. 코멘트가 실제 기사 흐름에 grounded.

## 후속(별도 플래그)
소스를 노출하니 테마 추출 false-positive(예: 로이터 공항 기사가 AI에, 반도체 ETF가 코인에 매칭)가 드러남 — 추출 정밀도 개선은 별도 태스크.

머지는 직접.

🤖 Generated with [Claude Code](https://claude.com/claude-code)