### PR TITLE
fix(card): 주목해볼만한 종목 카드가 화면에 안 뜨던 버그 (pickSurpriseStock minMentions 1)

### DIFF
--- a/packages/fomo-core/__tests__/stock-extraction.test.ts
+++ b/packages/fomo-core/__tests__/stock-extraction.test.ts
@@ -143,4 +143,17 @@ describe("pickSurpriseStock — 의외의 추천 종목(대장주 말고 같이 
   it("종목 0이면 null", () => {
     expect(pickSurpriseStock([{ title: "금리 인상 우려" }])).toBeNull();
   });
+  // 회귀(prod 버그): 키워드로 좁힌 부분집합에선 비-marquee 종목이 1회만 등장하는 게 흔하다.
+  // 기본 minMentions=2 였을 때 2+ 생존자가 전부 marquee라 제외 후 후보 0 → 항상 null(화면에 영영 안 뜸).
+  // 기본 1로 내려 grounded 1회 언급도 후보가 돼야 한다. (반도체 매칭 집합 ≈ 한미반도체:1 + 마르키:N 재현)
+  it("비-marquee 후보가 1회만 등장해도(marquee 다수) 그 종목을 고른다 — 기본 minMentions 1", () => {
+    const items = [
+      ...mk(5, "SK하이닉스 메모리 강세"),  // marquee 5
+      ...mk(3, "삼성전자 반도체"),          // marquee 3
+      { title: "한미반도체 HBM 장비 수주" }, // 비-marquee, 1회뿐
+    ];
+    const s = pickSurpriseStock(items);
+    expect(s).not.toBeNull();
+    expect(s!.canonical).toBe("한미반도체");
+  });
 });

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -202,12 +202,17 @@ export interface SurpriseStock {
  *   덜 알려진 종목 중 1개. = "어, 이게 왜 같이 떴지?". marquee(삼성전자·엔비디아·하이닉스 등) 제외가 핵심.
  *   남은 후보 점수 = 코스닥(중소형) 가중 × 저빈도(주목 덜 받음) 가중. 동점은 mentions 적은 순 → 가나다.
  * 정직성: marquee 빼고 후보 없으면 null → 카드 표기 안 함(가짜로 안 채움).
+ *
+ * minMentions 기본 1(extractStocks 의 전역 노이즈컷 2와 다름): 이 함수는 호출부에서 **이미 그 키워드로
+ *   좁혀진 부분집합**(theme-scoped news)을 받는다. 좁힌 집합에서 비-marquee 종목이 2회+ 등장하는 일은
+ *   드물어, 2로 두면 2+ 생존자가 늘 marquee뿐 → 제외 후 후보 0 → 항상 null(기능이 화면에 영영 안 뜸).
+ *   키워드 스코프 자체가 노이즈 필터라, 그 안의 grounded 1회 언급은 "같이 움직인 종목"의 유효 신호다.
  */
 export function pickSurpriseStock(
   items: readonly KeywordSourceItem[],
   opts: ExtractStocksOptions = {}
 ): SurpriseStock | null {
-  const stocks = extractStocks(items, { minMentions: opts.minMentions ?? 2 });
+  const stocks = extractStocks(items, { minMentions: opts.minMentions ?? 1 });
   const maxMentions = stocks[0]?.mentions ?? 1; // 빈도 정규화 기준(대장주 포함 1위)
   const byCanonical = new Map(STOCK_VOCAB.map((d) => [d.canonical, d]));
   // 초대형 대장주(marquee) 제외 — 삼성전자류는 "주목해볼만한"이 아님.


### PR DESCRIPTION
## 증상
[#537](https://github.com/mlender-ai/taro-stock-app/pull/537)에서 "주목해볼만한 종목"을 섹터 카드처럼 **독립 카드**로 붙였는데, 화면에 한 장도 안 떴다. prod `/api/fomo/keywords` 카드 9개 전부 `surpriseStock: null`.

## 루트 원인 (추측 아님 — 라이브 뉴스 425건으로 재현)
`pickSurpriseStock` 이 `extractStocks` 의 **전역 노이즈컷 기본값 `minMentions=2`** 를 그대로 물려받았다. 이 함수는 호출부([keyword-pipeline.ts:72](apps/web/lib/keyword-pipeline.ts))에서 *이미 그 키워드로 좁혀진* 뉴스 부분집합을 받는다. 좁힌 집합에서 비-marquee 종목이 2회+ 등장하는 일은 드물어, `minMentions=2` 생존자는 늘 대장주뿐 → marquee 제외 후 후보 0 → 항상 null.

```
[반도체] min2 생존자 = SK하이닉스:5, 삼성전자:3, 엔비디아:2  (전부 marquee) → null
[방산]  한화에어로스페이스:1  (min2 컷)                       → null
```

## 수정
`pickSurpriseStock` 의 기본 `minMentions` 를 **1** 로. 키워드 스코프 자체가 노이즈 필터라, 그 안의 grounded 1회 언급은 "같이 움직인 종목"의 유효 신호다. `extractStocks` 전역 기본값(2)은 그대로 — 이 함수만 1로 내림(JSDoc에 근거 명시).

**수정 후 (동일 라이브 데이터):** 반도체 → **한미반도체**(KOSDAQ), 방산 → **한화에어로스페이스**.

## 검증
- 라이브 뉴스 재현 스크립트로 before(전부 null)/after(한미반도체·한화에어로스페이스) 확인.
- 로컬 API(수정 엔진) → fomo-web 화면: **한미반도체 "주목해볼만한 종목"** 독립 카드가 섹터 카드 틀로 정상 노출(2/11, 주황 강조 띠).
- 회귀 테스트 추가(비-marquee가 1회만 등장해도 후보가 돼야 함). `npm test` 664 통과. typecheck 통과.

엔진/점수/캐시/marquee 제외 로직 불변. 순수 룰(LLM 무관). prod DDL 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)