### PR TITLE
fix(depth): 뎁스 로딩 게이트 + 워딩/엔티티 정제 (표시·정제층)

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1,8 +1,23 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { scoreToColor, type KeywordCard } from "@fomo/core";
+import { scoreToColor, cleanText, cleanQuote, type KeywordCard } from "@fomo/core";
 import { fetchThemeInsight, type CondensedInsight } from "@/lib/fomoApi";
+
+/** 응축(강세/약세/워딩) 로딩 중 표시 — "강세/약세 없는 중간 상태"가 노출되지 않게(핸드오프 §1).
+ *  카피는 임시(정중한 반말), 최종본은 광혁 조정. */
+function DepthBodySkeleton() {
+  return (
+    <section className="mt-6" aria-busy="true">
+      <p className="text-sm leading-6 text-muted">원문 읽고 강세·약세 정리하는 중…</p>
+      <div className="mt-3 space-y-2">
+        <div className="h-12 animate-pulse rounded-lg border border-hairline bg-surface" />
+        <div className="h-12 animate-pulse rounded-lg border border-hairline bg-surface" />
+        <div className="h-12 w-2/3 animate-pulse rounded-lg border border-hairline bg-surface" />
+      </div>
+    </section>
+  );
+}
 
 /**
  * 키워드 뎁스 페이지 — 카드/히스토리에서 공용. KEYWORD_CARD_FEED_DEV_SPEC v3 §3.
@@ -51,7 +66,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
     const label = `${s?.source ?? s?.title ?? ""}${tl ? ` · ${tl}` : ""}`;
     return (
       <li key={key} className="rounded-lg border border-hairline bg-surface px-3 py-2">
-        <span className="block text-sm leading-5 text-whiteout">{claim}</span>
+        <span className="block text-sm leading-5 text-whiteout">{cleanText(claim)}</span>
         {s &&
           (s.url ? (
             <a
@@ -86,24 +101,26 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
         </div>
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
-          <p className="text-sm leading-6 text-whiteout">{card.comment}</p>
+          <p className="text-sm leading-6 text-whiteout">{cleanText(card.comment)}</p>
 
-          {/* 왜 떴나 — 응축이 있으면 grounded whyHot, 없으면 기존 키워드 why */}
+          {/* 왜 떴나 — 응축이 있으면 grounded whyHot, 없으면 기존 키워드 why.
+              로딩 중엔 grounded 본문을 기다린다(중간 상태 노출 방지). */}
           <section className="mt-7">
             <p className="font-pixel text-sm text-whiteout">{card.depth.whyTitle}</p>
             <p className="mt-2 text-sm leading-6 text-muted">
-              {hasInsight ? insight!.whyHot : card.depth.why}
+              {loading ? "원문 읽는 중…" : cleanText(hasInsight ? insight!.whyHot : card.depth.why)}
             </p>
           </section>
 
