### PR TITLE
feat(supply): 수급 파서 PR1-a — 외국인·기관 일별 순매매(순수함수)

### DIFF
--- a/packages/fomo-core/__tests__/supply-demand.test.ts
+++ b/packages/fomo-core/__tests__/supply-demand.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseNaverInvestorFlow, latestInvestorFlow } from "../src/supply-demand";
+
+// 네이버 frgn.naver 실제 행 구조(2행) — 날짜·종가·전일비·등락률·거래량·기관·외국인·보유주수·보유율.
+// 기관/외국인만 부호(+/-) 동반. 등락률(+1.02%)은 % 라 순매매로 안 잡혀야 한다.
+const HTML = `
+<table>
+<tr onmouseover="x">
+  <td><span class="tah p10 gray03">2026.06.17</span></td>
+  <td><span class="tah p11">346,500</span></td>
+  <td><span class="tah p11 red02">3,500</span></td>
+  <td><span class="tah p11 red01">+1.02%</span></td>
+  <td><span class="tah p11">18,134,051</span></td>
+  <td><span class="tah p11 red01">+1,133,803</span></td>
+  <td><span class="tah p11 nv01">-2,000,080</span></td>
+  <td><span class="tah p11">2,780,810,260</span></td>
+  <td><span class="tah p11">47.57%</span></td>
+</tr>
+<tr onmouseover="x">
+  <td><span class="tah p10 gray03">2026.06.16</span></td>
+  <td><span class="tah p11">343,000</span></td>
+  <td><span class="tah p11 nv02">1,000</span></td>
+  <td><span class="tah p11 nv01">-0.29%</span></td>
+  <td><span class="tah p11">15,000,000</span></td>
+  <td><span class="tah p11 nv01">-500,000</span></td>
+  <td><span class="tah p11 red01">+1,200,000</span></td>
+  <td><span class="tah p11">2,778,000,000</span></td>
+  <td><span class="tah p11">47.50%</span></td>
+</tr>
+</table>`;
+
+describe("parseNaverInvestorFlow — 일별 외국인·기관 순매매(시점 명시)", () => {
+  it("기관·외국인 순매매를 부호 그대로 파싱, 등락률은 제외", () => {
+    const flows = parseNaverInvestorFlow(HTML);
+    expect(flows).toHaveLength(2);
+    expect(flows[0]).toEqual({ date: "2026-06-17", institutionNet: 1_133_803, foreignNet: -2_000_080 });
+    expect(flows[1]).toEqual({ date: "2026-06-16", institutionNet: -500_000, foreignNet: 1_200_000 });
+  });
+
+  it("기준일(date)이 항상 부착된다 (point-in-time 원칙)", () => {
+    for (const f of parseNaverInvestorFlow(HTML)) {
+      expect(f.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("빈/깨진 HTML → 빈 배열(가짜 금지)", () => {
+    expect(parseNaverInvestorFlow("")).toEqual([]);
+    expect(parseNaverInvestorFlow("<table><tr><td>no data</td></tr></table>")).toEqual([]);
+  });
+
+  it("결정적 — 같은 입력 같은 출력", () => {
+    expect(parseNaverInvestorFlow(HTML)).toEqual(parseNaverInvestorFlow(HTML));
+  });
+});
+
+describe("latestInvestorFlow", () => {
+  it("가장 최근 거래일을 고른다", () => {
+    expect(latestInvestorFlow(parseNaverInvestorFlow(HTML))?.date).toBe("2026-06-17");
+  });
+  it("빈 입력 → null", () => {
+    expect(latestInvestorFlow([])).toBeNull();
+  });
+});

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./mascot-lines";
 export * from "./calendar";
 export * from "./insights";
 export * from "./sanitize";
+export * from "./supply-demand";
 export * from "./banner";
 export * from "./markets";
 export * from "./mood-signals";

--- a/packages/fomo-core/src/supply-demand.ts
+++ b/packages/fomo-core/src/supply-demand.ts
@@ -1,0 +1,52 @@
+/**
+ * 수급(투자자별 순매매) — 네이버 금융 일별 외국인·기관 순매매 파서(순수). SUPPLY DEMAND SCORE HANDOFF.
+ *
+ * ⚠️ 시점(point-in-time) 원칙(§0): 이 데이터는 **장 마감 확정 일별** 수급이다(실시간 장중 아님).
+ *   각 레코드에 기준일(date)을 반드시 부착한다 — "오늘 수급"인 척 금지(정직 원칙).
+ *
+ * 소스: finance.naver.com/item/frgn.naver (KRX 확정치 재공개). 컬럼 순서:
+ *   날짜 · 종가 · 전일비 · 등락률 · 거래량 · [기관 순매매] · [외국인 순매매] · 외국인보유주수 · 외국인보유율
+ *   순매매 두 칸만 부호(+/-)가 붙어 구분된다(나머지 숫자는 무부호, 등락률은 % 동반).
+ *
+ * 네트워크·DB 0 (순수). fetch/저장은 apps/web 레이어가 담당. 데이터 없으면 빈 배열(가짜 금지).
+ */
+
+export interface InvestorFlow {
+  /** 기준일 "YYYY-MM-DD" (장 마감 확정 거래일). */
+  date: string;
+  /** 외국인 순매매량(주식 수, +매수 / -매도). */
+  foreignNet: number;
+  /** 기관 순매매량(주식 수, +매수 / -매도). */
+  institutionNet: number;
+}
+
+/** 부호 붙은 정수만(콤마 제거). 등락률(+1.02%)은 % 동반이라 매칭되지 않는다. */
+const SIGNED_INT = />\s*([+-][\d,]+)\s*<\/span>/g;
+
+/**
+ * 네이버 frgn.naver HTML → 일별 투자자 순매매(최신순). 파싱 실패/형식 변경 시 빈 배열.
+ * 날짜 마커(gray03)로 행을 자르고, 각 행의 부호 정수 2개를 [기관, 외국인] 순서로 읽는다.
+ */
+export function parseNaverInvestorFlow(html: string): InvestorFlow[] {
+  if (!html) return [];
+  const out: InvestorFlow[] = [];
+  // 날짜 셀(class="tah p10 gray03")을 기준으로 행 분할 — 각 조각이 하루치.
+  const chunks = html.split(/class="tah p10 gray03"/).slice(1);
+  for (const chunk of chunks) {
+    const d = chunk.match(/>\s*(\d{4})\.(\d{2})\.(\d{2})/);
+    if (!d) continue;
+    const date = `${d[1]}-${d[2]}-${d[3]}`;
+    const signed = [...chunk.matchAll(SIGNED_INT)].map((m) => Number(m[1]!.replace(/,/g, "")));
+    if (signed.length < 2 || signed.some((n) => !Number.isFinite(n))) continue;
+    // 컬럼 순서상 첫 부호값=기관, 둘째=외국인.
+    out.push({ date, institutionNet: signed[0]!, foreignNet: signed[1]! });
+  }
+  return out;
+}
+
+/** 가장 최근(장 마감 확정) 1거래일 수급. 없으면 null(정직한 빈 값). */
+export function latestInvestorFlow(flows: readonly InvestorFlow[]): InvestorFlow | null {
+  if (flows.length === 0) return null;
+  // date 내림차순 정렬 후 최신.
+  return [...flows].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))[0]!;
+}


### PR DESCRIPTION
수급 데이터 작업(SUPPLY DEMAND SCORE HANDOFF)의 **PR 분리 첫 조각**. 순수 파서 + 테스트만(안전).

## 변경
- `parseNaverInvestorFlow`(순수): 네이버 frgn HTML → 일별 기관·외국인 순매매. 순매매만 부호(+/-) 동반이라 등락률/종가와 구분. 형식 깨지면 빈 배열.
- **★시점 원칙(§0)**: 레코드마다 기준일(date) 부착 — 장마감 확정 일별, '오늘인 척' 금지.
- 테스트 6건.

## 🚩 보고 (핸드오프와 차이)
- **KRX 직접 막힘**: data.krx.go.kr 내부 엔드포인트가 OTP/세션 필요(`LOGOUT` 반환) → **네이버 금융**(KRX 확정치 재공개)으로. 새 외부 소스지만 기존 네이버 스크래핑과 동일 도메인이라 추가 위험 낮음.
- **개인 순매매**: 네이버 종목 페이지 미제공 → v1은 외국인·기관만(개인 후속).
- **수량 기준**(거래대금 후속).

## 다음 PR
- **1-b**: fetch(EUC-KR) + 누적 테이블(`SupplyDemandDaily`, 승인됨) + cron 일별 수집
- **2**: `KeywordSignals` 수급 보조 반영(시점 노출 + 불변테스트)
- **3**: 카드 공식지표 섹션 표시(외인/기관 + 기준일, 조언 금지)

## 검증
typecheck·lint·build·test(669) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)