### PR TITLE
C-1: 뉴스 소스 다양화 + tier 메타데이터

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -35,9 +35,20 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
 
   // sourceId → 원문(링크용).
   const srcOf = (id: string) => insight?.sources.find((s) => s.id === id);
+  // tier → 신뢰도 정직 표기(§4.5).
+  const tierLabel = (tier?: string) =>
+    tier === "official-high"
+      ? "공식 데이터"
+      : tier === "news-mid"
+        ? "뉴스"
+        : tier === "community-mid" || tier === "community-low"
+          ? "커뮤니티"
+          : "";
 
   const evidenceItem = (claim: string, sourceId: string, key: string) => {
     const s = srcOf(sourceId);
+    const tl = tierLabel(s?.tier);
+    const label = `${s?.source ?? s?.title ?? ""}${tl ? ` · ${tl}` : ""}`;
     return (
       <li key={key} className="rounded-lg border border-hairline bg-surface px-3 py-2">
         <span className="block text-sm leading-5 text-whiteout">{claim}</span>
@@ -49,10 +60,10 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
               rel="noreferrer"
               className="mt-1 block text-[11px] text-muted hover:text-whiteout"
             >
-              ↳ {s.source ?? s.title} · 원문 보기 →
+              ↳ {label} · 원문 보기 →
             </a>
           ) : (
-            <span className="mt-1 block text-[11px] text-muted">↳ {s.source ?? s.title}</span>
+            <span className="mt-1 block text-[11px] text-muted">↳ {label}</span>
           ))}
       </li>
     );

--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -5,7 +5,13 @@ import {
   type NaverNewsRaw,
   type NewsSource,
   type RawArticle,
+  type SourceTier,
 } from "@fomo/core";
+
+/** 파싱 결과 기사들에 tier 를 부착(수집 레이어 메타). */
+function withTier(articles: RawArticle[], tier: SourceTier): RawArticle[] {
+  return articles.map((a) => ({ ...a, tier }));
+}
 
 /**
  * FOMO 뉴스 소스 — 실제 기사 수집. docs/PIVOT_FEED_FIRST.md.
@@ -68,10 +74,15 @@ export const yahooSource: NewsSource = {
 
 // ───────────────────────── 한국 금융 뉴스 RSS ─────────────────────────
 // 증권/금융/시황 초점 피드(Node fetch 200 확인). 표준 RSS 2.0 → parseRssFeed.
-const KR_FEEDS: { id: string; url: string; source: string }[] = [
-  { id: "hankyung", url: "https://www.hankyung.com/feed/finance", source: "한국경제" },
-  { id: "mk", url: "https://www.mk.co.kr/rss/50200011/", source: "매일경제" },
-  { id: "yna", url: "https://www.yna.co.kr/rss/market.xml", source: "연합뉴스" },
+// C-1(DATA_ENGINE_STRATEGY §4.5): 매경 쏠림 해결 — 연합·한경·파이낸셜뉴스·연합인포맥스로 다양화.
+// 전부 news-mid tier(공식 데이터 FRED=official-high 는 C-2). 죽은 피드는 fetch 실패 시 [] 로 degrade.
+const KR_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] = [
+  { id: "hankyung", url: "https://www.hankyung.com/feed/finance", source: "한국경제", tier: "news-mid" },
+  { id: "mk", url: "https://www.mk.co.kr/rss/50200011/", source: "매일경제", tier: "news-mid" },
+  { id: "yna", url: "https://www.yna.co.kr/rss/market.xml", source: "연합뉴스", tier: "news-mid" },
+  { id: "yna-econ", url: "https://www.yna.co.kr/rss/economy.xml", source: "연합뉴스", tier: "news-mid" },
+  { id: "fnnews", url: "https://www.fnnews.com/rss/r20/fn_realnews_stock.xml", source: "파이낸셜뉴스", tier: "news-mid" },
+  { id: "einfomax", url: "https://news.einfomax.co.kr/rss/S1N2.xml", source: "연합인포맥스", tier: "news-mid" },
 ];
 
 // ───────────────────────── 네이버 금융 뉴스 (JSON) ─────────────────────────
@@ -91,7 +102,8 @@ export const naverNewsSource: NewsSource = {
       });
       if (!res.ok) return [];
       const json = (await res.json()) as NaverNewsRaw[];
-      return parseNaverNews(Array.isArray(json) ? json : [], new Date().toISOString());
+      // 네이버 worldNews = 해외 증시 뉴스(한국어 번역) — 외신 채널. news-mid.
+      return withTier(parseNaverNews(Array.isArray(json) ? json : [], new Date().toISOString()), "news-mid");
     } catch (err) {
       console.warn("[fomo/news] naver error", err);
       return [];
@@ -100,7 +112,7 @@ export const naverNewsSource: NewsSource = {
 };
 
 /** 한국 RSS 피드 1개 → 한국어 RawArticle[]. 실패 시 빈 배열. */
