### PR TITLE
feat(supply): 종목 뎁스 수급 표시(공식지표) — PR3 (§4)

### DIFF
--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
-import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
+import { condenseThemeInsight, stockDef, supplyDemandFact, type CondensedInsight } from "@fomo/core";
 import { withCors, kstDate } from "../../../../lib/fomo";
 import { understandStock } from "../../../../lib/theme-understanding";
+import { readLatestSupplyDemand } from "../../../../lib/supply-demand-store";
 
 /**
  * 개별 종목 이해·응축 API — NEXT_FEATURES_HANDOFF 작업3(BM 심장). 읽기 전용.
@@ -45,8 +46,17 @@ export async function GET(req: Request) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
   const payload = await getInsight(stock);
+
+  // 수급(외인·기관 장마감 확정) — 공식 지표 섹션에 객관 사실로 동봉(§4). 데이터 없으면 미표시(정직).
+  // 캐시 밖에서 1회 조회(일별이라 가벼움). 테이블 전/미수집이면 null → 기존 응답 그대로.
+  const code = stockDef(stock)?.naverCode;
+  const flow = code ? await readLatestSupplyDemand(code) : null;
+  const out = flow
+    ? { ...payload, officialFacts: [supplyDemandFact(flow), ...(payload.officialFacts ?? [])] }
+    : payload;
+
   return withCors(
-    NextResponse.json(payload, {
+    NextResponse.json(out, {
       headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=1800" },
     })
   );

--- a/packages/fomo-core/__tests__/supply-demand.test.ts
+++ b/packages/fomo-core/__tests__/supply-demand.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseNaverInvestorFlow, latestInvestorFlow } from "../src/supply-demand";
+import { parseNaverInvestorFlow, latestInvestorFlow, supplyDemandFact } from "../src/supply-demand";
 
 // 네이버 frgn.naver 실제 행 구조(2행) — 날짜·종가·전일비·등락률·거래량·기관·외국인·보유주수·보유율.
 // 기관/외국인만 부호(+/-) 동반. 등락률(+1.02%)은 % 라 순매매로 안 잡혀야 한다.
@@ -59,5 +59,25 @@ describe("latestInvestorFlow", () => {
   });
   it("빈 입력 → null", () => {
     expect(latestInvestorFlow([])).toBeNull();
+  });
+});
+
+describe("supplyDemandFact — 객관 사실 + 기준일, 조언 금지(§4)", () => {
+  it("방향과 기준일을 사실로 표기", () => {
+    const f = supplyDemandFact({ date: "2026-06-17", foreignNet: -2_000_080, institutionNet: 1_133_803 });
+    expect(f.label).toContain("외국인 순매도");
+    expect(f.label).toContain("기관 순매수");
+    expect(f.label).toContain("6/17 장마감");
+    expect(f.source).toContain("KRX");
+  });
+  it("조언·단정 어휘가 없다(규제선)", () => {
+    const f = supplyDemandFact({ date: "2026-06-16", foreignNet: 500, institutionNet: -700 });
+    const text = `${f.label} ${f.detail ?? ""}`;
+    expect(text).not.toMatch(/사세요|파세요|매수하|매도하|추천|위험하다|사라|팔아라|오를|내릴|급등|폭락/);
+  });
+  it("보합(0)도 정직하게", () => {
+    const f = supplyDemandFact({ date: "2026-06-15", foreignNet: 0, institutionNet: 0 });
+    expect(f.label).toContain("외국인 보합");
+    expect(f.label).toContain("기관 보합");
   });
 });

--- a/packages/fomo-core/src/supply-demand.ts
+++ b/packages/fomo-core/src/supply-demand.ts
@@ -50,3 +50,30 @@ export function latestInvestorFlow(flows: readonly InvestorFlow[]): InvestorFlow
   // date 내림차순 정렬 후 최신.
   return [...flows].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))[0]!;
 }
+
+import type { OfficialFact } from "./theme-understanding/types";
+
+function netDirection(net: number): string {
+  return net > 0 ? "순매수" : net < 0 ? "순매도" : "보합";
+}
+function fmtShares(net: number): string {
+  const abs = Math.abs(net);
+  if (abs >= 10_000) return `${Math.round(abs / 10_000).toLocaleString("en-US")}만주`;
+  return `${abs.toLocaleString("en-US")}주`;
+}
+
+/**
+ * 수급 → 공식 지표 카드(객관 사실 + 기준일). SUPPLY DEMAND SCORE HANDOFF §4.
+ * ✅ 사실만: "외국인 순매도 · 기관 순매수 (6/17 장마감)". 방향과 시점을 정직하게.
+ * ❌ 해석·조언 금지(사라/팔아라/위험 등) — 판단은 유저. 강세/약세 단정 안 함.
+ */
+export function supplyDemandFact(flow: InvestorFlow): OfficialFact {
+  const [, m, d] = flow.date.split("-");
+  const md = `${Number(m)}/${Number(d)}`;
+  return {
+    label: `수급 — 외국인 ${netDirection(flow.foreignNet)} · 기관 ${netDirection(flow.institutionNet)} (${md} 장마감)`,
+    detail: `외국인 ${fmtShares(flow.foreignNet)} ${netDirection(flow.foreignNet)}, 기관 ${fmtShares(flow.institutionNet)} ${netDirection(flow.institutionNet)} · ${flow.date} 장 마감 확정`,
+    source: "네이버 금융(KRX 확정)",
+    tier: "official-high",
+  };
+}


### PR DESCRIPTION
SUPPLY DEMAND SCORE HANDOFF §4. 수급 트랙 **마지막 PR**.

## 변경
- `supplyDemandFact`(순수): InvestorFlow → OfficialFact(tier=official-high). `수급 — 외국인 순매도 · 기관 순매수 (6/17 장마감)`. **방향+시점만, 조언·단정 금지**(규제선).
- `stock-insight` route: `stockDef→naverCode→readLatestSupplyDemand` → officialFacts에 prepend. 데이터 없으면 미표시(정직). 캐시 밖 1회 조회.
- 기존 공식지표 UI(FRED 옆) 자동 재사용 — **UI 무변경**.

## §4 충실
- ✅ "외국인 순매도, 기관 순매수 (6/17 기준)" — 사실+기준일
- ❌ 조언/단정 0 — 테스트로 금지어 검증(사라·팔아라·오를·급등 등)
- 개인은 v1 제외(네이버 미제공), 수량 기준

## 데이터 의존
테이블 생기고 cron 돌기 전엔 화면 무변경(폴백). 누적되면 자동 표시.

## 검증
typecheck·lint·build·test(675) 통과.

---
## 수급 트랙 전체 요약(PR1-a/1-b/2/3 완료)
- PR1-a #541: 파서 / PR1-b #542: fetch+누적테이블+cron / PR2 #543: 점수 보조 / PR3: 표시
- ⚠️ **남은 권한 작업(오너)**: `prisma db push`로 SupplyDemandDaily 테이블 생성 → cron이 누적 시작 → 점수·표시 자동 활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)