### PR TITLE
feat(card): 주목해볼만한 종목 독립 카드 (의외성 v2 — 대장주 제외)

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -1,22 +1,49 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { scoreToColor, scoreToEmoji, type KeywordCard, type KeywordConfidence } from "@fomo/core";
-import { KeywordDepthPage } from "@/components/KeywordDepthPage";
+import {
+  scoreToColor,
+  scoreToEmoji,
+  type KeywordCard,
+  type KeywordConfidence,
+  type SurpriseStock,
+} from "@fomo/core";
+import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchKeywords, fetchThemeInsight } from "@/lib/fomoApi";
 import { recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
 /**
- * 키워드 카드 덱 — 자연스러운 스와이프(드래그+뒤 카드 실제 콘텐츠 노출) + 하단 버튼 2개.
- * KEYWORD_CARD_FEED_DEV_SPEC v3. 오른쪽=관심 / 왼쪽=덜관심(둘 다 다음 카드로).
- * 본 카드는 히스토리 적재 + 덱에서 제외 → 다시 와도 다음 카드부터.
- * 뎁스에서 닫으면 본 카드가 스르륵 넘어가며(자동 스와이프) 다음 카드가 보인다.
+ * 키워드 카드 덱 — 섹터(키워드) 카드 + 그 사이에 "주목해볼만한 종목" 카드를 끼워 보여준다.
+ * KEYWORD_CARD_FEED_DEV_SPEC v3. 오른쪽=관심 / 왼쪽=덜관심. 탭/관심 → 자세히(뎁스).
+ * 섹터 카드는 테마 뎁스, 종목 카드는 종목 뎁스(stock-insight)로 연결.
  */
 const THRESHOLD = 90;
 const EXIT_MS = 320;
 const UP = "#FF5A36";
+
+/** 덱 한 장 — 섹터 카드 또는 종목 카드. */
+type DeckItem =
+  | { kind: "sector"; id: string; card: KeywordCard }
+  | { kind: "stock"; id: string; stock: SurpriseStock; fromKeyword: string };
+
+/** 섹터 카드 뒤에 그 섹터의 주목 종목 카드를 끼운다(있을 때만). */
+function toDeckItems(cards: readonly KeywordCard[]): DeckItem[] {
+  const out: DeckItem[] = [];
+  for (const card of cards) {
+    out.push({ kind: "sector", id: card.id, card });
+    if (card.surpriseStock) {
+      out.push({
+        kind: "stock",
+        id: `stock:${card.keyword}:${card.surpriseStock.canonical}`,
+        stock: card.surpriseStock,
+        fromKeyword: card.keyword,
+      });
+    }
+  }
+  return out;
+}
 
 function prefersReducedMotion(): boolean {
   return (
@@ -25,8 +52,8 @@ function prefersReducedMotion(): boolean {
   );
 }
 
-/** 카드 내용(앞/뒤 공용). progress 있으면 우하단에 n/N 표시(앞면만). */
-function CardFace({ card, progress }: { card: KeywordCard; progress?: string }) {
+/** 섹터(키워드) 카드 앞면. */
+function SectorFace({ card, progress }: { card: KeywordCard; progress?: string }) {
   const color = scoreToColor(card.fomoScore);
   return (
     <div className="flex h-full flex-col">
@@ -41,20 +68,58 @@ function CardFace({ card, progress }: { card: KeywordCard; progress?: string }) 
         <span className="font-pixel text-sm text-muted">{scoreToEmoji(card.fomoScore)} 포모 점수</span>
       </div>
       <p className="mt-6 text-lg leading-8 text-whiteout">{card.comment}</p>
-      {/* 의외의 추천 종목 — 대장주 말고 같이 뜬 종목 1개(있을 때만). 카피·디자인은 광혁 조정. */}
-      {card.surpriseStock && (
-        <div className="mt-4 flex items-center gap-2 rounded-lg border border-hairline bg-surface px-3 py-2">
-          <span className="text-sm" aria-hidden>💡</span>
-          <span className="text-xs text-muted">의외의 종목</span>
-          <span className="font-pixel text-sm" style={{ color }}>{card.surpriseStock.canonical}</span>
-        </div>
-      )}
       <div className="mt-auto flex items-center justify-between pt-6">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
         {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
       </div>
     </div>
   );
+}
+
+/** 종목 카드 앞면 — 섹터 카드와 같은 틀. 카피는 임시(광혁 조정). */
+function StockFace({
+  stock,
+  fromKeyword,
+  progress,
+}: {
+  stock: SurpriseStock;
+  fromKeyword: string;
+  progress?: string;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2">
+        <span className="text-2xl font-bold text-whiteout">{stock.canonical}</span>
+        <span className="text-xl" aria-hidden>💡</span>
+      </div>
+      <p className="mt-3 font-pixel text-sm" style={{ color: UP }}>
+        주목해볼만한 종목
+      </p>
+      <p className="mt-6 text-lg leading-8 text-whiteout">
+        ‘{fromKeyword}’ 흐름에서 대장주 말고 같이 움직인 종목이야.
+        <br />
+        왜 같이 떴는지 한번 볼래?
+      </p>
+      <div className="mt-auto flex items-center justify-between pt-6">
+        <span className="font-pixel text-[11px] text-muted">더보기 →</span>
+        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+      </div>
+    </div>
+  );
+}
+
+function FaceOf({ item, progress }: { item: DeckItem; progress?: string }) {
+  const p = progress !== undefined ? { progress } : {};
+  return item.kind === "sector" ? (
+    <SectorFace card={item.card} {...p} />
+  ) : (
+    <StockFace stock={item.stock} fromKeyword={item.fromKeyword} {...p} />
+  );
+}
+
+/** 카드 좌측 색 띠 — 섹터는 포모색, 종목은 강조색. */
+function colorOf(item: DeckItem): string {
+  return item.kind === "sector" ? scoreToColor(item.card.fomoScore) : UP;
 }
 
 /** confidence 정직 한마디(§5). high 면 노출 안 함. */
@@ -84,7 +149,7 @@ function DeckEmpty() {
 
 /**
  * 데이터 로딩 래퍼 — /api/fomo/keywords 실데이터를 받아 덱에 넘긴다.
- * 로딩=스켈레톤, 실패=담담한 빈 상태(무한 로딩 금지). confidence 는 덱 상단 한마디로.
+ * 로딩=전체화면 프로그레스, 실패=담담한 빈 상태(무한 로딩 금지). confidence 는 덱 상단 한마디로.
  */
 export function KeywordCardFeed() {
   const [state, setState] = useState<
@@ -123,9 +188,7 @@ function KeywordDeck({
   cards: readonly KeywordCard[];
   confidence: KeywordConfidence;
 }) {
-  // 마운트 시점의 "오늘 이미 본" 집합 — 본 카드는 덱에서 제외(다시 와도 다음 카드부터).
-  // ★버그: card.id 가 키워드("반도체")라 날짜 무관 고정 → 전체기간 히스토리로 거르면 어제 본 게
-  //   오늘도 걸려 덱이 비고 "다 봤다" 끝-상태가 최초 진입에 뜬다. → *오늘(KST) 본 것만* 필터링.
+  // 마운트 시점의 "오늘 이미 본" 집합 — 본 섹터 카드는 덱에서 제외(종목 카드는 섹터를 따라간다).
   const viewedIds = useState(() => {
     const kstDay = (ms: number) =>
       new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(new Date(ms));
@@ -133,33 +196,29 @@ function KeywordDeck({
     return new Set(getHistory().filter((h) => kstDay(h.ts) === today).map((h) => h.id));
   })[0];
   const [replay, setReplay] = useState(false);
-  const deck = replay ? [...cards] : cards.filter((c) => !viewedIds.has(c.id));
+  const sectorCards = replay ? [...cards] : cards.filter((c) => !viewedIds.has(c.id));
+  const deck = toDeckItems(sectorCards);
 
   const [idx, setIdx] = useState(0);
   const [dx, setDx] = useState(0);
   const [exiting, setExiting] = useState<null | "left" | "right">(null);
-  const [selected, setSelected] = useState<KeywordCard | null>(null);
+  const [selected, setSelected] = useState<DeckItem | null>(null);
   const dragging = useRef(false);
   const startX = useRef(0);
   const moved = useRef(false);
 
-  // 뎁스 프리페치 — 지금 보이는 카드의 theme-insight 를 백그라운드로 미리 불러와 서버 캐시를 데운다.
-  // 사용자가 메인을 보는 동안 뎁스가 준비돼, 탭하면 즉시 뜬다("같이 불러오기").
-  // cron 프리워밍과 시너지: 이미 데워졌으면 캐시 히트(LLM 0). 안 데워진 카드만 산출(어차피 탭하면 발생).
-  // 본/볼 카드 종류만 1회씩(중복 제거) — 비용 최소. fire-and-forget(결과는 버리고 캐시만 채움).
+  // 뎁스 프리페치 — 보이는 섹터 카드의 theme-insight 를 백그라운드로 미리 데운다(350ms 머문 것만, 중복 제거).
   const prefetched = useRef(new Set<string>());
   useEffect(() => {
     const top = deck[idx];
-    if (!top || prefetched.current.has(top.keyword)) return;
-    // 350ms 이상 머문 카드만 프리페치 — 빠르게 스와이프해 스쳐가는 카드는 산출 안 함(비용 최소).
+    if (!top || top.kind !== "sector" || prefetched.current.has(top.card.keyword)) return;
     const t = window.setTimeout(() => {
-      prefetched.current.add(top.keyword);
-      fetchThemeInsight(top.keyword).catch(() => prefetched.current.delete(top.keyword));
+      prefetched.current.add(top.card.keyword);
+      fetchThemeInsight(top.card.keyword).catch(() => prefetched.current.delete(top.card.keyword));
     }, 350);
     return () => window.clearTimeout(t);
   }, [deck, idx]);
 
-  // 본 카드를 한쪽으로 날리고 다음 카드로. (관심 기록은 호출부에서 별도)
   const flingNext = useCallback((dir: "left" | "right") => {
     if (prefersReducedMotion()) {
       setDx(0);
@@ -176,26 +235,25 @@ function KeywordDeck({
 
   const advance = useCallback(
     (dir: "left" | "right") => {
-      const card = deck[idx];
-      if (card) {
-        recordInterest(card.id, dir === "right" ? "more" : "less", Date.now());
-        recordViewed(card, Date.now());
+      const item = deck[idx];
+      if (item) {
+        recordInterest(item.id, dir === "right" ? "more" : "less", Date.now());
+        if (item.kind === "sector") recordViewed(item.card, Date.now()); // 종목 카드는 섹터를 따라가므로 별도 기록 X
       }
       flingNext(dir);
     },
     [deck, idx, flingNext]
   );
 
-  const openDepth = (card: KeywordCard) => {
-    recordViewed(card, Date.now());
-    setSelected(card);
+  const openItem = (item: DeckItem) => {
+    if (item.kind === "sector") recordViewed(item.card, Date.now());
+    setSelected(item);
   };
-  // CTA "관심"(A안) — "이거 더 볼래" → 관심 기록 + 뎁스 열기. 다음 카드 넘김은 뎁스 닫을 때(closeDepth).
-  const openInterest = (card: KeywordCard) => {
-    recordInterest(card.id, "more", Date.now());
-    openDepth(card);
+  // CTA "관심" — "이거 더 볼래" → 관심 기록 + 자세히. 다음 카드 넘김은 닫을 때.
+  const openInterest = (item: DeckItem) => {
+    recordInterest(item.id, "more", Date.now());
+    openItem(item);
   };
-  // 뎁스 닫으면 본 카드가 스르륵 넘어가며 다음 카드 노출.
   const closeDepth = () => {
     setSelected(null);
     window.setTimeout(() => flingNext("left"), 40);
@@ -249,12 +307,12 @@ function KeywordDeck({
   }
 
   const top = deck[idx]!;
-  const color = scoreToColor(top.fomoScore);
+  const color = colorOf(top);
   const topTransform = exiting
     ? `translateX(${exiting === "right" ? 140 : -140}%) rotate(${exiting === "right" ? 16 : -16}deg)`
     : `translateX(${dx}px) rotate(${dx * 0.04}deg)`;
   const topTransition = dragging.current ? "none" : `transform ${EXIT_MS}ms cubic-bezier(0.22,1,0.36,1)`;
-  const behind = [deck[idx + 1], deck[idx + 2]].filter(Boolean) as KeywordCard[];
+  const behind = [deck[idx + 1], deck[idx + 2]].filter(Boolean) as DeckItem[];
 
   return (
     <div className="w-full">
@@ -266,21 +324,21 @@ function KeywordDeck({
       {/* 카드 스택 (뒤 카드 실제 콘텐츠 노출) */}
       <div className="relative mx-auto h-[56vh] w-full select-none">
         {behind
-          .map((card, i) => ({ card, i }))
+          .map((item, i) => ({ item, i }))
           .reverse()
-          .map(({ card, i }) => (
+          .map(({ item, i }) => (
             <div
-              key={`b-${card.id}`}
+              key={`b-${item.id}`}
               aria-hidden
               className="absolute inset-0 overflow-hidden rounded-2xl border border-hairline bg-surface px-6 py-7"
               style={{
-                borderLeft: `2px solid ${scoreToColor(card.fomoScore)}`,
+                borderLeft: `2px solid ${colorOf(item)}`,
                 transform: `translateY(${(i + 1) * 12}px) scale(${1 - (i + 1) * 0.04})`,
                 opacity: 1 - (i + 1) * 0.18,
                 zIndex: 1,
               }}
             >
-              <CardFace card={card} />
+              <FaceOf item={item} />
             </div>
           ))}
 
@@ -291,7 +349,7 @@ function KeywordDeck({
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onClick={() => {
-            if (!moved.current && !exiting) openDepth(top);
+            if (!moved.current && !exiting) openItem(top);
           }}
           className="absolute inset-0 z-10 cursor-pointer overflow-hidden rounded-2xl border border-hairline bg-surface px-6 py-7"
           style={{ borderLeft: `2px solid ${color}`, transform: topTransform, transition: topTransition }}
@@ -310,7 +368,7 @@ function KeywordDeck({
             ← 덜 관심
           </span>
 
-          <CardFace card={top} progress={`${idx + 1} / ${deck.length}`} />
+          <FaceOf item={top} progress={`${idx + 1} / ${deck.length}`} />
         </div>
       </div>
 
@@ -335,7 +393,12 @@ function KeywordDeck({
         </button>
       </div>
 
-      {selected && <KeywordDepthPage card={selected} onClose={closeDepth} />}
+      {selected &&
+        (selected.kind === "sector" ? (
+          <KeywordDepthPage card={selected.card} onClose={closeDepth} />
+        ) : (
+          <StockInsightView stock={selected.stock.canonical} onClose={closeDepth} />
+        ))}
     </div>
   );
 }

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -281,7 +281,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
  * 그 종목의 grounded 강세/약세/워딩/공식지표를 보여준다. 테마 뎁스와 같은 grounding·정직성 규칙을 따른다.
  * (응축 부족이면 정직한 빈 상태 — 가짜로 안 채움.) 카피/전환은 임시, 최종은 광혁.
  */
-function StockInsightView({ stock, onClose }: { stock: string; onClose: () => void }) {
+export function StockInsightView({ stock, onClose }: { stock: string; onClose: () => void }) {
   const [insight, setInsight] = useState<CondensedInsight | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -27,6 +27,8 @@ export interface StockDef {
   country: StockCountry;
   /** 네이버 종토방 코드(국내 상장만) — 없으면 종토방 소스 미연결(미국주 등). */
   naverCode?: string;
+  /** 누구나 아는 초대형 대장주(삼성전자·엔비디아 등) — "주목해볼만한 종목" 후보에서 제외(의외성 0). */
+  marquee?: boolean;
 }
 
 /**
@@ -36,35 +38,35 @@ export interface StockDef {
  */
 export const STOCK_VOCAB: readonly StockDef[] = [
   // ── 한국(KOSPI/KOSDAQ) — 네이버 종토방 코드 보유 ──
-  { canonical: "삼성전자", aliases: ["삼성전자"], market: "KOSPI", country: "KR", naverCode: "005930" },
-  { canonical: "SK하이닉스", aliases: ["SK하이닉스", "하이닉스"], market: "KOSPI", country: "KR", naverCode: "000660" },
+  { canonical: "삼성전자", aliases: ["삼성전자"], market: "KOSPI", country: "KR", naverCode: "005930", marquee: true },
+  { canonical: "SK하이닉스", aliases: ["SK하이닉스", "하이닉스"], market: "KOSPI", country: "KR", naverCode: "000660", marquee: true },
   { canonical: "한미반도체", aliases: ["한미반도체"], market: "KOSDAQ", country: "KR", naverCode: "042700" },
   { canonical: "에코프로비엠", aliases: ["에코프로비엠"], market: "KOSDAQ", country: "KR", naverCode: "247540" },
   { canonical: "에코프로", aliases: ["에코프로"], market: "KOSDAQ", country: "KR", naverCode: "086520" },
-  { canonical: "LG에너지솔루션", aliases: ["LG에너지솔루션", "LG엔솔"], market: "KOSPI", country: "KR", naverCode: "373220" },
+  { canonical: "LG에너지솔루션", aliases: ["LG에너지솔루션", "LG엔솔"], market: "KOSPI", country: "KR", naverCode: "373220", marquee: true },
   { canonical: "삼성SDI", aliases: ["삼성SDI"], market: "KOSPI", country: "KR", naverCode: "006400" },
-  { canonical: "현대차", aliases: ["현대차", "현대자동차"], market: "KOSPI", country: "KR", naverCode: "005380" },
+  { canonical: "현대차", aliases: ["현대차", "현대자동차"], market: "KOSPI", country: "KR", naverCode: "005380", marquee: true },
   { canonical: "한화에어로스페이스", aliases: ["한화에어로스페이스", "한화에어로"], market: "KOSPI", country: "KR", naverCode: "012450" },
   { canonical: "두산에너빌리티", aliases: ["두산에너빌리티"], market: "KOSPI", country: "KR", naverCode: "034020" },
   { canonical: "셀트리온", aliases: ["셀트리온"], market: "KOSPI", country: "KR", naverCode: "068270" },
-  { canonical: "삼성바이오로직스", aliases: ["삼성바이오로직스", "삼성바이오"], market: "KOSPI", country: "KR", naverCode: "207940" },
-  { canonical: "카카오", aliases: ["카카오"], market: "KOSPI", country: "KR", naverCode: "035720" },
-  { canonical: "NAVER", aliases: ["NAVER", "네이버"], market: "KOSPI", country: "KR", naverCode: "035420" },
+  { canonical: "삼성바이오로직스", aliases: ["삼성바이오로직스", "삼성바이오"], market: "KOSPI", country: "KR", naverCode: "207940", marquee: true },
+  { canonical: "카카오", aliases: ["카카오"], market: "KOSPI", country: "KR", naverCode: "035720", marquee: true },
+  { canonical: "NAVER", aliases: ["NAVER", "네이버"], market: "KOSPI", country: "KR", naverCode: "035420", marquee: true },
 
   // ── 미국/글로벌 — 종토방 없음(레딧/외신으로 grounding, §1) ──
-  { canonical: "엔비디아", aliases: ["엔비디아", "Nvidia", "NVDA"], market: "NASDAQ", country: "US" },
-  { canonical: "TSMC", aliases: ["TSMC", "대만 TSMC", "티에스엠씨"], market: "NYSE", country: "GLOBAL" },
-  { canonical: "마이크로소프트", aliases: ["마이크로소프트", "Microsoft", "MSFT"], market: "NASDAQ", country: "US" },
-  { canonical: "애플", aliases: ["애플", "Apple", "AAPL"], market: "NASDAQ", country: "US" },
-  { canonical: "테슬라", aliases: ["테슬라", "Tesla", "TSLA"], market: "NASDAQ", country: "US" },
+  { canonical: "엔비디아", aliases: ["엔비디아", "Nvidia", "NVDA"], market: "NASDAQ", country: "US", marquee: true },
+  { canonical: "TSMC", aliases: ["TSMC", "대만 TSMC", "티에스엠씨"], market: "NYSE", country: "GLOBAL", marquee: true },
+  { canonical: "마이크로소프트", aliases: ["마이크로소프트", "Microsoft", "MSFT"], market: "NASDAQ", country: "US", marquee: true },
+  { canonical: "애플", aliases: ["애플", "Apple", "AAPL"], market: "NASDAQ", country: "US", marquee: true },
+  { canonical: "테슬라", aliases: ["테슬라", "Tesla", "TSLA"], market: "NASDAQ", country: "US", marquee: true },
   { canonical: "AMD", aliases: ["AMD"], market: "NASDAQ", country: "US" },
   { canonical: "브로드컴", aliases: ["브로드컴", "Broadcom", "AVGO"], market: "NASDAQ", country: "US" },
   { canonical: "팔란티어", aliases: ["팔란티어", "Palantir", "PLTR"], market: "NASDAQ", country: "US" },
   { canonical: "마이크론", aliases: ["마이크론", "Micron"], market: "NASDAQ", country: "US" },
 
   // ── 코인 ──
-  { canonical: "비트코인", aliases: ["비트코인", "bitcoin", "BTC"], market: "COIN", country: "GLOBAL" },
-  { canonical: "이더리움", aliases: ["이더리움", "ethereum", "ETH"], market: "COIN", country: "GLOBAL" },
+  { canonical: "비트코인", aliases: ["비트코인", "bitcoin", "BTC"], market: "COIN", country: "GLOBAL", marquee: true },
+  { canonical: "이더리움", aliases: ["이더리움", "ethereum", "ETH"], market: "COIN", country: "GLOBAL", marquee: true },
 ];
 
 /** 그날 원문에 등장한 종목(추출 결과). market/country 동봉, relatedHint 자리만 열어둠(D 이후). */
@@ -194,23 +196,27 @@ export interface SurpriseStock {
 }
 
 /**
- * 카드 1장의 "의외성 1위" 종목 — v1(광혁 피드백 루프 전제).
+ * 카드 1장의 "주목해볼만한 종목" — v2(광혁 피드백: 삼성전자 같은 초대형 대장주는 의외성 0).
  *
- * 의외성 정의(v1): **대장주(빈도 1위)가 아니면서, 덜 알려졌는데(코스닥·중소형) 그래도 여러 번 같이 뜬 종목.**
- *   = "어, 이게 왜 같이 떴지?" 직관. 대장주는 의외가 아니므로 1위는 제외.
- *   점수 = 코스닥 가중(덜 알려짐) × 저빈도 가중(주목 덜 받음). 동점은 mentions 적은 순 → 가나다.
- * 정직성: 후보 없으면(대장주만/종목 0) null → 카드에 표기 안 함(가짜로 안 채움).
+ * 의외성 정의(v2): **누구나 아는 초대형 대장주(marquee)를 전부 제외**하고, 그날 그 테마에서 같이 뜬
+ *   덜 알려진 종목 중 1개. = "어, 이게 왜 같이 떴지?". marquee(삼성전자·엔비디아·하이닉스 등) 제외가 핵심.
+ *   남은 후보 점수 = 코스닥(중소형) 가중 × 저빈도(주목 덜 받음) 가중. 동점은 mentions 적은 순 → 가나다.
+ * 정직성: marquee 빼고 후보 없으면 null → 카드 표기 안 함(가짜로 안 채움).
  */
 export function pickSurpriseStock(
   items: readonly KeywordSourceItem[],
   opts: ExtractStocksOptions = {}
 ): SurpriseStock | null {
   const stocks = extractStocks(items, { minMentions: opts.minMentions ?? 2 });
-  if (stocks.length <= 1) return null; // 대장주만 있거나 없으면 "의외"가 성립 안 함
-  const maxMentions = stocks[0]!.mentions; // 1위 빈도(정규화 기준)
-  const scored = stocks.slice(1).map((s) => {
+  const maxMentions = stocks[0]?.mentions ?? 1; // 빈도 정규화 기준(대장주 포함 1위)
+  const byCanonical = new Map(STOCK_VOCAB.map((d) => [d.canonical, d]));
+  // 초대형 대장주(marquee) 제외 — 삼성전자류는 "주목해볼만한"이 아님.
+  const candidates = stocks.filter((s) => !byCanonical.get(s.canonical)?.marquee);
+  if (candidates.length === 0) return null;
+
+  const scored = candidates.map((s) => {
     const lesserKnown = s.market === "KOSDAQ" ? 1.5 : 1.0; // 코스닥(중소형) = 덜 알려짐
-    const lowProfile = 1 - s.mentions / (maxMentions + 1); // 대장주 대비 덜 주목받을수록 ↑
+    const lowProfile = 1 - s.mentions / (maxMentions + 1); // 주목 덜 받을수록 ↑
     return { s, surprise: lesserKnown * (0.5 + lowProfile) };
   });
   scored.sort(


### PR DESCRIPTION
## 사용자 피드백 3건
1. **삼성전자가 '의외'로 나옴** → 초대형 대장주는 의외성 0. `StockDef.marquee` 플래그 추가, `pickSurpriseStock`이 marquee(삼성전자·SK하이닉스·엔비디아·애플·TSMC·테슬라·카카오·NAVER·현대차·LG엔솔·삼성바이오·비트코인·이더리움) **전면 제외**. 남은 후보 중 코스닥/저빈도 가중 1위.
2. **'의외의 종목' → '주목해볼만한 종목'** 문구 변경.
3. **카드 안 작은 줄 → 독립 카드**: 덱을 `sector|stock` union 으로 재구성. 섹터 카드 뒤에 그 섹터의 주목 종목 카드를 끼워, 넘기면 섹터 카드처럼 종목 카드가 나옴. 탭/관심 시 종목 뎁스(`StockInsightView`)로 연결.

## 변경
- `stocks.ts`: `marquee` 플래그 + `pickSurpriseStock` v2(marquee 제외).
- `KeywordCardFeed`: 덱 union 재구성 + `SectorFace`/`StockFace` + 종목 뎁스 연결.
- `KeywordDepthPage`: `StockInsightView` export.
- 엔진/점수/캐시 불변, 종목 추출 룰 기반(LLM 무관).

## 검증
typecheck·lint·build·test(663) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)