-function makeKoreanRssSource({ id, url, source }: (typeof KR_FEEDS)[number]): NewsSource {
+function makeKoreanRssSource({ id, url, source, tier }: (typeof KR_FEEDS)[number]): NewsSource {
   return {
     id,
     lang: "ko",
@@ -114,7 +126,7 @@ function makeKoreanRssSource({ id, url, source }: (typeof KR_FEEDS)[number]): Ne
         });
         if (!res.ok) return [];
         const xml = await res.text();
-        return parseRssFeed(xml, { source, lang: "ko", nowIso: new Date().toISOString() });
+        return withTier(parseRssFeed(xml, { source, lang: "ko", nowIso: new Date().toISOString() }), tier);
       } catch (err) {
         console.warn(`[fomo/news] ${id} error`, err);
         return [];

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -71,6 +71,7 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
       publishedAt: a.publishedAt,
       source: a.source,
       lang: a.lang,
+      ...(a.tier ? { tier: a.tier } : {}),
     }));
     const bucket = extractKeywords(items).find((k) => k.keyword === theme);
     for (const art of (bucket?.articles ?? []).slice(0, MAX_NEWS)) {
@@ -82,6 +83,7 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
         ...(art.source ? { source: art.source } : {}),
         ...(art.url ? { url: art.url } : {}),
         ...(art.publishedAt ? { publishedAt: art.publishedAt } : {}),
+        tier: art.tier ?? "news-mid",
       });
     }
   } else {
@@ -99,6 +101,7 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
           title: post.title,
           source: `네이버 종토방 ${c.label}`,
           ...(post.tsMs ? { publishedAt: new Date(post.tsMs).toISOString() } : {}),
+          tier: "community-mid", // 종토방 = 개미 본진(§4.5)
         });
       }
     } else if (r && r.status === "rejected") {

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -110,6 +110,23 @@ describe("균형(강세/약세) 정직 표기", () => {
   });
 });
 
