### PR TITLE
feat(ui): FOMO Index 표시 개선 — 스켈레톤·타이포·마스코트 배치 (#409, #412)

### DIFF
--- a/apps/fomo-club/app/(tabs)/today.tsx
+++ b/apps/fomo-club/app/(tabs)/today.tsx
@@ -52,21 +52,21 @@ export default function Today() {
           </View>
         )}
 
-        <Text style={styles.faceLabel}>오늘의 포모</Text>
-        <FomoFace face={index ? scoreToFace(index.score) : "curious"} size={96} glow={color} />
-
-        <View style={styles.indexBox}>
-          {index ? (
-            <>
-              <Text style={[styles.score, { color }]}>{index.score}</Text>
-              <Text style={styles.indexMeta}>
-                FOMO INDEX · {index.state}
-                {index.prevDayDelta ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}` : ""}
-              </Text>
-            </>
-          ) : (
-            <Text style={styles.indexMeta}>불러오는 중…</Text>
-          )}
+        <View style={styles.fomoRow}>
+          <FomoFace face={index ? scoreToFace(index.score) : "curious"} size={80} glow={color} />
+          <View style={styles.indexBox}>
+            {index ? (
+              <>
+                <Text style={[styles.score, { color }]}>{index.score}</Text>
+                <Text style={styles.indexMeta}>
+                  FOMO INDEX · {index.state}
+                  {index.prevDayDelta ? ` · 전일 ${index.prevDayDelta > 0 ? "+" : ""}${index.prevDayDelta}` : ""}
+                </Text>
+              </>
+            ) : (
+              <Text style={styles.indexMeta}>불러오는 중…</Text>
+            )}
+          </View>
         </View>
 
         {state && <Text style={styles.line}>{marketLine(state)}</Text>}
@@ -92,7 +92,8 @@ const styles = StyleSheet.create({
   sub: { color: FomoColors.muted, fontSize: 12 },
   block: { width: "100%", marginVertical: Spacing.s16 },
   faceLabel: { color: FomoColors.muted, fontSize: 12, marginBottom: Spacing.s8 },
-  indexBox: { alignItems: "center", marginTop: Spacing.s12 },
+  fomoRow: { flexDirection: "row", alignItems: "center", gap: Spacing.s16, marginTop: Spacing.s12 },
+  indexBox: { alignItems: "flex-start" },
   score: { fontSize: 40, fontWeight: "800", lineHeight: 44 },
   indexMeta: { color: FomoColors.muted, fontSize: 12, marginTop: 6 },
   line: { color: FomoColors.whiteout, fontSize: 14, lineHeight: 20, textAlign: "center", marginTop: Spacing.s12, maxWidth: 300 },

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { KeywordHistory } from "@/components/KeywordHistory";
+import { FomoIndexSkeleton } from "@/components/SkeletonLoader";
 import type {
   FomoIndexResponse,
   TallyResponse,
@@ -65,22 +66,28 @@ export function HomeView({
         </div>
 
         {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}
+        {!index && <FomoIndexSkeleton />}
         {index && !isFullFallback && (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
-            <span className="text-xs text-muted">오늘의 시장 온도</span>
-            <div className="flex items-baseline gap-2">
-              <span className="font-pixel text-xl leading-none" style={{ color }}>
-                {index.score}
-              </span>
-              <span className="font-pixel text-[11px] text-muted">{index.state}</span>
-              {index.prevDayDelta !== 0 && (
-                <span className="font-pixel text-[11px]" style={{ color }}>
-                  {index.prevDayDelta > 0
-                    ? `· 어제보다 ▲+${index.prevDayDelta}`
-                    : `· 어제보다 ▼${index.prevDayDelta}`}
+          <div className="mt-3 rounded-xl border border-hairline bg-surface px-4 py-2.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted">오늘의 시장 온도</span>
+              <div className="flex items-baseline gap-2">
+                <span className="font-pixel text-2xl leading-none" style={{ color }}>
+                  {index.score}
                 </span>
-              )}
+                <span className="font-pixel text-[11px] text-muted">{index.state}</span>
+                {index.prevDayDelta !== 0 && (
+                  <span className="font-pixel text-[11px]" style={{ color }}>
+                    {index.prevDayDelta > 0
+                      ? `· 어제보다 ▲+${index.prevDayDelta}`
+                      : `· 어제보다 ▼${index.prevDayDelta}`}
+                  </span>
+                )}
+              </div>
             </div>
+            {index.aiSummary && (
+              <p className="mt-1.5 text-[11px] leading-relaxed text-muted">{index.aiSummary}</p>
+            )}
           </div>
         )}
         {index && isFullFallback && (


### PR DESCRIPTION
## 구현 항목

CEO Brief #429 (2026-06-09) 실행 지시 중 코드베이스에 아직 반영되지 않은 항목을 구현했습니다.

### ✅ #409 — 로딩 상태 처리 보강 (PM)
- `apps/fomo-web/components/HomeView.tsx`: `index === null`(API 미응답/실패) 시 `FomoIndexSkeleton` 표시
- 기존에 `SkeletonLoader.tsx`는 존재했지만 `HomeView`에 연결되지 않았음

### ✅ #412 — UX/UI 개선 및 정보 위계 최적화 (Designer)
- `apps/fomo-web/components/HomeView.tsx`:
  - FOMO Index 점수 폰트: `text-xl` → `text-2xl` (가시성 향상)
  - `aiSummary` 비어있지 않으면 인덱스 아래 한 줄 표시 (Heat 근거 문맥 제공, #428 연계)
- `apps/fomo-club/app/(tabs)/today.tsx`:
  - FomoFace(마스코트)와 인덱스 박스를 가로 나란히 배치 → 감정과 숫자의 시각적 연결성 강화

### 이미 구현된 항목 (코드베이스 확인)
- **#428** `packages/fomo-core/src/index-engine/summary.ts`: 상위 2 Heat 헤드라인 포함 — 기구현
- **#426** `apps/web/lib/session-hmac.ts` + `vote/route.ts`: HMAC 서명 — 기구현
- **#425** `apps/web/app/api/fomo/emotions/today/route.ts`: `fallback: total === 0` — 기구현
- **#415** `packages/fomo-core/src/index-engine/calculate.ts`: `safeHeat` 폴백 — 기구현
- **#413** `packages/fomo-core/__tests__/calculate.test.ts` + `apps/web/__tests__/api/fomo/index.test.ts` — 기구현
- **#410** `apps/fomo-web/components/FomoFace.tsx`: `React.memo` — 기구현

## 킬리스트 (미구현)
| 항목 | 사유 |
|------|------|
| 애니메이션 효과 (#374) | 자동 폐기 카테고리 — 장식 폴리싱 금지 |
| 가짜 데이터 테스트 (#378) | 정직한 숫자 원칙 위반 |

## 검증
- [x] lint 통과 (경고 없음)
- [x] test 통과 (647 tests, 57 files)
- [x] build:web 통과

> typecheck는 `packages/shared/tsconfig.json`의 TS 6.0 deprecation 경고(baseUrl)가 사전 존재하여 실패 — 이 PR 변경과 무관한 기존 이슈

## 참조
이슈: #429 (CEO Brief 2026-06-09)
구현 근거 이슈: #409, #412

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTEiTyZk3bjWU5WD7DXtRA)_