### PR TITLE
perf(fomo): 뎁스/메인 영속 캐시 (Data Cache) — warm 즉시

### DIFF
--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
 import type { KeywordCard, KeywordConfidence } from "@fomo/core";
 import { withCors, kstDate } from "../../../../lib/fomo";
 import { computeKeywordCards } from "../../../../lib/keyword-pipeline";
@@ -32,18 +33,24 @@ interface KeywordsPayload {
   live: boolean;
 }
 
-// ── 라이브 결과 메모리 캐시(TTL) + in-flight dedup ──────────────────────────
-// snapshot-first 정신(§4.6): 한 사용자의 새로고침/동시 접속이 외부 소스를 반복 폭격하지 않게,
-// 라이브 산출 결과를 서버 인스턴스 단위로 짧게 캐시하고 동시 요청은 진행 중 Promise 를 공유한다.
-// (Phase 4 의 일일 DB 스냅샷이 메인이면 이 메모리 캐시는 스냅샷 미스 시 백업.)
-const TTL_MS = 30 * 60 * 1000;
-let cache: { at: number; payload: KeywordsPayload } | null = null;
+// ── 영속 캐시(Vercel Data Cache) + in-flight dedup ──────────────────────────
+// 성능(PERF LOADING HANDOFF §1·§2): 메인 카드는 뉴스 RSS·커뮤니티 HTML fetch + LLM 코멘트라 수~10초.
+// 기존 인스턴스 메모리 캐시는 Vercel 서버리스 콜드/다중 인스턴스에서 미스 잦아 자주 재산출됐다.
+// → computeKeywordCards 를 Data Cache(unstable_cache)로 영속화: (KST날짜)당 한 번만 산출,
+//   이후 모든 인스턴스가 즉시 읽기. DDL/외부 KV 불필요. revalidate 30분(시장 변동 반영) + 익일 자동 새 키.
+// snapshot-first(§4.6)는 그대로 — cron 스냅샷이 있으면 그게 1순위. 이 캐시는 라이브 폴백 경로의 영속화.
+// mock 폴백은 캐시 밖(실패를 굳히지 않게). inflight 로 인스턴스 내 동시 요청 dedup.
 let inflight: Promise<KeywordsPayload> | null = null;
 
-/** 라이브 산출(공유 파이프라인). 실패해도 throw 없이 mock 폴백. */
+/** 라이브 산출(공유 파이프라인). 성공분만 Data Cache 에 영속. 실패해도 throw 없이 mock 폴백. */
 async function computeLive(date: string): Promise<KeywordsPayload> {
   try {
-    const { cards, confidence } = await computeKeywordCards();
+    const load = unstable_cache(
+      async () => await computeKeywordCards(),
+      ["fomo-keywords-live", date],
+      { revalidate: 1800 }
+    );
+    const { cards, confidence } = await load();
     return { date, cards, confidence, live: true };
   } catch (err) {
     console.warn("[fomo/keywords] live compute failed — mock fallback", err);
@@ -52,28 +59,17 @@ async function computeLive(date: string): Promise<KeywordsPayload> {
   }
 }
 
-/** 스냅샷-우선 → 캐시 → 라이브 dedup. */
+/** 스냅샷-우선 → 라이브(Data Cache, dedup). */
 async function getPayload(date: string): Promise<KeywordsPayload> {
   // 1) 오늘 스냅샷(테이블 없으면 null) — cron 이 채운 안정 데이터를 외부 호출 없이 즉시 반환.
   const snap = await readKeywordSnapshot(date);
   if (snap) return { date, cards: snap.cards, confidence: snap.confidence, live: false };
 
-  // 2) 메모리 캐시.
-  if (cache && Date.now() - cache.at < TTL_MS && cache.payload.date === date) {
-    return cache.payload;
-  }
+  // 2) 라이브 산출 — Data Cache 가 영속 캐시, inflight 가 인스턴스 내 동시 dedup.
   if (inflight) return inflight;
-
-  // 3) 라이브 산출(dedup).
-  inflight = (async () => {
-    try {
-      const payload = await computeLive(date);
-      cache = { at: Date.now(), payload };
-      return payload;
-    } finally {
-      inflight = null;
-    }
-  })();
+  inflight = computeLive(date).finally(() => {
+    inflight = null;
+  });
   return inflight;
 }
 

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
 import { withCors, kstDate } from "../../../../lib/fomo";
 import { understandStock } from "../../../../lib/theme-understanding";
@@ -17,25 +18,25 @@ export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
 }
 
-// 버그1(깜빡임) 수정: 같은 KST 날짜 동안 결과 고정(date 키). theme-insight 와 동일 정책.
-const cache = new Map<string, { date: string; payload: CondensedInsight }>();
+// 성능(PERF LOADING HANDOFF §1·§2): understandStock 은 종목별 LLM 이라 더 느릴 수 있다.
+// theme-insight 와 동일 정책 — Vercel Data Cache(unstable_cache)로 영속화해 (KST날짜,종목)당 한 번만 LLM.
+// 인스턴스 무관·DDL 불필요. date 를 키에 넣어 그날 고정 + 익일 자동 새 키. inflight 로 인스턴스 내 dedup.
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(stock: string): Promise<CondensedInsight> {
   const today = kstDate();
-  const hit = cache.get(stock);
-  if (hit && hit.date === today) return hit.payload;
-
-  const running = inflight.get(stock);
+  const key = `${today}:${stock}`;
+  const running = inflight.get(key);
   if (running) return running;
 
-  const p = (async () => {
-    const condensed = condenseThemeInsight(await understandStock(stock));
-    cache.set(stock, { date: today, payload: condensed });
-    return condensed;
-  })().finally(() => inflight.delete(stock));
+  const load = unstable_cache(
+    async () => condenseThemeInsight(await understandStock(stock)),
+    ["fomo-stock-insight", today, stock],
+    { revalidate: 86400 }
+  );
 
-  inflight.set(stock, p);
+  const p = load().finally(() => inflight.delete(key));
+  inflight.set(key, p);
   return p;
 }
 

