### PR TITLE
워딩 안전 필터(룰+LLM) + 출처 다양성 표기 (Track C 선행)

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -87,6 +87,12 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
 
           {hasInsight ? (
             <>
+              {insight!.singleOutlet && insight!.outlets.length > 0 && (
+                <p className="mt-3 rounded-lg border border-hairline bg-surface px-3 py-2 text-[11px] leading-5 text-muted">
+                  ⚠️ 오늘은 <span className="text-whiteout">{insight!.outlets[0]}</span> 한 곳 기준이야 — 한 매체 안의 시각일 수 있어.
+                </p>
+              )}
+
               <section className="mt-6">
                 <p className="font-pixel text-sm" style={{ color: "var(--up, #ff5a5f)" }}>
                   📈 강세 관점

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -7,6 +7,7 @@ import {
   type SourceDoc,
   type ThemeInsight,
   type KeywordSourceItem,
+  type WordingVerdict,
 } from "@fomo/core";
 import { fetchNaverBoardPosts } from "@fomo/core";
 import { fetchAllNews } from "./fomo-news-sources";
@@ -108,7 +109,59 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
   return docs;
 }
 
-/** 테마 이해·구조화 — 수집 → LLM → grounding 검증(assemble). 실패 시 정직한 빈 상태. */
+/**
+ * 워딩 안전 LLM 판정(2단계) — 룰 필터(assemble)를 통과한 워딩을 한 번 더 본다.
+ * 거를 것: 욕설/혐오/정치선동/개인비방/특정종목 단정·매매권유/허위·찌라시. 살릴 것: 감정·심리 표현.
+ * 애매하면 unsafe(안전 우선). 실패 시 룰 통과분 유지(이미 룰-세이프). 변조 없음 — 통과/탈락만 결정.
+ */
+async function judgeWordingsSafety(
+  texts: readonly string[],
+  apiKey: string
+): Promise<Map<string, { safe: boolean; reason: string }>> {
+  const out = new Map<string, { safe: boolean; reason: string }>();
+  if (texts.length === 0) return out;
+  const prompt = [
+    "너는 투자 감정 앱의 커뮤니티 워딩 안전 심사관이다. 각 표현을 카드에 그대로 노출해도 되는지 판정해라.",
+    "거를 것(safe=false): 욕설/비방/혐오, 정치 선동, 개인 비방, 특정 종목 단정('무조건 간다/판다')·매매 권유, 허위·찌라시('내부정보/카더라').",
+    "살릴 것(safe=true): 투자자의 감정·심리를 드러내는 생생한 표현(예: '전강후약 쎄함', '존버 지친다').",
+    "애매하면 safe=false(안전 우선). 표현을 고치지 말고 판정만.",
+    '출력은 JSON 배열만: [{"text":"원문그대로","safe":true,"reason":"짧은 사유"}]',
+    "",
+    JSON.stringify(texts),
+  ].join("\n");
+  try {
+    const res = await fetch(AI_API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ model: MODEL, temperature: 0, messages: [{ role: "user", content: prompt }] }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!res.ok) {
+      console.warn("[wording-judge] LLM", res.status, "— 룰 통과분 유지");
+      return out;
+    }
+    const data = (await res.json()) as LlmResponse;
+    const content = data.choices?.[0]?.message?.content ?? "";
+    const start = content.indexOf("[");
+    const end = content.lastIndexOf("]");
+    if (start === -1 || end <= start) return out;
+    const arr = JSON.parse(content.slice(start, end + 1)) as unknown;
+    if (Array.isArray(arr)) {
+      for (const r of arr) {
+        if (r && typeof r === "object") {
+          const o = r as Record<string, unknown>;
+          const text = typeof o.text === "string" ? o.text.trim() : "";
+          if (text) out.set(text, { safe: o.safe === true, reason: typeof o.reason === "string" ? o.reason : "" });
+        }
+      }
+    }
+  } catch (err) {
+    console.warn("[wording-judge] error — 룰 통과분 유지", err);
+  }
+  return out;
+}
+
+/** 테마 이해·구조화 — 수집 → LLM → grounding 검증(assemble) → 워딩 LLM 안전 판정. 실패 시 정직한 빈 상태. */
 export async function understandTheme(theme: string): Promise<ThemeInsight> {
   const docs = await collectThemeDocs(theme);
   if (docs.length === 0) return emptyThemeInsight(theme, "수집된 원문이 없음(소스 도달 실패 또는 매칭 0)");
@@ -135,7 +188,30 @@ export async function understandTheme(theme: string): Promise<ThemeInsight> {
     }
     const data = (await res.json()) as LlmResponse;
     const raw = parseThemeInsightResponse(data.choices?.[0]?.message?.content ?? "");
-    return assembleThemeInsight(theme, docs, raw);
+    const insight = assembleThemeInsight(theme, docs, raw);
+
+    // 2단계: 룰 통과 워딩을 LLM 으로 한 번 더 안전 판정(욕설/단정/혐오/찌라시 — 룰이 못 잡는 뉘앙스).
+    if (insight.wordings.length === 0) return insight;
+    const judged = await judgeWordingsSafety(insight.wordings.map((w) => w.text), apiKey);
+    const llmAudit: WordingVerdict[] = insight.wordings.map((w) => {
+      const v = judged.get(w.text);
+      return {
+        text: w.text,
+        kept: v ? v.safe : true, // 판정 누락(LLM 실패) → 룰-세이프이므로 유지
+        reason: v ? v.reason || "LLM 판정" : "LLM 판정 생략(폴백 — 룰 통과 유지)",
+        stage: "llm",
+      };
+    });
+    const safeWordings = insight.wordings.filter((w) => (judged.get(w.text)?.safe ?? true));
+    const dropped = llmAudit.filter((a) => !a.kept);
+    if (dropped.length > 0) {
+      console.warn("[wording-judge] dropped:", dropped.map((d) => `"${d.text}"(${d.reason})`).join(" | "));
+    }
+    return {
+      ...insight,
+      wordings: safeWordings,
+      wordingAudit: [...(insight.wordingAudit ?? []), ...llmAudit],
+    };
   } catch (err) {
     console.warn("[theme-understanding] error", err);
     return emptyThemeInsight(theme, "이해 레이어 호출 실패 — 정직한 빈 상태");

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -6,6 +6,7 @@ import {
   buildThemeInsightPrompt,
   parseNaverBoardPosts,
   condenseThemeInsight,
+  screenWordingRule,
   type SourceDoc,
   type ThemeInsight,
 } from "../src";
@@ -109,6 +110,50 @@ describe("균형(강세/약세) 정직 표기", () => {
   });
 });
 
