### PR TITLE
perf(loading): 메인 보는 동안 뎁스 프리페치 — 탭하면 즉시

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { scoreToColor, scoreToEmoji, type KeywordCard, type KeywordConfidence } from "@fomo/core";
 import { KeywordDepthPage } from "@/components/KeywordDepthPage";
-import { fetchKeywords } from "@/lib/fomoApi";
+import { fetchKeywords, fetchThemeInsight } from "@/lib/fomoApi";
 import { recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
@@ -134,6 +134,22 @@ function KeywordDeck({
   const dragging = useRef(false);
   const startX = useRef(0);
   const moved = useRef(false);
+
+  // 뎁스 프리페치 — 지금 보이는 카드의 theme-insight 를 백그라운드로 미리 불러와 서버 캐시를 데운다.
+  // 사용자가 메인을 보는 동안 뎁스가 준비돼, 탭하면 즉시 뜬다("같이 불러오기").
+  // cron 프리워밍과 시너지: 이미 데워졌으면 캐시 히트(LLM 0). 안 데워진 카드만 산출(어차피 탭하면 발생).
+  // 본/볼 카드 종류만 1회씩(중복 제거) — 비용 최소. fire-and-forget(결과는 버리고 캐시만 채움).
+  const prefetched = useRef(new Set<string>());
+  useEffect(() => {
+    const top = deck[idx];
+    if (!top || prefetched.current.has(top.keyword)) return;
+    // 350ms 이상 머문 카드만 프리페치 — 빠르게 스와이프해 스쳐가는 카드는 산출 안 함(비용 최소).
+    const t = window.setTimeout(() => {
+      prefetched.current.add(top.keyword);
+      fetchThemeInsight(top.keyword).catch(() => prefetched.current.delete(top.keyword));
+    }, 350);
+    return () => window.clearTimeout(t);
+  }, [deck, idx]);
 
   // 본 카드를 한쪽으로 날리고 다음 카드로. (관심 기록은 호출부에서 별도)
   const flingNext = useCallback((dir: "left" | "right") => {


### PR DESCRIPTION
## 사용자 피드백
최초 진입 시 메인·뎁스·종목이 다 로딩이라 느림 → 메인 보는 동안 뎁스를 미리 불러오기.

## 변경 (표시·클라 레이어만)
보이는 카드(top)의 `theme-insight`를 백그라운드로 미리 호출해 **서버 Data Cache를 충전**. 사용자가 메인을 보는 몇 초 동안 뎁스가 준비돼, 카드 탭 시 즉시 뜸.

## 비용 최소 (사용자 요구)
- **cron 프리워밍과 시너지**: 이미 데워졌으면 캐시 히트(LLM 0). 누락분만 산출 — 어차피 탭하면 발생할 비용을 앞당기는 것.
- **중복 제거**(Set): 본/볼 카드 종류당 1회.
- **350ms debounce**: 빠르게 스쳐가는 카드는 산출 안 함.
- fire-and-forget — 엔진/점수/캐시 로직 불변.

## 한계
콜드(cron 미워밍 + 첫 방문)인 카드는 프리페치가 산출하는 동안(수 초) 탭하면 여전히 로딩 화면(#532/#533 프로그레스). 단 메인 보는 시간만큼 미리 시작되므로 체감 단축.

## 검증
typecheck·lint·build:web 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)