### PR TITLE
fix: 최초 진입 '다 봤다' 끝-상태 오노출 (viewedIds 오늘로 한정)

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -123,8 +123,15 @@ function KeywordDeck({
   cards: readonly KeywordCard[];
   confidence: KeywordConfidence;
 }) {
-  // 마운트 시점의 "이미 본" 집합 — 본 카드는 덱에서 제외(다시 와도 다음 카드부터).
-  const viewedIds = useState(() => new Set(getHistory().map((h) => h.id)))[0];
+  // 마운트 시점의 "오늘 이미 본" 집합 — 본 카드는 덱에서 제외(다시 와도 다음 카드부터).
+  // ★버그: card.id 가 키워드("반도체")라 날짜 무관 고정 → 전체기간 히스토리로 거르면 어제 본 게
+  //   오늘도 걸려 덱이 비고 "다 봤다" 끝-상태가 최초 진입에 뜬다. → *오늘(KST) 본 것만* 필터링.
+  const viewedIds = useState(() => {
+    const kstDay = (ms: number) =>
+      new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(new Date(ms));
+    const today = kstDay(Date.now());
+    return new Set(getHistory().filter((h) => kstDay(h.ts) === today).map((h) => h.id));
+  })[0];
   const [replay, setReplay] = useState(false);
   const deck = replay ? [...cards] : cards.filter((c) => !viewedIds.has(c.id));
 


### PR DESCRIPTION
## 증상
최초/재진입 시 스플래시→로딩 후 카드가 아니라 "오늘 사람들 시선은 여기까지였어"(끝-상태)가 가끔 뜸.

## 원인
`card.id` 가 키워드("반도체")라 **날짜 무관 고정**인데, `KeywordDeck` 의 `viewedIds` 를 **전체기간** localStorage 히스토리(`getHistory()`)로 만든다. → 어제 본 키워드가 오늘도 "본 것"으로 필터링돼 덱이 비고 `idx >= deck.length` → 끝-상태. 재방문/다음날이면 거의 항상 재현(키워드 집합이 작고 고정이라).

## 수정
`viewedIds` 를 **오늘(KST) 본 것만** 필터(`getHistory().filter(kstDay(ts)===today)`). 날짜 넘어가면 캐리오버 없이 풀 덱. 같은 날 본 카드는 그대로 제외(다음 카드부터 — 기존 의도 유지).

## 검증
- typecheck ✅ / build:fomo-web ✅
- 라이브: localStorage 에 "어제 5개 다 봄" 심은 뒤 재로드 → 끝-상태 **안 뜨고** 풀 덱(반도체 85, 1/5) 노출(스크린샷).

CI green 자동 머지. 엔진/점수/톤 불변, fomo-web 컴포넌트 1곳만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)