+describe("소스 tier 전파 (C-1)", () => {
+  it("SourceDoc.tier → InsightSourceRef.tier 로 전파(가중·표기용)", () => {
+    const docs: SourceDoc[] = [
+      { id: "S1", kind: "news", title: "외국인 매수세가 삼성전자", source: "연합뉴스", tier: "news-mid" },
+    ];
+    const raw = {
+      stocks: [],
+      bull: [{ claim: "외국인이 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+      bear: [],
+      wordings: [],
+      stanceNote: "",
+    };
+    const r = assembleThemeInsight("반도체", docs, raw);
+    expect(r.sources[0]!.tier).toBe("news-mid");
+  });
+});
+
 describe("워딩 안전 필터 (룰 단계, Track C 선행)", () => {
   it("욕설/혐오 → 탈락", () => {
     expect(screenWordingRule("시발 존버 지친다").kept).toBe(false);

--- a/packages/fomo-core/src/keyword-cards/extract.ts
+++ b/packages/fomo-core/src/keyword-cards/extract.ts
@@ -14,6 +14,8 @@ export interface KeywordSourceItem {
   summary?: string;
   /** 원문 링크(있으면 카드 소스에서 클릭 가능). */
   url?: string;
+  /** 소스 신뢰도 등급(DATA_ENGINE_STRATEGY §4.5). 이해 레이어로 전달돼 가중·표기에 쓰임. */
+  tier?: import("../news-feed/types").SourceTier;
   /** 발행/작성 시각 ISO. 최신성·가속 계산용(없으면 무시). */
   publishedAt?: string;
   /** 커뮤니티 참여도(upvote+댓글 합). 뉴스는 0/생략. */

--- a/packages/fomo-core/src/news-feed/types.ts
+++ b/packages/fomo-core/src/news-feed/types.ts
@@ -12,6 +12,13 @@
 export type NewsLang = "en" | "ko";
 
 /** 정규화된 원본 기사 — 소스(Yahoo/네이버/연합 등) 무관 공통 형태. */
+/**
+ * 소스 신뢰도 등급(tier) — DATA_ENGINE_STRATEGY §4.5. 가지치기를 설정화하기 위한 메타.
+ * 같은 "강세"라도 official-high(FRED) > news-mid(연합/한경) > community-mid(종토방) > community-low(디시).
+ * 나중에 "디시 가중치↓" 같은 조정이 코드 수술이 아니라 tier 가중치 한 줄이 되게 한다.
+ */
+export type SourceTier = "official-high" | "news-mid" | "community-mid" | "community-low";
+
 export interface RawArticle {
   /** 안정 식별자 (보통 url 해시/슬러그). */
   id: string;
@@ -29,6 +36,8 @@ export interface RawArticle {
   category?: string;
   /** 어느 티커/종목에서 수집됐는지. */
   symbol?: string;
+  /** 소스 신뢰도 등급 — 수집 레이어가 부착(가지치기·가중치용). */
+  tier?: SourceTier;
   /** 소스 원어. 점수기·번역기가 참고. */
   lang: NewsLang;
   /** 향후 한국어 번역 자리 (지금은 비움). */

--- a/packages/fomo-core/src/theme-understanding/assemble.ts
+++ b/packages/fomo-core/src/theme-understanding/assemble.ts
@@ -120,6 +120,7 @@ function usedSources(
       title: d.title,
       ...(d.source ? { source: d.source } : {}),
       ...(d.url ? { url: d.url } : {}),
+      ...(d.tier ? { tier: d.tier } : {}),
     });
   }
   return out;

--- a/packages/fomo-core/src/theme-understanding/types.ts
+++ b/packages/fomo-core/src/theme-understanding/types.ts
@@ -10,6 +10,8 @@
 
 export type SourceKind = "news" | "community";
 
+export type { SourceTier } from "../news-feed/types";
+
 /** 수집한 원문 1건(제목·본문 보존 — 커뮤니티 글도 제목을 버리지 않는다). */
 export interface SourceDoc {
   /** 인용 식별자(예: "S1"). 근거가 어느 원문에서 나왔는지 추적·검증용. */
@@ -22,6 +24,8 @@ export interface SourceDoc {
   source?: string;
   url?: string;
   publishedAt?: string;
+  /** 소스 신뢰도 등급(§4.5) — 가중·정직 표기용. */
+  tier?: import("../news-feed/types").SourceTier;
 }
 
 /** 강세/약세 근거 1건 — 반드시 원문에 박힌 인용으로 뒷받침. */
@@ -52,6 +56,8 @@ export interface InsightSourceRef {
   title: string;
   source?: string;
   url?: string;
+  /** 소스 신뢰도 등급(§4.5) — 카드/뎁스에 정직 표기. */
+  tier?: import("../news-feed/types").SourceTier;
 }
 
 /** 한 테마의 이해·구조화 결과. */


### PR DESCRIPTION
DATA_ENGINE_STRATEGY §4.5 Phase C-1. 매경 쏠림 해결 + 모든 데이터에 tier 부착.

## 변경
- **뉴스 다양화**: 연합(경제)·파이낸셜뉴스·연합인포맥스 추가 → **6개 출처**(로이터/한경/매경/연합/파이낸셜/인포맥스). 죽은 피드는 fetch 실패 시 [] degrade(사전 200 검증).
- **tier 메타데이터**(§4.5 가지치기 설정화): `SourceTier`(official-high/news-mid/community-mid/community-low) 정의. 뉴스=`news-mid`, 종토방=`community-mid`. RawArticle→KeywordSourceItem→SourceDoc→InsightSourceRef 까지 전파.
- **B 연동**: 뎁스 출처 옆에 tier 라벨(공식 데이터/뉴스/커뮤니티) 정직 표기 + 기존 출처 쏠림 표시와 함께.

## 원칙
A·B 엔진(이해·재가공) 위에 **소스만 추가** — 이해 레이어가 새 소스 소화 확인. grounding·강세약세 균형·투자조언 금지·정직한 빈 상태 유지. UI/스와이프/점수 불변(뎁스 라벨만).

## 검증
- typecheck ✅ / vitest **609**(+1 tier 전파) ✅ / build:web ✅ / build:fomo-web ✅
- 실수집 396건 → 6출처, 전부 tier 부착 확인(파이낸셜뉴스 16·연합인포맥스 20 등).

§5.5 정책: CI green → 자동 머지(DDL·유료 API 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)