### PR TITLE
perf(warm): 자정 직후 워밍 — 새벽 cold 제거 (개선 ③)

### DIFF
--- a/.github/workflows/warm-insights.yml
+++ b/.github/workflows/warm-insights.yml
@@ -8,10 +8,12 @@ name: Warm Depth Insights
 
 on:
   schedule:
-    # KST = UTC+9. 각 슬롯 시작 직후 워밍.
-    - cron: "0 0 * * *"  # 09:00 KST — morning 슬롯
-    - cron: "0 4 * * *"  # 13:00 KST — afternoon 슬롯
-    - cron: "0 7 * * *"  # 16:00 KST — evening 슬롯
+    # KST = UTC+9. 캐시 키가 (KST날짜,테마)라 그날 첫 워밍이 종일 warm 을 만든다.
+    # 자정 직후(00:20 KST) 먼저 데워 새벽~오전 cold 구간 제거 + 장중 갱신(SWR revalidate 6h).
+    - cron: "20 15 * * *" # 00:20 KST — 그날 키 생성 직후(새벽 cold 제거)
+    - cron: "0 0 * * *"   # 09:00 KST — 장 시작
+    - cron: "0 4 * * *"   # 13:00 KST — 장중 갱신
+    - cron: "0 7 * * *"   # 16:00 KST — 장 마감 후 갱신
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
개선 ③ — cold 첫 방문 구간 축소.

## 배경
캐시 키 `(KST날짜,테마)`라 cold는 '그날 첫 진입'뿐인데, 워밍 cron 첫 실행이 09시(KST)라 **자정~오전 첫 방문자가 cold**(20~30초)였습니다.

## 변경
워밍 cron에 **00:20 KST(15:20 UTC)** 슬롯 추가 — 그날 캐시 키 생성 직후 데워서 새벽 구간 cold 제거. 장중(09/13/16)은 SWR(revalidate 6h)로 대기 없이 백그라운드 갱신.

비용: +1 워밍/일.

## 남는 cold
00:20 워밍이 도는 ~수 분, 그리고 그 전 자정~00:20(트래픽 최소)만. 사실상 종일 warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)