### PR TITLE
C-3: 디시 주식갤러리 연동 (community-low, 워딩 필터)

### DIFF
--- a/apps/web/lib/dcinside.ts
+++ b/apps/web/lib/dcinside.ts
@@ -1,0 +1,33 @@
+import { parseDcGalleryTitles } from "@fomo/core";
+
+/**
+ * 디시인사이드 주식갤러리 수집 — DATA_ENGINE_STRATEGY §4.5 C-3. (네트워크)
+ *
+ * 공개 웹(gall.dcinside.com). 제목 원문만 가져온다(본문은 안 긁음 — 가벼움+안전).
+ * community-low tier. 욕설·단정은 워딩 필터(룰+LLM)가 카드 진입 전 거른다.
+ * 실패 시 빈 배열(정직한 폴백).
+ */
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const STOCK_GALLERY = "https://gall.dcinside.com/board/lists/?id=stock";
+
+/** 주식갤러리 최근 게시물 제목. 실패 시 []. */
+export async function fetchDcStockTitles(limit = 30): Promise<string[]> {
+  try {
+    const res = await fetch(STOCK_GALLERY, {
+      headers: { "user-agent": UA, accept: "text/html,application/xhtml+xml" },
+      signal: AbortSignal.timeout(10_000),
+      next: { revalidate: 600 },
+    });
+    if (!res.ok) {
+      console.warn("[dcinside] HTTP", res.status);
+      return [];
+    }
+    return parseDcGalleryTitles(await res.text(), limit);
+  } catch (err) {
+    console.warn("[dcinside] error", err);
+    return [];
+  }
+}

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -13,6 +13,7 @@ import {
 import { fetchNaverBoardPosts } from "@fomo/core";
 import { fetchAllNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
+import { fetchDcStockTitles } from "./dcinside";
 
 /**
  * 이해 레이어 오케스트레이션 — DATA_ENGINE_STRATEGY §4 Track A. (네트워크 + LLM)
@@ -55,8 +56,9 @@ interface LlmResponse {
 export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
   const codes = THEME_NAVER_CODES[theme] ?? [];
 
-  const [newsRes, ...commRes] = await Promise.allSettled([
+  const [newsRes, dcRes, ...commRes] = await Promise.allSettled([
     fetchAllNews(),
+    fetchDcStockTitles(),
     ...codes.map((c) => fetchNaverBoardPosts(c.code)),
   ]);
 
@@ -110,6 +112,24 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
       console.warn("[theme-understanding] community error", c.label, r.reason);
     }
   });
+
+  // 디시 주식갤러리(C-3) — 날것 심리(community-low). 테마 관련 글만 필터(기존 extract 재사용).
+  // 욕설·단정은 워딩 필터(룰+LLM)가 카드 진입 전 거른다.
+  if (dcRes.status === "fulfilled" && dcRes.value.length > 0) {
+    const dcItems: KeywordSourceItem[] = dcRes.value.map((t) => ({ title: t }));
+    const dcBucket = extractKeywords(dcItems).find((k) => k.keyword === theme);
+    for (const art of (dcBucket?.articles ?? []).slice(0, 6)) {
+      docs.push({
+        id: nextId(),
+        kind: "community",
+        title: art.title,
+        source: "디시 주식갤러리",
+        tier: "community-low",
+      });
+    }
+  } else if (dcRes.status === "rejected") {
+    console.warn("[theme-understanding] dcinside error", dcRes.reason);
+  }
 
   // 공식 데이터(FRED) — 금리·거시 테마에 연준 공식 숫자(official-high). grounding 강화(C-2).
   try {

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -110,6 +110,29 @@ describe("균형(강세/약세) 정직 표기", () => {
   });
 });
 
+describe("디시 주식갤러리 파서 (C-3)", () => {
+  it("parseDcGalleryTitles — board/view 앵커 제목 추출(태그/엔티티 정리·중복·숫자만 스킵)", async () => {
+    const { parseDcGalleryTitles } = await import("../src");
+    const html = `
+      <td class="gall_tit"><a href="/board/view/?id=stock&amp;no=123">삼성전자 <b>가즈아</b></a></td>
+      <td class="gall_tit"><a href="/board/view/?id=stock&no=124">반도체 슈퍼사이클 온다</a></td>
+      <td class="gall_tit"><a href="/board/view/?id=stock&no=125">반도체 슈퍼사이클 온다</a></td>
+      <td><a href="/board/view/?id=stock&no=126">42</a></td>
+    `;
+    const out = parseDcGalleryTitles(html, 10);
+    expect(out).toContain("삼성전자 가즈아");
+    expect(out).toContain("반도체 슈퍼사이클 온다");
+    expect(out.filter((t) => t === "반도체 슈퍼사이클 온다")).toHaveLength(1); // 중복 제거
+    expect(out).not.toContain("42"); // 숫자만 스킵
+  });
+
+  it("빈/무효 입력 → 빈 배열", async () => {
+    const { parseDcGalleryTitles } = await import("../src");
+    expect(parseDcGalleryTitles("")).toEqual([]);
+    expect(parseDcGalleryTitles("<div>no anchors</div>")).toEqual([]);
+  });
+});
+
 describe("FRED 공식 데이터 (C-2)", () => {
   it("parseFredCsvLatest — 최신 유효 관측치(결측 '.' 스킵)", async () => {
     const { parseFredCsvLatest } = await import("../src");

--- a/packages/fomo-core/src/theme-understanding/dcinside.ts
+++ b/packages/fomo-core/src/theme-understanding/dcinside.ts
@@ -1,0 +1,29 @@
+/**
+ * 디시인사이드 주식갤러리 파서 — DATA_ENGINE_STRATEGY §4.5 C-3. 순수(네트워크 0).
+ *
+ * 가장 날것의 개미 심리(community-low). 욕설·단정·찌라시 多 → **워딩 필터 필수**(이미 적용).
+ * 여기선 게시물 제목만 보존 추출(개수가 아니라 내용). 안전 판정은 wording-filter + LLM judge 가 한다.
+ */
+
+/**
+ * 갤러리 리스트 HTML → 게시물 제목 배열. board/view 앵커 텍스트를 뽑고 태그/엔티티 정리.
+ * 공지·이벤트·숫자만/빈 제목은 스킵. limit 개까지(최신 우선 = HTML 등장 순).
+ */
+export function parseDcGalleryTitles(html: string, limit = 30): string[] {
+  if (!html) return [];
+  const re = /href="\/board\/view\/\?id=[a-z0-9_]+(?:&amp;|&)no=\d+[^"]*"[^>]*>([\s\S]*?)<\/a>/g;
+  const out: string[] = [];
+  const seen = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null && out.length < limit) {
+    const t = (m[1] ?? "")
+      .replace(/<[^>]+>/g, "")
+      .replace(/&[a-z]+;/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (t.length < 2 || /^\d+$/.test(t) || seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+  }
+  return out;
+}

--- a/packages/fomo-core/src/theme-understanding/index.ts
+++ b/packages/fomo-core/src/theme-understanding/index.ts
@@ -5,3 +5,4 @@ export * from "./assemble";
 export * from "./condense";
 export * from "./wording-filter";
 export * from "./fred";
+export * from "./dcinside";


### PR DESCRIPTION
DATA_ENGINE_STRATEGY §4.5 Phase C-3. 가장 날것의 개미 심리(디시 주식갤러리) 추가. 토스 대체재(토스는 로그인벽 → 제외).

## 변경
- `theme-understanding/dcinside.ts`(순수): `parseDcGalleryTitles` — board/view 앵커 제목 추출(태그/엔티티 정리·중복·숫자만 스킵).
- `apps/web/lib/dcinside.ts`: gall.dcinside.com 주식갤러리 **제목만** 페치(본문 X — 가벼움+안전). 실패 시 [].
- `collectThemeDocs`: 디시 글을 **테마 관련만 필터**(기존 extract 재사용) → `community-low` 문서.

## 안전 (C-3 전제)
디시는 욕설·단정·찌라시 多 → **기존 워딩 필터(룰+LLM)가 카드 진입 전 차단**. 디시 path도 동일 파이프라인. 통과 워딩만 원문 그대로 노출, 0개면 빈 섹션.

## 검증
- typecheck ✅ / vitest **614**(+2 파서) ✅ / build:web ✅ / build:fomo-web ✅
- 디시 30제목 페치 정상. 워딩 audit 실증: ❌"안티들…사주"(비방)·❌"…매수위험할듯"(매매권유) 탈락 / ✅심리·전략 표현 유지.
- 오늘 디시 주식갤은 일반 매크로 글 위주라 5테마 매칭 0(정직한 동작 — 테마 글 등장 시 community-low로 흐름).

A·B 엔진 위에 소스만 추가. grounding·균형·정직성 유지. §5.5: CI green → 자동 머지(공개 웹, DDL·유료 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)