-          {/* 공식 지표(FRED 등) — 강세/약세와 별개의 중립 사실 숫자(C-2). hasInsight 무관. */}
-          {insight?.officialFacts && insight.officialFacts.length > 0 && (
+          {/* 공식 지표(FRED 등) — 강세/약세와 별개의 중립 사실 숫자(C-2). hasInsight 무관.
+              로딩 중이면 표시하지 않는다(도착 후 노출 — 깜빡임 방지). */}
+          {!loading && insight?.officialFacts && insight.officialFacts.length > 0 && (
             <section className="mt-6">
               <p className="font-pixel text-sm text-whiteout">📊 공식 지표</p>
               <ul className="mt-2 space-y-2">
                 {insight.officialFacts.map((f, i) => (
                   <li key={`of-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
-                    <span className="block text-sm leading-5 text-whiteout">{f.label}</span>
+                    <span className="block text-sm leading-5 text-whiteout">{cleanText(f.label)}</span>
                     {f.url ? (
                       <a href={f.url} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
                         ↳ {f.source} · 공식 데이터 →
@@ -117,7 +134,9 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             </section>
           )}
 
-          {hasInsight ? (
+          {loading ? (
+            <DepthBodySkeleton />
+          ) : hasInsight ? (
             <>
               {insight!.lean.bullCount + insight!.lean.bearCount > 0 && (
                 <p className="mt-3 text-[11px] leading-5 text-muted">
@@ -168,8 +187,8 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
                       const s = srcOf(w.sourceId);
                       return (
                         <li key={`w-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
-                          <span className="block text-sm leading-5 text-whiteout">“{w.text}”</span>
-                          {s && <span className="mt-1 block text-[11px] text-muted">↳ {s.source ?? s.title}</span>}
+                          <span className="block text-sm leading-5 text-whiteout">“{cleanQuote(w.text)}”</span>
+                          {s && <span className="mt-1 block text-[11px] text-muted">↳ {cleanText(s.source ?? s.title)}</span>}
                         </li>
                       );
                     })}
@@ -178,11 +197,11 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
               )}
             </>
           ) : (
-            // 폴백 — 로딩 중이거나 응축 부족: 기존 뉴스 소스(#500). 빈 화면 금지.
+            // 폴백 — 응축 부족(insufficient): 기존 뉴스 소스(#500). 빈 화면 금지.
+            // 로딩 중은 위 DepthBodySkeleton 이 담당하므로 여기는 항상 도착 후 상태다.
             card.sources.length > 0 && (
               <section className="mt-6">
                 <p className="font-pixel text-sm text-whiteout">오늘 이런 뉴스가 돌았어</p>
-                {loading && <p className="mt-1 text-[11px] text-muted">원문 읽는 중…</p>}
                 <ul className="mt-2 space-y-2">
                   {card.sources.map((s, i) =>
                     s.url ? (
@@ -193,16 +212,16 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
                           rel="noreferrer"
                           className="block rounded-lg border border-hairline bg-surface px-3 py-2 transition-colors hover:border-whiteout/30"
                         >
-                          <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
+                          <span className="block text-sm leading-5 text-whiteout">{cleanText(s.title)}</span>
                           {s.source && (
-                            <span className="mt-0.5 block text-[11px] text-muted">{s.source} · 원문 보기 →</span>
+                            <span className="mt-0.5 block text-[11px] text-muted">{cleanText(s.source)} · 원문 보기 →</span>
                           )}
                         </a>
                       </li>
                     ) : (
                       <li key={i} className="rounded-lg border border-hairline bg-surface px-3 py-2">
-                        <span className="block text-sm leading-5 text-whiteout">{s.title}</span>
-                        {s.source && <span className="mt-0.5 block text-[11px] text-muted">{s.source}</span>}
+                        <span className="block text-sm leading-5 text-whiteout">{cleanText(s.title)}</span>
+                        {s.source && <span className="mt-0.5 block text-[11px] text-muted">{cleanText(s.source)}</span>}
                       </li>
                     )
                   )}

--- a/packages/fomo-core/__tests__/sanitize.test.ts
+++ b/packages/fomo-core/__tests__/sanitize.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { decodeHtmlEntities, stripWrappingQuotes, cleanText, cleanQuote } from "../src/sanitize";
+
+describe("decodeHtmlEntities", () => {
+  it("named 엔티티를 디코드한다", () => {
+    expect(decodeHtmlEntities("그가 &quot;사자&quot; 라고 했다")).toBe('그가 "사자" 라고 했다');
+    expect(decodeHtmlEntities("A &amp; B &lt;tag&gt;")).toBe("A & B <tag>");
+    expect(decodeHtmlEntities("don&#39;t")).toBe("don't");
+  });
+
+  it("십진/십육진 숫자 엔티티를 디코드한다", () => {
+    expect(decodeHtmlEntities("&#34;quote&#34;")).toBe('"quote"');
+    expect(decodeHtmlEntities("&#x27;apos&#x27;")).toBe("'apos'");
+  });
+
+  it("&amp; 이중 디코드를 피한다", () => {
+    // &amp;quot; 는 한 번만 풀려 &quot; 가 아니라 그대로 '&quot;' 이어야 한다(원문 보존).
+    expect(decodeHtmlEntities("&amp;quot;")).toBe('&quot;');
+  });
+
+  it("엔티티 없으면 원문 유지", () => {
+    expect(decodeHtmlEntities("평범한 문장")).toBe("평범한 문장");
+  });
+});
+
+describe("stripWrappingQuotes", () => {
+  it("양끝 따옴표 한 겹을 벗긴다", () => {
+    expect(stripWrappingQuotes('"국장 장투할거야?"')).toBe("국장 장투할거야?");
+    expect(stripWrappingQuotes("'치고 빠질래'")).toBe("치고 빠질래");
+  });
+
+  it("중첩 따옴표를 모두 벗긴다 (버그 3-a)", () => {
+    expect(stripWrappingQuotes('""국장 장투할거야? 난 치고 빠질래""')).toBe(
+      "국장 장투할거야? 난 치고 빠질래"
+    );
+    expect(stripWrappingQuotes("“‘섞인 따옴표’”")).toBe("섞인 따옴표");
+  });
+
+  it("짝이 안 맞으면 벗기지 않는다", () => {
+    expect(stripWrappingQuotes('"열린 따옴표만')).toBe('"열린 따옴표만');
+    expect(stripWrappingQuotes("중간에 \"따옴표\" 있는 문장")).toBe('중간에 "따옴표" 있는 문장');
+  });
+
+  it("빈 문자열·따옴표만 있는 경우 안전", () => {
+    expect(stripWrappingQuotes("")).toBe("");
+    expect(stripWrappingQuotes('""')).toBe("");
+  });
+});
+
+describe("cleanText / cleanQuote", () => {
+  it("cleanText: 엔티티 디코드 + 트림, 따옴표는 보존", () => {
+    expect(cleanText('  그가 &quot;말&quot;했다  ')).toBe('그가 "말"했다');
+    expect(cleanText(null)).toBe("");
+    expect(cleanText(undefined)).toBe("");
+  });
+
+  it("cleanQuote: 디코드 후 감싼 따옴표까지 제거 (화면이 다시 입힘)", () => {
+    // &quot; 로 감싸인 원문 → 디코드하면 "…" → 다시 한 겹 벗겨 알맹이만
+    expect(cleanQuote("&quot;난 치고 빠질래&quot;")).toBe("난 치고 빠질래");
+    expect(cleanQuote('""국장 장투할거야?""')).toBe("국장 장투할거야?");
+    expect(cleanQuote(null)).toBe("");
+  });
+
+  it("cleanQuote: 따옴표 없는 평문은 그대로", () => {
+    expect(cleanQuote("그냥 한 말")).toBe("그냥 한 말");
+  });
+});

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./state";
 export * from "./mascot-lines";
 export * from "./calendar";
 export * from "./insights";
+export * from "./sanitize";
 export * from "./banner";
 export * from "./markets";
 export * from "./mood-signals";

--- a/packages/fomo-core/src/sanitize.ts
+++ b/packages/fomo-core/src/sanitize.ts
@@ -1,0 +1,90 @@
+/**
+ * 출력 정제(sanitize) — 표시 직전 후처리. theme-understanding 추출 로직 본체와 무관.
+ *
+ * 책임 두 가지(BUGFIX DEPTH HANDOFF §2, §2-B):
+ *  1) HTML 엔티티 디코드 — 수집 원문의 `&quot; &amp; &#39;` 등이 날것으로 노출되는 것 방지.
+ *  2) 감싼 따옴표 제거 — 화면에서 따옴표를 다시 입히는 워딩에 원문 따옴표가 겹쳐 `""…""` 되는 것 방지.
+ *
+ * 순수 함수. 추출/점수/응축 로직은 절대 건드리지 않는다 — 이미 만들어진 문자열의 표면만 다듬는다.
+ */
+
+/** 자주 나오는 named HTML 엔티티 (수집 소스가 뱉는 범위). */
+const NAMED_ENTITIES: Record<string, string> = {
+  "&quot;": '"',
+  "&apos;": "'",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&nbsp;": " ",
+  "&#34;": '"',
+  "&#39;": "'",
+};
+
+/**
+ * HTML 엔티티를 정상 문자로 디코드. named + 십진(&#39;)·십육진(&#x27;) 숫자 엔티티 모두 처리.
+ * `&amp;` 는 마지막에 풀어 이중 디코드(`&amp;quot;` → `"`)를 피한다.
+ */
+export function decodeHtmlEntities(input: string): string {
+  if (!input) return input;
+  let s = input;
+  // 숫자 엔티티 먼저 (&#39; / &#x27;)
+  s = s.replace(/&#(\d+);/g, (_, d: string) => safeFromCodePoint(parseInt(d, 10)));
+  s = s.replace(/&#[xX]([0-9a-fA-F]+);/g, (_, h: string) => safeFromCodePoint(parseInt(h, 16)));
+  // named — &amp; 는 잠시 보류
+  for (const [ent, ch] of Object.entries(NAMED_ENTITIES)) {
+    if (ent === "&amp;") continue;
+    s = s.split(ent).join(ch);
+  }
+  s = s.split("&amp;").join("&");
+  return s;
+}
+
+function safeFromCodePoint(cp: number): string {
+  if (!Number.isFinite(cp) || cp < 0 || cp > 0x10ffff) return "";
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return "";
+  }
+}
+
+/** 양끝을 감싼 따옴표 쌍을 한 겹씩 벗긴다(중첩이면 반복). 짝이 맞을 때만. */
+const QUOTE_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['"', '"'],
+  ["'", "'"],
+  ["“", "”"], // “ ”
+  ["‘", "’"], // ‘ ’
+  ["「", "」"], // 「 」
+  ["«", "»"], // « »
+];
+
+export function stripWrappingQuotes(input: string): string {
+  let s = input.trim();
+  let changed = true;
+  while (changed && s.length >= 2) {
+    changed = false;
+    for (const [open, close] of QUOTE_PAIRS) {
+      if (s.startsWith(open) && s.endsWith(close) && s.length > open.length + close.length - 1) {
+        s = s.slice(open.length, s.length - close.length).trim();
+        changed = true;
+        break;
+      }
+    }
+  }
+  return s;
+}
+
+/** 일반 텍스트 정제 — 엔티티 디코드 + 트림. (제목·근거·whyHot 등) */
+export function cleanText(input: string | null | undefined): string {
+  if (!input) return "";
+  return decodeHtmlEntities(input).trim();
+}
+
+/**
+ * 인용 텍스트 정제 — 엔티티 디코드 + 감싼 따옴표 제거.
+ * 화면에서 따옴표를 다시 입히는 워딩 전용(중첩 방지).
+ */
+export function cleanQuote(input: string | null | undefined): string {
+  if (!input) return "";
+  return stripWrappingQuotes(decodeHtmlEntities(input));
+}


### PR DESCRIPTION
> ⚠️ **자동 머지 금지** — 작업 3(understandStock/KeywordDepthPage)과 충돌 여부 확인 후 광혁이 머지.

## 건드린 층 (핸드오프 원칙 준수)
| 층 | 파일 | 내용 |
|---|---|---|
| 표시 | `KeywordDepthPage.tsx` | 로딩 게이트 — 응축 도착 전 강세/약세/워딩 자리에 스켈레톤 |
| 정제 | `packages/fomo-core/src/sanitize.ts` (신규) | HTML 엔티티 디코드 + 따옴표 중첩 제거 (순수함수, vitest 11건) |
| — | — | **엔진(theme-understanding/condense·assemble) 본체는 일절 안 건드림** ✅ |

## 버그 대응
- **§1 로딩 처리**: `loading` 중엔 `DepthBodySkeleton`, `insight` 도착(`loading=false`) 후에만 강세/약세 본문. '강세/약세 빠진 중간 화면' 차단. 공식지표(FRED)·whyHot도 도착 후 노출.
- **§2 따옴표 중첩**: `cleanQuote`로 워딩 `""…""` → 한 겹만.
- **§2-B HTML 엔티티**: `decodeHtmlEntities`로 `&quot; &amp; &#39;` 등 디코드. 워딩·근거·제목·whyHot·공식지표에 적용.

## 🚩 보고 (미수정 — 엔진/수집 본체 문제)
**§3-b 출처 라벨 오염**은 표시 코드로 못 고칩니다:
- '워딩에 매일경제(뉴스)' → LLM이 워딩 `sourceId`에 커뮤니티가 아닌 뉴스 doc을 지정 (condense/assemble 추출).
- '약세 근거에 종토방이 뉴스로' → `SourceDoc.tier` 배정이 수집 단계에서 틀림.
- 표시층에서 '워딩이면 무조건 커뮤니티' 식으로 덮으면 **정직한 숫자 원칙 위반**(뉴스 원문인데 커뮤니티로 표기). → 핸드오프대로 **작업 3과 함께** 엔진/수집에서 교정 필요.

## 1-B 최초 진입 로딩
표시는 이미 `DeckSkeleton`(animate-pulse) 존재 — 양호. **성능 원인(첫 페치가 LLM 응축을 동기로 다 도는지)은 엔진 영역이라 보고만** 합니다.

## 검증
- typecheck·lint·build:web 통과
- fomo-core 295 tests 통과 (sanitize 11건 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)