### PR TITLE
C-2: FRED 연동 (연준 공식 데이터, official-high)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ AI_API_URL="https://models.github.ai/inference/chat/completions"
 AI_API_KEY="USE_GITHUB_TOKEN"
 AI_MODEL="openai/gpt-4.1"
 AI_TEMPERATURE="0.2"
+# FRED(미 연준 공식 데이터, DATA_ENGINE_STRATEGY C-2). 없어도 키리스(fredgraph.csv)로 동작.
+# 키 발급(무료): https://fred.stlouisfed.org/docs/api/api_key.html → 설정 시 공식 JSON API 로 업그레이드.
+FRED_API_KEY=""
 RESEARCH_PUBLISHED_SNAPSHOT_URL="https://raw.githubusercontent.com/mlender-ai/auto-trading-bot/main/generated/research/latest.json"
 NEWSLETTER_TO=""
 NEWSLETTER_FROM=""

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -96,6 +96,27 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             </p>
           </section>
 
+          {/* 공식 지표(FRED 등) — 강세/약세와 별개의 중립 사실 숫자(C-2). hasInsight 무관. */}
+          {insight?.officialFacts && insight.officialFacts.length > 0 && (
+            <section className="mt-6">
+              <p className="font-pixel text-sm text-whiteout">📊 공식 지표</p>
+              <ul className="mt-2 space-y-2">
+                {insight.officialFacts.map((f, i) => (
+                  <li key={`of-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                    <span className="block text-sm leading-5 text-whiteout">{f.label}</span>
+                    {f.url ? (
+                      <a href={f.url} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
+                        ↳ {f.source} · 공식 데이터 →
+                      </a>
+                    ) : (
+                      <span className="mt-1 block text-[11px] text-muted">↳ {f.source} · 공식 데이터</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
           {hasInsight ? (
             <>
               {insight!.singleOutlet && insight!.outlets.length > 0 && (

--- a/apps/web/lib/fred.ts
+++ b/apps/web/lib/fred.ts
@@ -1,0 +1,89 @@
+import { parseFredCsvLatest, buildFredDoc, FRED_SERIES, type SourceDoc } from "@fomo/core";
+
+/**
+ * FRED 수집 — DATA_ENGINE_STRATEGY §4.5 C-2. (네트워크)
+ *
+ * 기본은 **키리스 공개 엔드포인트**(fredgraph.csv) — API 키 없이 동작.
+ * FRED_API_KEY 가 있으면 공식 JSON API 로 업그레이드(더 견고). 둘 다 실패 시 빈 배열(정직한 폴백).
+ *
+ * 키리스 CSV 는 전체 히스토리가 커서 타임아웃 → cosd(최근 시작일)로 구간 제한.
+ */
+
+const FRED_API_KEY = process.env["FRED_API_KEY"] ?? "";
+const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
+/** 최근 N일만 — 월간(FEDFUNDS/CPI)도 충분히 커버하면서 페이로드를 작게. */
+const LOOKBACK_DAYS = 150;
+
+/** 테마 → FRED 시리즈. 지금은 금리(거시)만 — 다른 테마는 FRED 근거 없음. */
+const FRED_THEME_SERIES: Record<string, string[]> = {
+  금리: ["FEDFUNDS", "DGS10", "DGS2"],
+};
+
+function cosd(): string {
+  const d = new Date(Date.now() - LOOKBACK_DAYS * 86_400_000);
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "UTC" }).format(d); // YYYY-MM-DD
+}
+
+/** 키리스 CSV 경로. 실패 시 null. */
+async function fetchCsvLatest(seriesId: string): Promise<{ date: string; value: number } | null> {
+  try {
+    const url = `https://fred.stlouisfed.org/graph/fredgraph.csv?id=${encodeURIComponent(seriesId)}&cosd=${cosd()}`;
+    const res = await fetch(url, {
+      headers: { "user-agent": UA, accept: "text/csv,*/*" },
+      signal: AbortSignal.timeout(15_000),
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    return parseFredCsvLatest(await res.text());
+  } catch (err) {
+    console.warn(`[fred] csv ${seriesId} error`, err);
+    return null;
+  }
+}
+
+interface FredJsonResp {
+  observations?: { date: string; value: string }[];
+}
+
+/** 키 있을 때 공식 JSON API(더 견고). 실패 시 null → CSV 폴백. */
+async function fetchJsonLatest(seriesId: string): Promise<{ date: string; value: number } | null> {
+  try {
+    const url =
+      `https://api.stlouisfed.org/fred/series/observations?series_id=${encodeURIComponent(seriesId)}` +
+      `&api_key=${FRED_API_KEY}&file_type=json&sort_order=desc&limit=10&observation_start=${cosd()}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(15_000), next: { revalidate: 3600 } });
+    if (!res.ok) return null;
+    const data = (await res.json()) as FredJsonResp;
+    for (const o of data.observations ?? []) {
+      const v = Number.parseFloat(o.value);
+      if (Number.isFinite(v)) return { date: o.date, value: v };
+    }
+    return null;
+  } catch (err) {
+    console.warn(`[fred] json ${seriesId} error`, err);
+    return null;
+  }
+}
+
+/** 테마의 FRED 공식 데이터 SourceDoc[]. idStart 부터 id 부여(S{n}). 미매핑/실패 시 빈 배열. */
+export async function fetchFredDocs(theme: string, makeId: () => string): Promise<SourceDoc[]> {
+  const series = FRED_THEME_SERIES[theme];
+  if (!series || series.length === 0) return [];
+
+  const settled = await Promise.allSettled(
+    series.map(async (s) => {
+      // 키 있으면 JSON 우선, 실패하면 키리스 CSV 로 폴백.
+      const obs = (FRED_API_KEY && (await fetchJsonLatest(s))) || (await fetchCsvLatest(s));
+      return obs ? { seriesId: s, obs } : null;
+    })
+  );
+
+  const docs: SourceDoc[] = [];
+  for (const r of settled) {
+    if (r.status === "fulfilled" && r.value && FRED_SERIES[r.value.seriesId]) {
+      const doc = buildFredDoc(makeId(), r.value.seriesId, r.value.obs);
+      if (doc) docs.push(doc);
+    }
+  }
+  return docs;
+}

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -8,9 +8,11 @@ import {
   type ThemeInsight,
   type KeywordSourceItem,
   type WordingVerdict,
+  type OfficialFact,
 } from "@fomo/core";
 import { fetchNaverBoardPosts } from "@fomo/core";
 import { fetchAllNews } from "./fomo-news-sources";
+import { fetchFredDocs } from "./fred";
 
 /**
  * 이해 레이어 오케스트레이션 — DATA_ENGINE_STRATEGY §4 Track A. (네트워크 + LLM)
@@ -109,6 +111,13 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
     }
   });
 
+  // 공식 데이터(FRED) — 금리·거시 테마에 연준 공식 숫자(official-high). grounding 강화(C-2).
+  try {
+    docs.push(...(await fetchFredDocs(theme, nextId)));
+  } catch (err) {
+    console.warn("[theme-understanding] fred error", err);
+  }
+
   return docs;
 }
 
@@ -164,14 +173,32 @@ async function judgeWordingsSafety(
   return out;
 }
 
+/** 공식 데이터(FRED 등 kind=official) 원문을 중립 팩트 리스트로(방향성 주장 아님 — C-2). */
+function officialFactsFrom(docs: readonly SourceDoc[]): OfficialFact[] {
+  return docs
+    .filter((d) => d.kind === "official" && d.source && d.tier)
+    .map((d) => ({
+      label: d.title,
+      ...(d.body ? { detail: d.body } : {}),
+      source: d.source!,
+      ...(d.url ? { url: d.url } : {}),
+      tier: d.tier!,
+    }));
+}
+
 /** 테마 이해·구조화 — 수집 → LLM → grounding 검증(assemble) → 워딩 LLM 안전 판정. 실패 시 정직한 빈 상태. */
 export async function understandTheme(theme: string): Promise<ThemeInsight> {
   const docs = await collectThemeDocs(theme);
   if (docs.length === 0) return emptyThemeInsight(theme, "수집된 원문이 없음(소스 도달 실패 또는 매칭 0)");
 
+  // 공식 지표 팩트(FRED) — LLM 결과와 별개로 항상 노출(있으면). 강세/약세로 해석하지 않는다.
+  const officialFacts = officialFactsFrom(docs);
+  const withFacts = (insight: ThemeInsight): ThemeInsight =>
+    officialFacts.length > 0 ? { ...insight, officialFacts } : insight;
+
   const apiKey = resolveAiKey();
   if (!AI_API_URL || !apiKey) {
-    return emptyThemeInsight(theme, "AI 미설정 — 이해 레이어 비활성(정직한 빈 상태)");
+    return withFacts(emptyThemeInsight(theme, "AI 미설정 — 이해 레이어 비활성(정직한 빈 상태)"));
   }
 
   try {
@@ -187,14 +214,14 @@ export async function understandTheme(theme: string): Promise<ThemeInsight> {
     });
     if (!res.ok) {
       console.warn("[theme-understanding] LLM", res.status);
-      return emptyThemeInsight(theme, `LLM ${res.status} — 정직한 빈 상태`);
+      return withFacts(emptyThemeInsight(theme, `LLM ${res.status} — 정직한 빈 상태`));
     }
     const data = (await res.json()) as LlmResponse;
     const raw = parseThemeInsightResponse(data.choices?.[0]?.message?.content ?? "");
     const insight = assembleThemeInsight(theme, docs, raw);
 
     // 2단계: 룰 통과 워딩을 LLM 으로 한 번 더 안전 판정(욕설/단정/혐오/찌라시 — 룰이 못 잡는 뉘앙스).
-    if (insight.wordings.length === 0) return insight;
+    if (insight.wordings.length === 0) return withFacts(insight);
     const judged = await judgeWordingsSafety(insight.wordings.map((w) => w.text), apiKey);
     const llmAudit: WordingVerdict[] = insight.wordings.map((w) => {
       const v = judged.get(w.text);
@@ -210,13 +237,13 @@ export async function understandTheme(theme: string): Promise<ThemeInsight> {
     if (dropped.length > 0) {
       console.warn("[wording-judge] dropped:", dropped.map((d) => `"${d.text}"(${d.reason})`).join(" | "));
     }
-    return {
+    return withFacts({
       ...insight,
       wordings: safeWordings,
       wordingAudit: [...(insight.wordingAudit ?? []), ...llmAudit],
-    };
+    });
   } catch (err) {
     console.warn("[theme-understanding] error", err);
-    return emptyThemeInsight(theme, "이해 레이어 호출 실패 — 정직한 빈 상태");
+    return withFacts(emptyThemeInsight(theme, "이해 레이어 호출 실패 — 정직한 빈 상태"));
   }
 }

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -110,6 +110,43 @@ describe("균형(강세/약세) 정직 표기", () => {
   });
 });
 
+describe("FRED 공식 데이터 (C-2)", () => {
+  it("parseFredCsvLatest — 최신 유효 관측치(결측 '.' 스킵)", async () => {
+    const { parseFredCsvLatest } = await import("../src");
+    const csv = "observation_date,FEDFUNDS\n2026-03-01,4.33\n2026-04-01,.\n2026-05-01,3.63\n";
+    expect(parseFredCsvLatest(csv)).toEqual({ date: "2026-05-01", value: 3.63 });
+    expect(parseFredCsvLatest("")).toBeNull();
+    expect(parseFredCsvLatest("observation_date,X\n2026-05-01,.\n")).toBeNull(); // 전부 결측
+  });
+
+  it("buildFredDoc — 팩트 문장 + official-high + kind official(주장 아닌 숫자)", async () => {
+    const { buildFredDoc } = await import("../src");
+    const doc = buildFredDoc("S1", "FEDFUNDS", { date: "2026-05-01", value: 3.63 })!;
+    expect(doc.kind).toBe("official");
+    expect(doc.tier).toBe("official-high");
+    expect(doc.title).toContain("3.63%");
+    expect(doc.body).toContain("FRED FEDFUNDS");
+    expect(doc.source).toContain("FRED");
+    // 사전에 없는 시리즈 → null
+    expect(buildFredDoc("S2", "UNKNOWN_X", { date: "2026-05-01", value: 1 })).toBeNull();
+  });
+
+  it("FRED 문장은 이해 레이어의 grounding 근거로 쓰인다(quote substring)", async () => {
+    const { buildFredDoc } = await import("../src");
+    const doc = buildFredDoc("S1", "FEDFUNDS", { date: "2026-05-01", value: 3.63 })!;
+    const raw = {
+      stocks: [],
+      bull: [],
+      bear: [{ claim: "기준금리가 높게 유지돼 부담이라는 시각", sourceId: "S1", quote: "기준금리(연방기금금리)는 3.63%" }],
+      wordings: [],
+      stanceNote: "",
+    };
+    const r = assembleThemeInsight("금리", [doc], raw);
+    expect(r.bear).toHaveLength(1); // 연준 숫자에 grounded → 통과
+    expect(r.sources[0]!.tier).toBe("official-high");
+  });
+});
+
 describe("소스 tier 전파 (C-1)", () => {
   it("SourceDoc.tier → InsightSourceRef.tier 로 전파(가중·표기용)", () => {
     const docs: SourceDoc[] = [

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -46,6 +46,8 @@ export interface CondensedInsight {
   reason: string;
   /** 워딩 필터 감사 로그(통과·탈락 + 사유, 검수용). */
   wordingAudit?: import("./types").WordingVerdict[];
+  /** 공식 지표 팩트(FRED 등) — 중립 사실 숫자(C-2). 강세/약세와 별개. */
+  officialFacts?: import("./types").OfficialFact[];
 }
 
 export interface CondenseOptions {
@@ -77,6 +79,9 @@ export function condenseThemeInsight(
     confidence: insight.confidence,
     reason: insight.reason,
     ...(insight.wordingAudit ? { wordingAudit: insight.wordingAudit } : {}),
+    ...(insight.officialFacts && insight.officialFacts.length > 0
+      ? { officialFacts: insight.officialFacts }
+      : {}),
   };
 
   // 정직한 빈 상태 — A가 근거를 못 뽑았으면 응축도 비운다(가짜 생성 금지).

--- a/packages/fomo-core/src/theme-understanding/fred.ts
+++ b/packages/fomo-core/src/theme-understanding/fred.ts
@@ -1,0 +1,68 @@
+import type { SourceDoc } from "./types";
+
+/**
+ * FRED(미 연준 세인트루이스) 공식 경제 데이터 — DATA_ENGINE_STRATEGY §4.5 C-2.
+ *
+ * "주장 아닌 연준 숫자"로 grounding 강화. 금리·거시 테마에 official-high tier 근거를 댄다.
+ * 순수부: CSV 파싱 + 시리즈 사전 + 팩트 문장(SourceDoc) 빌드. fetch(키리스/키) 는 apps/web.
+ */
+
+export interface FredSeriesDef {
+  /** 한국어 표기명. */
+  name: string;
+  /** 단위 접미(예: "%"). 없으면 "". */
+  unit: string;
+}
+
+/** 추적 시리즈 사전(금리·거시). 확장 가능. */
+export const FRED_SERIES: Record<string, FredSeriesDef> = {
+  FEDFUNDS: { name: "미국 기준금리(연방기금금리)", unit: "%" },
+  DGS10: { name: "미국 10년물 국채금리", unit: "%" },
+  DGS2: { name: "미국 2년물 국채금리", unit: "%" },
+  CPIAUCSL: { name: "미국 소비자물가지수(CPI)", unit: "" },
+  UNRATE: { name: "미국 실업률", unit: "%" },
+};
+
+export interface FredObservation {
+  date: string;
+  value: number;
+}
+
+/**
+ * fredgraph.csv 본문 → 최신 유효 관측치. 결측("."), 헤더, 빈 줄은 건너뛴다.
+ * CSV 형식: `observation_date,SERIES\n2026-05-01,3.63\n...`
+ */
+export function parseFredCsvLatest(csv: string): FredObservation | null {
+  if (!csv) return null;
+  const lines = csv.trim().split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 1; i--) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    const [date, raw] = line.split(",");
+    if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    const v = Number.parseFloat(raw ?? "");
+    if (!Number.isFinite(v)) continue; // 결측 "." 등
+    return { date, value: v };
+  }
+  return null;
+}
+
+/**
+ * 시리즈 + 관측치 → 팩트 SourceDoc(tier=official-high). 사전에 없는 시리즈면 null.
+ * 문장은 "주장"이 아니라 "사실 수치" — 이해 레이어가 이걸 근거(quote)로 grounding 한다.
+ */
+export function buildFredDoc(id: string, seriesId: string, obs: FredObservation): SourceDoc | null {
+  const def = FRED_SERIES[seriesId];
+  if (!def) return null;
+  const valueText = `${obs.value}${def.unit}`;
+  return {
+    id,
+    kind: "official",
+    title: `${def.name} ${valueText}`,
+    body: `${obs.date} 기준, ${def.name}는 ${valueText}다. (미 연준 공식 데이터 · FRED ${seriesId})`,
+    source: "FRED(미 연준)",
+    url: `https://fred.stlouisfed.org/series/${seriesId}`,
+    publishedAt: `${obs.date}T00:00:00Z`,
+    tier: "official-high",
+  };
+}

--- a/packages/fomo-core/src/theme-understanding/index.ts
+++ b/packages/fomo-core/src/theme-understanding/index.ts
@@ -4,3 +4,4 @@ export * from "./parse";
 export * from "./assemble";
 export * from "./condense";
 export * from "./wording-filter";
+export * from "./fred";

--- a/packages/fomo-core/src/theme-understanding/prompt.ts
+++ b/packages/fomo-core/src/theme-understanding/prompt.ts
@@ -32,6 +32,7 @@ export function buildThemeInsightPrompt(theme: string, docs: readonly SourceDoc[
     "3) 투자조언·매매신호·미래 단정 금지(사라/팔아라/매수/오른다/목표가 X). 사실 전달만.",
     "4) wordings: 사람들이 *실제로 한 말*(특히 커뮤니티 원문)을 그대로 인용. 없으면 빈 배열.",
     "5) stocks: 원문에서 언급된 종목/섹터만.",
+    "6) 공식 데이터(official — FRED/연준 등 실제 숫자)가 원문에 있으면, 관련 사실 근거에 *우선 인용*하라. 주장보다 신뢰도가 높다.",
     "",
     "수집된 원문:",
     corpus || "(원문 없음)",

--- a/packages/fomo-core/src/theme-understanding/types.ts
+++ b/packages/fomo-core/src/theme-understanding/types.ts
@@ -8,7 +8,7 @@
  *   투자조언/매매신호 금지(판단 재료지 답이 아님) · 데이터 부족 시 정직한 빈 상태.
  */
 
-export type SourceKind = "news" | "community";
+export type SourceKind = "news" | "community" | "official";
 
 export type { SourceTier } from "../news-feed/types";
 
@@ -60,6 +60,17 @@ export interface InsightSourceRef {
   tier?: import("../news-feed/types").SourceTier;
 }
 
+/** 공식 지표 팩트(FRED 등) — 방향성 주장이 아니라 *중립 사실 숫자*. official-high. */
+export interface OfficialFact {
+  /** 예: "미국 기준금리(연방기금금리) 3.63%". */
+  label: string;
+  /** 보충 문장(시점 등). */
+  detail?: string;
+  source: string;
+  url?: string;
+  tier: import("../news-feed/types").SourceTier;
+}
+
 /** 한 테마의 이해·구조화 결과. */
 export interface ThemeInsight {
   theme: string;
@@ -81,4 +92,6 @@ export interface ThemeInsight {
   reason: string;
   /** 워딩 필터 전/후 감사 로그(통과·탈락 + 사유, 검수용). */
   wordingAudit?: import("./wording-filter").WordingVerdict[];
+  /** 공식 지표 팩트(FRED 등) — 강세/약세와 별개로 중립 사실 노출(C-2). */
+  officialFacts?: OfficialFact[];
 }


### PR DESCRIPTION
DATA_ENGINE_STRATEGY §4.5 Phase C-2. 금리·거시 테마에 "주장 아닌 연준 숫자"를 근거로 — grounding 강화.

## 키 처리
- **키 없이 동작**(키리스 `fredgraph.csv`). 제가 FRED 키를 발급할 수 없어(계정 필요) 키리스로 우선 연동.
- `FRED_API_KEY` 설정 시 공식 JSON API 로 자동 업그레이드(없으면 CSV, 둘 다 실패 시 빈 배열).
- **키 추가 가이드(원하실 때)**: https://fred.stlouisfed.org/docs/api/api_key.html 에서 무료 발급 → Vercel `FRED_API_KEY` 추가(제가 `vercel env`로 넣어드릴 수도 있습니다, 키 값만 주시면).

## 변경
- `theme-understanding/fred.ts`(순수): `FRED_SERIES` 사전 + `parseFredCsvLatest`(결측 '.' 스킵) + `buildFredDoc`(팩트 문장, `kind=official`, `tier=official-high`).
- `apps/web/lib/fred.ts`: 키리스 CSV(`cosd` 구간 제한 — 전체 히스토리 타임아웃 회피) / 키 우선·CSV 폴백.
- `collectThemeDocs`: 금리 테마에 FRED 문서(FEDFUNDS/DGS10/DGS2) 추가.
- **중립 사실로 노출**: 공식 숫자를 강세/약세로 억지 해석 안 함 → `officialFacts`(별도). 뎁스에 **"📊 공식 지표"** 섹션(official-high + 출처 링크).
- `SourceKind`에 `official` 추가. `.env.example` FRED_API_KEY.

## 검증
- typecheck ✅ / vitest **612**(+3 FRED 순수) ✅ / build:web ✅ / build:fomo-web ✅
- 키리스 실수집: 금리 뎁스 공식 지표 3건(기준금리 3.63%·10년물 4.45%·2년물 4.05%) / 반도체 0건(정상, 섹션 미표시).

A·B 엔진 위에 소스만 추가, grounding·균형·정직성 유지. §5.5: CI green → 자동 머지(공개 API, DDL·유료 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)