### PR TITLE
[CEO Brief #429] 스켈레톤 로딩 연결 + aiSummary 라이브 표시 + 타이포 개선

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { KeywordHistory } from "@/components/KeywordHistory";
+import { FomoIndexSkeleton } from "@/components/SkeletonLoader";
 import type {
   FomoIndexResponse,
   TallyResponse,
@@ -65,22 +66,31 @@ export function HomeView({
         </div>
 
         {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}
+        {/* index 미로드 시 스켈레톤 (이슈 #409) — API 호출 실패 시 빈 화면 대신 담담한 대기 표시 */}
+        {!index && <FomoIndexSkeleton />}
         {index && !isFullFallback && (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
-            <span className="text-xs text-muted">오늘의 시장 온도</span>
-            <div className="flex items-baseline gap-2">
-              <span className="font-pixel text-xl leading-none" style={{ color }}>
-                {index.score}
-              </span>
-              <span className="font-pixel text-[11px] text-muted">{index.state}</span>
-              {index.prevDayDelta !== 0 && (
-                <span className="font-pixel text-[11px]" style={{ color }}>
-                  {index.prevDayDelta > 0
-                    ? `· 어제보다 ▲+${index.prevDayDelta}`
-                    : `· 어제보다 ▼${index.prevDayDelta}`}
+          <div className="mt-3 rounded-xl border border-hairline bg-surface px-4 py-2.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted">오늘의 시장 온도</span>
+              <div className="flex items-baseline gap-2">
+                {/* 이슈 #412: 점수 가시성 개선 — text-xl → text-2xl */}
+                <span className="font-pixel text-2xl leading-none" style={{ color }}>
+                  {index.score}
                 </span>
-              )}
+                <span className="font-pixel text-[11px] text-muted">{index.state}</span>
+                {index.prevDayDelta !== 0 && (
+                  <span className="font-pixel text-[11px]" style={{ color }}>
+                    {index.prevDayDelta > 0
+                      ? `· 어제보다 ▲+${index.prevDayDelta}`
+                      : `· 어제보다 ▼${index.prevDayDelta}`}
+                  </span>
+                )}
+              </div>
             </div>
+            {/* aiSummary: Heat 정보 포함 요약 (이슈 #428 buildSummary 결과) */}
+            {index.aiSummary && (
+              <p className="mt-1.5 text-[11px] leading-relaxed text-muted">{index.aiSummary}</p>
+            )}
           </div>
         )}
         {index && isFullFallback && (

--- a/apps/fomo-web/components/SkeletonLoader.tsx
+++ b/apps/fomo-web/components/SkeletonLoader.tsx
@@ -13,12 +13,15 @@ function SkeletonBox({ className = "" }: { className?: string }) {
   );
 }
 
-/** FOMO Index 숫자 + 상태 라벨 영역 스켈레톤. */
+/** FOMO Index 스트립 영역 스켈레톤 — HomeView 상단 띠와 동일 레이아웃. */
 export function FomoIndexSkeleton() {
   return (
-    <div className="mt-3 flex flex-col items-center gap-2">
-      <SkeletonBox className="h-10 w-16" />
-      <SkeletonBox className="h-3 w-32" />
+    <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+      <SkeletonBox className="h-3 w-24" />
+      <div className="flex items-baseline gap-2">
+        <SkeletonBox className="h-6 w-8" />
+        <SkeletonBox className="h-3 w-10" />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/api/fomo/index/route.ts
+++ b/apps/web/app/api/fomo/index/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { scoreToColor, scoreToDescription } from "@fomo/core";
+import { scoreToColor, scoreToDescription, buildSummary } from "@fomo/core";
 import { prisma } from "../../../../lib/prisma";
 import { kstDate, computeLiveFomoIndex, corsJson, withCors } from "../../../../lib/fomo";
 import { createLogger } from "../../../../lib/logger";
@@ -54,7 +54,7 @@ export async function GET() {
         emotion:   comp("emotion"),
         whale:     comp("whale"),
       },
-      aiSummary:    "",
+      aiSummary:    buildSummary(idx),
       prevDayDelta: 0,
       avg30Delta:   0,
       live: true,


### PR DESCRIPTION
## 구현 항목

### 이미 구현된 항목 (이전 실행에서 완료)
- **#428 (Prompt Engineer)** — `summary.ts`의 `buildSummary`가 상위 2개 Heat 비율을 포함한 헤드라인 생성 (`@author CEO Brief 2026-06-09 #428` 주석 확인)
- **#426 (Security)** — `apps/web/lib/session-hmac.ts`에 HMAC-SHA256 서명 검증 구현, `vote/route.ts`에서 sessionId 형식 검사 + 위변조 감지 적용
- **#425 (Backend)** — `/api/fomo/emotions/today`에 `fallback: total === 0` 반환, `vote/route.ts`에 sessionId validator 및 HMAC 검증 적용
- **#415 (CTO)** — 모든 Heat 모듈(marketHeat, communityHeat, emotionHeat, whaleHeat)에 try/catch + 폴백, `calculate.ts`의 `safeHeat` 래퍼
- **#413 (QA)** — `packages/fomo-core/__tests__/calculate.test.ts`에 4개 Heat × 폴백 + buildSummary 정합성 테스트 포함
- **#410 (Frontend)** — `apps/fomo-web/components/FomoFace.tsx`에 `React.memo` + 커스텀 비교 함수 적용 (`이슈 #410` 주석 확인)

### 이번 PR에서 구현한 항목

#### #409 — 스켈레톤 로딩 연결
- `SkeletonLoader.tsx`의 `FomoIndexSkeleton`을 HomeView 스트립 레이아웃과 동일한 형태로 업데이트
- `HomeView.tsx`에서 `index === null` 시 `FomoIndexSkeleton` 표시 (기존: 빈 화면)

#### #428 — 라이브 aiSummary 갭 수정
- `/api/fomo/index/route.ts` 라이브 계산 분기에서 `aiSummary: ""` → `buildSummary(idx)` 호출
- 스냅샷 없을 때도 Heat 정보 포함 요약이 클라이언트에 전달됨

#### #412 — FOMO Index 타이포그래피 개선
- FOMO Index 점수 폰트 크기 `text-xl`(20px) → `text-2xl`(24px)
- `aiSummary`가 있을 때 스트립 아래 Heat 요약 문장 표시 (11px, muted)

## 킬리스트 (미구현)
- **애니메이션 효과 (#374)** — 장식 폴리싱 금지 카테고리로 자동 폐기
- **가짜 데이터 테스트 (#378)** — 정직한 숫자 원칙 위반으로 자동 폐기

## 검증
- [x] lint 통과
- [x] typecheck 통과 (6개 패키지 모두)
- [x] build:web 통과
- [x] test 통과 (55 files, 616 tests)

## 참조
이슈: #429 (CEO Brief 2026-06-09)

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01UduaBBz7qa97uxmyBVNKNW)_