### PR TITLE
perf(fomo): cron 프리워밍 — 뎁스 cold(첫 진입 33초) 제거

### DIFF
--- a/.github/workflows/warm-insights.yml
+++ b/.github/workflows/warm-insights.yml
@@ -1,0 +1,42 @@
+name: Warm Depth Insights
+
+# 뎁스 인사이트 프리워밍 (PERF — cold 첫 진입 제거).
+# 그날 키워드 테마 + 등장 종목의 theme/stock-insight 를 배포 endpoint 로 HTTP 호출해
+# Vercel Data Cache 를 *현재 슬롯 키*로 미리 채운다 → 사용자는 항상 warm(즉시).
+# 슬롯(kstSlot): morning(09~13) / afternoon(13~16) / evening(16~). 슬롯 시작마다 워밍.
+# 테이블 신설 없음(기존 Data Cache 재사용). 제품 데이터 파이프라인 — 에이전트 자율 루프 아님.
+
+on:
+  schedule:
+    # KST = UTC+9. 각 슬롯 시작 직후 워밍.
+    - cron: "0 0 * * *"  # 09:00 KST — morning 슬롯
+    - cron: "0 4 * * *"  # 13:00 KST — afternoon 슬롯
+    - cron: "0 7 * * *"  # 16:00 KST — evening 슬롯
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-insights
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Warm depth insights
+        env:
+          # 배포 API 베이스(미설정 시 스크립트 기본값 = prod).
+          WARM_BASE_URL: ${{ vars.WARM_BASE_URL }}
+          # 종목 추출(collectThemeStocks)은 룰 기반이라 LLM 불필요하나, 수집 소스 키가 있으면 품질↑.
+          FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+        run: npm run warm:insights

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "research:newsletter": "tsx scripts/research-newsletter.ts",
     "fomo:index": "tsx scripts/fomo-index-pipeline.ts",
     "keywords:generate": "tsx scripts/keywords-generate.ts",
