### PR TITLE
test: theme-understanding 불변 규칙 5종 (BTRACK §1 회귀 방지)

### DIFF
--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -20,6 +20,73 @@ const DOCS: SourceDoc[] = [
 
 const baseRaw: RawThemeInsight = { stocks: [], bull: [], bear: [], wordings: [], stanceNote: "" };
 
+// ─────────────────────────────────────────────────────────────────────────────
+// ★ 불변 규칙 (회귀 방지, BTRACK_VERIFIED_HANDOFF §1) — 절대 원칙의 코드화.
+// 이 5종이 빨개지면 그건 회귀다. 테스트를 약화시키지 말고 코드를 고친다.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("★ 불변 규칙 (회귀 방지)", () => {
+  const fullRaw: RawThemeInsight = {
+    stocks: ["삼성전자"],
+    bull: [{ claim: "외국인이 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+    bear: [{ claim: "단기 차익실현이 나왔어", sourceId: "S2", quote: "차익실현에 나섰다" }],
+    wordings: [{ text: "가즈아 풀매수", sourceId: "S3" }],
+    stanceNote: "",
+  };
+
+  it("불변1 — 결정성: 같은 input 이면 항상 같은 output(강세/약세/워딩 동일)", () => {
+    const a = assembleThemeInsight("반도체", DOCS, fullRaw);
+    const b = assembleThemeInsight("반도체", DOCS, fullRaw);
+    expect(a).toEqual(b);
+    expect(a.bull.length).toBe(b.bull.length);
+    expect(a.bear.length).toBe(b.bear.length);
+    expect(a.wordings).toEqual(b.wordings);
+  });
+
+  it("불변2a — 워딩은 community 만(news/official 워딩 폐기)", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인이 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+      wordings: [{ text: "외국인 매수세가 삼성전자", sourceId: "S1" }], // news → 폐기
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).wordings).toHaveLength(0);
+  });
+
+  it("불변2b — 강세/약세 근거는 news/official 만(community 근거 폐기)", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "가즈아 분위기", sourceId: "S3", quote: "가즈아 풀매수" }], // community → 폐기
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).bull).toHaveLength(0);
+  });
+
+  it("불변3 — grounding: 원문에 없는 quote(환각)는 폐기", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "지어낸 일반론", sourceId: "S1", quote: "이 문장은 원문에 절대 없다" }],
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).bull).toHaveLength(0);
+  });
+
+  it("불변4 — 균형/정직: 약세 0이면 stance 가 '약세 안 보여'로 정직 표기(가짜 안 채움)", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "외국인이 담았어", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+    };
+    const r = assembleThemeInsight("반도체", DOCS, raw);
+    expect(r.stance).toBe("bull-dominant");
+    expect(r.bear).toHaveLength(0);
+    expect(r.stanceNote).toMatch(/약세.*안 보여/);
+  });
+
+  it("불변5 — 투자조언 차단: 매수/매도/예측 명령형 claim 은 폐기", () => {
+    const raw: RawThemeInsight = {
+      ...baseRaw,
+      bull: [{ claim: "지금 삼성전자 매수해라", sourceId: "S1", quote: "외국인 매수세가 삼성전자" }],
+    };
+    expect(assembleThemeInsight("반도체", DOCS, raw).bull).toHaveLength(0);
+  });
+});
+
 describe("assembleThemeInsight — grounding 가드(환각 차단)", () => {
   it("원문에 박힌 quote 만 통과, 지어낸 quote 는 폐기", () => {
     const raw: RawThemeInsight = {


### PR DESCRIPTION
BTRACK_VERIFIED_HANDOFF §1 — B 트랙 코드 짜기 전, 엔진 불변 규칙을 테스트로 고정. 최근 버그(약세 깜빡임·출처 오염)가 난 theme-understanding 엔진에 테스트가 0개였던 문제 해소.

## 불변 5종 (assemble 순수함수)
1. **결정성** — 같은 input → 같은 output. ★신규(나머지 4는 #518/#519에서 이미 커버, 한 블록으로 통합)
2a. 워딩 = community 전용 / 2b. 강세·약세 근거 = news·official 전용
3. grounding(환각 quote 폐기) · 4. 균형/정직(약세 0 → 정직 표기) · 5. 투자조언 차단

## 회귀 감지 시연
community 강제 제거하면 불변2a 빨개짐 → 원복 시 통과 확인. 앞으로 어떤 수정도 원칙 깨면 CI red.

## §2 goal 루프
typecheck ✅ / test **636** ✅ / build ✅ (전부 exit 0).

테스트만 추가(로직 0). CI green 자동 머지. 이후 B 트랙 PR들이 이 불변 위에서 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)