### PR TITLE
Track A: 이해 레이어 PoC (데이터 엔진 트랙)

### DIFF
--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -1,0 +1,143 @@
+import {
+  extractKeywords,
+  buildThemeInsightPrompt,
+  parseThemeInsightResponse,
+  assembleThemeInsight,
+  emptyThemeInsight,
+  type SourceDoc,
+  type ThemeInsight,
+  type KeywordSourceItem,
+} from "@fomo/core";
+import { fetchNaverBoardPosts } from "@fomo/core";
+import { fetchAllNews } from "./fomo-news-sources";
+
+/**
+ * 이해 레이어 오케스트레이션 — DATA_ENGINE_STRATEGY §4 Track A. (네트워크 + LLM)
+ *
+ * 기존 수집(뉴스 RSS + 네이버 종토방)이 가져온 *원문*을 모아 LLM 에이전트가 읽고 구조화한다.
+ * 순수 가공·가드(grounding/투자조언/균형)는 @fomo/core(assembleThemeInsight)에 위임 — 여기는 수집+호출만.
+ *
+ * 정직성: AI 미설정·실패·원문 부족 → emptyThemeInsight(정직한 빈 상태). 가짜 생성 금지.
+ */
+
+const AI_API_URL = process.env["AI_API_URL"] ?? "";
+// 한 테마만 깊게 보는 PoC → 품질 우선 본 모델. 충실 추출 위해 온도 낮게.
+const MODEL = process.env["AI_MODEL"] || "openai/gpt-4.1";
+const TEMPERATURE = Number.parseFloat(process.env["AI_TEMPERATURE"] ?? "") || 0.2;
+
+const MAX_NEWS = 12;
+const MAX_COMMUNITY = 10;
+
+/** 테마 → 종토방 종목코드(원문 커뮤니티 수집 대상). 지금은 반도체만(PoC). */
+const THEME_NAVER_CODES: Record<string, { code: string; label: string }[]> = {
+  반도체: [
+    { code: "005930", label: "삼성전자" },
+    { code: "000660", label: "SK하이닉스" },
+  ],
+};
+
+function resolveAiKey(): string {
+  const configured = process.env["AI_API_KEY"] ?? "";
+  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
+    return process.env["GITHUB_TOKEN"] ?? "";
+  }
+  return configured;
+}
+
+interface LlmResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/** 뉴스 + 종토방 원문을 SourceDoc[] 로(제목·본문 보존, S1.. 식별자 부여). */
+export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
+  const codes = THEME_NAVER_CODES[theme] ?? [];
+
+  const [newsRes, ...commRes] = await Promise.allSettled([
+    fetchAllNews(),
+    ...codes.map((c) => fetchNaverBoardPosts(c.code)),
+  ]);
+
+  const docs: SourceDoc[] = [];
+  let n = 0;
+  const nextId = () => `S${++n}`;
+
+  // 뉴스 — 해당 테마로 매칭된 기사만(기존 extract 재사용, 카운팅 아님 — 필터로만 사용).
+  if (newsRes.status === "fulfilled") {
+    const items: KeywordSourceItem[] = newsRes.value.map((a) => ({
+      title: a.title,
+      ...(a.summary ? { summary: a.summary } : {}),
+      ...(a.url ? { url: a.url } : {}),
+      publishedAt: a.publishedAt,
+      source: a.source,
+      lang: a.lang,
+    }));
+    const bucket = extractKeywords(items).find((k) => k.keyword === theme);
+    for (const art of (bucket?.articles ?? []).slice(0, MAX_NEWS)) {
+      docs.push({
+        id: nextId(),
+        kind: "news",
+        title: art.title,
+        ...(art.summary ? { body: art.summary } : {}),
+        ...(art.source ? { source: art.source } : {}),
+        ...(art.url ? { url: art.url } : {}),
+        ...(art.publishedAt ? { publishedAt: art.publishedAt } : {}),
+      });
+    }
+  } else {
+    console.warn("[theme-understanding] news error", newsRes.reason);
+  }
+
+  // 커뮤니티(종토방) — 제목 원문 보존(개수가 아니라 내용).
+  codes.forEach((c, i) => {
+    const r = commRes[i];
+    if (r && r.status === "fulfilled") {
+      for (const post of r.value.slice(0, Math.ceil(MAX_COMMUNITY / codes.length))) {
+        docs.push({
+          id: nextId(),
+          kind: "community",
+          title: post.title,
+          source: `네이버 종토방 ${c.label}`,
+          ...(post.tsMs ? { publishedAt: new Date(post.tsMs).toISOString() } : {}),
+        });
+      }
+    } else if (r && r.status === "rejected") {
+      console.warn("[theme-understanding] community error", c.label, r.reason);
+    }
+  });
+
+  return docs;
+}
+
+/** 테마 이해·구조화 — 수집 → LLM → grounding 검증(assemble). 실패 시 정직한 빈 상태. */
+export async function understandTheme(theme: string): Promise<ThemeInsight> {
+  const docs = await collectThemeDocs(theme);
+  if (docs.length === 0) return emptyThemeInsight(theme, "수집된 원문이 없음(소스 도달 실패 또는 매칭 0)");
+
+  const apiKey = resolveAiKey();
+  if (!AI_API_URL || !apiKey) {
+    return emptyThemeInsight(theme, "AI 미설정 — 이해 레이어 비활성(정직한 빈 상태)");
+  }
+
+  try {
+    const res = await fetch(AI_API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model: MODEL,
+        temperature: TEMPERATURE,
+        messages: [{ role: "user", content: buildThemeInsightPrompt(theme, docs) }],
+      }),
+      signal: AbortSignal.timeout(45_000),
+    });
+    if (!res.ok) {
+      console.warn("[theme-understanding] LLM", res.status);
+      return emptyThemeInsight(theme, `LLM ${res.status} — 정직한 빈 상태`);
+    }
+    const data = (await res.json()) as LlmResponse;
+    const raw = parseThemeInsightResponse(data.choices?.[0]?.message?.content ?? "");
+    return assembleThemeInsight(theme, docs, raw);
+  } catch (err) {
+    console.warn("[theme-understanding] error", err);
+    return emptyThemeInsight(theme, "이해 레이어 호출 실패 — 정직한 빈 상태");
+  }
+}

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  assembleThemeInsight,
+  emptyThemeInsight,
+  parseThemeInsightResponse,
+  buildThemeInsightPrompt,
+  parseNaverBoardPosts,
+  type SourceDoc,
+} from "../src";
+import type { RawThemeInsight } from "../src/theme-understanding/parse";
+
+const DOCS: SourceDoc[] = [
+  { id: "S1", kind: "news", title: "엔비디아 신고가, HBM 수요 폭발", body: "외국인 매수세가 삼성전자·SK하이닉스로 번졌다.", source: "한국경제" },
+  { id: "S2", kind: "news", title: "반도체 고점 논란, 일부 차익실현", body: "단기 과열 우려에 일부 기관이 차익실현에 나섰다.", source: "매일경제" },
+  { id: "S3", kind: "community", title: "삼성전자 가즈아 풀매수", source: "네이버 종토방 삼성전자" },
+];
+
+const baseRaw: RawThemeInsight = { stocks: [], bull: [], bear: [], wordings: [], stanceNote: "" };
+
+describe("assembleThemeInsight — grounding 가드(환각 차단)", () => {
+  it("원문에 박힌 quote 만 통과, 지어낸 quote 는 폐기", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      stocks: ["삼성전자", "SK하이닉스"],
+      bull: [
+        { claim: "외국인 매수세가 반도체 대형주로 번졌어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }, // grounded
+        { claim: "메모리 초호황 사이클이 시작됐대", sourceId: "S1", quote: "초호황 슈퍼사이클 진입" }, // 원문에 없음 → 폐기
+      ],
+      bear: [{ claim: "단기 과열로 차익실현이 나왔어", sourceId: "S2", quote: "차익실현에 나섰다" }],
+    };
+    const r = assembleThemeInsight("반도체", DOCS, raw);
+    expect(r.bull.map((e) => e.claim)).toEqual(["외국인 매수세가 반도체 대형주로 번졌어"]);
+    expect(r.bear).toHaveLength(1);
+    expect(r.stance).toBe("balanced");
+    expect(r.stocks).toEqual(["삼성전자", "SK하이닉스"]); // 원문에 등장
+  });
+
+  it("존재하지 않는 sourceId 인용 → 폐기", () => {
+    const raw: RawThemeInsight = { ...baseRaw, bull: [{ claim: "근거", sourceId: "S99", quote: "엔비디아" }] };
+    expect(assembleThemeInsight("반도체", DOCS, raw).bull).toHaveLength(0);
+  });
+
+  it("너무 짧은 quote 는 grounding 으로 인정 안 함(아무 데나 걸림 방지)", () => {
+    const raw: RawThemeInsight = { ...baseRaw, bull: [{ claim: "c", sourceId: "S1", quote: "수" }] };
+    expect(assembleThemeInsight("반도체", DOCS, raw).bull).toHaveLength(0);
+  });
+
+  it("투자조언/매매신호 claim 은 폐기(키워드 엔진 가드 재활용)", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "지금 삼성전자 매수해라", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).bull).toHaveLength(0);
+  });
+});
+
+describe("균형(강세/약세) 정직 표기", () => {
+  it("강세만 grounded → bull-dominant + 약세 안 보임 정직 표기", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인이 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+    };
+    const r = assembleThemeInsight("반도체", DOCS, raw);
+    expect(r.stance).toBe("bull-dominant");
+    expect(r.stanceNote).toContain("약세");
+    expect(r.stanceNote).toContain("안 보여");
+  });
+
+  it("강세·약세 둘 다 → balanced", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인 매수", sourceId: "S1", quote: "외국인 매수세" }],
+      bear: [{ claim: "차익실현", sourceId: "S2", quote: "차익실현에 나섰다" }],
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).stance).toBe("balanced");
+  });
+
+  it("grounded 근거 0건 → insufficient(정직한 빈 상태)", () => {
+    const raw: RawThemeInsight = { ...baseRaw, bull: [{ claim: "x", sourceId: "S1", quote: "원문에없는문구입니다" }] };
+    const r = assembleThemeInsight("반도체", DOCS, raw);
+    expect(r.stance).toBe("insufficient");
+    expect(r.confidence).toBe("insufficient");
+  });
+
+  it("원문 없음 / raw null → 정직한 빈 상태", () => {
+    expect(assembleThemeInsight("반도체", [], baseRaw).confidence).toBe("insufficient");
+    expect(assembleThemeInsight("반도체", DOCS, null).confidence).toBe("insufficient");
+    expect(emptyThemeInsight("반도체", "테스트").bull).toEqual([]);
+  });
+
+  it("confidence 는 PoC 상 최대 low(가짜 high 금지)", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인 매수", sourceId: "S1", quote: "외국인 매수세" }],
+      bear: [{ claim: "차익실현", sourceId: "S2", quote: "차익실현에 나섰다" }],
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).confidence).toBe("low");
+  });
+
+  it("사용된 출처만 sources 에(검증용 — 근거가 가리킨 원문)", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인 매수", sourceId: "S1", quote: "외국인 매수세" }],
+    };
+    const r = assembleThemeInsight("반도체", DOCS, raw);
+    expect(r.sources.map((s) => s.id)).toEqual(["S1"]);
+  });
+});
+
+describe("워딩(여론 원문) grounding", () => {
+  it("커뮤니티 원문에 실재하는 워딩만 통과", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인 매수", sourceId: "S1", quote: "외국인 매수세" }],
+      wordings: [
+        { text: "가즈아 풀매수", sourceId: "S3" }, // 원문에 있음
+        { text: "다들 손절했다더라", sourceId: "S3" }, // 원문에 없음 → 폐기
+      ],
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).wordings.map((w) => w.text)).toEqual(["가즈아 풀매수"]);
+  });
+});
+
+describe("parse / prompt / 커뮤니티 원문 보존", () => {
+  it("parseThemeInsightResponse — 코드펜스/잡텍스트 허용", () => {
+    const raw = '응답:\n```json\n{"stocks":["삼성전자"],"bull":[{"claim":"c","sourceId":"S1","quote":"q"}],"bear":[],"wordings":[],"stanceNote":""}\n```';
+    const p = parseThemeInsightResponse(raw)!;
+    expect(p.stocks).toEqual(["삼성전자"]);
+    expect(p.bull).toHaveLength(1);
+    expect(parseThemeInsightResponse("not json")).toBeNull();
+  });
+
+  it("buildThemeInsightPrompt — 원문 번호·환각금지·균형·JSON 지시 포함", () => {
+    const p = buildThemeInsightPrompt("반도체", DOCS);
+    expect(p).toContain("[S1]");
+    expect(p).toContain("일반론");
+    expect(p).toMatch(/강세|약세/);
+    expect(p).toContain("quote");
+  });
+
+  it("parseNaverBoardPosts — 제목 보존 + 감성 분류(개수 아님)", () => {
+    const html = `
+      <a href="board_read.naver?code=005930&nid=1" title="삼성전자 가즈아 풀매수">x</a><span>2026.06.14 11:00</span>
+      <a href="board_read.naver?code=005930&nid=2" title="고점이다 손절각">y</a><span>2026.06.14 10:00</span>
+    `;
+    const posts = parseNaverBoardPosts(html, Date.parse("2026-06-14T03:30:00Z"), 10);
+    expect(posts).toHaveLength(2);
+    expect(posts.map((p) => p.title)).toContain("삼성전자 가즈아 풀매수");
+    expect(posts.find((p) => p.title.includes("가즈아"))!.tone).toBe("bull");
+    expect(posts.find((p) => p.title.includes("손절"))!.tone).toBe("bear");
+  });
+});