+    "warm:insights": "tsx scripts/warm-insights.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/scripts/warm-insights.ts
+++ b/scripts/warm-insights.ts
@@ -1,0 +1,69 @@
+/**
+ * 뎁스 인사이트 프리워밍 — cold(첫 진입) 제거. PERF LOADING HANDOFF 후속(광혁 결정: cron 프리워밍).
+ *
+ * 문제: theme/stock-insight 는 첫 산출 시 LLM 20~30초. 영속 캐시(Vercel Data Cache)는 두 번째부터
+ *   즉시지만, 그날·그 슬롯의 *첫* 사용자는 cold 를 맞는다.
+ * 해결: cron 이 슬롯 시작마다 그날 테마+등장 종목의 endpoint 를 HTTP 로 미리 호출 → Data Cache 를
+ *   현재 슬롯 키로 채운다. 사용자는 항상 warm(즉시). 테이블 신설 없음(기존 Data Cache 재사용).
+ *
+ * Data Cache 는 Vercel 런타임 안에서만 채워지므로, 로컬 함수 호출이 아니라 *배포 endpoint HTTP 호출*이어야 한다.
+ * (종목 목록만 collectThemeStocks 로 추출 — 이건 LLM 없는 룰 기반 수집이라 가볍다.)
+ *
+ * env: WARM_BASE_URL(배포 API 베이스, 기본 prod). cron: warm-insights.yml(슬롯 시작 09/13/16 KST).
+ */
+import { collectThemeStocks } from "../apps/web/lib/theme-understanding";
+
+const BASE = (process.env.WARM_BASE_URL || "https://taro-stock-web.vercel.app").replace(/\/$/, "");
+const MIN_MENTIONS = 2; // 종목 추출 임계(가짜 연관 방지 — 빈도 낮은 종목은 워밍 제외)
+const REQ_TIMEOUT_MS = 60_000; // understandTheme/Stock 의 LLM timeout(45s)보다 여유
+
+async function warm(path: string): Promise<void> {
+  const t0 = Date.now();
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      headers: { "x-warm": "1" },
+      signal: AbortSignal.timeout(REQ_TIMEOUT_MS),
+    });
+    console.log(`  ${res.ok ? "✓" : "✗"} ${res.status} ${Date.now() - t0}ms  ${path}`);
+  } catch (err) {
+    console.warn(`  ✗ ERR ${Date.now() - t0}ms  ${path} — ${(err as Error)?.message}`);
+  }
+}
+
+async function main() {
+  console.log(`[warm-insights] base=${BASE}`);
+
+  // 1) 그날 키워드 테마 목록(배포 endpoint — 같은 캐시를 공유한다).
+  const kwRes = await fetch(`${BASE}/api/fomo/keywords`, { signal: AbortSignal.timeout(REQ_TIMEOUT_MS) });
+  const kw = (await kwRes.json()) as { cards?: { keyword: string }[] };
+  const themes = [...new Set((kw.cards ?? []).map((c) => c.keyword).filter(Boolean))];
+  console.log(`[warm-insights] 테마 ${themes.length}개: ${themes.join(", ")}`);
+
+  // 2) 테마 뎁스 워밍 + 그 테마에 등장한 종목 수집.
+  const stocks = new Set<string>();
+  for (const theme of themes) {
+    await warm(`/api/fomo/theme-insight?theme=${encodeURIComponent(theme)}`);
+    try {
+      const extracted = await collectThemeStocks(theme, { minMentions: MIN_MENTIONS });
+      for (const s of extracted) stocks.add(s.canonical);
+    } catch (err) {
+      console.warn(`  종목 추출 실패: ${theme} — ${(err as Error)?.message}`);
+    }
+  }
+
+  // 3) 그날 등장 종목 뎁스 워밍(가장 느렸던 경로 — cold 33초의 주범).
+  const stockList = [...stocks];
+  console.log(`[warm-insights] 종목 ${stockList.length}개: ${stockList.join(", ")}`);
+  for (const stock of stockList) {
+    await warm(`/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`);
+  }
+
+  console.log(`[warm-insights] 완료 — 테마 ${themes.length} + 종목 ${stockList.length} 워밍`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[warm-insights] 실패", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## 배경 (실측 진단)
영속 캐시(#525/#526)로 **warm 재방문은 0.05초**가 됐지만, 사용자가 여전히 느리다고 느낀 건 **cold(캐시 빈 첫 진입)**:

| 경로 | cold | warm |
|---|---|---|
| keywords | 빠름 | 0.15s |
| theme-insight | 최대 38s | 0.05s |
| **stock-insight** | **33s** 🔴 | 0.06s |

`understandStock`은 원문 수집 후 LLM 2회(이해 + 워딩 안전판정) 순차 → 첫 산출이 느림. 캐시가 비는 새 종목/키워드 첫 진입마다 발생.

## 해결 — cron 프리워밍 (광혁 결정)
cron이 슬롯 시작마다 그날 테마+종목 endpoint를 HTTP로 미리 호출 → **Vercel Data Cache를 현재 슬롯 키로 채움** → 사용자는 항상 warm(즉시). **테이블 신설 없음**(기존 Data Cache 재사용).

- `scripts/warm-insights.ts`: keywords → 테마 목록 → 각 테마 `theme-insight` 워밍 + `collectThemeStocks`(룰 기반, LLM 무관)로 종목 추출 → 각 종목 `stock-insight` 워밍.
- `.github/workflows/warm-insights.yml`: 슬롯 시작 `00/04/07 UTC`(= 09/13/16 KST) cron. 슬롯 키와 정렬.
- `npm run warm:insights`.

## 스모크 테스트 (prod)
테마 8개 워밍 성공 — 캐시된 반도체 28ms, cold 11~38s 산출하며 캐시 채움 확인. exit 0.

## 💰 비용 (cron 게이트 — 보고)
슬롯당 (테마 ~8 + 종목 ~10~15) × 2 LLM(이해+워딩판정) ≈ **40~50 LLM 호출**, ×3슬롯/일 ≈ **120~150 LLM/일**. 이게 사용자 cold 제거의 대가입니다. dawn(00~09 KST)은 트래픽 적어 워밍 생략(필요 시 cron 한 줄 추가).

## 검증
typecheck·lint·build:web 통과.

> 머지하면 cron이 등록되어 다음 슬롯부터 자동 워밍. 즉시 확인하려면 Actions에서 `Warm Depth Insights` workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
