### PR TITLE
Track B: 재가공/응축 + 뎁스 화면 반영

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1,13 +1,63 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { scoreToColor, type KeywordCard } from "@fomo/core";
+import { fetchThemeInsight, type CondensedInsight } from "@/lib/fomoApi";
 
 /**
  * 키워드 뎁스 페이지 — 카드/히스토리에서 공용. KEYWORD_CARD_FEED_DEV_SPEC v3 §3.
- * "오늘 왜 쏠렸어" + "근데 이건 기억해"(균형추) + 관련 종목 미니 + 유료자리 표시 + 면책.
+ *
+ * 데이터 엔진 Track A+B: 카드 탭 시 /api/fomo/theme-insight 를 lazy fetch 해
+ * "강세 관점 / 약세 관점 / 사람들 워딩"(원문 grounded 응축)을 보여준다. 출처 링크로 원문 검증 가능.
+ * 응축이 아직(로딩)이거나 데이터 부족(insufficient)이면 기존 뉴스 소스(#500)로 정직하게 폴백.
+ * 메인 카드·스와이프는 안 건드린다 — 뎁스 콘텐츠만.
  */
 export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose: () => void }) {
   const color = scoreToColor(card.fomoScore);
+  const [insight, setInsight] = useState<CondensedInsight | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setInsight(null);
+    fetchThemeInsight(card.keyword)
+      .then((r) => alive && setInsight(r))
+      .catch(() => alive && setInsight(null))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [card.keyword]);
+
+  const hasInsight =
+    !!insight && insight.confidence !== "insufficient" && insight.bull.length + insight.bear.length > 0;
+
+  // sourceId → 원문(링크용).
+  const srcOf = (id: string) => insight?.sources.find((s) => s.id === id);
+
+  const evidenceItem = (claim: string, sourceId: string, key: string) => {
+    const s = srcOf(sourceId);
+    return (
+      <li key={key} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+        <span className="block text-sm leading-5 text-whiteout">{claim}</span>
+        {s &&
+          (s.url ? (
+            <a
+              href={s.url}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-1 block text-[11px] text-muted hover:text-whiteout"
+            >
+              ↳ {s.source ?? s.title} · 원문 보기 →
+            </a>
+          ) : (
+            <span className="mt-1 block text-[11px] text-muted">↳ {s.source ?? s.title}</span>
+          ))}
+      </li>
+    );
+  };
+
   return (
     <div className="fixed inset-0 z-[60] bg-black">
       <div className="mx-auto flex h-full max-w-md flex-col">
@@ -27,39 +77,91 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
           <p className="text-sm leading-6 text-whiteout">{card.comment}</p>
 
+          {/* 왜 떴나 — 응축이 있으면 grounded whyHot, 없으면 기존 키워드 why */}
           <section className="mt-7">
             <p className="font-pixel text-sm text-whiteout">{card.depth.whyTitle}</p>
-            <p className="mt-2 text-sm leading-6 text-muted">{card.depth.why}</p>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              {hasInsight ? insight!.whyHot : card.depth.why}
+            </p>
           </section>
 
-          {card.sources.length > 0 && (
-            <section className="mt-6">
-              <p className="font-pixel text-sm text-whiteout">오늘 이런 뉴스가 돌았어</p>
-              <ul className="mt-2 space-y-2">
-                {card.sources.map((s, i) =>
-                  s.url ? (
-                    <li key={i}>
-                      <a
-                        href={s.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="block rounded-lg border border-hairline bg-surface px-3 py-2 transition-colors hover:border-whiteout/30"
-                      >
-                        <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
-                        {s.source && (
-                          <span className="mt-0.5 block text-[11px] text-muted">{s.source} · 원문 보기 →</span>
-                        )}
-                      </a>
-                    </li>
-                  ) : (
-                    <li key={i} className="rounded-lg border border-hairline bg-surface px-3 py-2">
-                      <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
-                      {s.source && <span className="mt-0.5 block text-[11px] text-muted">{s.source}</span>}
-                    </li>
-                  )
+          {hasInsight ? (
+            <>
+              <section className="mt-6">
+                <p className="font-pixel text-sm" style={{ color: "var(--up, #ff5a5f)" }}>
+                  📈 강세 관점
+                </p>
+                {insight!.bull.length > 0 ? (
+                  <ul className="mt-2 space-y-2">
+                    {insight!.bull.map((p, i) => evidenceItem(p.claim, p.sourceId, `bull-${i}`))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-sm leading-6 text-muted">원문에서 강세 근거는 안 보였어.</p>
                 )}
-              </ul>
-            </section>
+              </section>
+
+              <section className="mt-6">
+                <p className="font-pixel text-sm" style={{ color: "var(--down, #4f8cff)" }}>
+                  📉 약세 관점
+                </p>
+                {insight!.bear.length > 0 ? (
+                  <ul className="mt-2 space-y-2">
+                    {insight!.bear.map((p, i) => evidenceItem(p.claim, p.sourceId, `bear-${i}`))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-sm leading-6 text-muted">{insight!.stanceNote}</p>
+                )}
+              </section>
+
+              {insight!.wordings.length > 0 && (
+                <section className="mt-6">
+                  <p className="font-pixel text-sm text-whiteout">🗣️ 사람들 워딩</p>
+                  <ul className="mt-2 space-y-2">
+                    {insight!.wordings.map((w, i) => {
+                      const s = srcOf(w.sourceId);
+                      return (
+                        <li key={`w-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                          <span className="block text-sm leading-5 text-whiteout">“{w.text}”</span>
+                          {s && <span className="mt-1 block text-[11px] text-muted">↳ {s.source ?? s.title}</span>}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              )}
+            </>
+          ) : (
+            // 폴백 — 로딩 중이거나 응축 부족: 기존 뉴스 소스(#500). 빈 화면 금지.
+            card.sources.length > 0 && (
+              <section className="mt-6">
+                <p className="font-pixel text-sm text-whiteout">오늘 이런 뉴스가 돌았어</p>
+                {loading && <p className="mt-1 text-[11px] text-muted">원문 읽는 중…</p>}
+                <ul className="mt-2 space-y-2">
+                  {card.sources.map((s, i) =>
+                    s.url ? (
+                      <li key={i}>
+                        <a
+                          href={s.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="block rounded-lg border border-hairline bg-surface px-3 py-2 transition-colors hover:border-whiteout/30"
+                        >
+                          <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
+                          {s.source && (
+                            <span className="mt-0.5 block text-[11px] text-muted">{s.source} · 원문 보기 →</span>
+                          )}
+                        </a>
+                      </li>
+                    ) : (
+                      <li key={i} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                        <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
+                        {s.source && <span className="mt-0.5 block text-[11px] text-muted">{s.source}</span>}
+                      </li>
+                    )
+                  )}
+                </ul>
+              </section>
+            )
           )}
 
           <section className="mt-6">

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -89,6 +89,13 @@ export interface KeywordsResponse {
 }
 export const fetchKeywords = () => get<KeywordsResponse>("/api/fomo/keywords");
 
+/** 테마 이해·응축(데이터 엔진 Track A+B) — 뎁스 페이지가 카드 탭 시 lazy 로 부른다. */
+export type { CondensedInsight } from "@fomo/core";
+export const fetchThemeInsight = (theme: string) =>
+  get<import("@fomo/core").CondensedInsight>(
+    `/api/fomo/theme-insight?theme=${encodeURIComponent(theme)}`
+  );
+
 export const fetchCalendar = (sessionId: string, month?: string) =>
   get<CalendarResponse>(
     `/api/fomo/emotions/calendar?sessionId=${encodeURIComponent(sessionId)}${month ? `&month=${month}` : ""}`

--- a/apps/web/app/api/fomo/theme-insight/route.ts
+++ b/apps/web/app/api/fomo/theme-insight/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
+import { withCors } from "../../../../lib/fomo";
+import { understandTheme } from "../../../../lib/theme-understanding";
+
+/**
+ * 테마 이해·응축 API — DATA_ENGINE_STRATEGY Track A+B. 뎁스 페이지가 카드 탭 시 lazy 로 부른다.
+ *
+ * understandTheme(A: 원문 읽고 grounded 구조화) → condenseThemeInsight(B: 한 카드 분량 결정론적 응축).
+ * 메인 피드(/api/fomo/keywords)는 안 건드린다 — 무겁기 때문(LLM+종토 fetch)에 *탭할 때만* 산출.
+ *
+ * 정직성: AI 미설정·원문 부족 → confidence:"insufficient"(가짜 응축 금지). 뎁스는 그때 기존 소스로 폴백.
+ */
+export const dynamic = "force-dynamic";
+// 원문 수집 + LLM 이해가 수십 초 걸릴 수 있어 데드라인 넉넉히.
+export const maxDuration = 60;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+// 테마별 TTL 캐시 + in-flight dedup(같은 테마 동시 탭 → 외부 소스 반복 폭격 방지).
+const TTL_MS = 30 * 60 * 1000;
+const cache = new Map<string, { at: number; payload: CondensedInsight }>();
+const inflight = new Map<string, Promise<CondensedInsight>>();
+
+async function getInsight(theme: string): Promise<CondensedInsight> {
+  const hit = cache.get(theme);
+  if (hit && Date.now() - hit.at < TTL_MS) return hit.payload;
+
+  const running = inflight.get(theme);
+  if (running) return running;
+
+  const p = (async () => {
+    const insight = await understandTheme(theme);
+    const condensed = condenseThemeInsight(insight);
+    cache.set(theme, { at: Date.now(), payload: condensed });
+    return condensed;
+  })().finally(() => inflight.delete(theme));
+
+  inflight.set(theme, p);
+  return p;
+}
+
+export async function GET(req: Request) {
+  const theme = new URL(req.url).searchParams.get("theme")?.trim();
+  if (!theme) {
+    return withCors(NextResponse.json({ error: "theme required" }, { status: 400 }));
+  }
+  const payload = await getInsight(theme);
+  return withCors(
+    NextResponse.json(payload, {
+      headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=1800" },
+    })
+  );
+}

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -5,7 +5,9 @@ import {
   parseThemeInsightResponse,
   buildThemeInsightPrompt,
   parseNaverBoardPosts,
+  condenseThemeInsight,
   type SourceDoc,
+  type ThemeInsight,
 } from "../src";
 import type { RawThemeInsight } from "../src/theme-understanding/parse";
 
@@ -136,6 +138,62 @@ describe("parse / prompt / 커뮤니티 원문 보존", () => {
     expect(p).toContain("일반론");
     expect(p).toMatch(/강세|약세/);
     expect(p).toContain("quote");
+  });
+
+  it("condenseThemeInsight — 응축은 grounded claim 만 조립(새 사실 없음) + 균형 유지", () => {
+    const insight: ThemeInsight = {
+      theme: "반도체",
+      stocks: ["삼성전자"],
+      bull: [
+        { claim: "외국인이 삼성전자를 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" },
+        { claim: "소부장 ETF가 뛰었어", sourceId: "S2", quote: "소부장 ETF 뛰었다" },
+        { claim: "세번째 강세", sourceId: "S1", quote: "외국인 매수세" },
+      ],
+      bear: [{ claim: "투톱이 주춤했어", sourceId: "S2", quote: "주춤할 때" }],
+      wordings: [
+        { text: "전강후약 쎄함", sourceId: "S3" },
+        { text: "불기둥", sourceId: "S3" },
+        { text: "세번째워딩", sourceId: "S3" },
+      ],
+      stance: "balanced",
+      stanceNote: "강세와 약세 관점이 원문에 둘 다 있어.",
+      sources: [{ id: "S1", kind: "news", title: "t1", url: "https://x/1" }],
+      confidence: "low",
+    };
+    const c = condenseThemeInsight(insight, { maxPerSide: 2, maxWordings: 2 });
+    expect(c.bull).toHaveLength(2); // maxPerSide
+    expect(c.bear).toHaveLength(1);
+    expect(c.wordings).toHaveLength(2); // maxWordings
+    // whyHot 의 사실 문장은 전부 A의 claim 그대로(환각 없음).
+    expect(c.whyHot).toContain("외국인이 삼성전자를 담았어");
+    expect(c.whyHot).toContain("투톱이 주춤했어");
+    // 출처(링크) 유지.
+    expect(c.sources[0]!.url).toBe("https://x/1");
+    expect(c.confidence).toBe("low");
+  });
+
+  it("condense — 강세만이면 약세 안 보임 정직 표기(균형)", () => {
+    const insight: ThemeInsight = {
+      theme: "반도체",
+      stocks: [],
+      bull: [{ claim: "강세근거", sourceId: "S1", quote: "q" }],
+      bear: [],
+      wordings: [],
+      stance: "bull-dominant",
+      stanceNote: "약세 관점은 원문에서 안 보여.",
+      sources: [],
+      confidence: "low",
+    };
+    const c = condenseThemeInsight(insight);
+    expect(c.whyHot).toContain("약세 관점은 원문에서 안 보여");
+    expect(c.bear).toHaveLength(0);
+  });
+
+  it("condense — insufficient 면 가짜 응축 없이 빈 상태 통과", () => {
+    const c = condenseThemeInsight(emptyThemeInsight("반도체", "원문 없음"));
+    expect(c.confidence).toBe("insufficient");
+    expect(c.bull).toEqual([]);
+    expect(c.bear).toEqual([]);
   });
 
   it("parseNaverBoardPosts — 제목 보존 + 감성 분류(개수 아님)", () => {

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -1,0 +1,108 @@
+import type {
+  Evidence,
+  InsightSourceRef,
+  KeyWording,
+  ThemeInsight,
+  ThemeInsightConfidence,
+  ThemeStance,
+} from "./types";
+
+/**
+ * 재가공/응축 레이어 — DATA_ENGINE_STRATEGY §4 Track B.
+ *
+ * A(understandTheme)의 grounded 출력을 "한 카드 분량"으로 응축한다.
+ *
+ * 환각 차단(절대 원칙 "응축 과정에서 원문에 없는 말이 새로 끼어들면 안 된다"):
+ *   응축은 *새 생성(LLM)이 아니라* A의 이미-grounded 된 근거를 **결정론적으로 선택·조립**한다.
+ *   whyHot 의 사실 문장은 전부 A의 claim 그대로(연결어만 비사실 스캐폴딩). → grounding 100% 유지.
+ *
+ * 균형 필수: 강세/약세 둘 다. 한쪽뿐이면 stanceNote 로 정직 표기(A에서 계산된 값 그대로).
+ * 정직한 빈 상태: A가 insufficient 면 응축도 insufficient(가짜 응축 금지).
+ */
+
+export interface CondensedPoint {
+  claim: string;
+  /** 근거 출처(SourceDoc.id) — sources 에서 url 매핑. */
+  sourceId: string;
+}
+
+export interface CondensedInsight {
+  theme: string;
+  /** "왜 떴나" 2~3문장 — A의 grounded claim 들을 결정론적으로 종합(새 사실 추가 없음). */
+  whyHot: string;
+  bull: CondensedPoint[];
+  bear: CondensedPoint[];
+  wordings: KeyWording[];
+  stance: ThemeStance;
+  stanceNote: string;
+  /** 근거가 가리킨 원문(원문 보기 링크용 — 검증 가능하게 유지). */
+  sources: InsightSourceRef[];
+  confidence: ThemeInsightConfidence;
+}
+
+export interface CondenseOptions {
+  maxPerSide?: number;
+  maxWordings?: number;
+}
+
+const toPoint = (e: Evidence): CondensedPoint => ({ claim: e.claim, sourceId: e.sourceId });
+
+/** 응축 — 결정론적 선택 + 비사실 연결어로 whyHot 조립(사실은 전부 A의 claim). */
+export function condenseThemeInsight(
+  insight: ThemeInsight,
+  opts: CondenseOptions = {}
+): CondensedInsight {
+  const maxPerSide = opts.maxPerSide ?? 2;
+  const maxWordings = opts.maxWordings ?? 2;
+
+  const base = {
+    theme: insight.theme,
+    stance: insight.stance,
+    stanceNote: insight.stanceNote,
+    sources: insight.sources,
+    confidence: insight.confidence,
+  };
+
+  // 정직한 빈 상태 — A가 근거를 못 뽑았으면 응축도 비운다(가짜 생성 금지).
+  if (insight.confidence === "insufficient" || insight.bull.length + insight.bear.length === 0) {
+    return { ...base, whyHot: insight.stanceNote, bull: [], bear: [], wordings: [] };
+  }
+
+  const bull = insight.bull.slice(0, maxPerSide);
+  const bear = insight.bear.slice(0, maxPerSide);
+  const wordings = insight.wordings.slice(0, maxWordings);
+
+  return {
+    ...base,
+    whyHot: buildWhyHot(insight.theme, insight.stance, insight.stanceNote, bull, bear),
+    bull: bull.map(toPoint),
+    bear: bear.map(toPoint),
+    wordings,
+  };
+}
+
+/**
+ * whyHot — 결정론적. 사실 문장은 A의 claim 그대로 박고, 연결어("오늘 X는…")만 스캐폴딩.
+ * 새로운 사실/일반론을 만들지 않는다(환각 차단).
+ */
+function buildWhyHot(
+  theme: string,
+  stance: ThemeStance,
+  stanceNote: string,
+  bull: readonly Evidence[],
+  bear: readonly Evidence[]
+): string {
+  const join = (xs: readonly Evidence[]) => xs.map((e) => e.claim.replace(/\s+$/, "")).join(" ");
+
+  if (stance === "bull-dominant") {
+    return `오늘 ${theme} 쪽은 강세 얘기가 우세해. ${join(bull)} ${stanceNote}`.trim();
+  }
+  if (stance === "bear-dominant") {
+    return `오늘 ${theme} 쪽은 약세·리스크 얘기가 우세해. ${join(bear)} ${stanceNote}`.trim();
+  }
+  // balanced
+  const parts = [`오늘 ${theme}는 강세와 약세가 엇갈려.`];
+  if (bull.length) parts.push(`강세 쪽은 — ${join(bull)}`);
+  if (bear.length) parts.push(`약세 쪽은 — ${join(bear)}`);
+  return parts.join(" ");
+}

--- a/packages/fomo-core/src/theme-understanding/index.ts
+++ b/packages/fomo-core/src/theme-understanding/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./prompt";
 export * from "./parse";
 export * from "./assemble";
+export * from "./condense";


### PR DESCRIPTION
DATA_ENGINE_STRATEGY §4 Phase B. A(understandTheme)의 grounded 구조화를 "한 카드 분량"으로 응축하고, **뎁스 페이지에 연결**(A와 달리 화면 반영).

## 환각 차단 (핵심)
응축은 **새 LLM 생성이 아니라 A의 이미-grounded claim을 결정론적으로 선택·조립**. whyHot의 사실 문장은 전부 A claim 그대로(연결어만 비사실) → 응축 단계에서 원문에 없는 말이 새로 끼어들 수 없음.

## 변경
- **순수** `theme-understanding/condense.ts`: `condenseThemeInsight` — 강세/약세 상위 N + 워딩 M 선택, whyHot 결정론 조립, 균형(일방이면 stanceNote 정직), insufficient면 빈 상태 통과.
- **API** `/api/fomo/theme-insight?theme=` (lazy, TTL 캐시, maxDuration 60). 메인 피드 불변 — 무거워서 카드 탭할 때만 산출.
- **화면** `fomoApi.fetchThemeInsight` + `KeywordDepthPage`: 탭 시 fetch → **강세 관점 / 약세 관점 / 사람들 워딩 + 출처 링크**. 로딩·insufficient면 기존 뉴스 소스(#500)로 정직 폴백. **메인 카드·스와이프 불변**.

## 검증 (실화면)
- typecheck ✅ / vitest **602**(+3 condense) ✅ / build:web ✅ / build:fomo-web ✅
- 로컬(AI 토큰 주입) 반도체 뎁스 스크린샷: 📈강세 2(한국경제 원문링크) · 📉약세 1 + 🗣️워딩(네이버 종토방 "삼성은 지는해") · whyHot grounded · **원문 링크 라이브**(hankyung URL 확인).

## ⚠️ 프로덕션 가시성
뎁스의 이해 레이어는 Vercel에 **AI_API_KEY(또는 GITHUB_TOKEN)** 설정이 있어야 보인다. 없으면 `insufficient` → 기존 #500 소스로 정직 폴백(깨지지 않음). 키가 설정돼 있어야 강세/약세가 화면에 뜸.

머지 후 프로덕션에서 직접 확인 가능. 안 보이면 AI 키 설정 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)