### PR TITLE
feat(supply): 수급 점수 보조 신호 — PR2 (§3)

### DIFF
--- a/apps/web/lib/keyword-pipeline.ts
+++ b/apps/web/lib/keyword-pipeline.ts
@@ -6,6 +6,7 @@ import {
   overallConfidence,
   fetchCommunity,
   pickSurpriseStock,
+  extractStocks,
   MOCK_KEYWORD_CARDS,
   type KeywordCard,
   type KeywordConfidence,
@@ -13,6 +14,33 @@ import {
 } from "@fomo/core";
 import { fetchAllNews } from "./fomo-news-sources";
 import { addKeywordCardComments } from "./fomo-keyword-comment";
+import { readLatestSupplyDemand } from "./supply-demand-store";
+
+/**
+ * 키워드별 수급 보조 신호(0~1, 장마감 확정 방향). SUPPLY DEMAND SCORE HANDOFF §3.
+ * 그 테마 종목들의 외인+기관 순매매 합의 방향만 약하게(매수세 0.65 / 매도세 0.35 / 중립 0.5).
+ * 수급 데이터(SupplyDemandDaily) 없으면(테이블 전/미수집) 해당 키워드 생략 → 점수 영향 0(불변·정직).
+ */
+async function buildSupplyByKeyword(
+  extracted: readonly { keyword: string; articles: KeywordSourceItem[] }[]
+): Promise<Record<string, number>> {
+  const out: Record<string, number> = {};
+  await Promise.all(
+    extracted.map(async (kw) => {
+      const codes = extractStocks(kw.articles, { minMentions: 1 })
+        .map((s) => s.naverCode)
+        .filter((c): c is string => !!c);
+      if (codes.length === 0) return;
+      const flows = (await Promise.all(codes.map((c) => readLatestSupplyDemand(c)))).filter(
+        (f): f is NonNullable<typeof f> => f != null
+      );
+      if (flows.length === 0) return; // 데이터 없으면 생략(가짜 금지)
+      const net = flows.reduce((s, f) => s + f.foreignNet + f.institutionNet, 0);
+      out[kw.keyword] = net > 0 ? 0.65 : net < 0 ? 0.35 : 0.5;
+    })
+  );
+  return out;
+}
 
 /**
  * 키워드 카드 산출 파이프라인(공유). KEYWORD_ENGINE_SPEC §4 / Phase 2~3.
@@ -56,7 +84,9 @@ export async function computeKeywordCards(): Promise<KeywordPayloadCore> {
   }
 
   const extracted = mergeCommunityEngagement(extractKeywords(items), communitySignals);
-  const scored = scoreKeywords(extracted, { nowMs: Date.now() });
+  // 수급 보조 신호(데이터 없으면 빈 객체 → 점수 불변). 장마감 확정 방향만 약하게 반영(§3).
+  const supplyByKeyword = await buildSupplyByKeyword(extracted);
+  const scored = scoreKeywords(extracted, { nowMs: Date.now(), supplyByKeyword });
   const ruleCards = buildKeywordCards(scored);
 
   // 키워드 0건 = 보여줄 게 없음 → mock 명시적 폴백(§5).

--- a/packages/fomo-core/__tests__/keyword-engine.test.ts
+++ b/packages/fomo-core/__tests__/keyword-engine.test.ts
@@ -100,6 +100,28 @@ describe("scoreKeywords (군중 쏠림 0~100)", () => {
   it("빈 입력 → 빈 배열(에러 없음, 폴백)", () => {
     expect(scoreKeywords([], { nowMs: NOW })).toEqual([]);
   });
+
+  // SUPPLY DEMAND SCORE HANDOFF §3 — 수급 보조 신호(불변/결정성)
+  it("수급 미주입(현재 기본) — 점수가 기존과 동일하고 supplyDemand=null (불변)", () => {
+    const ex = extractKeywords(SAMPLE);
+    const a = scoreKeywords(ex, { nowMs: NOW });
+    const b = scoreKeywords(ex, { nowMs: NOW, supplyByKeyword: {} });
+    expect(b.map((s) => s.fomoScore)).toEqual(a.map((s) => s.fomoScore));
+    for (const s of b) expect(s.signals.supplyDemand).toBeNull();
+  });
+
+  it("수급 주입 시 방향이 점수에 약하게 블렌딩되고 결정적", () => {
+    const ex = extractKeywords(SAMPLE);
+    const kw = ex[0]!.keyword;
+    const base = scoreKeywords(ex, { nowMs: NOW }).find((s) => s.keyword === kw)!.fomoScore;
+    const buy = scoreKeywords(ex, { nowMs: NOW, supplyByKeyword: { [kw]: 0.65 } }).find((s) => s.keyword === kw)!;
+    const sell = scoreKeywords(ex, { nowMs: NOW, supplyByKeyword: { [kw]: 0.35 } }).find((s) => s.keyword === kw)!;
+    expect(buy.signals.supplyDemand).toBe(0.65);
+    expect(buy.fomoScore).toBeGreaterThanOrEqual(sell.fomoScore); // 매수세가 매도세보다 높거나 같게
+    // 블렌딩은 10%라 base 근처 — 결정적
+    expect(scoreKeywords(ex, { nowMs: NOW, supplyByKeyword: { [kw]: 0.65 } }).find((s) => s.keyword === kw)!.fomoScore).toBe(buy.fomoScore);
+    expect(Math.abs(buy.fomoScore - base)).toBeLessThanOrEqual(15); // 보조라 큰 변동 없음
+  });
 });
 
 describe("extractKeywords — 오추출 방지(단어경계·일반어 제거, 2026-06-14)", () => {

--- a/packages/fomo-core/src/keyword-cards/score.ts
+++ b/packages/fomo-core/src/keyword-cards/score.ts
@@ -28,6 +28,12 @@ export interface KeywordSignals {
   volume: number;
   /** (b) 언급 가속 0~1 — 최근 6h vs 직전 6h. 인트라데이 시계열 미보유 시 null(Phase 4+). */
   accel: number | null;
+  /**
+   * (e) 수급 0~1 — 그 테마 종목들의 외인+기관 순매매 **방향**(장마감 확정 직전거래일).
+   * SUPPLY DEMAND SCORE HANDOFF §3: 기준선 없는 지금은 방향(매수세/매도세)만 보조로, 가중치 낮게.
+   * 데이터 없으면 null → 점수 영향 0(언급량 주신호 유지). 기준선 쌓이면 "이례성"으로 승격(별도).
+   */
+  supplyDemand: number | null;
 }
 
 export interface ScoredKeyword extends ExtractedKeyword {
@@ -71,7 +77,15 @@ function toneSignal(kw: ExtractedKeyword, nowMs: number): number {
 export interface ScoreOptions {
   /** 현재 시각(ms) — 최신성·테스트 주입용. */
   nowMs: number;
+  /**
+   * 키워드별 수급 신호(0~1, 장마감 확정 방향). 데이터 없는 키워드는 생략 → null(점수 영향 0).
+   * 미주입(현재 기본)이면 모든 키워드 null → 점수는 언급량 기준 그대로(불변).
+   */
+  supplyByKeyword?: Readonly<Record<string, number>>;
 }
+
+/** 수급 보조 가중치 — §3 "가중치 낮게 시작". 데이터 있을 때만 base 점수에 10% 블렌딩. */
+const SUPPLY_BLEND = 0.1;
 
 /**
  * 추출된 키워드 → 포모 점수. 점수 내림차순 정렬.
@@ -102,16 +116,26 @@ export function scoreKeywords(keywords: ExtractedKeyword[], opts: ScoreOptions):
     const volume = clamp01(kw.mentions / maxMention);
     const community = anyCommunity ? clamp01(kw.engagement / maxCommunity) : 0;
 
-    const fomoScore = clamp100((w.volume * volume + w.tone * tone + w.community * community) * 100);
+    const base = clamp100((w.volume * volume + w.tone * tone + w.community * community) * 100);
+
+    // (e) 수급 보조 — 데이터 있을 때만 방향을 base 에 10% 블렌딩(§3 가중치 낮게). 없으면 base 그대로(불변).
+    const supplyDemand = opts.supplyByKeyword?.[kw.keyword] ?? null;
+    const fomoScore =
+      supplyDemand !== null
+        ? clamp100(base * (1 - SUPPLY_BLEND) + supplyDemand * 100 * SUPPLY_BLEND)
+        : base;
 
     return {
       ...kw,
       fomoScore,
       confidence: "low",
-      signals: { tone, community, volume, accel: null },
+      signals: { tone, community, volume, accel: null, supplyDemand },
       reason:
         `volume=${volume.toFixed(2)} tone=${tone.toFixed(2)} community=${community.toFixed(2)} ` +
         `(w ${w.volume.toFixed(2)}/${w.tone.toFixed(2)}/${w.community.toFixed(2)}) | ` +
+        (supplyDemand !== null
+          ? `supply=${supplyDemand.toFixed(2)}(장마감 확정, blend ${SUPPLY_BLEND}) | `
+          : "") +
         `(a)volume=당일 상대mention, (b)accel 미산출, 30일 절대기준선 부재 → confidence low`,
     };
   });


### PR DESCRIPTION
SUPPLY DEMAND SCORE HANDOFF §3. 언급량 편중(반도체 늘 1등) 객관화의 첫 보조 신호.

## 변경
- `KeywordSignals.supplyDemand`(number|null) + `ScoreOptions.supplyByKeyword`. `accel=null` 패턴 그대로.
- **불변**: 수급 미주입(현재 — 테이블 전)이면 점수가 기존과 **100% 동일**, supplyDemand=null.
- 데이터 있으면 방향을 base에 **10% 블렌딩**(가중치 낮게, §3). 매수세 0.65 / 매도세 0.35 / 중립 0.5.
- `keyword-pipeline`: 키워드 종목들의 외인+기관 순매매 합 방향을 `readLatestSupplyDemand`로 조회·주입. 데이터 없으면 빈 객체 → 불변·정직.
- **시점**: reason에 '장마감 확정' 명시. confidence low 유지.

## 정직성/불변 테스트
- 미주입 시 기존 점수 동일 + supplyDemand=null
- 주입 시 방향 블렌딩 결정적, 보조라 변동 작음(±15 이내)

## 한계(§3)
기준선(평소 평균/표준편차) 없는 지금은 **방향만** 약하게. '평소 대비 이례성(z-score) 승격'은 데이터 2~3주 누적 후 별도 PR.

## 검증
typecheck·lint·build·test(672) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)