### PR TITLE
chore(fomo-web): 피드 상단 군더더기 3개 제거

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -58,10 +58,9 @@ export function HomeView({
   return (
     <>
       <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-20 pt-4">
-        {/* 상단 얇은 띠: 로고 + 가입 없이 둘러보기 */}
-        <div className="flex items-center justify-between">
+        {/* 상단 얇은 띠: 로고 */}
+        <div className="flex items-center">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-          <span className="text-xs text-muted">가입 없이 둘러보기</span>
         </div>
 
         {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}

--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -122,18 +122,6 @@ function colorOf(item: DeckItem): string {
   return item.kind === "sector" ? scoreToColor(item.card.fomoScore) : UP;
 }
 
-/** confidence 정직 한마디(§5). high 면 노출 안 함. */
-function ConfidenceNote({ confidence }: { confidence: KeywordConfidence }) {
-  if (confidence === "high") return null;
-  const text =
-    confidence === "fallback"
-      ? "오늘은 시장이 너무 조용해서 보여줄 게 별로 없어. 그것도 정상이야."
-      : "오늘은 데이터가 좀 적어서 포모도 긴가민가해 🤔";
-  return (
-    <p className="mb-2 px-2 text-center text-[11px] leading-5 text-muted">{text}</p>
-  );
-}
-
 /** 담담한 빈 상태(수집 실패/데이터 없음) — 무한 로딩 금지. */
 function DeckEmpty() {
   return (
@@ -178,16 +166,10 @@ export function KeywordCardFeed() {
   if (state.kind === "loading")
     return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
   if (state.kind === "error") return <DeckEmpty />;
-  return <KeywordDeck cards={state.cards} confidence={state.confidence} />;
+  return <KeywordDeck cards={state.cards} />;
 }
 
-function KeywordDeck({
-  cards,
-  confidence,
-}: {
-  cards: readonly KeywordCard[];
-  confidence: KeywordConfidence;
-}) {
+function KeywordDeck({ cards }: { cards: readonly KeywordCard[] }) {
   // 마운트 시점의 "오늘 이미 본" 집합 — 본 섹터 카드는 덱에서 제외(종목 카드는 섹터를 따라간다).
   const viewedIds = useState(() => {
     const kstDay = (ms: number) =>
@@ -316,11 +298,6 @@ function KeywordDeck({
 
   return (
     <div className="w-full">
-      <ConfidenceNote confidence={confidence} />
-      <p className="mb-2 px-1 text-center text-xs text-muted">
-        오른쪽=<span style={{ color: UP }}>관심</span> · 왼쪽=덜 관심 · 탭하면 자세히
-      </p>
-
       {/* 카드 스택 (뒤 카드 실제 콘텐츠 노출) */}
       <div className="relative mx-auto h-[56vh] w-full select-none">
         {behind


### PR DESCRIPTION
광혁 피드백 — 의미 없는 노출 제거.

- "오늘은 데이터가 좀 적어서 포모도 긴가민가해 🤔" (ConfidenceNote) 삭제 + 미사용 함수 제거
- "오른쪽=관심 · 왼쪽=덜 관심 · 탭하면 자세히" 힌트 줄 삭제
- 헤더 "가입 없이 둘러보기" 라벨 삭제 (로고만)

KeywordDeck `confidence` prop이 미사용이 돼 함께 제거. 엔진/덱 로직 불변. typecheck 통과, 프리뷰로 3개 모두 사라진 것 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)