### PR TITLE
feat(loading): 전체 화면 로딩(추정 바 + 단계 텍스트) — 메인/뎁스/종목

### DIFF
--- a/apps/fomo-web/components/FullPageLoading.tsx
+++ b/apps/fomo-web/components/FullPageLoading.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 전체 화면 로딩 — 추정 프로그레스 바 + 단계 텍스트 (LOADING PROGRESS HANDOFF C안).
+ *
+ * 스켈레톤·빈 박스 대신 콘텐츠 영역을 통째로 덮어 "죽은 듯한 중간 상태"를 없앤다.
+ * 메인/뎁스/종목 세 화면이 공유(추정시간·단계 텍스트만 prop 으로).
+ *
+ * 정직성:
+ *  - LLM 은 정확한 진척을 안 주므로 *추정* 바(평균 소요 기준 차오름). 90%에서 멈춰 가짜 100% 금지.
+ *  - 실제 완료는 부모가 loading=false 로 이 컴포넌트를 언마운트하며 콘텐츠로 전환.
+ *  - 추정 초과 시 마지막 단계("거의 다 됐어")로 안내.
+ * warm(캐시 적중): REVEAL_DELAY_MS 이내 완료면 로딩 화면 자체를 안 그려 깜빡임 방지.
+ *
+ * 카피·바 디자인 최종본은 광혁 영역 — 여기선 상태·추정시간만 정확히 표현.
+ */
+const REVEAL_DELAY_MS = 150; // 이 시간 내 완료(warm)면 로딩 화면이 아예 안 뜸
+const TICK_MS = 100;
+const MAX_RATIO = 0.9; // 가짜 100% 금지 — 추정 바는 90%에서 정지
+
+export function FullPageLoading({
+  estimateMs,
+  steps,
+}: {
+  estimateMs: number;
+  steps: readonly string[];
+}) {
+  const [elapsed, setElapsed] = useState(0);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const start = Date.now();
+    const reveal = window.setTimeout(() => setShown(true), REVEAL_DELAY_MS);
+    const tick = window.setInterval(() => setElapsed(Date.now() - start), TICK_MS);
+    return () => {
+      window.clearTimeout(reveal);
+      window.clearInterval(tick);
+    };
+  }, []);
+
+  if (!shown) return null;
+
+  const ratio = Math.min(MAX_RATIO, estimateMs > 0 ? elapsed / estimateMs : MAX_RATIO);
+  const pct = Math.round(ratio * 100);
+  // 단계 — 진척 비율로 인덱스. 추정 초과면 마지막 단계 고정("거의 다 됐어").
+  const overEstimate = elapsed >= estimateMs;
+  const idx = overEstimate
+    ? steps.length - 1
+    : Math.min(steps.length - 1, Math.floor((elapsed / estimateMs) * steps.length));
+  const label = steps[idx] ?? "";
+
+  return (
+    <div
+      className="fomo-phase-in flex min-h-[60vh] flex-1 flex-col items-center justify-center gap-4 px-10"
+      aria-busy="true"
+      role="status"
+    >
+      <div className="h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-elevated">
+        <div
+          className="h-full rounded-full bg-whiteout transition-[width] duration-300 ease-out"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-sm leading-6 text-muted">{label}</p>
+    </div>
+  );
+}
+
+/** 화면별 추정시간·단계 텍스트(임시 카피 — 광혁 조정). 캐시 적중 시엔 안 보임. */
+export const LOADING_PRESETS = {
+  main: {
+    estimateMs: 8_000,
+    steps: ["오늘 뭐에 쏠렸는지 모으는 중…", "키워드 정리하는 중…", "거의 다 됐어"] as const,
+  },
+  theme: {
+    estimateMs: 15_000,
+    steps: ["원문 읽는 중…", "강세·약세 정리하는 중…", "거의 다 됐어"] as const,
+  },
+  stock: {
+    estimateMs: 80_000,
+    steps: ["원문 읽는 중…", "강세·약세 정리하는 중…", "거의 다 됐어"] as const,
+  },
+} as const;

