### PR TITLE
feat(fomo-web): 숨은 연관주 섹션 + 종목 전용 화면 (BM 1단계 PR2)

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { scoreToColor, cleanText, cleanQuote, type KeywordCard } from "@fomo/core";
-import { fetchThemeInsight, type CondensedInsight } from "@/lib/fomoApi";
+import { fetchThemeInsight, fetchStockInsight, type CondensedInsight } from "@/lib/fomoApi";
 
 /** 응축(강세/약세/워딩) 로딩 중 표시 — "강세/약세 없는 중간 상태"가 노출되지 않게(핸드오프 §1).
  *  카피는 임시(정중한 반말), 최종본은 광혁 조정. */
@@ -31,6 +31,8 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
   const color = scoreToColor(card.fomoScore);
   const [insight, setInsight] = useState<CondensedInsight | null>(null);
   const [loading, setLoading] = useState(true);
+  // 숨은 연관주 탭 → 종목 전용 화면(stock-insight 재활용). null 이면 안 띄움.
+  const [stockSubject, setStockSubject] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -189,6 +191,35 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
                   </ul>
                 </section>
               )}
+
+              {/* 숨은 연관주(BM 발굴 엔진) — 대장주 아닌, 이 테마 때문에 같이 움직인 종목.
+                  연관 근거(reason)는 원문 grounded claim 그대로. 탭하면 그 종목만 따로 본다(stock-insight 재활용).
+                  카피/전환은 임시(광혁 조정 영역). 없으면 섹션 자체를 숨긴다(가짜로 안 채움). */}
+              {insight!.relatedStocks.length > 0 && (
+                <section className="mt-6">
+                  <p className="font-pixel text-sm text-whiteout">🔗 같이 움직인 종목</p>
+                  <p className="mt-1 text-[11px] leading-5 text-muted">
+                    대장주 말고, 이 테마 때문에 같이 들썩인 덜 알려진 종목들. 탭하면 그 종목만 따로 봐.
+                  </p>
+                  <ul className="mt-2 space-y-2">
+                    {insight!.relatedStocks.map((r, i) => (
+                      <li key={`rel-${i}`}>
+                        <button
+                          type="button"
+                          onClick={() => setStockSubject(r.stock)}
+                          className="block w-full rounded-lg border border-hairline bg-surface px-3 py-2 text-left transition-colors hover:border-whiteout/30"
+                        >
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="font-pixel text-sm text-whiteout">{cleanText(r.stock)}</span>
+                            <span className="shrink-0 text-[11px] text-muted">자세히 →</span>
+                          </span>
+                          <span className="mt-1 block text-[12px] leading-5 text-muted">{cleanText(r.reason)}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
             </>
           ) : (
             // 폴백 — 응축 부족(insufficient): 기존 뉴스 소스(#500). 빈 화면 금지.
@@ -245,6 +276,177 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
 
           <p className="mt-8 text-center text-[11px] leading-5 text-muted">
             지난 흐름을 친구처럼 풀어준 거야. 투자 조언은 아니야.
+          </p>
+        </div>
+      </div>
+
+      {/* 종목 전용 화면 — 연관주 탭 시 stock-insight(understandStock) 재활용. z-[70] 으로 뎁스 위에 덮는다. */}
+      {stockSubject && (
+        <StockInsightView stock={stockSubject} onClose={() => setStockSubject(null)} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * 종목 전용 화면 — 숨은 연관주 탭 시. /api/fomo/stock-insight(understandStock #514, 영속 캐시) 를 lazy fetch 해
+ * 그 종목의 grounded 강세/약세/워딩/공식지표를 보여준다. 테마 뎁스와 같은 grounding·정직성 규칙을 따른다.
+ * (응축 부족이면 정직한 빈 상태 — 가짜로 안 채움.) 카피/전환은 임시, 최종은 광혁.
+ */
+function StockInsightView({ stock, onClose }: { stock: string; onClose: () => void }) {
+  const [insight, setInsight] = useState<CondensedInsight | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setInsight(null);
+    fetchStockInsight(stock)
+      .then((r) => alive && setInsight(r))
+      .catch(() => alive && setInsight(null))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [stock]);
+
+  const hasInsight =
+    !!insight && insight.confidence !== "insufficient" && insight.bull.length + insight.bear.length > 0;
+
+  const srcOf = (id: string) => insight?.sources.find((s) => s.id === id);
+  const kindLabel = (kind?: string) =>
+    kind === "official" ? "공식 데이터" : kind === "community" ? "커뮤니티" : kind === "news" ? "뉴스" : "";
+
+  const evidenceItem = (claim: string, sourceId: string, key: string) => {
+    const s = srcOf(sourceId);
+    const kl = kindLabel(s?.kind);
+    const label = `${s?.source ?? s?.title ?? ""}${kl ? ` · ${kl}` : ""}`;
+    return (
+      <li key={key} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+        <span className="block text-sm leading-5 text-whiteout">{cleanText(claim)}</span>
+        {s &&
+          (s.url ? (
+            <a href={s.url} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
+              ↳ {label} · 원문 보기 →
+            </a>
+          ) : (
+            <span className="mt-1 block text-[11px] text-muted">↳ {label}</span>
+          ))}
+      </li>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-[70] bg-black">
+      <div className="mx-auto flex h-full max-w-md flex-col">
+        <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
+          <div className="flex items-center gap-2.5">
+            <button onClick={onClose} className="font-pixel text-sm text-muted hover:text-whiteout" aria-label="뒤로">
+              ← 뒤로
+            </button>
+            <span className="text-lg font-bold text-whiteout">{cleanText(stock)}</span>
+          </div>
+          <span className="font-pixel text-xs text-muted">종목</span>
+        </div>
+
+        <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
+          <section>
+            <p className="font-pixel text-sm text-whiteout">왜 같이 움직였나</p>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              {loading ? "원문 읽는 중…" : hasInsight ? cleanText(insight!.whyHot) : "이 종목만으로는 응축할 원문이 아직 부족해. 그것도 정상이야."}
+            </p>
+          </section>
+
+          {!loading && insight?.officialFacts && insight.officialFacts.length > 0 && (
+            <section className="mt-6">
+              <p className="font-pixel text-sm text-whiteout">📊 공식 지표</p>
+              <ul className="mt-2 space-y-2">
+                {insight.officialFacts.map((f, i) => (
+                  <li key={`of-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                    <span className="block text-sm leading-5 text-whiteout">{cleanText(f.label)}</span>
+                    {f.url ? (
+                      <a href={f.url} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
+                        ↳ {f.source} · 공식 데이터 →
+                      </a>
+                    ) : (
+                      <span className="mt-1 block text-[11px] text-muted">↳ {f.source} · 공식 데이터</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {loading ? (
+            <DepthBodySkeleton />
+          ) : hasInsight ? (
+            <>
+              {insight!.lean.bullCount + insight!.lean.bearCount > 0 && (
+                <p className="mt-3 text-[11px] leading-5 text-muted">
+                  오늘 쏠림 · <span style={{ color: "var(--up, #ff5a5f)" }}>강세 {insight!.lean.bullCount}</span>
+                  {" : "}
+                  <span style={{ color: "var(--down, #4f8cff)" }}>약세 {insight!.lean.bearCount}</span>
+                  {insight!.lean.oneSided ? " · 반대 관점 안 보임" : ""}
+                </p>
+              )}
+
+              {insight!.singleOutlet && insight!.outlets.length > 0 && (
+                <p className="mt-3 rounded-lg border border-hairline bg-surface px-3 py-2 text-[11px] leading-5 text-muted">
+                  ⚠️ 오늘은 <span className="text-whiteout">{insight!.outlets[0]}</span> 한 곳 기준이야 — 한 매체 안의 시각일 수 있어.
+                </p>
+              )}
+
+              <section className="mt-6">
+                <p className="font-pixel text-sm" style={{ color: "var(--up, #ff5a5f)" }}>
+                  📈 강세 관점
+                </p>
+                {insight!.bull.length > 0 ? (
+                  <ul className="mt-2 space-y-2">
+                    {insight!.bull.map((p, i) => evidenceItem(p.claim, p.sourceId, `bull-${i}`))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-sm leading-6 text-muted">원문에서 강세 근거는 안 보였어.</p>
+                )}
+              </section>
+
+              <section className="mt-6">
+                <p className="font-pixel text-sm" style={{ color: "var(--down, #4f8cff)" }}>
+                  📉 약세 관점
+                </p>
+                {insight!.bear.length > 0 ? (
+                  <ul className="mt-2 space-y-2">
+                    {insight!.bear.map((p, i) => evidenceItem(p.claim, p.sourceId, `bear-${i}`))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-sm leading-6 text-muted">{insight!.stanceNote}</p>
+                )}
+              </section>
+
+              {insight!.wordings.length > 0 && (
+                <section className="mt-6">
+                  <p className="font-pixel text-sm text-whiteout">🗣️ 사람들 워딩</p>
+                  <ul className="mt-2 space-y-2">
+                    {insight!.wordings.map((w, i) => {
+                      const s = srcOf(w.sourceId);
+                      return (
+                        <li key={`w-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                          <span className="block text-sm leading-5 text-whiteout">“{cleanQuote(w.text)}”</span>
+                          {s && <span className="mt-1 block text-[11px] text-muted">↳ {cleanText(s.source ?? s.title)}</span>}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              )}
+            </>
+          ) : (
+            <p className="mt-6 text-sm leading-6 text-muted">
+              이 종목으로 모인 원문이 아직 적어. 더 쌓이면 강세·약세로 풀어줄게.
+            </p>
+          )}
+
+          <p className="mt-8 text-center text-[11px] leading-5 text-muted">
+            원문을 친구처럼 풀어준 거야. 투자 조언은 아니야.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## 무엇

발굴 엔진(#529/#530, `discoverRelatedStocks`)이 뽑은 `insight.relatedStocks` 를 키워드 뎁스 화면에 연결한 **화면 연결 PR**(BM 1단계의 화면 반쪽). 엔진(로직) PR과 분리(BM §6).

### 변경 — `apps/fomo-web/components/KeywordDepthPage.tsx` 단일 파일
- 뎁스에 **🔗 같이 움직인 종목** 섹션: 대장주 아닌, grounded 연관 근거가 있는 종목만 노출. 없으면 섹션 자체를 숨김(가짜로 안 채움). teaser = 연관 근거(`reason`) = 원문 grounded claim 그대로.
- 탭 → **`StockInsightView`** (z-[70] 오버레이): `/api/fomo/stock-insight`(understandStock #514, 영속 캐시) lazy fetch → 그 종목의 grounded 강세/약세/워딩/공식지표 + 쏠림 + 한 곳 기준 경고를 **테마 뎁스와 동일한 grounding·정직성 규칙**으로 표시. `insufficient` 면 정직한 빈 상태, 로딩 중 스켈레톤, 뒤로 네비게이션.
- 엔진은 데이터·연결만 제공. **카피/전환 애니메이션은 임시(광혁 조정 영역).**

### 비목표(이번에 안 함)
잠금/teaser 유료화, 광고, 구독, 퀴즈, 독립 종목 카드.

## 검증
- `npm run typecheck` 전 패키지 통과.
- 라이브(fomo-web → prod API, Gemini): 반도체 뎁스 → 연관주 **저스템**(삼성·SK 장비 납품), **네패스**(AI 첨단 패키징) — 둘 다 의외성·grounded. 저스템 탭 → grounded 강세 2 / 약세 1 + 원문 링크 + 한 곳 기준 경고 정상. **투자조언/매매신호 누출 없음.**

## 💰 비용 게이트
연관주 탭 → `stock-insight` 는 **종목당 LLM 호출 1회**(understandStock). 콜드: ~80s(Gemini). 이후 **영속 캐시**(`unstable_cache`, revalidate 86400, (kstDate,slot,subject) 키) → 같은 날 같은 종목 재탭은 즉시·비용 0. 신규 LLM 비용은 사용자가 실제 탭한 종목만 발생(테마당 최대 2종목).

> ⚠️ 콜드 캐시 1회차에서 응답이 완료 전 `insufficient` 로 떨어져 정직한 빈 상태가 잠깐 보일 수 있음(캐시 채워진 뒤 정상). 이는 prod stock-insight 라우트의 콜드스타트 특성으로, 컴포넌트는 두 상태 모두 정직하게 표시(설계대로). 추적 가치 있으면 별도 트랙.

🤖 Generated with [Claude Code](https://claude.com/claude-code)