### PR TITLE
작업2(1/2): 강세/약세 쏠림(lean) 엔진 — 뎁스

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -119,6 +119,15 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
 
           {hasInsight ? (
             <>
+              {insight!.lean.bullCount + insight!.lean.bearCount > 0 && (
+                <p className="mt-3 text-[11px] leading-5 text-muted">
+                  오늘 쏠림 · <span style={{ color: "var(--up, #ff5a5f)" }}>강세 {insight!.lean.bullCount}</span>
+                  {" : "}
+                  <span style={{ color: "var(--down, #4f8cff)" }}>약세 {insight!.lean.bearCount}</span>
+                  {insight!.lean.oneSided ? " · 반대 관점 안 보임" : ""}
+                </p>
+              )}
+
               {insight!.singleOutlet && insight!.outlets.length > 0 && (
                 <p className="mt-3 rounded-lg border border-hairline bg-surface px-3 py-2 text-[11px] leading-5 text-muted">
                   ⚠️ 오늘은 <span className="text-whiteout">{insight!.outlets[0]}</span> 한 곳 기준이야 — 한 매체 안의 시각일 수 있어.

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -294,6 +294,28 @@ describe("parse / prompt / 커뮤니티 원문 보존", () => {
     expect(c.confidence).toBe("low");
   });
 
+  it("condense — lean(쏠림): grounded 전체 카운트 + 방향 + oneSided", () => {
+    const mk = (bull: number, bear: number): ThemeInsight => ({
+      theme: "반도체",
+      stocks: [],
+      bull: Array.from({ length: bull }, (_, i) => ({ claim: `b${i}`, sourceId: "S1", quote: "q" })),
+      bear: Array.from({ length: bear }, (_, i) => ({ claim: `r${i}`, sourceId: "S1", quote: "q" })),
+      wordings: [],
+      stance: "balanced",
+      stanceNote: "",
+      sources: [{ id: "S1", kind: "news", title: "t" }],
+      confidence: "low",
+      reason: "r",
+    });
+    // slice(maxPerSide=2) 와 무관하게 lean 은 전체 카운트.
+    const a = condenseThemeInsight(mk(9, 1));
+    expect(a.lean).toEqual({ bullCount: 9, bearCount: 1, direction: "bull", oneSided: false });
+    expect(a.bull.length).toBe(2); // 표시는 slice
+    expect(condenseThemeInsight(mk(3, 3)).lean.direction).toBe("balanced");
+    expect(condenseThemeInsight(mk(5, 0)).lean).toMatchObject({ direction: "bull", oneSided: true });
+    expect(condenseThemeInsight(mk(0, 4)).lean).toMatchObject({ direction: "bear", oneSided: true });
+  });
+
   it("condense — 강세만이면 약세 안 보임 정직 표기(균형)", () => {
     const insight: ThemeInsight = {
       theme: "반도체",

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -26,6 +26,19 @@ export interface CondensedPoint {
   sourceId: string;
 }
 
+/**
+ * 강세/약세 쏠림(NEXT_FEATURES_HANDOFF 작업2). 점수=얼마나 뜨거운가, lean=어느 쪽으로 기울었나.
+ * grounded 카운트(전체) 기반. 방향 *제시*가 아니라 쏠림 *알림*(CTA 재료, 매매신호 아님).
+ */
+export interface LeanInfo {
+  bullCount: number;
+  bearCount: number;
+  /** 차이 1 이하면 balanced. */
+  direction: "bull" | "bear" | "balanced";
+  /** 한쪽이 0(반대 관점 안 보임). */
+  oneSided: boolean;
+}
+
 export interface CondensedInsight {
   theme: string;
   /** "왜 떴나" 2~3문장 — A의 grounded claim 들을 결정론적으로 종합(새 사실 추가 없음). */
@@ -42,6 +55,8 @@ export interface CondensedInsight {
   /** 출처가 한 매체에만 쏠렸나(true면 "한 곳 안의 균형"일 뿐 — UI/정직성 표기). */
   singleOutlet: boolean;
   confidence: ThemeInsightConfidence;
+  /** 강세/약세 쏠림(작업2) — grounded 전체 카운트. CTA·시각화 재료. */
+  lean: LeanInfo;
   /** 정직성/진단 — 왜 이 confidence·stance 인지(A의 reason 그대로). 빈 상태 원인 추적용. */
   reason: string;
   /** 워딩 필터 감사 로그(통과·탈락 + 사유, 검수용). */
@@ -69,6 +84,17 @@ export function condenseThemeInsight(
   const outlets = [...new Set(insight.sources.map((s) => s.source).filter((x): x is string => !!x))];
   const singleOutlet = outlets.length <= 1;
 
+  // 쏠림(작업2) — grounded *전체* 카운트로(표시용 slice 전). 차이 1 이하면 balanced.
+  const bullCount = insight.bull.length;
+  const bearCount = insight.bear.length;
+  const lean: LeanInfo = {
+    bullCount,
+    bearCount,
+    direction:
+      Math.abs(bullCount - bearCount) <= 1 ? "balanced" : bullCount > bearCount ? "bull" : "bear",
+    oneSided: bullCount + bearCount > 0 && (bullCount === 0 || bearCount === 0),
+  };
+
   const base = {
     theme: insight.theme,
     stance: insight.stance,
@@ -76,6 +102,7 @@ export function condenseThemeInsight(
     sources: insight.sources,
     outlets,
     singleOutlet,
+    lean,
     confidence: insight.confidence,
     reason: insight.reason,
     ...(insight.wordingAudit ? { wordingAudit: insight.wordingAudit } : {}),


### PR DESCRIPTION
NEXT_FEATURES_HANDOFF 작업2 — 엔진 파트(무료, 비용 증가 없음).

## 변경
- `CondensedInsight.lean = { bullCount, bearCount, direction, oneSided }` — grounded 이해 레이어의 강세N:약세M **전체 카운트**(표시용 slice 와 무관). 차이 ≤1 = balanced, 한쪽 0 = oneSided.
- 뎁스에 '오늘 쏠림 · 강세 N : 약세 M (반대 관점 안 보임)' 한 줄(색 토큰 up/down).
- **방향 제시가 아니라 쏠림 알림**(CTA 재료, 매매신호 X). 투자조언 금지·grounding·균형 유지.

## 검증
- typecheck ✅ / vitest **616**(+1 lean) ✅ / build:web ✅ / build:fomo-web ✅

## ⚠️ 별도(비용 게이트) — 다음 보고
메인 카드(피드)에 lean 을 실어 광혁의 시각화(카드 색/VS bar)에 쓰려면, lean 의 출처인 **이해 패스(understandTheme)를 피드 경로에서 돌려야** 함(현재는 탭 전용·무거움). 매 로드 비용↑ 또는 일일 cron 스냅샷(db push 게이트). → 머지 후 옵션 보고 드리고 결정.

§머지정책: 엔진 파트 CI green 시 자동 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)