--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -6,6 +6,7 @@ import { KeywordDepthPage } from "@/components/KeywordDepthPage";
 import { fetchKeywords } from "@/lib/fomoApi";
 import { recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
+import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
 /**
  * 키워드 카드 덱 — 자연스러운 스와이프(드래그+뒤 카드 실제 콘텐츠 노출) + 하단 버튼 2개.
@@ -60,16 +61,6 @@ function ConfidenceNote({ confidence }: { confidence: KeywordConfidence }) {
   );
 }
 
-/** 스와이프 스켈레톤(로딩) — 무한 로딩 대신 카드 형태만 비워 보여준다. */
-function DeckSkeleton() {
-  return (
-    <div className="w-full">
-      <div className="mx-auto h-[56vh] w-full animate-pulse rounded-2xl border border-hairline bg-surface" />
-      <p className="mt-4 text-center text-xs text-muted">오늘 뭐에 쏠렸는지 보는 중…</p>
-    </div>
-  );
-}
-
 /** 담담한 빈 상태(수집 실패/데이터 없음) — 무한 로딩 금지. */
 function DeckEmpty() {
   return (
@@ -111,7 +102,8 @@ export function KeywordCardFeed() {
     };
   }, []);
 
-  if (state.kind === "loading") return <DeckSkeleton />;
+  if (state.kind === "loading")
+    return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
   if (state.kind === "error") return <DeckEmpty />;
   return <KeywordDeck cards={state.cards} confidence={state.confidence} />;
 }

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -3,21 +3,7 @@
 import { useEffect, useState } from "react";
 import { scoreToColor, cleanText, cleanQuote, type KeywordCard } from "@fomo/core";
 import { fetchThemeInsight, fetchStockInsight, type CondensedInsight } from "@/lib/fomoApi";
-
-/** 응축(강세/약세/워딩) 로딩 중 표시 — "강세/약세 없는 중간 상태"가 노출되지 않게(핸드오프 §1).
- *  카피는 임시(정중한 반말), 최종본은 광혁 조정. */
-function DepthBodySkeleton() {
-  return (
-    <section className="mt-6" aria-busy="true">
-      <p className="text-sm leading-6 text-muted">원문 읽고 강세·약세 정리하는 중…</p>
-      <div className="mt-3 space-y-2">
-        <div className="h-12 animate-pulse rounded-lg border border-hairline bg-surface" />
-        <div className="h-12 animate-pulse rounded-lg border border-hairline bg-surface" />
-        <div className="h-12 w-2/3 animate-pulse rounded-lg border border-hairline bg-surface" />
-      </div>
-    </section>
-  );
-}
+import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
 /**
  * 키워드 뎁스 페이지 — 카드/히스토리에서 공용. KEYWORD_CARD_FEED_DEV_SPEC v3 §3.
@@ -97,20 +83,22 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
         </div>
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
+          {loading ? (
+            <FullPageLoading estimateMs={LOADING_PRESETS.theme.estimateMs} steps={LOADING_PRESETS.theme.steps} />
+          ) : (
+          <>
           <p className="text-sm leading-6 text-whiteout">{cleanText(card.comment)}</p>
 
-          {/* 왜 떴나 — 응축이 있으면 grounded whyHot, 없으면 기존 키워드 why.
-              로딩 중엔 grounded 본문을 기다린다(중간 상태 노출 방지). */}
+          {/* 왜 떴나 — 응축이 있으면 grounded whyHot, 없으면 기존 키워드 why. */}
           <section className="mt-7">
             <p className="font-pixel text-sm text-whiteout">{card.depth.whyTitle}</p>
             <p className="mt-2 text-sm leading-6 text-muted">
-              {loading ? "원문 읽는 중…" : cleanText(hasInsight ? insight!.whyHot : card.depth.why)}
+              {cleanText(hasInsight ? insight!.whyHot : card.depth.why)}
             </p>
           </section>
 