--- a/apps/web/app/api/fomo/theme-insight/route.ts
+++ b/apps/web/app/api/fomo/theme-insight/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
 import { withCors, kstDate } from "../../../../lib/fomo";
 import { understandTheme } from "../../../../lib/theme-understanding";
@@ -19,28 +20,28 @@ export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
 }
 
-// 버그1(깜빡임) 수정: understandTheme 는 LLM 이라 비결정적 → 매 요청 재산출 시 강세/약세가 들쭉날쭉.
-// 같은 KST 날짜 동안 한 번 뽑은 결과를 **그날 끝까지 고정**(date 키). 강력 새로고침(클라 no-cache)도
-// 서버 캐시는 유지 → 같은 카드는 그날 같은 강세/약세. (LLM 호출 방식·프롬프트는 불변 — 캐시 레이어만.)
-// 한계: 서버리스 인스턴스별 메모리라 콜드스타트/다중 인스턴스에선 재산출 가능 — 완전 고정은 스냅샷(DDL) 후속.
-const cache = new Map<string, { date: string; payload: CondensedInsight }>();
+// 성능(PERF LOADING HANDOFF §1·§2): understandTheme 는 LLM+원문 fetch 라 20~30초.
+// 인스턴스 메모리 Map 은 Vercel 서버리스 콜드/다중 인스턴스에서 미스 잦아 매번 재산출됐다.
+// → Vercel Data Cache(unstable_cache)로 영속화: 인스턴스 무관, 같은 (KST날짜,테마)면 한 번만 LLM,
+//   이후 모든 인스턴스가 즉시 읽기(warm 즉시). DDL/외부 KV 불필요(빌트인).
+// date 를 캐시 키에 넣어 "그날 고정"(깜빡임 방지) + 익일 자동 새 키. revalidate 24h(키가 매일 바뀌므로 상한일 뿐).
+// inflight: 한 인스턴스 내 동시 요청이 cold 산출을 중복 호출하지 않게 dedup.
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(theme: string): Promise<CondensedInsight> {
   const today = kstDate();
-  const hit = cache.get(theme);
-  if (hit && hit.date === today) return hit.payload; // 그날 안에선 고정
-
-  const running = inflight.get(theme);
+  const key = `${today}:${theme}`;
+  const running = inflight.get(key);
   if (running) return running;
 
-  const p = (async () => {
-    const condensed = condenseThemeInsight(await understandTheme(theme));
-    cache.set(theme, { date: today, payload: condensed });
-    return condensed;
-  })().finally(() => inflight.delete(theme));
+  const load = unstable_cache(
+    async () => condenseThemeInsight(await understandTheme(theme)),
+    ["fomo-theme-insight", today, theme],
+    { revalidate: 86400 }
+  );
 
-  inflight.set(theme, p);
+  const p = load().finally(() => inflight.delete(key));
+  inflight.set(key, p);
   return p;
 }
 


### PR DESCRIPTION
## 원인 (핸드오프 §0 확인)
`theme-insight`·`stock-insight`·`keywords` 세 route 모두 `export const dynamic = 'force-dynamic'` + **인스턴스 메모리 `Map`** 캐시. Vercel 서버리스는 인스턴스가 자주 새로 떠서 캐시 미스 → 매 진입 LLM(20~30초) 재산출. 메인↔뎁스도 각자 실시간 LLM(공유 안 됨) — **핸드오프 §0 진단 그대로 확인**.

## 해법 (1순위 — DDL 없이 warm 즉시)
무거운 산출을 **Vercel Data Cache(`unstable_cache`)**로 영속화. 인스턴스 무관·빌트인·무료:

| route | 캐시 대상 | 키 | revalidate |
|---|---|---|---|
| theme-insight | `understandTheme→condense` | `(KST날짜, 테마)` | 24h |
| stock-insight | `understandStock→condense` | `(KST날짜, 종목)` | 24h |
| keywords | `computeKeywordCards` | `(KST날짜)` | 30분 |

- **그날 고정**: 키에 KST 날짜 → 같은 날 같은 강세/약세(깜빡임 방지), 익일 자동 새 키.
- **dedup**: `inflight` Map 유지 — 한 인스턴스 cold 동시 요청 중복 LLM 방지.
- **정직성**: keywords snapshot-first(§4.6) 그대로, mock 폴백은 캐시 밖(실패를 굳히지 않음). 엔진/프롬프트 불변.

## 체감 (광혁 판정 요청 — §4)
- **warm**(같은 카드/종목 2번째 진입, 인스턴스 무관): LLM 스킵 → **즉시**.
- **cold**(그날 첫 산출): 여전히 LLM 소요 — 이건 cron 프리컴퓨트(2순위)로만 제거 가능.

## 🚩 후속 (미포함 — 게이트)
**cron 프리컴퓨트(스냅샷)**로 cold까지 없애려면 **테마/종목 인사이트 테이블 신설 = prod DDL → 직접 승인 게이트**. 기존 `KeywordCardSnapshot`은 메인 카드용이고, `TickerInsight`는 구조 불일치라 재사용 불가. 승인 시 별도 PR.

## 검증
typecheck·lint·build:web·test(647) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)