### PR TITLE
feat(supply): 수급 수집+누적+cron — PR1-b

### DIFF
--- a/.github/workflows/supply-demand-pipeline.yml
+++ b/.github/workflows/supply-demand-pipeline.yml
@@ -1,0 +1,38 @@
+name: Supply Demand Pipeline
+
+# 일별 투자자 수급(외국인·기관 순매매) 수집·누적. SUPPLY DEMAND SCORE HANDOFF §1·§2.
+# 장 마감 확정치를 네이버 금융에서 수집 → SupplyDemandDaily 누적(기준선 씨앗).
+# 제품 데이터 파이프라인(에이전트 자율 루프 아님) — 정지 대상 아님.
+#
+# 전제: prod 에 SupplyDemandDaily 테이블이 있어야 저장(운영 규약상 prisma db push 직접 승인 후 활성).
+# 테이블 전이라도 수집 로그까지는 돌고, store 가 폴백(0건 누적)으로 누락을 가시화한다.
+
+on:
+  schedule:
+    # KST = UTC+9. 한국장 마감(15:30) 후 확정치 안정화 시점 — 18:30 KST(09:30 UTC) 평일.
+    - cron: "30 9 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supply-demand
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install deps
+        run: npm ci
+      - name: Prisma generate
+        run: npm run prisma:generate
+      - name: Collect supply-demand
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npm run supply:collect

--- a/apps/web/lib/supply-demand-store.ts
+++ b/apps/web/lib/supply-demand-store.ts
@@ -1,0 +1,48 @@
+import type { InvestorFlow } from "@fomo/core";
+import { prisma } from "./prisma";
+
+/**
+ * 수급 누적 저장/조회 — SupplyDemandDaily. SUPPLY DEMAND SCORE HANDOFF §2(기준선 씨앗).
+ *
+ * db push 게이트: 테이블이 아직 prod 에 없을 수 있다(운영 규약 — DDL 직접 승인).
+ *   그 동안에도 cron/라우트가 죽지 않게, 읽기·쓰기 모두 실패하면 조용히 폴백(null/0)한다.
+ *   테이블이 생기면 자동 활성화(코드 변경 불필요).
+ */
+
+/** flows 를 (ticker,date) unique 로 upsert. 저장 건수 반환. 테이블 미생성이면 0(중단). */
+export async function writeSupplyDemand(
+  ticker: string,
+  flows: readonly InvestorFlow[]
+): Promise<number> {
+  let n = 0;
+  for (const f of flows) {
+    try {
+      await prisma.supplyDemandDaily.upsert({
+        where: { ticker_date: { ticker, date: f.date } },
+        create: { ticker, date: f.date, foreignNet: f.foreignNet, institutionNet: f.institutionNet },
+        update: { foreignNet: f.foreignNet, institutionNet: f.institutionNet },
+      });
+      n++;
+    } catch (err) {
+      // 테이블 미생성(P2021) 등 — 조용히 폴백. 누적은 테이블 생기면 시작된다.
+      console.warn("[supply-demand-store] write skipped (table missing?)", (err as Error)?.message);
+      return n;
+    }
+  }
+  return n;
+}
+
+/** 한 종목의 가장 최근(장마감 확정) 수급. 없거나 테이블 미생성이면 null(정직한 폴백). */
+export async function readLatestSupplyDemand(ticker: string): Promise<InvestorFlow | null> {
+  try {
+    const row = await prisma.supplyDemandDaily.findFirst({
+      where: { ticker },
+      orderBy: { date: "desc" },
+    });
+    if (!row) return null;
+    return { date: row.date, foreignNet: row.foreignNet, institutionNet: row.institutionNet };
+  } catch (err) {
+    console.warn("[supply-demand-store] read skipped (table missing?)", (err as Error)?.message);
+    return null;
+  }
+}