-          {/* 공식 지표(FRED 등) — 강세/약세와 별개의 중립 사실 숫자(C-2). hasInsight 무관.
-              로딩 중이면 표시하지 않는다(도착 후 노출 — 깜빡임 방지). */}
-          {!loading && insight?.officialFacts && insight.officialFacts.length > 0 && (
+          {/* 공식 지표(FRED 등) — 강세/약세와 별개의 중립 사실 숫자(C-2). hasInsight 무관. */}
+          {insight?.officialFacts && insight.officialFacts.length > 0 && (
             <section className="mt-6">
               <p className="font-pixel text-sm text-whiteout">📊 공식 지표</p>
               <ul className="mt-2 space-y-2">
@@ -130,9 +118,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             </section>
           )}
 
-          {loading ? (
-            <DepthBodySkeleton />
-          ) : hasInsight ? (
+          {hasInsight ? (
             <>
               {insight!.lean.bullCount + insight!.lean.bearCount > 0 && (
                 <p className="mt-3 text-[11px] leading-5 text-muted">
@@ -223,7 +209,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             </>
           ) : (
             // 폴백 — 응축 부족(insufficient): 기존 뉴스 소스(#500). 빈 화면 금지.
-            // 로딩 중은 위 DepthBodySkeleton 이 담당하므로 여기는 항상 도착 후 상태다.
+            // 로딩 중은 상위 FullPageLoading 이 담당하므로 여기는 항상 도착 후 상태다.
             card.sources.length > 0 && (
               <section className="mt-6">
                 <p className="font-pixel text-sm text-whiteout">오늘 이런 뉴스가 돌았어</p>
@@ -277,6 +263,8 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
           <p className="mt-8 text-center text-[11px] leading-5 text-muted">
             지난 흐름을 친구처럼 풀어준 거야. 투자 조언은 아니야.
           </p>
+          </>
+          )}
         </div>
       </div>
 
@@ -350,14 +338,18 @@ function StockInsightView({ stock, onClose }: { stock: string; onClose: () => vo
         </div>
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
+          {loading ? (
+            <FullPageLoading estimateMs={LOADING_PRESETS.stock.estimateMs} steps={LOADING_PRESETS.stock.steps} />
+          ) : (
+          <>
           <section>
             <p className="font-pixel text-sm text-whiteout">왜 같이 움직였나</p>
             <p className="mt-2 text-sm leading-6 text-muted">
-              {loading ? "원문 읽는 중…" : hasInsight ? cleanText(insight!.whyHot) : "이 종목만으로는 응축할 원문이 아직 부족해. 그것도 정상이야."}
+              {hasInsight ? cleanText(insight!.whyHot) : "이 종목만으로는 응축할 원문이 아직 부족해. 그것도 정상이야."}
             </p>
           </section>
 
-          {!loading && insight?.officialFacts && insight.officialFacts.length > 0 && (
+          {insight?.officialFacts && insight.officialFacts.length > 0 && (
             <section className="mt-6">
               <p className="font-pixel text-sm text-whiteout">📊 공식 지표</p>
               <ul className="mt-2 space-y-2">
@@ -377,9 +369,7 @@ function StockInsightView({ stock, onClose }: { stock: string; onClose: () => vo
             </section>
           )}
 
-          {loading ? (
-            <DepthBodySkeleton />
-          ) : hasInsight ? (
+          {hasInsight ? (
             <>
               {insight!.lean.bullCount + insight!.lean.bearCount > 0 && (
                 <p className="mt-3 text-[11px] leading-5 text-muted">
@@ -448,6 +438,8 @@ function StockInsightView({ stock, onClose }: { stock: string; onClose: () => vo
           <p className="mt-8 text-center text-[11px] leading-5 text-muted">
             원문을 친구처럼 풀어준 거야. 투자 조언은 아니야.
           </p>
+          </>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
> ⚠️ **PR 올리고 멈춤** — UX(바·카피) 영역이라 광혁이 Vercel preview에서 화면 직접 확인 후 머지.
> 표시 레이어만 — 데이터/점수/캐시/발굴 로직 불변.

## 목적 (LOADING PROGRESS HANDOFF C안)
빈 박스·스켈레톤의 "죽은 듯한 중간 상태"를 없애고, 데이터 준비 전엔 **콘텐츠 영역을 전체 로딩 화면(추정 바 + 단계 텍스트)으로 덮고** 준비되면 한 번에 전환. 메인·뎁스·종목 세 화면 전부.

> 한계 명시: 이건 **체감 개선**이지 속도 단축 아님. 콜드 80초 자체는 안 줄어듦(캐시/cron은 기존 유지).

## 변경
- **`FullPageLoading.tsx`** (신규 공통, 3곳 재사용):
  - 추정 프로그레스 바 — **90%에서 정지(가짜 100% 금지)**. 실제 완료는 부모가 `loading=false`로 언마운트하며 콘텐츠 전환.
  - **warm 깜빡임 방지**: 150ms 이내 완료(캐시 적중)면 로딩 화면을 아예 안 그림.
  - 단계 텍스트(진척 비율 연동) + 추정 초과 시 "거의 다 됐어".
  - `LOADING_PRESETS`: main 8s / theme 15s / stock 80s — 화면별 추정시간·단계.
- **메인**(KeywordCardFeed): `DeckSkeleton` 제거 → FullPageLoading.
- **뎁스**(KeywordDepthPage) 테마·종목: `DepthBodySkeleton` + `loading ? "원문 읽는 중"` 분기 제거, body 전체를 로딩 분기로 감쌈.

## 멈추기 전 확인용 (§6) — preview에서 봐주세요
- [ ] 메인·뎁스·종목 로딩 중 전체 화면 프로그레스(스켈레톤·빈 박스 안 보임)
- [ ] warm 재진입 시 로딩 화면 깜빡임 없이 즉시 콘텐츠
- [ ] 콜드(종목 첫 탭 ~80s) 시 바 차오름 + 단계 텍스트 전환
- [ ] 가짜 100% 후 멈춤 없음

## 검증
typecheck·lint·build:web 통과. (UI 컴포넌트라 단위테스트 없음 — 화면 확인이 검증.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
