### PR TITLE
feat(engine): 종목/테마 확장 — 그날 뜬 종목(글로벌 포함) + 테마 풀 (B 트랙)

### DIFF
--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -1,16 +1,22 @@
 import {
   extractKeywords,
+  extractStocks,
+  stockDef,
+  stockMatchesText,
   buildThemeInsightPrompt,
   parseThemeInsightResponse,
   assembleThemeInsight,
   emptyThemeInsight,
+  fetchNaverBoardPosts,
+  fetchSubredditPosts,
+  DEFAULT_SUBREDDITS,
   type SourceDoc,
   type ThemeInsight,
   type KeywordSourceItem,
+  type ExtractedStock,
   type WordingVerdict,
   type OfficialFact,
 } from "@fomo/core";
-import { fetchNaverBoardPosts } from "@fomo/core";
 import { fetchAllNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
@@ -206,35 +212,37 @@ function officialFactsFrom(docs: readonly SourceDoc[]): OfficialFact[] {
     }));
 }
 
-/** 종목명 → 네이버 종토방 코드(국내 상장만). 해외주(엔비디아 등)는 종토방 없음 → 뉴스+디시만. */
-const STOCK_NAVER_CODES: Record<string, string> = {
-  삼성전자: "005930",
-  SK하이닉스: "000660",
-  카카오: "035720",
-  NAVER: "035420",
-  에코프로비엠: "247540",
-  LG에너지솔루션: "373220",
-  셀트리온: "068270",
-  삼성바이오로직스: "207940",
-};
-
-/** 개별 종목 원문 수집(작업3) — 뉴스(종목명 필터) + 종토방(국내) + 디시(종목명 필터). FRED 없음. */
+/**
+ * 개별 종목 원문 수집(B 트랙 §1) — 종목 *국적*에 맞는 소스를 연결한다.
+ * - 한국 종목(종토방 코드 보유): 한국뉴스(종목명 필터) + 네이버 종토방 + 디시.
+ * - 미국/글로벌 종목(엔비디아 등): 뉴스(종목명 필터) + **레딧 글 제목**(외신/해외 커뮤니티) + 디시.
+ * grounding 가드 그대로 — 별칭(엔비디아=Nvidia=NVDA)이 원문에 실제 substring/단어경계로 존재하는 글만.
+ */
 export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
