### PR TITLE
fix: 키워드 테마 추출 false-positive (단어경계 + 일반어 제거)

### DIFF
--- a/packages/fomo-core/__tests__/keyword-engine.test.ts
+++ b/packages/fomo-core/__tests__/keyword-engine.test.ts
@@ -101,3 +101,37 @@ describe("scoreKeywords (군중 쏠림 0~100)", () => {
     expect(scoreKeywords([], { nowMs: NOW })).toEqual([]);
   });
 });
+
+describe("extractKeywords — 오추출 방지(단어경계·일반어 제거, 2026-06-14)", () => {
+  const themesOf = (item: KeywordSourceItem) => extractKeywords([item]).map((e) => e.keyword);
+
+  it("'Shanghai'의 'ai' 부분일치 → AI 오추출 안 됨", () => {
+    const item: KeywordSourceItem = {
+      title: "상하이 국제공항 여객 처리량 감소",
+      summary: "Shanghai Pudong airport passenger volume fell 1.0%",
+      source: "로이터",
+    };
+    expect(themesOf(item)).not.toContain("AI");
+  });
+
+  it("'federal'의 'fed' 부분일치 → 금리 오추출 안 됨", () => {
+    expect(themesOf({ title: "US federal holiday calendar updated" })).not.toContain("금리");
+  });
+
+  it("반도체 ETF 기사 → 코인 오추출 안 됨('ETF' 사전어 제거)", () => {
+    const item: KeywordSourceItem = { title: "'조정이 기회' 반도체株 3배 ETF에 뭉칫돈", source: "매일경제" };
+    const themes = themesOf(item);
+    expect(themes).toContain("반도체");
+    expect(themes).not.toContain("코인");
+  });
+
+  it("영문 약어는 독립 단어일 때만 매칭 — 'AI 반도체 수요'는 AI+반도체", () => {
+    const themes = themesOf({ title: "AI 반도체 수요 폭발, Fed 금리 동결" });
+    expect(themes).toEqual(expect.arrayContaining(["AI", "반도체", "금리"]));
+  });
+
+  it("정상 키워드는 여전히 매칭 — 한글/약어", () => {
+    expect(themesOf({ title: "비트코인 급등, ethereum도 강세" })).toContain("코인");
+    expect(themesOf({ title: "엔비디아 GPT 칩 수요" })).toEqual(expect.arrayContaining(["반도체", "AI"]));
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/extract.ts
+++ b/packages/fomo-core/src/keyword-cards/extract.ts
@@ -48,7 +48,8 @@ export const THEME_DICTIONARY: Record<string, ThemeDef> = {
   },
   코인: {
     emoji: "₿",
-    terms: ["비트코인", "이더리움", "코인", "암호화폐", "가상자산", "crypto", "bitcoin", "btc", "ethereum", "eth", "ETF"],
+    // "ETF" 제외 — 일반 래퍼라 반도체/지수 ETF 기사까지 코인으로 오추출(2026-06-14 false-positive).
+    terms: ["비트코인", "이더리움", "코인", "암호화폐", "가상자산", "스테이블코인", "crypto", "bitcoin", "btc", "ethereum", "eth"],
     related: ["비트코인", "이더리움"],
   },
   금리: {
@@ -81,12 +82,52 @@ export interface ExtractedKeyword {
   consecutiveDays?: number;
 }
 
-/** 한 글이 어떤 테마에 매칭되는지 — 사전 용어 substring(대소문자 무시). */
+/** ASCII 영숫자 용어(단어경계 매칭 대상)인가. "AI"/"GPT"/"eth" 등 — 'shanghai'의 'ai' 부분일치 방지. */
+function isAsciiTerm(t: string): boolean {
+  return /^[a-z0-9]+$/i.test(t);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+interface ThemeMatcher {
+  keyword: string;
+  /** 비-ASCII(한글 등) 용어 — 부분일치(소문자). */
+  substrings: readonly string[];
+  /** ASCII 약어 — 단어경계 매칭(앞뒤에 영숫자 없을 때만). 룩비하인드 없이 호환되게. */
+  regexes: readonly RegExp[];
+}
+
+/**
+ * 테마별 매처 사전 컴파일. ASCII 용어는 단어경계로, 한글 용어는 부분일치로.
+ * (2026-06-14) 단순 substring 이 "AI"→"shanghai", "fed"→"federal" 같은 오추출을 냈다.
+ */
+const THEME_MATCHERS: readonly ThemeMatcher[] = Object.entries(THEME_DICTIONARY).map(
+  ([keyword, def]) => {
+    const substrings: string[] = [];
+    const regexes: RegExp[] = [];
+    for (const t of def.terms) {
+      const low = t.toLowerCase();
+      if (isAsciiTerm(t)) {
+        // 앞뒤가 문자열 끝이거나 비영숫자일 때만 — "ai"가 "shanghai" 안에서 안 걸리게.
+        regexes.push(new RegExp(`(^|[^a-z0-9])${escapeRegex(low)}([^a-z0-9]|$)`));
+      } else {
+        substrings.push(low);
+      }
+    }
+    return { keyword, substrings, regexes };
+  }
+);
+
+/** 한 글이 어떤 테마에 매칭되는지 — 한글=부분일치, 영문 약어=단어경계(대소문자 무시). */
 function matchedThemes(item: KeywordSourceItem): string[] {
   const blob = `${item.title} ${item.summary ?? ""}`.toLowerCase();
   const hits: string[] = [];
-  for (const [keyword, def] of Object.entries(THEME_DICTIONARY)) {
-    if (def.terms.some((t) => blob.includes(t.toLowerCase()))) hits.push(keyword);
+  for (const m of THEME_MATCHERS) {
+    if (m.substrings.some((s) => blob.includes(s)) || m.regexes.some((re) => re.test(blob))) {
+      hits.push(m.keyword);
+    }
   }
   return hits;
 }


### PR DESCRIPTION
#500에서 카드 depth에 실제 소스를 노출하면서 드러난 추출 노이즈 수정.

## 원인
`matchedThemes()`가 사전 용어를 단순 substring(소문자) 매칭:
- **`AI`(→`ai`)가 `shanghai`에 매칭** → 상하이 공항(로이터) 기사가 AI 테마로.
- **`ETF`가 일반 래퍼** → 반도체 소부장 ETF 기사가 코인 테마로.
- `fed`→`federal` 류 동일 문제.

## 수정
- **ASCII 영숫자 용어 = 단어경계 매칭** (`(^|[^a-z0-9])term([^a-z0-9]|$)`, 룩비하인드 없이 Safari 등 호환). 한글 용어는 부분일치 유지. 테마별 매처 모듈 로드 시 1회 컴파일.
- **코인 사전에서 `ETF` 제거** (+`스테이블코인` 추가).

## 검증
- typecheck ✅ / vitest **585**(+5 회귀) ✅ / build:web ✅
- 회귀 테스트: shanghai→AI❌, federal→금리❌, 반도체 ETF→코인❌, 정상(AI/반도체/금리/코인/약어)✅
- **실데이터**: AI 버킷에서 상하이 공항 기사 사라짐, 코인 버킷에서 반도체 ETF 기사 사라짐. 정상 매칭 유지.

머지는 직접.

🤖 Generated with [Claude Code](https://claude.com/claude-code)