### PR TITLE
feat(bm): 발굴 엔진 — 연관 확산(숨은 연관주) v1

### DIFF
--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -6,6 +6,7 @@ import {
   buildThemeInsightPrompt,
   parseNaverBoardPosts,
   condenseThemeInsight,
+  discoverRelatedStocks,
   screenWordingRule,
   type SourceDoc,
   type ThemeInsight,
@@ -503,5 +504,59 @@ describe("parse / prompt / 커뮤니티 원문 보존", () => {
     expect(posts.map((p) => p.title)).toContain("삼성전자 가즈아 풀매수");
     expect(posts.find((p) => p.title.includes("가즈아"))!.tone).toBe("bull");
     expect(posts.find((p) => p.title.includes("손절"))!.tone).toBe("bear");
+  });
+});
+
+describe("발굴 엔진 — 연관 확산 (BM 구멍1, 불변)", () => {
+  // 반도체 대장주(THEME_DICTIONARY.related) = 삼성전자/SK하이닉스/엔비디아.
+  const mk = (stocks: string[], bull: { claim: string; sourceId: string; quote: string }[]): ThemeInsight => ({
+    theme: "반도체",
+    stocks,
+    bull,
+    bear: [],
+    wordings: [],
+    stance: "bull-dominant",
+    stanceNote: "",
+    sources: [{ id: "S1", kind: "news", title: "t", source: "한국경제" }],
+    confidence: "low",
+    reason: "r",
+  });
+
+  it("의외성 — 대장주(삼성전자)는 연관주로 안 뽑힌다", () => {
+    const insight = mk(
+      ["삼성전자", "한미반도체"],
+      [
+        { claim: "삼성전자가 외국인 매수세", sourceId: "S1", quote: "외국인 매수세" },
+        { claim: "한미반도체가 삼성에 HBM 장비를 납품한다", sourceId: "S1", quote: "HBM 장비" },
+      ]
+    );
+    const r = discoverRelatedStocks(insight);
+    expect(r.map((x) => x.stock)).toEqual(["한미반도체"]); // 삼성전자(대장주) 제외
+    expect(r[0]!.reason).toContain("한미반도체"); // grounded 연관 근거
+    expect(r[0]!.sourceId).toBe("S1");
+  });
+
+  it("grounding — 연관 근거(claim 언급) 없는 종목은 폐기", () => {
+    // HPSP 가 stocks 에 있지만 어떤 claim 도 HPSP 를 언급 안 함 → 폐기.
+    const insight = mk(
+      ["HPSP", "한미반도체"],
+      [{ claim: "한미반도체가 장비를 납품한다", sourceId: "S1", quote: "장비" }]
+    );
+    expect(discoverRelatedStocks(insight).map((x) => x.stock)).toEqual(["한미반도체"]);
+  });
+
+  it("결정성 — 같은 insight → 같은 연관주", () => {
+    const insight = mk(
+      ["한미반도체", "HPSP"],
+      [
+        { claim: "한미반도체 납품 확대", sourceId: "S1", quote: "납품" },
+        { claim: "HPSP 수주 증가", sourceId: "S1", quote: "수주" },
+      ]
+    );
+    expect(discoverRelatedStocks(insight)).toEqual(discoverRelatedStocks(insight));
+  });
+
+  it("정직한 빈 상태 — 연관주 없으면 빈 배열(가짜 안 채움)", () => {
+    expect(discoverRelatedStocks(mk(["삼성전자"], []))).toEqual([]);
   });
 });

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -6,6 +6,7 @@ import type {
   ThemeInsightConfidence,
   ThemeStance,
 } from "./types";
+import { discoverRelatedStocks } from "./discover";
 
 /**
  * 재가공/응축 레이어 — DATA_ENGINE_STRATEGY §4 Track B.
@@ -63,6 +64,8 @@ export interface CondensedInsight {
   wordingAudit?: import("./types").WordingVerdict[];
   /** 공식 지표 팩트(FRED 등) — 중립 사실 숫자(C-2). 강세/약세와 별개. */
   officialFacts?: import("./types").OfficialFact[];