--- a/apps/web/lib/supply-demand.ts
+++ b/apps/web/lib/supply-demand.ts
@@ -1,0 +1,31 @@
+import { parseNaverInvestorFlow, type InvestorFlow } from "@fomo/core";
+
+/**
+ * 수급 수집(fetch) — 네이버 금융 일별 외국인·기관 순매매. SUPPLY DEMAND SCORE HANDOFF §1.
+ *
+ * KRX 직접(data.krx.go.kr)은 OTP/세션 필요(LOGOUT) → KRX 확정치를 재공개하는 네이버 금융 사용.
+ * frgn.naver 는 EUC-KR 인코딩 → arrayBuffer + TextDecoder('euc-kr'). 파싱은 fomo-core 순수 파서.
+ * 실패/차단 시 빈 배열(정직한 폴백 — 가짜 금지). 시점(기준일)은 파서가 각 레코드에 부착.
+ */
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+/** 한 종목(코드)의 일별 외국인·기관 순매매(최신순). 실패 시 빈 배열. */
+export async function fetchSupplyDemand(code: string, timeoutMs = 15_000): Promise<InvestorFlow[]> {
+  try {
+    const res = await fetch(`https://finance.naver.com/item/frgn.naver?code=${encodeURIComponent(code)}`, {
+      headers: { "User-Agent": UA, "Accept-Language": "ko-KR,ko;q=0.9" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) {
+      console.warn("[supply-demand] fetch non-OK", code, res.status);
+      return [];
+    }
+    const buf = await res.arrayBuffer();
+    const html = new TextDecoder("euc-kr").decode(buf);
+    return parseNaverInvestorFlow(html);
+  } catch (err) {
+    console.warn("[supply-demand] fetch failed", code, (err as Error)?.message);
+    return [];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fomo:index": "tsx scripts/fomo-index-pipeline.ts",
     "keywords:generate": "tsx scripts/keywords-generate.ts",
     "warm:insights": "tsx scripts/warm-insights.ts",
+    "supply:collect": "tsx scripts/supply-demand-collect.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -790,3 +790,18 @@ model KeywordCardSnapshot {
   confidence String // "high" | "medium" | "low" | "fallback"
   createdAt  DateTime @default(now())
 }
+
+// 일별 투자자 수급(외국인·기관 순매매) 누적 — SUPPLY DEMAND SCORE HANDOFF §2.
+// 시점 원칙: date = 장 마감 확정 거래일. 2~3주 쌓이면 "평소 대비 이례성"(z-score) 산출 토대.
+// db push 게이트: prisma db push 는 오너 직접 승인. 테이블 전이라도 cron/라우트는 폴백(빈 값)으로 동작.
+model SupplyDemandDaily {
+  id             String   @id @default(cuid())
+  ticker         String // 종목 코드(네이버/KRX 6자리)
+  date           String // YYYY-MM-DD (장마감 확정 거래일)
+  foreignNet     Float // 외국인 순매매량(주, +매수/-매도)
+  institutionNet Float // 기관 순매매량(주, +매수/-매도)
+  createdAt      DateTime @default(now())
+
+  @@unique([ticker, date])
+  @@index([ticker, date])
+}

--- a/scripts/supply-demand-collect.ts
+++ b/scripts/supply-demand-collect.ts
@@ -1,0 +1,50 @@
+/**
+ * 수급 일별 수집·누적 cron. SUPPLY DEMAND SCORE HANDOFF §1·§2.
+ *
+ * 네이버 금융 일별 외국인·기관 순매매를 STOCK_VOCAB 국내 종목(naverCode 보유)별로 수집 →
+ * SupplyDemandDaily 에 (ticker,date) upsert(누적). 장 마감 확정치 — 시점(기준일)은 데이터에 부착됨.
+ *
+ * DATABASE_URL 없으면 수집만 하고 로그(드라이런). 테이블 미생성이면 store 가 폴백(0건) — 누락 가시화.
+ * 차단/실패해도 throw 없이 다음 종목 진행(빈 값 폴백). 레이트: 종목 간 짧은 간격.
+ */
+import { STOCK_VOCAB } from "@fomo/core";
+import { fetchSupplyDemand } from "../apps/web/lib/supply-demand";
+import { writeSupplyDemand } from "../apps/web/lib/supply-demand-store";
+
+const GAP_MS = 400; // 종목 간 간격(네이버 레이트 보호)
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const targets = STOCK_VOCAB.filter((d) => d.naverCode); // 국내 상장만(네이버 종목 페이지)
+  const hasDb = !!process.env.DATABASE_URL;
+  console.log(`[supply-demand] 대상 ${targets.length}종목, DB=${hasDb ? "on" : "dry-run"}`);
+
+  let collected = 0;
+  let saved = 0;
+  for (const d of targets) {
+    const flows = await fetchSupplyDemand(d.naverCode!);
+    if (flows.length === 0) {
+      console.warn(`  ✗ ${d.canonical}(${d.naverCode}): 수급 0(차단/형식변경?)`);
+      await sleep(GAP_MS);
+      continue;
+    }
+    collected += flows.length;
+    const latest = flows[0]!;
+    if (hasDb) {
+      const n = await writeSupplyDemand(d.naverCode!, flows);
+      saved += n;
+      console.log(`  ✓ ${d.canonical}: ${flows.length}건 수집 / ${n}건 누적 (최근 ${latest.date} 외인 ${latest.foreignNet} 기관 ${latest.institutionNet})`);
+    } else {
+      console.log(`  ✓ ${d.canonical}: ${flows.length}건 (DRY, 최근 ${latest.date})`);
+    }
+    await sleep(GAP_MS);
+  }
+  console.log(`[supply-demand] 완료 — 수집 ${collected}건, 누적 저장 ${saved}건`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[supply-demand] 실패", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
SUPPLY DEMAND SCORE HANDOFF §1·§2. PR1-a(파서) 위에 수집·누적.

## 변경
- **fetch**(`supply-demand.ts`): 네이버 frgn EUC-KR(arrayBuffer+TextDecoder) → 순수 파서. 실패 시 빈 배열.
- **누적 테이블**(`SupplyDemandDaily`): (ticker,date) unique — §2 기준선 씨앗. 시점=장마감 확정일.
- **store**: upsert/read, 테이블 미생성이면 폴백(0/null) — 누락 가시화(가짜 금지).
- **cron**(`supply-demand-pipeline.yml`, 18:30 KST 평일) + `supply:collect`: STOCK_VOCAB 국내 14종목 일별 수집·누적, 종목간 400ms.

## 라이브 스모크 (dry-run)
14종목 × 20거래일 수집 성공(기준일 2026-06-17), exit 0.

## 🚩 게이트/권한
- **`prisma db push` 는 오너 직접**(운영 규약 — 키/DB 권한). 테이블 생기기 전엔 store 폴백으로 cron·라우트 안전. 테이블 생기면 자동 누적 시작(코드 변경 불필요).
- 새 외부 소스(네이버 frgn): 기존 네이버 스크래핑과 동일 도메인, 일 1회·종목간 400ms — 레이트 부담 낮음.

## 후속
PR2 점수 보조 반영 / PR3 카드 공식지표 표시.

## 검증
typecheck·lint·build·prisma validate 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)