### PR TITLE
perf(fomo): 뎁스 시간대 슬롯 갱신 (KST 4구간)

### DIFF
--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
-import { withCors, kstDate } from "../../../../lib/fomo";
+import { withCors, kstDate, kstSlot } from "../../../../lib/fomo";
 import { understandStock } from "../../../../lib/theme-understanding";
 
 /**
@@ -25,13 +25,14 @@ const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(stock: string): Promise<CondensedInsight> {
   const today = kstDate();
-  const key = `${today}:${stock}`;
+  const slot = kstSlot();
+  const key = `${today}:${slot}:${stock}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
     async () => condenseThemeInsight(await understandStock(stock)),
-    ["fomo-stock-insight", today, stock],
+    ["fomo-stock-insight", today, slot, stock],
     { revalidate: 86400 }
   );
 

--- a/apps/web/app/api/fomo/theme-insight/route.ts
+++ b/apps/web/app/api/fomo/theme-insight/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
-import { withCors, kstDate } from "../../../../lib/fomo";
+import { withCors, kstDate, kstSlot } from "../../../../lib/fomo";
 import { understandTheme } from "../../../../lib/theme-understanding";
 
 /**
@@ -24,19 +24,21 @@ export function OPTIONS() {
 // 인스턴스 메모리 Map 은 Vercel 서버리스 콜드/다중 인스턴스에서 미스 잦아 매번 재산출됐다.
 // → Vercel Data Cache(unstable_cache)로 영속화: 인스턴스 무관, 같은 (KST날짜,테마)면 한 번만 LLM,
 //   이후 모든 인스턴스가 즉시 읽기(warm 즉시). DDL/외부 KV 불필요(빌트인).
-// date 를 캐시 키에 넣어 "그날 고정"(깜빡임 방지) + 익일 자동 새 키. revalidate 24h(키가 매일 바뀌므로 상한일 뿐).
+// 캐시 키 = (KST날짜, 시간슬롯, 테마). 같은 슬롯 안에선 고정(깜빡임 방지), 슬롯이 바뀌면 새 키 →
+// 그날 최신 뉴스로 재산출(저녁엔 저녁 뉴스 반영). revalidate 는 키가 슬롯/날짜로 바뀌므로 상한일 뿐.
 // inflight: 한 인스턴스 내 동시 요청이 cold 산출을 중복 호출하지 않게 dedup.
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(theme: string): Promise<CondensedInsight> {
   const today = kstDate();
-  const key = `${today}:${theme}`;
+  const slot = kstSlot();
+  const key = `${today}:${slot}:${theme}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
     async () => condenseThemeInsight(await understandTheme(theme)),
-    ["fomo-theme-insight", today, theme],
+    ["fomo-theme-insight", today, slot, theme],
     { revalidate: 86400 }
   );
 

--- a/apps/web/lib/fomo.ts
+++ b/apps/web/lib/fomo.ts
@@ -21,6 +21,25 @@ export function kstDate(offsetDays = 0): string {
   return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(now);
 }
 
+/**
+ * KST 시간대 슬롯 — 뎁스 인사이트 캐시 키에 넣어 하루를 4구간으로 나눈다.
+ * 같은 슬롯 안에선 캐시 고정(깜빡임 방지), 슬롯이 바뀌면 새 키 → 그날 최신 뉴스로 재산출.
+ *   dawn(~09) · morning(09~13, 장 시작) · afternoon(13~16, 장 마감 전후) · evening(16~, 마감 후)
+ */
+export function kstSlot(): "dawn" | "morning" | "afternoon" | "evening" {
+  const h = Number(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: "Asia/Seoul",
+      hour: "2-digit",
+      hour12: false,
+    }).format(new Date())
+  ) % 24; // "24" → 0 정규화
+  if (h < 9) return "dawn";
+  if (h < 13) return "morning";
+  if (h < 16) return "afternoon";
+  return "evening";
+}
+
 export function isEmotionType(v: unknown): v is EmotionType {
   return typeof v === "string" && (EMOTION_TYPES as readonly string[]).includes(v);
 }


### PR DESCRIPTION
## 배경
"오전 9시에 본 뎁스가 밤 11시에도 고정"이던 동작을 **시간대 슬롯 갱신**으로 (광혁 결정).

## 변경
- `kstSlot()`: KST 하루를 4구간 — `dawn`(~09) · `morning`(09~13, 장 시작) · `afternoon`(13~16, 장 마감 전후) · `evening`(16~, 마감 후).
- `theme-insight`·`stock-insight` 캐시 키에 슬롯 추가 → `(KST날짜, 슬롯, 테마/종목)`.

## 동작
| | before | after |
|---|---|---|
| 같은 슬롯 재방문 | 고정 | 고정 (깜빡임 없음, warm 즉시) |
| 9시(morning) vs 11시(evening) | **동일** | **다름** — 저녁엔 그날 최신 뉴스 반영 |
| cold(LLM) 발생 | 그날 1회 | 슬롯 전환 첫 진입(하루 최대 4회/키) |

메인 카드는 기존 30분 갱신 그대로(이 PR 무관). 엔진/프롬프트 불변 — 캐시 키만 변경.

## 검증
typecheck·lint·build:web 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)