-  const code = STOCK_NAVER_CODES[stock];
-  const [newsRes, dcRes, commRes] = await Promise.allSettled([
+  const def = stockDef(stock);
+  const code = def?.naverCode;
+  const isForeign = def ? def.country !== "KR" : false;
+  const matches = (s: string) => stockMatchesText(stock, s);
+
+  const [newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
     fetchAllNews(),
     fetchDcStockTitles(),
     code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
+    // 미국/글로벌 종목만 레딧 원문 수집(국내주는 종토방이 본진). 코인은 cryptocurrency 포함.
+    isForeign
+      ? Promise.allSettled(DEFAULT_SUBREDDITS.map((s) => fetchSubredditPosts(s))).then((rs) =>
+          rs.flatMap((r) => (r.status === "fulfilled" ? r.value : []))
+        )
+      : Promise.resolve([]),
   ]);
 
   const docs: SourceDoc[] = [];
   let n = 0;
   const nextId = () => `S${++n}`;
-  const mentions = (s: string) => s.includes(stock);
 
-  // 뉴스 — 종목명이 제목/요약에 등장하는 기사만.
+  // 뉴스 — 종목명(별칭 포함)이 제목/요약에 등장하는 기사만.
   if (newsRes.status === "fulfilled") {
-    const hit = newsRes.value.filter((a) => mentions(`${a.title} ${a.summary ?? ""}`)).slice(0, MAX_NEWS);
+    const hit = newsRes.value.filter((a) => matches(`${a.title} ${a.summary ?? ""}`)).slice(0, MAX_NEWS);
     for (const a of hit) {
       docs.push({
         id: nextId(),
@@ -265,14 +273,48 @@ export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
     }
   }
 
+  // 레딧(미국/글로벌 종목) — 종목 별칭이 제목에 등장하는 글만. 해외 심리 grounding.
+  if (redditRes.status === "fulfilled") {
+    const hit = (redditRes.value as { title: string; tsMs: number }[])
+      .filter((p) => matches(p.title))
+      .slice(0, MAX_COMMUNITY);
+    for (const p of hit) {
+      docs.push({
+        id: nextId(),
+        kind: "community",
+        title: p.title,
+        source: "Reddit",
+        ...(p.tsMs ? { publishedAt: new Date(p.tsMs).toISOString() } : {}),
+        tier: "community-mid",
+      });
+    }
+  }
+
   // 디시 — 종목명 언급 글만(community-low). 워딩 필터가 진입 전 거른다.
   if (dcRes.status === "fulfilled") {
-    for (const t of dcRes.value.filter(mentions).slice(0, 6)) {
+    for (const t of dcRes.value.filter(matches).slice(0, 6)) {
       docs.push({ id: nextId(), kind: "community", title: t, source: "디시 주식갤러리", tier: "community-low" });
     }
   }
 
   return docs;
+}
+
+/**
+ * 그날 테마 원문에 실제 등장한 종목 추출(B 트랙 §1) — 마스터 리스트 없이 "원문이 곧 필터".
+ * 테마 docs(뉴스+커뮤니티)를 종목 어휘로 스캔 → 빈도 임계 이상만, market 동봉(시장 분리 훅).
+ * 화면·표기(국기/시장 라벨)는 광혁 UI. 엔진은 데이터(종목·market·빈도)만 정확히 제공한다.
+ */
+export async function collectThemeStocks(
+  theme: string,
+  opts: { minMentions?: number } = {}
+): Promise<ExtractedStock[]> {
+  const docs = await collectThemeDocs(theme);
+  const items: KeywordSourceItem[] = docs.map((d) => ({
+    title: d.title,
+    ...(d.body ? { summary: d.body } : {}),
+  }));
+  return extractStocks(items, opts);
 }
 
 /** 개별 종목 이해·구조화(작업3, BM 심장) — 테마와 동일 구조/가드. 자료 적으면 정직한 빈 상태. */

--- a/packages/fomo-core/__tests__/stock-extraction.test.ts
+++ b/packages/fomo-core/__tests__/stock-extraction.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractStocks,
+  stockMatchesText,
+  stockDef,
+  extractKeywords,
+  THEME_DICTIONARY,
+  type KeywordSourceItem,
+} from "../src";
+
+// 그날 원문 형태(뉴스+커뮤니티 제목). 엔비디아(글로벌)·삼성전자(KR)는 여러 번, 애플은 1번만.
+const DOCS: KeywordSourceItem[] = [
+  { title: "엔비디아 신고가, HBM 수요 폭발" },
+  { title: "Nvidia earnings beat, AI demand strong", summary: "NVDA up" }, // 같은 종목 다른 별칭
+  { title: "엔비디아 효과에 SK하이닉스·삼성전자 동반 강세" },
+  { title: "삼성전자 파운드리 수주 기대" },
+  { title: "애플 신제품 루머" }, // 1회 → 임계(2) 미만
+  { title: "오늘 날씨 맑음" }, // 종목 0
+];
+
+describe("extractStocks — 그날 원문에 등장한 종목만(B 트랙 §1)", () => {
+  it("임계(기본 2) 이상 등장 종목만, 빈도 내림차순", () => {
+    const stocks = extractStocks(DOCS);
+    const names = stocks.map((s) => s.canonical);
+    expect(names).toContain("엔비디아"); // 3건
+    expect(names).toContain("삼성전자"); // 2건
+    expect(names).not.toContain("애플"); // 1건 → 노이즈 컷
+    // 엔비디아가 삼성전자보다 많이 등장 → 앞
+    expect(names.indexOf("엔비디아")).toBeLessThan(names.indexOf("삼성전자"));
+  });
+
+  it("같은 글에 별칭 여러 개 나와도 글 1건으로 카운트", () => {
+    const stocks = extractStocks([
+      { title: "엔비디아 Nvidia NVDA 삼중 언급" }, // 1건
+      { title: "엔비디아 추가 상승" }, // 1건
+    ]);
+    expect(stocks.find((s) => s.canonical === "엔비디아")?.mentions).toBe(2);
+  });
+
+  it("market/country 동봉 + naverCode는 국내만 + relatedHint는 빈 배열(가짜 연관 금지)", () => {
+    const stocks = extractStocks(DOCS);
+    const nvda = stocks.find((s) => s.canonical === "엔비디아")!;
+    const samsung = stocks.find((s) => s.canonical === "삼성전자")!;
+    expect(nvda.market).toBe("NASDAQ");
+    expect(nvda.country).toBe("US");
+    expect(nvda.naverCode).toBeUndefined(); // 미국주 → 종토방 없음
+    expect(samsung.market).toBe("KOSPI");
+    expect(samsung.country).toBe("KR");
+    expect(samsung.naverCode).toBe("005930");
+    expect(nvda.relatedHint).toEqual([]); // D 이후 — 지금은 항상 비움
+  });
+
+  it("minMentions 옵션 — 1로 낮추면 1회 종목도 포함", () => {
+    const names = extractStocks(DOCS, { minMentions: 1 }).map((s) => s.canonical);
+    expect(names).toContain("애플");
+  });
+
+  it("빈 입력 → 빈 배열(에러 없음)", () => {
+    expect(extractStocks([])).toEqual([]);
+  });
+});
+
+describe("stockMatchesText — 별칭/티커 grounding", () => {
+  it("엔비디아=Nvidia=NVDA 모두 인식", () => {
+    expect(stockMatchesText("엔비디아", "엔비디아 급등")).toBe(true);
+    expect(stockMatchesText("엔비디아", "Nvidia rallies")).toBe(true);
+    expect(stockMatchesText("엔비디아", "NVDA to the moon")).toBe(true);
+    expect(stockMatchesText("엔비디아", "삼성전자만 언급")).toBe(false);
+  });
+  it("티커는 단어경계 — 단어 속에서 오인식 안 함", () => {
+    expect(stockMatchesText("AMD", "AMD 신제품")).toBe(true);
+    expect(stockMatchesText("AMD", "camden street")).toBe(false); // 'amd' 부분일치 방지
+  });
+  it("stockDef 로 정의 조회", () => {
+    expect(stockDef("엔비디아")?.country).toBe("US");
+    expect(stockDef("없는종목")).toBeUndefined();
+  });
+});
+
+describe("테마 풀 확장(B 트랙 §2) — 후킹 테마 추가 + 동적 노출", () => {
+  it("새 테마가 사전에 있다", () => {
+    for (const t of ["방산", "바이오", "원자력", "공급망"]) {
+      expect(THEME_DICTIONARY[t]).toBeDefined();
+    }
+  });
+  it("그날 원문에 뜬 테마만 추출(안 뜨면 자동 제외)", () => {
+    const items: KeywordSourceItem[] = [
+      { title: "한화에어로스페이스 방산 수출 호조" },
+      { title: "두산에너빌리티 원전·SMR 수주" },
+    ];
+    const keys = extractKeywords(items).map((k) => k.keyword);
+    expect(keys).toContain("방산");
+    expect(keys).toContain("원자력");
+    expect(keys).not.toContain("바이오"); // 안 뜸 → 제외(정직)
+  });
+  it("오인식 방지 — '무기한'은 방산 아님, '제약사항'은 바이오 아님", () => {
+    const keys = extractKeywords([
+      { title: "회의 무기한 연기, 제약사항 검토" },
+    ]).map((k) => k.keyword);
+    expect(keys).not.toContain("방산");
+    expect(keys).not.toContain("바이오");
+  });
+});

--- a/packages/fomo-core/src/index-engine/redditFetcher.ts
+++ b/packages/fomo-core/src/index-engine/redditFetcher.ts
@@ -132,6 +132,45 @@ export async function fetchSubredditSignal(
   }
 }
 
+/** 레딧 글 1건(제목 원문) — 미국주 grounding 용(B 트랙 §1). 집계가 아니라 *원문 제목*. */
+export interface RedditPost {
+  title: string;
+  ups: number;
+  numComments: number;
+  /** 작성 시각 ms(UTC). */
+  tsMs: number;
+}
+
+/**
+ * 단일 서브레딧 hot 글의 *제목 원문*을 반환(집계 아님). 실패 시 빈 배열(폴백 우선).
+ * 미국 종목(엔비디아 등)을 레딧 원문에 substring-grounding 하려면 제목 텍스트가 필요하다.
+ */
+export async function fetchSubredditPosts(
+  subreddit: string,
+  timeoutMs = 5000,
+): Promise<RedditPost[]> {
+  const url = `https://www.reddit.com/r/${encodeURIComponent(subreddit)}/hot.json?limit=25&raw_json=1`;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      headers: { "User-Agent": "fomo-club:community-heat:v1.0 (by /u/fomo-club-bot)" },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const listing = (await res.json()) as RedditListing;
+    return listing.data.children.map((c) => ({
+      title: c.data.title,
+      ups: Math.max(0, c.data.ups),
+      numComments: Math.max(0, c.data.num_comments),
+      tsMs: Math.max(0, c.data.created_utc) * 1000,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 /**
  * 여러 서브레딧을 병렬 수집하여 RedditSignal[]을 반환한다.
  * 실패한 서브레딧은 결과에서 제외된다 (부분 실패 허용).

--- a/packages/fomo-core/src/keyword-cards/extract.ts
+++ b/packages/fomo-core/src/keyword-cards/extract.ts
@@ -64,6 +64,29 @@ export const THEME_DICTIONARY: Record<string, ThemeDef> = {
     terms: ["2차전지", "2차 전지", "배터리", "에코프로", "LG에너지", "전기차", "battery"],
     related: ["에코프로비엠", "LG에너지솔루션"],
   },
+  // ── 테마 풀 확장(B 트랙 §2) — 평평하게, "이름 보고 궁금한" 후킹 단위만(분류학 아님). ──
+  // 동적 노출: 그날 매칭 0이면 자동 제외(extractKeywords), 식은 건 점수로 가라앉음(score.ts).
+  방산: {
+    emoji: "🛡️",
+    terms: ["방산", "방위산업", "한화에어로", "LIG넥스원", "현대로템", "방위비", "defense"],
+    related: ["한화에어로스페이스", "LIG넥스원"],
+  },
+  바이오: {
+    emoji: "💊",
+    terms: ["바이오", "셀트리온", "삼성바이오", "신약", "임상", "FDA", "제약주"],
+    related: ["셀트리온", "삼성바이오로직스"],
+  },
+  원자력: {
+    emoji: "⚡",
+    terms: ["원자력", "원전", "SMR", "두산에너빌리티", "한국전력", "한전", "nuclear"],
+    related: ["두산에너빌리티", "한국전력"],
+  },
+  공급망: {
+    emoji: "🔗",
+    // 관련 종목이 그날따라 달라 related 는 비워둔다(가짜 연관 금지 — §0). 종목은 그날 원문이 추린다.
+    terms: ["공급망", "희토류", "리쇼어링", "관세", "수출규제"],
+    related: [],
+  },
 };
 
 export interface ExtractedKeyword {

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -5,3 +5,4 @@ export * from "./score";
 export * from "./community";
 export * from "./comment";
 export * from "./josa";
+export * from "./stocks";

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -1,0 +1,177 @@
+import type { KeywordSourceItem } from "./extract";
+
+/**
+ * 종목 인식 사전 + "그날 원문에 실제 등장한 종목" 추출. STOCK_THEME_EXPANSION_HANDOFF(B 트랙) §1.
+ *
+ * 순수 함수(네트워크·DB 0). 입력: 그날 수집된 원문 글(뉴스·종토방·디시·레딧 등).
+ * 출력: 원문에 임계 이상 등장한 종목만(빈도가 곧 필터). **종목 마스터 리스트로 카드를 찍지 않는다.**
+ *
+ * 핵심 원칙(§0 "구조는 열되 지금은 평평하게"):
+ * - 여기 사전은 카드 생성 목록이 아니라 *인식 어휘*다. 카드/뎁스 대상은 그날 원문이 추려준다.
+ * - market/country/naverCode 는 데이터로 *채워만 둔다*(시장 분리·개인화 훅, 아이디어 A). 분기 로직 X.
+ * - relatedHint 는 연관 그래프(방식 3, D 이후) 자리만 열어둔다. 채우는 로직은 지금 만들지 않는다.
+ * - 연관(종목↔종목)·계층은 만들지 않는다(가짜 연관 금지).
+ */
+
+/** 시장 구분(표시/필터 훅 — 지금은 값만 채움). */
+export type StockMarket = "KOSPI" | "KOSDAQ" | "NASDAQ" | "NYSE" | "COIN";
+/** 종목 국적 — 국적에 맞는 소스(한국=종토방, 미국=레딧/외신) 연결에 쓴다(§1 소스 매핑). */
+export type StockCountry = "KR" | "US" | "GLOBAL";
+
+export interface StockDef {
+  /** 카드/뎁스에 노출할 표준 종목명. */
+  canonical: string;
+  /** 인식용 별칭(한글명·영문명·티커). 한 종목이 여러 표기로 원문에 등장. */
+  aliases: readonly string[];
+  market: StockMarket;
+  country: StockCountry;
+  /** 네이버 종토방 코드(국내 상장만) — 없으면 종토방 소스 미연결(미국주 등). */
+  naverCode?: string;
+}
+
+/**
+ * 종목 인식 어휘(보수적). 현재 테마들이 실제로 끌어오는 대표 종목 + 글로벌 진원지(엔비디아·TSMC 등).
+ * 늘릴 때는 "그날 원문에 충분히 등장하는가"만 보면 되고, 안 뜨는 날은 자동으로 빠진다.
+ * 오인식 1건이 신뢰를 깨므로 별칭은 좁게(애매한 약어 지양).
+ */
+export const STOCK_VOCAB: readonly StockDef[] = [
+  // ── 한국(KOSPI/KOSDAQ) — 네이버 종토방 코드 보유 ──
+  { canonical: "삼성전자", aliases: ["삼성전자"], market: "KOSPI", country: "KR", naverCode: "005930" },
+  { canonical: "SK하이닉스", aliases: ["SK하이닉스", "하이닉스"], market: "KOSPI", country: "KR", naverCode: "000660" },
+  { canonical: "한미반도체", aliases: ["한미반도체"], market: "KOSDAQ", country: "KR", naverCode: "042700" },
+  { canonical: "에코프로비엠", aliases: ["에코프로비엠"], market: "KOSDAQ", country: "KR", naverCode: "247540" },
+  { canonical: "에코프로", aliases: ["에코프로"], market: "KOSDAQ", country: "KR", naverCode: "086520" },
+  { canonical: "LG에너지솔루션", aliases: ["LG에너지솔루션", "LG엔솔"], market: "KOSPI", country: "KR", naverCode: "373220" },
+  { canonical: "삼성SDI", aliases: ["삼성SDI"], market: "KOSPI", country: "KR", naverCode: "006400" },
+  { canonical: "현대차", aliases: ["현대차", "현대자동차"], market: "KOSPI", country: "KR", naverCode: "005380" },
+  { canonical: "한화에어로스페이스", aliases: ["한화에어로스페이스", "한화에어로"], market: "KOSPI", country: "KR", naverCode: "012450" },
+  { canonical: "두산에너빌리티", aliases: ["두산에너빌리티"], market: "KOSPI", country: "KR", naverCode: "034020" },
+  { canonical: "셀트리온", aliases: ["셀트리온"], market: "KOSPI", country: "KR", naverCode: "068270" },
+  { canonical: "삼성바이오로직스", aliases: ["삼성바이오로직스", "삼성바이오"], market: "KOSPI", country: "KR", naverCode: "207940" },
+  { canonical: "카카오", aliases: ["카카오"], market: "KOSPI", country: "KR", naverCode: "035720" },
+  { canonical: "NAVER", aliases: ["NAVER", "네이버"], market: "KOSPI", country: "KR", naverCode: "035420" },
+
+  // ── 미국/글로벌 — 종토방 없음(레딧/외신으로 grounding, §1) ──
+  { canonical: "엔비디아", aliases: ["엔비디아", "Nvidia", "NVDA"], market: "NASDAQ", country: "US" },
+  { canonical: "TSMC", aliases: ["TSMC", "대만 TSMC", "티에스엠씨"], market: "NYSE", country: "GLOBAL" },
+  { canonical: "마이크로소프트", aliases: ["마이크로소프트", "Microsoft", "MSFT"], market: "NASDAQ", country: "US" },
+  { canonical: "애플", aliases: ["애플", "Apple", "AAPL"], market: "NASDAQ", country: "US" },
+  { canonical: "테슬라", aliases: ["테슬라", "Tesla", "TSLA"], market: "NASDAQ", country: "US" },
+  { canonical: "AMD", aliases: ["AMD"], market: "NASDAQ", country: "US" },
+  { canonical: "브로드컴", aliases: ["브로드컴", "Broadcom", "AVGO"], market: "NASDAQ", country: "US" },
+  { canonical: "팔란티어", aliases: ["팔란티어", "Palantir", "PLTR"], market: "NASDAQ", country: "US" },
+  { canonical: "마이크론", aliases: ["마이크론", "Micron"], market: "NASDAQ", country: "US" },
+
+  // ── 코인 ──
+  { canonical: "비트코인", aliases: ["비트코인", "bitcoin", "BTC"], market: "COIN", country: "GLOBAL" },
+  { canonical: "이더리움", aliases: ["이더리움", "ethereum", "ETH"], market: "COIN", country: "GLOBAL" },
+];
+
+/** 그날 원문에 등장한 종목(추출 결과). market/country 동봉, relatedHint 자리만 열어둠(D 이후). */
+export interface ExtractedStock {
+  canonical: string;
+  market: StockMarket;
+  country: StockCountry;
+  naverCode?: string;
+  /** 원문 등장 글 수(빈도 = 강도). */
+  mentions: number;
+  /** 연관 종목 힌트(방식 3, D 이후) — 지금은 항상 빈 배열(가짜 연관 금지). */
+  relatedHint: readonly string[];
+}
+
+function isAsciiAlias(t: string): boolean {
+  return /^[a-z0-9]+$/i.test(t);
+}
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+interface StockMatcher {
+  def: StockDef;
+  /** 한글 등 비-ASCII 별칭 — 부분일치(소문자). */
+  substrings: readonly string[];
+  /** ASCII 티커/영문명 — 단어경계 매칭("AMD"가 "camden" 안에서 안 걸리게). */
+  regexes: readonly RegExp[];
+}
+
+const STOCK_MATCHERS: readonly StockMatcher[] = STOCK_VOCAB.map((def) => {
+  const substrings: string[] = [];
+  const regexes: RegExp[] = [];
+  for (const a of def.aliases) {
+    const low = a.toLowerCase();
+    if (isAsciiAlias(a)) regexes.push(new RegExp(`(^|[^a-z0-9])${escapeRegex(low)}([^a-z0-9]|$)`));
+    else substrings.push(low);
+  }
+  return { def, substrings, regexes };
+});
+
+/** 한 글이 어떤 종목을 언급하나 — 한글=부분일치, 영문/티커=단어경계(대소문자 무시). */
+function matchedStocks(text: string): string[] {
+  const blob = text.toLowerCase();
+  const hits: string[] = [];
+  for (const m of STOCK_MATCHERS) {
+    if (m.substrings.some((s) => blob.includes(s)) || m.regexes.some((re) => re.test(blob))) {
+      hits.push(m.def.canonical);
+    }
+  }
+  return hits;
+}
+
+export interface ExtractStocksOptions {
+  /** 노이즈 컷 — 이 횟수 미만 등장 종목은 제외(스쳐간 1회 언급 배제). 기본 2. */
+  minMentions?: number;
+}
+
+/**
+ * 그날 원문 글 → 등장 종목 추출(빈도 임계 컷). §1 "원문이 곧 필터".
+ * - 글 1건에 같은 종목이 여러 별칭으로 나와도 그 글은 1회로 센다(글 수 기준).
+ * - mentions 내림차순 정렬. 임계 미만은 제외(노이즈).
+ * - grounding: 별칭이 원문에 substring/단어경계로 실제 존재해야만 카운트(가짜 종목 금지).
+ */
+export function extractStocks(
+  items: readonly KeywordSourceItem[],
+  opts: ExtractStocksOptions = {}
+): ExtractedStock[] {
+  const minMentions = opts.minMentions ?? 2;
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const blob = `${item.title} ${item.summary ?? ""}`;
+    const seen = new Set(matchedStocks(blob)); // 한 글 = 종목당 1회
+    for (const canonical of seen) counts.set(canonical, (counts.get(canonical) ?? 0) + 1);
+  }
+
+  const byCanonical = new Map(STOCK_VOCAB.map((d) => [d.canonical, d]));
+  const out: ExtractedStock[] = [];
+  for (const [canonical, mentions] of counts) {
+    if (mentions < minMentions) continue;
+    const def = byCanonical.get(canonical)!;
+    out.push({
+      canonical,
+      market: def.market,
+      country: def.country,
+      ...(def.naverCode ? { naverCode: def.naverCode } : {}),
+      mentions,
+      relatedHint: [], // D 이후 — 지금은 항상 비움(손으로 박지 않는다)
+    });
+  }
+  out.sort((a, b) => b.mentions - a.mentions || a.canonical.localeCompare(b.canonical));
+  return out;
+}
+
+/** 종목명 → 정의(소스 매핑 등에 사용). 없으면 undefined. */
+export function stockDef(canonical: string): StockDef | undefined {
+  return STOCK_VOCAB.find((d) => d.canonical === canonical);
+}
+
+const MATCHER_BY_CANONICAL = new Map(STOCK_MATCHERS.map((m) => [m.def.canonical, m]));
+
+/**
+ * text 가 그 종목을 *어떤 별칭으로든* 언급하나 — 뉴스/레딧 원문 필터·grounding 용.
+ * 한글 별칭=부분일치, 영문/티커=단어경계(엔비디아=Nvidia=NVDA 모두 인식). 미등록 종목은 단순 포함.
+ */
+export function stockMatchesText(canonical: string, text: string): boolean {
+  const m = MATCHER_BY_CANONICAL.get(canonical);
+  const blob = text.toLowerCase();
+  if (!m) return blob.includes(canonical.toLowerCase());
+  return m.substrings.some((s) => blob.includes(s)) || m.regexes.some((re) => re.test(blob));
+}


### PR DESCRIPTION
STOCK_THEME_EXPANSION_HANDOFF(B 트랙) **엔진 파트**. 화면·카피·표기(국기/시장 라벨)는 광혁 직접.

## §1 종목 확장 — "원문이 곧 필터"(마스터 리스트 X)
- **`keyword-cards/stocks.ts`(신규, 순수)**: 종목 인식 어휘(KR+글로벌) + `extractStocks()`. 그날 원문에 **임계(기본 2) 이상 등장한 종목만** 추출(빈도=강도, 스쳐간 1회 컷). grounding=별칭 substring/단어경계(엔비디아=Nvidia=NVDA).
  - **`market`**(KOSPI/NASDAQ/COIN…)·`country`·`naverCode` 동봉 — 시장분리·개인화 **훅(값만)**, 분기 로직 X.
  - **`relatedHint`**: 빈 배열 자리만 열어둠(연관 그래프=방식3, D 이후 — 가짜 연관 금지).
- **`redditFetcher.fetchSubredditPosts`(신규)**: 레딧 글 *제목 원문*(미국주 grounding 용).
- **`collectStockDocs`**: 종목 **국적별 소스 매핑** — KR=네이버 종토방+한국뉴스+디시 / 미국·글로벌=레딧+뉴스+디시.
- **`collectThemeStocks`(신규)**: 테마 그날 원문 → 등장 종목(`extractStocks`). 엔진은 데이터만 제공.

## §2 테마 풀 확장 — 평평하게, 후킹 단위(분류학 X)
- 방산·바이오·원자력·공급망 추가(총 9개). **동적 노출**: 그날 매칭 0이면 자동 제외, 식은 테마는 점수로 가라앉음(기존 score/extract 재사용 — 새 로직 X).
- 오인식 가드("무기한"/"제약사항" 등 false-positive 회피).

## 안 한 것(§3 함정 회피)
시장 분리 화면/3층 계층(아이디어 A), 종목↔종목 연관 그래프(방식 3), 종목 마스터 리스트, 스와이프 UX 변경, 광전자류 좁은 테마 독립 카드 — 전부 미구현(데이터 구조만 열어둠).

## 비용 게이트(§5)
**LLM 호출 증가 없음.** `extractStocks`는 순수(0 LLM). `collectStockDocs`의 미국주 레딧 수집은 *네트워크*일 뿐 LLM 아님. 종목/테마 뎁스는 종전대로 **탭당 1콜(on-demand)** — bulk 추가 없음.

## 검증
- `npm run test` **647 passed**(stock-extraction 11 신규) · typecheck(core/web) · `build:web` 통과.

## 샘플(대표 데이터 — 샌드박스 egress 차단으로 실피드 대신 형태 재현)
- 반도체 테마 원문 → **엔비디아**(NASDAQ/US→레딧+외신), **삼성전자**(KOSPI/KR→종토방). 임계 미만(TSMC·SK하이닉스 각 1회)은 자동 제외.
- 식은 **2차전지**(1건+약세) → 최하위로 가라앉음.

https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC)_