--- a/packages/fomo-core/src/index-engine/naverFetcher.ts
+++ b/packages/fomo-core/src/index-engine/naverFetcher.ts
@@ -141,3 +141,71 @@ export async function fetchNaverSignals(
     .map((r) => r.value)
     .filter((v): v is CommunitySourceSignal => v != null);
 }
+
+// ── 원문 보존 게시물 (DATA_ENGINE_STRATEGY Track A — 제목을 버리지 않는다) ──────────
+// 기존 parseNaverBoard 는 집계(개수)만 반환한다. 이해 레이어는 글 제목 원문이 필요해
+// *추가* 함수로 제목을 보존해 돌려준다(기존 집계 경로는 그대로).
+
+export interface NaverBoardPost {
+  /** 게시물 제목 원문. */
+  title: string;
+  /** 작성 시각(ms, KST). 파싱 실패 시 null. */
+  tsMs: number | null;
+  /** 제목 감성 분류(강세/약세 균형 참고용). */
+  tone: "bull" | "bear" | "neutral";
+}
+
+/**
+ * 네이버 종토 HTML → 게시물 제목 배열(순수). 최근 24h 우선, 최신순, limit 개.
+ * parseNaverBoard 와 같은 추출 로직을 쓰되 *집계하지 않고 제목을 보존*한다.
+ */
+export function parseNaverBoardPosts(html: string, nowMs: number, limit = 15): NaverBoardPost[] {
+  try {
+    const titles = [...html.matchAll(/board_read\.naver\?[^"]*"[^>]*title="([^"]*)"/g)]
+      .map((m) => (m[1] ?? "").trim())
+      .filter((t) => t.length > 0);
+    if (titles.length === 0) return [];
+
+    const dates = [...html.matchAll(/(\d{4}\.\d{2}\.\d{2} \d{2}:\d{2})/g)].map((m) => m[1] ?? "");
+    const cutoff = nowMs - 24 * 3600 * 1000;
+    const aligned = dates.length === titles.length;
+
+    const posts: NaverBoardPost[] = titles.map((title, i) => ({
+      title,
+      tsMs: aligned ? parseNaverDate(dates[i]!) : null,
+      tone: classifyKoreanTitle(title),
+    }));
+
+    const recent = aligned
+      ? posts.filter((p) => p.tsMs == null || p.tsMs >= cutoff)
+      : posts;
+    // 최신순(시각 없는 건 뒤로).
+    recent.sort((a, b) => (b.tsMs ?? 0) - (a.tsMs ?? 0));
+    return recent.slice(0, limit);
+  } catch {
+    return [];
+  }
+}
+
+/** 단일 종목 종토 게시물 제목 fetch (실패 시 빈 배열 — 정직한 폴백). */
+export async function fetchNaverBoardPosts(
+  code: string,
+  timeoutMs = 5000,
+  nowMs: number = Date.now(),
+  limit = 15,
+): Promise<NaverBoardPost[]> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    const res = await fetch(`https://finance.naver.com/item/board.naver?code=${encodeURIComponent(code)}`, {
+      headers: { "User-Agent": UA, "Accept-Language": "ko-KR,ko;q=0.9" },
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const html = await res.text();
+    return parseNaverBoardPosts(html, nowMs, limit);
+  } catch {
+    return [];
+  }
+}

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./news-feed";
 export * from "./stock-cards";
 export * from "./keyword-cards";
 export * from "./shake-score";
+export * from "./theme-understanding";
 export * from "./voices";
 export * from "./index-engine/types";
 export * from "./index-engine/marketHeat";

--- a/packages/fomo-core/src/theme-understanding/assemble.ts
+++ b/packages/fomo-core/src/theme-understanding/assemble.ts
@@ -1,0 +1,187 @@
+import type {
+  Evidence,
+  InsightSourceRef,
+  KeyWording,
+  SourceDoc,
+  ThemeInsight,
+  ThemeInsightConfidence,
+  ThemeStance,
+} from "./types";
+import type { RawEvidence, RawThemeInsight, RawWording } from "./parse";
+
+/**
+ * 이해 레이어의 핵심 가드 — DATA_ENGINE_STRATEGY §6 / 운영자 강조.
+ *
+ * LLM 이 뱉은 raw 구조화를 *원문에 박힌 것만* 남기고 조립한다:
+ *  1) 환각 차단: 각 근거의 quote 가 인용한 SourceDoc 의 제목/본문에 실제 substring 으로 있어야 통과.
+ *     없으면 폐기(일반론·지어낸 근거 제거). sourceId 가 없는 원문을 가리켜도 폐기.
+ *  2) 투자조언 가드: claim 이 금칙어(매수/매도/오른다 단정 등) 위반이면 폐기(키워드 엔진 가드 재활용).
+ *  3) 균형: 강세/약세 둘 다 살아남으면 balanced, 한쪽뿐이면 그 사실을 stanceNote 로 정직하게.
+ *  4) 정직한 빈 상태: grounded 근거가 0이면 confidence "insufficient".
+ */
+
+/**
+ * 이해 레이어 전용 투자조언/매매신호 가드.
+ *
+ * 키워드 코멘트 가드(COMMENT_FORBIDDEN)와 *목적이 다르다*: 코멘트는 친구 목소리라 "매수/매도"
+ * 단어 자체를 막지만, 이해 레이어의 claim 은 *사실 보도*다("외국인 매수세가 번졌다"는 판단 재료지 신호 아님).
+ * 그래서 단어가 아니라 **행동 지시(명령형)·미래 단정·추천**만 막는다 — 사실(과거/현재 매수·매도 동향)은 허용.
+ * "판단 재료지 답이 아님" 원칙을 더 정확히 강제한다.
+ */
+export const INSIGHT_FORBIDDEN: RegExp =
+  /사라|팔아라|사세요|파세요|매수\s*(?:해|하세요|하라|추천|타이밍)|매도\s*(?:해|하세요|하라|추천)|손절\s*(?:해|하세요|하라)|익절\s*(?:해|하세요|하라)|담아라|담으세요|들어가라|들어가세요|풀매수\s*(?:해|하라|각)|불타기|줍줍|추천(?:해|할|합니다|한다|드려|드립니다)|오른다|오를\s*(?:거|것|듯|전망|예정)|내린다|내릴\s*(?:거|것|듯)|급등할|폭등할|폭락할|간다|가즈아|텐배거|떡상|떡락|목표가|지금\s*안\s*사면/;
+
+/** 인용 검증용 정규화 — 공백 제거(LLM 이 띄어쓰기를 다르게 옮겨도 매칭). */
+function norm(s: string): string {
+  return s.replace(/\s+/g, "");
+}
+
+/** quote 가 너무 짧으면(아무 데나 걸림) grounding 으로 인정 안 함. */
+const MIN_QUOTE_LEN = 4;
+
+function isGrounded(quote: string, docText: string): boolean {
+  const q = norm(quote);
+  if (q.length < MIN_QUOTE_LEN) return false;
+  return norm(docText).includes(q);
+}
+
+/** raw 근거 배열 → grounded + 투자조언 가드 통과 + 중복 제거. */
+function groundEvidence(
+  raw: readonly RawEvidence[],
+  docById: Map<string, SourceDoc>
+): Evidence[] {
+  const out: Evidence[] = [];
+  const seen = new Set<string>();
+  for (const e of raw) {
+    const doc = docById.get(e.sourceId);
+    if (!doc) continue; // 존재하지 않는 원문 인용 → 폐기(환각)
+    const docText = `${doc.title} ${doc.body ?? ""}`;
+    if (!isGrounded(e.quote, docText)) continue; // 원문에 없는 인용 → 폐기(환각)
+    if (INSIGHT_FORBIDDEN.test(e.claim)) continue; // 투자조언/매매신호(명령·예측·추천) → 폐기
+    const key = norm(e.claim);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ claim: e.claim, sourceId: e.sourceId, quote: e.quote });
+  }
+  return out;
+}
+
+function groundWordings(
+  raw: readonly RawWording[],
+  docById: Map<string, SourceDoc>
+): KeyWording[] {
+  const out: KeyWording[] = [];
+  const seen = new Set<string>();
+  for (const w of raw) {
+    const doc = docById.get(w.sourceId);
+    if (!doc) continue;
+    const docText = `${doc.title} ${doc.body ?? ""}`;
+    if (!isGrounded(w.text, docText)) continue; // 워딩도 원문에 실재해야(지어낸 여론 차단)
+    const key = norm(w.text);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ text: w.text, sourceId: w.sourceId });
+  }
+  return out;
+}
+
+function decideStance(bull: number, bear: number): { stance: ThemeStance; note: string } {
+  if (bull === 0 && bear === 0)
+    return { stance: "insufficient", note: "원문에서 강세·약세 근거를 충분히 찾지 못했어." };
+  if (bull > 0 && bear === 0)
+    return { stance: "bull-dominant", note: "오늘은 강세 의견이 우세하고, 반대(약세) 관점은 원문에서 안 보여." };
+  if (bear > 0 && bull === 0)
+    return { stance: "bear-dominant", note: "오늘은 약세/리스크 쪽 얘기가 우세하고, 강세 관점은 원문에서 안 보여." };
+  return { stance: "balanced", note: "강세와 약세 관점이 원문에 둘 다 있어." };
+}
+
+/** 근거가 인용한 원문만 출처 목록으로(검증용). */
+function usedSources(
+  bull: readonly Evidence[],
+  bear: readonly Evidence[],
+  wordings: readonly KeyWording[],
+  docById: Map<string, SourceDoc>
+): InsightSourceRef[] {
+  const ids = new Set<string>();
+  for (const e of [...bull, ...bear]) ids.add(e.sourceId);
+  for (const w of wordings) ids.add(w.sourceId);
+  const out: InsightSourceRef[] = [];
+  for (const id of ids) {
+    const d = docById.get(id);
+    if (!d) continue;
+    out.push({
+      id: d.id,
+      kind: d.kind,
+      title: d.title,
+      ...(d.source ? { source: d.source } : {}),
+      ...(d.url ? { url: d.url } : {}),
+    });
+  }
+  return out;
+}
+
+/** 원문이 아예 없을 때 등 — 정직한 빈 상태. */
+export function emptyThemeInsight(theme: string, reason: string): ThemeInsight {
+  return {
+    theme,
+    stocks: [],
+    bull: [],
+    bear: [],
+    wordings: [],
+    stance: "insufficient",
+    stanceNote: "보여줄 만큼 원문이 모이지 않았어. 그것도 정상이야.",
+    sources: [],
+    confidence: "insufficient",
+    reason,
+  };
+}
+
+/**
+ * raw(LLM 출력) + 원문 → 검증된 ThemeInsight. raw 가 null(파싱 실패)이면 정직한 빈 상태.
+ */
+export function assembleThemeInsight(
+  theme: string,
+  docs: readonly SourceDoc[],
+  raw: RawThemeInsight | null
+): ThemeInsight {
+  if (docs.length === 0) return emptyThemeInsight(theme, "수집된 원문이 없음");
+  if (!raw) return emptyThemeInsight(theme, "이해 레이어 응답 파싱 실패 — 정직한 빈 상태");
+
+  const docById = new Map(docs.map((d) => [d.id, d]));
+  const bull = groundEvidence(raw.bull, docById);
+  const bear = groundEvidence(raw.bear, docById);
+  const wordings = groundWordings(raw.wordings, docById);
+
+  // 원문에 언급된 종목만(가벼운 검증 — 종목명이 원문 어딘가 등장).
+  const corpus = norm(docs.map((d) => `${d.title} ${d.body ?? ""}`).join(" "));
+  const stocks = raw.stocks.filter((s) => corpus.includes(norm(s)));
+
+  const grounded = bull.length + bear.length;
+  if (grounded === 0) {
+    return {
+      ...emptyThemeInsight(theme, "원문 grounded 근거 0건 — 환각 가드가 전부 폐기"),
+      stocks,
+      wordings,
+      sources: usedSources([], [], wordings, docById),
+    };
+  }
+
+  const { stance, note } = decideStance(bull.length, bear.length);
+  // 일방이면 LLM 의 stanceNote 보다 우리가 계산한 정직 표기를 우선(가짜 균형 방지).
+  const stanceNote = stance === "balanced" && raw.stanceNote ? raw.stanceNote : note;
+  // PoC: 30일 기준선 없음 → 최대 "low"(가짜 high 금지). grounded 만 있으면 low.
+  const confidence: ThemeInsightConfidence = "low";
+
+  return {
+    theme,
+    stocks,
+    bull,
+    bear,
+    wordings,
+    stance,
+    stanceNote,
+    sources: usedSources(bull, bear, wordings, docById),
+    confidence,
+    reason: `원문 ${docs.length}건 → grounded 강세 ${bull.length} · 약세 ${bear.length} · 워딩 ${wordings.length} (30일 기준선 없어 low)`,
+  };
+}

