### PR TITLE
fix(cta): '관심' 버튼 → 뎁스 열기 (A안, §1-C)

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -167,6 +167,11 @@ function KeywordDeck({
     recordViewed(card, Date.now());
     setSelected(card);
   };
+  // CTA "관심"(A안) — "이거 더 볼래" → 관심 기록 + 뎁스 열기. 다음 카드 넘김은 뎁스 닫을 때(closeDepth).
+  const openInterest = (card: KeywordCard) => {
+    recordInterest(card.id, "more", Date.now());
+    openDepth(card);
+  };
   // 뎁스 닫으면 본 카드가 스르륵 넘어가며 다음 카드 노출.
   const closeDepth = () => {
     setSelected(null);
@@ -297,9 +302,9 @@ function KeywordDeck({
           ✕
         </button>
         <button
-          onClick={() => advance("right")}
+          onClick={() => openInterest(top)}
           disabled={!!exiting}
-          aria-label="관심"
+          aria-label="관심 — 자세히 보기"
           className="flex h-14 flex-1 items-center justify-center rounded-full font-pixel text-sm text-white transition-opacity disabled:opacity-40"
           style={{ backgroundColor: UP }}
         >


### PR DESCRIPTION
> ⚠️ **자동 머지 금지** — 작업 3과 충돌 여부 확인 후 광혁이 머지.

## 버그 §1-C (광혁 A안 결정)
**증상**: 메인에서 '관심' 버튼을 누르면 뎁스로 안 가고 다음 카드로만 넘어감.
**A안**: '관심' = '이거 더 볼래' → **누르면 뎁스 열림 + 관심 기록**.

## 변경 (버튼 핸들러만 — 표시층)
| 버튼 | before | after |
|---|---|---|
| 관심 | `advance('right')` (다음 카드) | `openInterest(top)` = 관심 기록 + 뎁스 열기 |
| ✕ 덜 관심 | `advance('left')` | 그대로 |

- 뎁스 닫으면 기존 `closeDepth`가 카드를 넘김 → 관심 표시 후 자연스럽게 다음 카드.
- ⚠️ **스와이프 로직(advance/flingNext) 본체는 안 건드림** — 핸드오프 '버튼-동작 연결만 교정' 원칙. 오른쪽 스와이프는 기존대로(넘김) 유지.

## 카피 (광혁 영역)
상단 안내 `오른쪽=관심 · 왼쪽=덜 관심 · 탭하면 자세히`와 스와이프/버튼 일관성 문구는 카피 결정 시 조정 — 코드는 안 건드렸습니다.

## 검증
typecheck·lint·build:web 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)