### PR TITLE
fix(depth): 사람들 워딩=커뮤니티 출처만 (§3-b, 개선 ④)

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { scoreToColor, cleanText, cleanQuote, type KeywordCard } from "@fomo/core";
+import { scoreToColor, cleanText, cleanQuote, communityWordings, type KeywordCard } from "@fomo/core";
 import { fetchThemeInsight, fetchStockInsight, type CondensedInsight } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
@@ -161,11 +161,11 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
                 )}
               </section>
 
-              {insight!.wordings.length > 0 && (
+              {communityWordings(insight!).length > 0 && (
                 <section className="mt-6">
                   <p className="font-pixel text-sm text-whiteout">🗣️ 사람들 워딩</p>
                   <ul className="mt-2 space-y-2">
-                    {insight!.wordings.map((w, i) => {
+                    {communityWordings(insight!).map((w, i) => {
                       const s = srcOf(w.sourceId);
                       return (
                         <li key={`w-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
@@ -412,11 +412,11 @@ export function StockInsightView({ stock, onClose }: { stock: string; onClose: (
                 )}
               </section>
 
-              {insight!.wordings.length > 0 && (
+              {communityWordings(insight!).length > 0 && (
                 <section className="mt-6">
                   <p className="font-pixel text-sm text-whiteout">🗣️ 사람들 워딩</p>
                   <ul className="mt-2 space-y-2">
-                    {insight!.wordings.map((w, i) => {
+                    {communityWordings(insight!).map((w, i) => {
                       const s = srcOf(w.sourceId);
                       return (
                         <li key={`w-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">

--- a/packages/fomo-core/__tests__/theme-understanding.test.ts
+++ b/packages/fomo-core/__tests__/theme-understanding.test.ts
@@ -3,6 +3,7 @@ import {
   assembleThemeInsight,
   emptyThemeInsight,
   parseThemeInsightResponse,
+  communityWordings,
   buildThemeInsightPrompt,
   parseNaverBoardPosts,
   condenseThemeInsight,
@@ -602,5 +603,31 @@ describe("parseThemeInsightResponse — 깨진 LLM JSON 복구(바이오 파싱 
   });
   it("JSON 이 전혀 없으면 null", () => {
     expect(parseThemeInsightResponse("죄송합니다, 답변을 드릴 수 없습니다.")).toBeNull();
+  });
+});
+
+describe("communityWordings — 워딩은 커뮤니티 출처만(§3-b)", () => {
+  const insight = {
+    theme: "반도체", whyHot: "", bull: [], bear: [], stance: "balanced", stanceNote: "",
+    outlets: [], singleOutlet: false, confidence: "low", lean: { bullCount: 0, bearCount: 0, oneSided: false },
+    reason: "", relatedStocks: [],
+    wordings: [
+      { text: "존버한다", sourceId: "S1" },   // 커뮤니티
+      { text: "기사 인용", sourceId: "S2" },   // 뉴스 — 제외돼야
+      { text: "공식 발표", sourceId: "S3" },   // 공식 — 제외돼야
+    ],
+    sources: [
+      { id: "S1", kind: "community", title: "종토방" },
+      { id: "S2", kind: "news", title: "매일경제" },
+      { id: "S3", kind: "official", title: "FRED" },
+    ],
+  } as never;
+  it("뉴스·공식 출처 워딩은 거르고 커뮤니티만 남긴다", () => {
+    const out = communityWordings(insight);
+    expect(out.map((w) => w.text)).toEqual(["존버한다"]);
+  });
+  it("커뮤니티 워딩이 없으면 빈 배열", () => {
+    const none = { ...insight, wordings: [{ text: "기사", sourceId: "S2" }] } as never;
+    expect(communityWordings(none)).toEqual([]);
   });
 });

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -161,3 +161,12 @@ function buildWhyHot(
   if (bear.length) parts.push(`약세 쪽은 — ${join(bear)}`);
   return parts.join(" ");
 }
+
+/**
+ * "사람들 워딩"은 커뮤니티 출처만(BUGFIX DEPTH HANDOFF §3-b). 뉴스·공식 sourceId 가 붙은 워딩은 제외 —
+ * 워딩은 사람들(커뮤니티)의 목소리이지 기사 인용이 아니다. 표시층이 이걸로 워딩을 거른다(엔진 불변).
+ */
+export function communityWordings(insight: CondensedInsight): KeyWording[] {
+  const kindById = new Map(insight.sources.map((s) => [s.id, s.kind]));
+  return insight.wordings.filter((w) => kindById.get(w.sourceId) === "community");
+}


### PR DESCRIPTION
개선 ④ — '사람들 워딩'에 뉴스 출처(매일경제)가 섞이던 문제(§3-b).

## 원인·해법
워딩은 정의상 **사람들(커뮤니티) 목소리**인데 LLM이 워딩에 뉴스 sourceId를 붙이는 경우가 있었습니다. 추출(엔진) 영역은 안 건드리고, 표시 직전에 **정의대로 커뮤니티 출처만** 남깁니다.
- `communityWordings(insight)` 순수함수: `sources.kind==='community'` 워딩만. 뉴스·공식 제외.
- KeywordDepthPage 워딩 섹션 2곳(테마·종목)에 적용. 커뮤니티 워딩 0이면 섹션 숨김(정직).

## 검증
- 테스트: 뉴스/공식 출처 워딩 제외, 빈 배열
- 엔진 불변(표시·정제층만), typecheck·lint·build·test 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)