--- a/packages/fomo-core/src/theme-understanding/index.ts
+++ b/packages/fomo-core/src/theme-understanding/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./prompt";
+export * from "./parse";
+export * from "./assemble";

--- a/packages/fomo-core/src/theme-understanding/parse.ts
+++ b/packages/fomo-core/src/theme-understanding/parse.ts
@@ -1,0 +1,77 @@
+/**
+ * LLM 응답(JSON) 파서 — 순수. 코드펜스/잡텍스트 허용. 검증·grounding 은 assemble 이 한다.
+ */
+
+export interface RawEvidence {
+  claim: string;
+  sourceId: string;
+  quote: string;
+}
+export interface RawWording {
+  text: string;
+  sourceId: string;
+}
+export interface RawThemeInsight {
+  stocks: string[];
+  bull: RawEvidence[];
+  bear: RawEvidence[];
+  wordings: RawWording[];
+  stanceNote: string;
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+function strArr(v: unknown): string[] {
+  return Array.isArray(v) ? v.map(str).filter(Boolean) : [];
+}
+function evidenceArr(v: unknown): RawEvidence[] {
+  if (!Array.isArray(v)) return [];
+  const out: RawEvidence[] = [];
+  for (const r of v) {
+    if (r && typeof r === "object") {
+      const o = r as Record<string, unknown>;
+      const claim = str(o.claim);
+      const sourceId = str(o.sourceId);
+      const quote = str(o.quote);
+      if (claim && sourceId) out.push({ claim, sourceId, quote });
+    }
+  }
+  return out;
+}
+function wordingArr(v: unknown): RawWording[] {
+  if (!Array.isArray(v)) return [];
+  const out: RawWording[] = [];
+  for (const r of v) {
+    if (r && typeof r === "object") {
+      const o = r as Record<string, unknown>;
+      const text = str(o.text);
+      const sourceId = str(o.sourceId);
+      if (text && sourceId) out.push({ text, sourceId });
+    }
+  }
+  return out;
+}
+
+/** content → RawThemeInsight. 파싱 불가 시 null(호출부가 정직한 빈 상태로). */
+export function parseThemeInsightResponse(content: string): RawThemeInsight | null {
+  if (!content) return null;
+  const start = content.indexOf("{");
+  const end = content.lastIndexOf("}");
+  if (start === -1 || end <= start) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(content.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const o = obj as Record<string, unknown>;
+  return {
+    stocks: strArr(o.stocks),
+    bull: evidenceArr(o.bull),
+    bear: evidenceArr(o.bear),
+    wordings: wordingArr(o.wordings),
+    stanceNote: str(o.stanceNote),
+  };
+}

--- a/packages/fomo-core/src/theme-understanding/prompt.ts
+++ b/packages/fomo-core/src/theme-understanding/prompt.ts
@@ -1,0 +1,42 @@
+import type { SourceDoc } from "./types";
+
+/**
+ * 이해 레이어 프롬프트 — DATA_ENGINE_STRATEGY §4 Track A. 순수(네트워크 0).
+ *
+ * 핵심 제약(SSOT, 운영자 강조):
+ * 1) 근거는 *제공된 원문에만* 출처가 있어야 한다. 일반론·배경지식 금지("반도체는 경기민감주"류 X).
+ *    각 근거에 그 원문에 실제로 있는 문구(quote)를 함께 — assemble 이 substring 으로 검증, 없으면 폐기.
+ * 2) 강세/약세 둘 다. 한쪽뿐이면 지어내지 말고 그 사실을 stanceNote 로 정직하게.
+ * 3) 투자조언·매매신호 금지(사라/팔아라/오른다 단정 X). 판단 재료지 답이 아님.
+ */
+export function buildThemeInsightPrompt(theme: string, docs: readonly SourceDoc[]): string {
+  const corpus = docs
+    .map((d) => {
+      const meta = [d.source, d.publishedAt].filter(Boolean).join(" · ");
+      const bodyLine = d.body ? `\n   본문: ${d.body}` : "";
+      return `[${d.id}] (${d.kind}${meta ? " · " + meta : ""})\n   제목: ${d.title}${bodyLine}`;
+    })
+    .join("\n\n");
+
+  return [
+    `너는 '${theme}' 테마를 조사하는 애널리스트다. 아래 *수집된 원문만* 읽고 구조화해라.`,
+    "수집한 원문 외의 배경지식·일반론은 절대 쓰지 마라(예: '반도체는 변동성이 크다' 같은 일반론 금지).",
+    "",
+    "규칙(어기면 그 항목은 폐기된다):",
+    "1) 모든 강세/약세 근거는 위 원문 중 하나에서 나와야 한다. 각 근거에:",
+    "   - claim: 그 근거를 친구에게 설명하듯 한 줄(쉽게, 용어 풀어서).",
+    "   - sourceId: 근거가 나온 원문 번호(예: \"S1\").",
+    "   - quote: 그 원문 제목/본문에 *실제로 있는* 문구를 그대로(짧게라도). 지어내지 마라.",
+    "2) 강세(bull)와 약세(bear)를 모두 찾아라. 한쪽이 원문에 정말 없으면 그쪽은 빈 배열로 두고,",
+    "   stanceNote 에 그 사실을 적어라(예: \"약세 관점은 원문에서 안 보임\"). 없는 근거를 만들지 마라.",
+    "3) 투자조언·매매신호·미래 단정 금지(사라/팔아라/매수/오른다/목표가 X). 사실 전달만.",
+    "4) wordings: 사람들이 *실제로 한 말*(특히 커뮤니티 원문)을 그대로 인용. 없으면 빈 배열.",
+    "5) stocks: 원문에서 언급된 종목/섹터만.",
+    "",
+    "수집된 원문:",
+    corpus || "(원문 없음)",
+    "",
+    "출력은 JSON 객체만(그 외 텍스트 0):",
+    '{"stocks":[],"bull":[{"claim":"","sourceId":"S1","quote":""}],"bear":[],"wordings":[{"text":"","sourceId":"S2"}],"stanceNote":""}',
+  ].join("\n");
+}

--- a/packages/fomo-core/src/theme-understanding/types.ts
+++ b/packages/fomo-core/src/theme-understanding/types.ts
@@ -1,0 +1,74 @@
+/**
+ * 이해 레이어 타입 — DATA_ENGINE_STRATEGY §3·§4 Track A.
+ *
+ * 기존 키워드 엔진(extract/score/comment)은 "카운팅"이다. 이 레이어는 그 위에 *추가*로,
+ * 수집한 원문을 LLM 이 *읽고* 구조화한 "판단 재료"를 만든다(분류 아닌 이해).
+ *
+ * 절대 규칙(SSOT): 근거는 원문에 출처가 있어야 한다(환각 금지) · 강세/약세 균형(일방이면 정직 표기) ·
+ *   투자조언/매매신호 금지(판단 재료지 답이 아님) · 데이터 부족 시 정직한 빈 상태.
+ */
+
+export type SourceKind = "news" | "community";
+
+/** 수집한 원문 1건(제목·본문 보존 — 커뮤니티 글도 제목을 버리지 않는다). */
+export interface SourceDoc {
+  /** 인용 식별자(예: "S1"). 근거가 어느 원문에서 나왔는지 추적·검증용. */
+  id: string;
+  kind: SourceKind;
+  title: string;
+  /** 요약/본문(있으면). 뉴스 RSS 요약·커뮤니티 본문 등. */
+  body?: string;
+  /** 매체/커뮤니티명(예: "한국경제", "네이버 종토방 005930"). */
+  source?: string;
+  url?: string;
+  publishedAt?: string;
+}
+
+/** 강세/약세 근거 1건 — 반드시 원문에 박힌 인용으로 뒷받침. */
+export interface Evidence {
+  /** 재가공된 근거 한 줄(이해의 결과). */
+  claim: string;
+  /** 어느 SourceDoc 에서 나왔나(SourceDoc.id). */
+  sourceId: string;
+  /** 그 원문에 *실제로* 있는 문구(검증용 — assemble 이 substring 으로 확인, 없으면 폐기). */
+  quote: string;
+}
+
+/** 사람들이 실제로 한 말(여론 워딩 — 개수가 아니라 내용). */
+export interface KeyWording {
+  text: string;
+  sourceId: string;
+}
+
+export type ThemeStance = "balanced" | "bull-dominant" | "bear-dominant" | "insufficient";
+export type ThemeInsightConfidence = "ok" | "low" | "insufficient";
+
+/** 응답에 동봉하는 원문 출처(유저/검수자가 근거를 원문과 대조). */
+export interface InsightSourceRef {
+  id: string;
+  kind: SourceKind;
+  title: string;
+  source?: string;
+  url?: string;
+}
+
+/** 한 테마의 이해·구조화 결과. */
+export interface ThemeInsight {
+  theme: string;
+  /** 원문에서 짚힌 종목/섹터. */
+  stocks: string[];
+  /** 강세 근거(원문 grounded). */
+  bull: Evidence[];
+  /** 약세 근거(원문 grounded). */
+  bear: Evidence[];
+  /** 사람들 실제 워딩. */
+  wordings: KeyWording[];
+  stance: ThemeStance;
+  /** 일방일 때 그 사실을 정직하게(예: "약세 관점은 원문에서 안 보임"). */
+  stanceNote: string;
+  /** 근거가 박힌 원문 목록(검증용). */
+  sources: InsightSourceRef[];
+  confidence: ThemeInsightConfidence;
+  /** 정직성/디버그 — 왜 이 confidence·stance 인지. */
+  reason: string;
+}


### PR DESCRIPTION
DATA_ENGINE_STRATEGY §4 Phase A. **카드 엔진(Phase 1~5)과 별개인 데이터 엔진 트랙.** 기존 extract/score/comment·UI·카드·점수 불변, 그 위에 "이해" 레이어를 *추가*. 뒷단만.

수집한 원문(뉴스+종토방)을 LLM이 **읽고 구조화** — 카운팅이 아니라 이해.

## 구조 (순수 ↔ LLM 분리)
- **순수부** `packages/fomo-core/src/theme-understanding/`: `SourceDoc`(원문 보존)·`Evidence{claim,sourceId,quote}`·`ThemeInsight` + 프롬프트 + 파서 + **assemble(가드)**.
- **원문 보존** `naverFetcher.ts`: `parseNaverBoardPosts`/`fetchNaverBoardPosts` 추가 — 종토방 **제목 원문 보존**(기존 집계 경로 불변).
- **LLM·수집부** `apps/web/lib/theme-understanding.ts`: 반도체 원문 수집 → LLM → assemble.

## 두 핵심 가드 (운영자 강조)
1. **환각 차단(grounding)**: 각 근거의 `quote`가 인용한 원문에 **실제 substring으로 박혀있어야 통과** — 없으면 폐기. 존재 않는 sourceId·너무 짧은 quote도 폐기. → 일반론/지어낸 근거 제거.
2. **강세/약세 균형**: 둘 다 grounded면 `balanced`, 한쪽뿐이면 지어내지 않고 **그 사실을 stanceNote로 정직 표기**("약세 관점은 원문에서 안 보임").
- + `INSIGHT_FORBIDDEN`: 명령/예측/추천만 폐기. 사실 보도("외국인 매수세")는 허용 — 코멘트 가드와 목적 구분.
- + 데이터 부족/AI 미설정/파싱 실패 → `insufficient` **정직한 빈 상태**.

## 검증
- typecheck ✅ / vitest **594**(+14: grounding 폐기·균형·빈상태·파서·종토방 제목보존) ✅ / build:web ✅
- **실데이터(반도체)**: 원문 22건(뉴스 12+종토방 10) → 강세 9·약세 1 (**balanced**). 각 근거에 원문 인용+S# 출처 첨부(예: "반도체 슈퍼사이클 이제 막 시작됐다"[S7=한경 실기사]). 종토방 워딩 보존("하닉 팔고", "하이닉스 내일 개폭등 예정").
- **정직한 빈 상태**: AI 미설정 시 `insufficient`, 근거 0 — 가짜 생성 없음.

## 안 한 것 (범위 밖)
- 소스 확장(Track C), 지식 누적(Track D), 재가공 응축(Track B), UI/카드/점수 변경.

User Zero 검수용입니다. 각 강세/약세가 "어느 원문에서 나왔는지" S# + 인용으로 대조 가능. 머지는 직접.

🤖 Generated with [Claude Code](https://claude.com/claude-code)