### PR TITLE
hotfix(fomo-web): 카드 세로 중앙정렬

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -89,7 +89,7 @@ export function HomeView({
           </div>
         )}
 
-        <div className="mt-3">
+        <div className={`mt-3 flex flex-1 flex-col ${tab === "card" ? "justify-center" : ""}`}>
           {tab === "card" ? <KeywordCardFeed /> : <KeywordHistory />}
         </div>
       </main>


### PR DESCRIPTION
군더더기 제거 후 카드가 시장 온도 바 바로 아래에 붙어 상단으로 쏠려 보임.

피드 래퍼를 `flex-1`로 남은 공간을 채우고 카드 탭일 때 `justify-center`로 시장 온도 바와 하단 탭 사이 세로 중앙에 배치. 히스토리 탭은 상단 정렬 유지. 프리뷰 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)