+describe("워딩 안전 필터 (룰 단계, Track C 선행)", () => {
+  it("욕설/혐오 → 탈락", () => {
+    expect(screenWordingRule("시발 존버 지친다").kept).toBe(false);
+    expect(screenWordingRule("틀딱들 다 팔아").kept).toBe(false);
+  });
+  it("종목 단정/매매신호/찌라시 → 탈락", () => {
+    expect(screenWordingRule("삼성 무조건 간다").kept).toBe(false);
+    expect(screenWordingRule("내부 정보 입수했다").kept).toBe(false);
+    expect(screenWordingRule("이거 100% 상한가").kept).toBe(false);
+  });
+  it("감정·심리 표현 → 통과(원문 그대로)", () => {
+    expect(screenWordingRule("전강후약 쎄함").kept).toBe(true);
+    expect(screenWordingRule("존버 지친다").kept).toBe(true);
+    expect(screenWordingRule("국장 장투할거야? 난 치고 빠질래").kept).toBe(true);
+  });
+  it("탈락 사유(reason)를 남긴다(검수용)", () => {
+    expect(screenWordingRule("시발").reason).toContain("욕설");
+    expect(screenWordingRule("무조건 간다").reason).toMatch(/단정|매매|찌라시/);
+  });
+
+  it("assemble: 룰 위반 워딩은 wordings 에서 빠지고 audit 에 사유로 남는다", () => {
+    const docs: SourceDoc[] = [
+      { id: "S1", kind: "news", title: "외국인 매수세가 삼성전자", source: "한국경제" },
+      { id: "S3", kind: "community", title: "전강후약 쎄함 씨발 무조건 간다", source: "종토방" },
+    ];
+    const raw = {
+      stocks: [],
+      bull: [{ claim: "외국인이 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+      bear: [],
+      wordings: [
+        { text: "전강후약 쎄함", sourceId: "S3" },
+        { text: "씨발 무조건 간다", sourceId: "S3" },
+      ],
+      stanceNote: "",
+    };
+    const r = assembleThemeInsight("반도체", docs, raw);
+    expect(r.wordings.map((w) => w.text)).toEqual(["전강후약 쎄함"]); // 욕설/단정 워딩 제거
+    expect(r.wordingAudit).toBeDefined();
+    const bad = r.wordingAudit!.find((a) => a.text === "씨발 무조건 간다")!;
+    expect(bad.kept).toBe(false);
+    expect(bad.reason).toContain("욕설");
+  });
+});
+
 describe("워딩(여론 원문) grounding", () => {
   it("커뮤니티 원문에 실재하는 워딩만 통과", () => {
     const raw: RawThemeInsight = {
@@ -194,6 +239,27 @@ describe("parse / prompt / 커뮤니티 원문 보존", () => {
     expect(c.confidence).toBe("insufficient");
     expect(c.bull).toEqual([]);
     expect(c.bear).toEqual([]);
+  });
+
+  it("condense — 출처 다양성: 한 매체뿐이면 singleOutlet, 여러 매체면 false", () => {
+    const mk = (sources: { id: string; source: string }[]): ThemeInsight => ({
+      theme: "반도체",
+      stocks: [],
+      bull: [{ claim: "강세", sourceId: sources[0]!.id, quote: "q" }],
+      bear: [],
+      wordings: [],
+      stance: "bull-dominant",
+      stanceNote: "약세 안 보임",
+      sources: sources.map((s) => ({ id: s.id, kind: "news" as const, title: "t", source: s.source })),
+      confidence: "low",
+      reason: "r",
+    });
+    const single = condenseThemeInsight(mk([{ id: "S1", source: "매일경제" }, { id: "S2", source: "매일경제" }]));
+    expect(single.outlets).toEqual(["매일경제"]);
+    expect(single.singleOutlet).toBe(true);
+    const multi = condenseThemeInsight(mk([{ id: "S1", source: "매일경제" }, { id: "S2", source: "한국경제" }]));
+    expect(multi.outlets.sort()).toEqual(["한국경제", "매일경제"].sort());
+    expect(multi.singleOutlet).toBe(false);
   });
 
   it("parseNaverBoardPosts — 제목 보존 + 감성 분류(개수 아님)", () => {

--- a/packages/fomo-core/src/theme-understanding/assemble.ts
+++ b/packages/fomo-core/src/theme-understanding/assemble.ts
@@ -8,6 +8,7 @@ import type {
   ThemeStance,
 } from "./types";
 import type { RawEvidence, RawThemeInsight, RawWording } from "./parse";
+import { screenWordingRule, type WordingVerdict } from "./wording-filter";
 
 /**
  * 이해 레이어의 핵심 가드 — DATA_ENGINE_STRATEGY §6 / 운영자 강조.
@@ -69,8 +70,9 @@ function groundEvidence(
 function groundWordings(
   raw: readonly RawWording[],
   docById: Map<string, SourceDoc>
-): KeyWording[] {
+): { wordings: KeyWording[]; audit: WordingVerdict[] } {
   const out: KeyWording[] = [];
+  const audit: WordingVerdict[] = [];
   const seen = new Set<string>();
   for (const w of raw) {
     const doc = docById.get(w.sourceId);
@@ -80,9 +82,12 @@ function groundWordings(
     const key = norm(w.text);
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push({ text: w.text, sourceId: w.sourceId });
+    // 룰 안전 필터(욕설/단정/찌라시 명백한 것 차단). 통과/탈락 모두 감사 로그.
+    const verdict = screenWordingRule(w.text);
+    audit.push(verdict);
+    if (verdict.kept) out.push({ text: w.text, sourceId: w.sourceId });
   }
-  return out;
+  return { wordings: out, audit };
 }
 
 function decideStance(bull: number, bear: number): { stance: ThemeStance; note: string } {
@@ -150,7 +155,7 @@ export function assembleThemeInsight(
   const docById = new Map(docs.map((d) => [d.id, d]));
   const bull = groundEvidence(raw.bull, docById);
   const bear = groundEvidence(raw.bear, docById);
-  const wordings = groundWordings(raw.wordings, docById);
+  const { wordings, audit: wordingAudit } = groundWordings(raw.wordings, docById);
 
   // 원문에 언급된 종목만(가벼운 검증 — 종목명이 원문 어딘가 등장).
   const corpus = norm(docs.map((d) => `${d.title} ${d.body ?? ""}`).join(" "));
@@ -163,6 +168,7 @@ export function assembleThemeInsight(
       stocks,
       wordings,
       sources: usedSources([], [], wordings, docById),
+      wordingAudit,
     };
   }
 
@@ -183,5 +189,6 @@ export function assembleThemeInsight(
     sources: usedSources(bull, bear, wordings, docById),
     confidence,
     reason: `원문 ${docs.length}건 → grounded 강세 ${bull.length} · 약세 ${bear.length} · 워딩 ${wordings.length} (30일 기준선 없어 low)`,
+    wordingAudit,
   };
 }

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -37,9 +37,15 @@ export interface CondensedInsight {
   stanceNote: string;
   /** 근거가 가리킨 원문(원문 보기 링크용 — 검증 가능하게 유지). */
   sources: InsightSourceRef[];
+  /** 서로 다른 매체/소스 이름(출처 다양성). 1개뿐이면 "한 곳 기준"을 정직 표기. */
+  outlets: string[];
+  /** 출처가 한 매체에만 쏠렸나(true면 "한 곳 안의 균형"일 뿐 — UI/정직성 표기). */
+  singleOutlet: boolean;
   confidence: ThemeInsightConfidence;
   /** 정직성/진단 — 왜 이 confidence·stance 인지(A의 reason 그대로). 빈 상태 원인 추적용. */
   reason: string;
+  /** 워딩 필터 감사 로그(통과·탈락 + 사유, 검수용). */
+  wordingAudit?: import("./types").WordingVerdict[];
 }
 
 export interface CondenseOptions {
@@ -57,13 +63,20 @@ export function condenseThemeInsight(
   const maxPerSide = opts.maxPerSide ?? 2;
   const maxWordings = opts.maxWordings ?? 2;
 
+  // 출처 다양성 — 서로 다른 매체 이름. 소스를 늘리는 건 C 의 몫이고, 여기선 *쏠림을 정직히 표기*만.
+  const outlets = [...new Set(insight.sources.map((s) => s.source).filter((x): x is string => !!x))];
+  const singleOutlet = outlets.length <= 1;
+
   const base = {
     theme: insight.theme,
     stance: insight.stance,
     stanceNote: insight.stanceNote,
     sources: insight.sources,
+    outlets,
+    singleOutlet,
     confidence: insight.confidence,
     reason: insight.reason,
+    ...(insight.wordingAudit ? { wordingAudit: insight.wordingAudit } : {}),
   };
 
   // 정직한 빈 상태 — A가 근거를 못 뽑았으면 응축도 비운다(가짜 생성 금지).

--- a/packages/fomo-core/src/theme-understanding/index.ts
+++ b/packages/fomo-core/src/theme-understanding/index.ts
@@ -3,3 +3,4 @@ export * from "./prompt";
 export * from "./parse";
 export * from "./assemble";
 export * from "./condense";
+export * from "./wording-filter";

--- a/packages/fomo-core/src/theme-understanding/types.ts
+++ b/packages/fomo-core/src/theme-understanding/types.ts
@@ -40,6 +40,8 @@ export interface KeyWording {
   sourceId: string;
 }
 
+export type { WordingVerdict } from "./wording-filter";
+
 export type ThemeStance = "balanced" | "bull-dominant" | "bear-dominant" | "insufficient";
 export type ThemeInsightConfidence = "ok" | "low" | "insufficient";
 
@@ -71,4 +73,6 @@ export interface ThemeInsight {
   confidence: ThemeInsightConfidence;
   /** 정직성/디버그 — 왜 이 confidence·stance 인지. */
   reason: string;
+  /** 워딩 필터 전/후 감사 로그(통과·탈락 + 사유, 검수용). */
+  wordingAudit?: import("./wording-filter").WordingVerdict[];
 }

--- a/packages/fomo-core/src/theme-understanding/wording-filter.ts
+++ b/packages/fomo-core/src/theme-understanding/wording-filter.ts
@@ -1,0 +1,42 @@
+/**
+ * 워딩 안전 필터 (룰 단계) — DATA_ENGINE_STRATEGY Track C 선행 안전장치.
+ *
+ * 커뮤니티 워딩을 카드에 넣기 전 거른다. 소스를 넓히면(C) 거친 말·단정·찌라시가 폭발하므로,
+ * 필터 없이 노출하면 제품이 그 말을 *보증*하는 꼴이 된다. 룰(여기) + LLM 판정(apps/web) 조합.
+ *
+ * 거를 것: 욕설/비방, 종목 단정("무조건 간다/판다"), 찌라시/허위 단정, 정치/혐오.
+ * 살릴 것: 감정·심리를 드러내는 생생한 표현("전강후약 쎄함" 등).
+ * 애매하면 버린다(정직·안전 우선) — 단, 룰은 명백한 것만 자르고 애매함은 LLM 단계에 맡긴다.
+ *
+ * 통과한 워딩은 원문 그대로(변조 금지). 왜 걸렀는지 reason 을 남겨 검수 가능하게 한다.
+ */
+
+export interface WordingVerdict {
+  /** 원문 워딩(변조 없음). */
+  text: string;
+  kept: boolean;
+  /** 통과/탈락 사유(검수용). */
+  reason: string;
+  stage: "rule" | "llm";
+}
+
+/** 욕설·비방·혐오(명백). */
+const PROFANITY =
+  /(씨발|시발|ㅅㅂ|존나|ㅈㄴ|병신|ㅂㅅ|지랄|새끼|개[새세]끼|좆|썅|닥쳐|꺼져|애미|틀딱|급식충|한남|김치녀|메갈|일베|토착왜구|빨갱이)/;
+
+/** 종목 단정·매매신호·허위/찌라시(명백). 감정 표현은 안 걸리게 '무조건/100%/확정' 등 강한 단정만. */
+const ASSERTION_OR_RUMOR =
+  /(무조건\s*(간다|오른다|먹는다|상한가|떡상)|반드시\s*(간다|오른다|먹는다)|100\s*%|확정\s*(상한가|떡상|간다)|올인\s*해|전재산|풀매수\s*각|필패|내부\s*정보|카더라|지라시|찌라시|상한가\s*간다|무조건간다|지금\s*안\s*사면\s*후회)/;
+
+/**
+ * 룰 단계 판정. 명백한 위반만 자르고(kept:false), 나머지는 통과(LLM 단계가 애매함 재판정).
+ * 통과/탈락 모두 reason 을 남긴다.
+ */
+export function screenWordingRule(text: string): WordingVerdict {
+  const t = text.trim();
+  if (!t) return { text, kept: false, reason: "빈 워딩", stage: "rule" };
+  if (PROFANITY.test(t)) return { text, kept: false, reason: "욕설/비방/혐오", stage: "rule" };
+  if (ASSERTION_OR_RUMOR.test(t))
+    return { text, kept: false, reason: "종목 단정/매매신호/찌라시", stage: "rule" };
+  return { text, kept: true, reason: "룰 통과", stage: "rule" };
+}


### PR DESCRIPTION
C(수집 확장) 전 필수 안전장치. 소스를 넓히면 거친 말·단정·찌라시가 폭발 → 필터 없이 노출하면 제품이 그 말을 *보증*하는 꼴. 미리 깐다.

## 워딩 필터 (룰 + LLM 조합)
- **룰**(`wording-filter.ts`, 순수): 욕설/혐오·종목 단정("무조건 간다")·매매신호·찌라시 명백한 것 차단. `screenWordingRule → {kept, reason}`.
- **LLM**(`judgeWordingsSafety`): 룰 통과분을 한 번 더 — 권유·비방·미확인정보 등 뉘앙스. 애매하면 unsafe(안전 우선). LLM 실패 시 룰 통과분 유지.
- 통과 워딩은 **원문 그대로**(변조 금지). 통과/탈락 사유를 `wordingAudit`로 남겨 검수 가능. 통과 0개면 워딩 섹션 빔(가짜로 안 채움).

## 출처 다양성 표기
- `CondensedInsight.outlets/singleOutlet`. 근거 출처가 한 매체뿐이면 뎁스에 **"⚠️ 오늘은 OO 한 곳 기준"** 정직 표기. (소스 자체 확장은 C)

## 검증
- typecheck ✅ / vitest **608**(+6: 룰 필터·assemble 감사·출처 다양성) ✅ / build:web ✅ / build:fomo-web ✅
- **실데이터 워딩 판정**(반도체/AI): ❌"주식으로빚내도걱정마라"(권유) · ❌"미국도 mou 각잡는데"(찌라시) · ❌"2분기 100조다 먼 잡소리"(단정/비방) / ✅"난 그냥 잘란다"(심리) · ✅"조정이 기회"
- **화면**: 뎁스에 강세/약세/워딩(필터 통과분) 렌더 확인(스크린샷). 출처 노트는 single-outlet일 때만 — 오늘 데이터는 다중 출처라 미표시(정상 동작), 단위테스트로 로직 검증.

## 원칙 유지
grounding · 강세/약세 균형 · 투자조언 금지 · UI/스와이프/점수/메인 카피 불변(뎁스 콘텐츠만).

CI 통과 시 머지 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)