+  /** 숨은 연관주(BM 발굴 엔진) — 대장주 아닌, grounded 연관 근거가 있는 종목. 없으면 빈 배열. */
+  relatedStocks: import("./discover").RelatedStock[];
 }
 
 export interface CondenseOptions {
@@ -95,6 +98,9 @@ export function condenseThemeInsight(
     oneSided: bullCount + bearCount > 0 && (bullCount === 0 || bearCount === 0),
   };
 
+  // 발굴 엔진(BM) — understandTheme 출력 위 가공(LLM 0). 대장주 제외 + grounded 연관 근거만.
+  const relatedStocks = discoverRelatedStocks(insight);
+
   const base = {
     theme: insight.theme,
     stance: insight.stance,
@@ -103,6 +109,7 @@ export function condenseThemeInsight(
     outlets,
     singleOutlet,
     lean,
+    relatedStocks,
     confidence: insight.confidence,
     reason: insight.reason,
     ...(insight.wordingAudit ? { wordingAudit: insight.wordingAudit } : {}),

--- a/packages/fomo-core/src/theme-understanding/discover.ts
+++ b/packages/fomo-core/src/theme-understanding/discover.ts
@@ -1,0 +1,51 @@
+import { THEME_DICTIONARY } from "../keyword-cards/extract";
+import type { ThemeInsight } from "./types";
+
+/**
+ * 발굴 엔진(연관 확산) — BM_STRATEGY 구멍1 1차. 순수(네트워크/LLM 0).
+ *
+ * understandTheme 출력 *위에서만* 가공한다(추가 LLM 호출 없음 — 토큰 절약).
+ * 고르는 기준 = **연관 ∩ 의외성**:
+ *  - 연관: 테마 원문의 grounded 근거에 함께 등장한 종목(맥락 안 — 생뚱맞은 섹터 금지).
+ *  - 의외성: 대장주(테마 사전 related = 다 아는 것)는 제외 → "덜 알려진 수혜주".
+ *  - 연관 근거 필수(grounding): "왜 연관인지"가 grounded 근거(claim)에 있어야 한다. 없으면 폐기(환각 금지).
+ * 데이터 부족하면 빈 배열(가짜로 안 채움). 같은 insight → 같은 결과(결정성).
+ */
+export interface RelatedStock {
+  /** 발굴된 연관주명. */
+  stock: string;
+  /** 왜 연관인지 — grounded 근거 claim 그대로(원문에 박힘). */
+  reason: string;
+  /** 근거 출처(SourceDoc.id). */
+  sourceId: string;
+  /** 어느 관점 근거에서 나왔나. */
+  side: "bull" | "bear";
+}
+
+const norm = (s: string) => s.replace(/\s+/g, "");
+
+export function discoverRelatedStocks(insight: ThemeInsight, opts: { max?: number } = {}): RelatedStock[] {
+  const max = opts.max ?? 2;
+  // 대장주(다 아는 것) = 테마 사전 related + 테마명. 의외성을 위해 후보에서 제외.
+  const majors = new Set(
+    [...(THEME_DICTIONARY[insight.theme]?.related ?? []), insight.theme].map(norm)
+  );
+  const evidence = [
+    ...insight.bull.map((e) => ({ e, side: "bull" as const })),
+    ...insight.bear.map((e) => ({ e, side: "bear" as const })),
+  ];
+
+  const out: RelatedStock[] = [];
+  const seen = new Set<string>();
+  for (const stock of insight.stocks) {
+    const ns = norm(stock);
+    if (!ns || majors.has(ns) || seen.has(ns)) continue; // 의외성: 대장주·중복 제외
+    // 연관 근거(grounding): 이 종목을 *언급한* grounded 근거를 찾는다. 없으면 폐기.
+    const hit = evidence.find(({ e }) => norm(e.claim).includes(ns));
+    if (!hit) continue;
+    seen.add(ns);
+    out.push({ stock, reason: hit.e.claim, sourceId: hit.e.sourceId, side: hit.side });
+    if (out.length >= max) break;
+  }
+  return out;
+}

--- a/packages/fomo-core/src/theme-understanding/index.ts
+++ b/packages/fomo-core/src/theme-understanding/index.ts
@@ -6,3 +6,4 @@ export * from "./condense";
 export * from "./wording-filter";
 export * from "./fred";
 export * from "./dcinside";
+export * from "./discover";


### PR DESCRIPTION
BM_STRATEGY 구멍1 1차 R&D. 잠금/광고/구독(구멍2)은 안 만듦 — 발굴이 "쓸 만한가"부터 증명.

## 엔진 (LLM 0 — 토큰 절약)
`discoverRelatedStocks(insight)` — understandTheme 출력 *위에서만* 가공. 새 수집·LLM 호출 없음.
- **연관**: 테마 grounded 근거(claim)에 함께 등장한 종목만.
- **의외성**: 대장주(`THEME_DICTIONARY.related` = 다 아는 것) 제외 → 덜 알려진 수혜주.
- **grounding**: "왜 연관"이 grounded claim 에 있어야(없으면 폐기, 환각 금지). 없으면 빈 배열(가짜 안 채움).
- `CondensedInsight.relatedStocks` 로 노출(API 자동). 결정성(insight 가 그날 고정 → 같은 연관주).

## 불변 테스트 (BM §4)
대장주 제외 · 연관근거 없으면 폐기 · 결정성 · 정직한 빈 상태. goal 루프: typecheck/test **651**/build green.

## 다음(분리)
화면 연결(뎁스 [숨은 연관주] + teaser + 탭→stock-insight 재활용) = PR2. 화면·카피·전환 = 광혁.

prod DDL 없음. CI green 자동 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)