### PR TITLE
feat(supply): KIS 연동 셋팅 — 개인 수급(키 받기 전 골격)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ AI_TEMPERATURE="0.2"
 # FRED(미 연준 공식 데이터, DATA_ENGINE_STRATEGY C-2). 없어도 키리스(fredgraph.csv)로 동작.
 # 키 발급(무료): https://fred.stlouisfed.org/docs/api/api_key.html → 설정 시 공식 JSON API 로 업그레이드.
 FRED_API_KEY=""
+# 한국투자증권 KIS Open API — 투자자 매매동향(개인·외국인·기관). 수급 정밀화(개인 포함).
+# 무료. 발급: https://apiportal.koreainvestment.com → 계좌 연결 → 앱키/시크릿. 둘 다 설정 시 KIS 경로 활성(없으면 네이버 폴백).
+KIS_APP_KEY=""
+KIS_APP_SECRET=""
 RESEARCH_PUBLISHED_SNAPSHOT_URL="https://raw.githubusercontent.com/mlender-ai/auto-trading-bot/main/generated/research/latest.json"
 NEWSLETTER_TO=""
 NEWSLETTER_FROM=""

--- a/.github/workflows/supply-demand-pipeline.yml
+++ b/.github/workflows/supply-demand-pipeline.yml
@@ -35,4 +35,7 @@ jobs:
       - name: Collect supply-demand
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # KIS 앱키가 secrets 에 있으면 개인까지 수집(없으면 네이버 폴백).
+          KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
+          KIS_APP_SECRET: ${{ secrets.KIS_APP_SECRET }}
         run: npm run supply:collect

--- a/apps/web/lib/kis.ts
+++ b/apps/web/lib/kis.ts
@@ -1,0 +1,80 @@
+import { parseKisInvestorFlow, type InvestorFlow } from "@fomo/core";
+
+/**
+ * 한국투자증권(KIS) Open API — 투자자 매매동향(개인·외국인·기관). SUPPLY DEMAND 정밀화(②).
+ *
+ * 네이버는 외국인·기관 수량만 → KIS 로 개인까지 확보. 무료(앱키 발급), OAuth 토큰 24h.
+ * 키(KIS_APP_KEY/SECRET) 없으면 전부 null 반환 → 호출부가 네이버로 폴백(안전).
+ *
+ * ⚠️ 앱키 발급 후 할 일(딱 1가지): 실제 응답 1회 찍어 packages/fomo-core/supply-demand.ts 의
+ *    parseKisInvestorFlow 필드명(stck_bsop_date / prsn·frgn·orgn_ntby_qty)만 맞추면 끝.
+ */
+const KIS_BASE = process.env.KIS_BASE_URL || "https://openapi.koreainvestment.com:9443";
+const TR_INVESTOR = "FHKST01010900"; // 주식현재가 투자자
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+/** 키가 설정돼 있으면 KIS 경로 활성. */
+export function kisEnabled(): boolean {
+  return !!(process.env.KIS_APP_KEY && process.env.KIS_APP_SECRET);
+}
+
+/** 접근토큰(24h) 발급·캐시. 키 없거나 실패 시 null. */
+async function getToken(): Promise<string | null> {
+  if (!kisEnabled()) return null;
+  if (cachedToken && Date.now() < cachedToken.expiresAt) return cachedToken.token;
+  try {
+    const res = await fetch(`${KIS_BASE}/oauth2/tokenP`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        appkey: process.env.KIS_APP_KEY,
+        appsecret: process.env.KIS_APP_SECRET,
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      console.warn("[kis] token non-OK", res.status);
+      return null;
+    }
+    const d = (await res.json()) as { access_token?: string; expires_in?: number };
+    if (!d.access_token) return null;
+    // 만료 10분 전까지 재사용.
+    cachedToken = { token: d.access_token, expiresAt: Date.now() + ((d.expires_in ?? 86400) - 600) * 1000 };
+    return cachedToken.token;
+  } catch (err) {
+    console.warn("[kis] token failed", (err as Error)?.message);
+    return null;
+  }
+}
+
+/** 한 종목의 투자자 매매동향(개인 포함). 키 없음/실패 시 null → 네이버 폴백. */
+export async function fetchKisInvestorFlow(code: string): Promise<InvestorFlow | null> {
+  const token = await getToken();
+  if (!token) return null;
+  try {
+    const url =
+      `${KIS_BASE}/uapi/domestic-stock/v1/quotations/inquire-investor` +
+      `?FID_COND_MRKT_DIV_CODE=J&FID_INPUT_ISCD=${encodeURIComponent(code)}`;
+    const res = await fetch(url, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        appkey: process.env.KIS_APP_KEY!,
+        appsecret: process.env.KIS_APP_SECRET!,
+        tr_id: TR_INVESTOR,
+        custtype: "P",
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      console.warn("[kis] investor non-OK", code, res.status);
+      return null;
+    }
+    const d = (await res.json()) as { output?: Record<string, unknown>[] };
+    return parseKisInvestorFlow(d.output?.[0]); // 최신 영업일 행
+  } catch (err) {
+    console.warn("[kis] investor failed", code, (err as Error)?.message);
+    return null;
+  }
+}

--- a/apps/web/lib/supply-demand-store.ts
+++ b/apps/web/lib/supply-demand-store.ts
@@ -19,8 +19,18 @@ export async function writeSupplyDemand(
     try {
       await prisma.supplyDemandDaily.upsert({
         where: { ticker_date: { ticker, date: f.date } },
-        create: { ticker, date: f.date, foreignNet: f.foreignNet, institutionNet: f.institutionNet },
-        update: { foreignNet: f.foreignNet, institutionNet: f.institutionNet },
+        create: {
+          ticker,
+          date: f.date,
+          foreignNet: f.foreignNet,
+          institutionNet: f.institutionNet,
+          individualNet: f.individualNet ?? null,
+        },
+        update: {
+          foreignNet: f.foreignNet,
+          institutionNet: f.institutionNet,
+          individualNet: f.individualNet ?? null,
+        },
       });
       n++;
     } catch (err) {
@@ -40,7 +50,12 @@ export async function readLatestSupplyDemand(ticker: string): Promise<InvestorFl
       orderBy: { date: "desc" },
     });
     if (!row) return null;
-    return { date: row.date, foreignNet: row.foreignNet, institutionNet: row.institutionNet };
+    return {
+      date: row.date,
+      foreignNet: row.foreignNet,
+      institutionNet: row.institutionNet,
+      ...(row.individualNet != null ? { individualNet: row.individualNet } : {}),
+    };
   } catch (err) {
     console.warn("[supply-demand-store] read skipped (table missing?)", (err as Error)?.message);
     return null;

--- a/packages/fomo-core/__tests__/supply-demand.test.ts
+++ b/packages/fomo-core/__tests__/supply-demand.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseNaverInvestorFlow, latestInvestorFlow, supplyDemandFact } from "../src/supply-demand";
+import {
+  parseNaverInvestorFlow,
+  latestInvestorFlow,
+  supplyDemandFact,
+  parseKisInvestorFlow,
+} from "../src/supply-demand";
 
 // 네이버 frgn.naver 실제 행 구조(2행) — 날짜·종가·전일비·등락률·거래량·기관·외국인·보유주수·보유율.
 // 기관/외국인만 부호(+/-) 동반. 등락률(+1.02%)은 % 라 순매매로 안 잡혀야 한다.
@@ -79,5 +84,40 @@ describe("supplyDemandFact — 객관 사실 + 기준일, 조언 금지(§4)", (
     const f = supplyDemandFact({ date: "2026-06-15", foreignNet: 0, institutionNet: 0 });
     expect(f.label).toContain("외국인 보합");
     expect(f.label).toContain("기관 보합");
+  });
+});
+
+describe("parseKisInvestorFlow — KIS 투자자 매매동향(개인 포함, best-guess 필드)", () => {
+  it("개인·외국인·기관 순매매를 파싱하고 기준일 부착", () => {
+    const row = {
+      stck_bsop_date: "20260618",
+      frgn_ntby_qty: "2424675",
+      orgn_ntby_qty: "1943262",
+      prsn_ntby_qty: "-4367937",
+    };
+    const f = parseKisInvestorFlow(row);
+    expect(f).not.toBeNull();
+    expect(f!.date).toBe("2026-06-18");
+    expect(f!.foreignNet).toBe(2424675);
+    expect(f!.institutionNet).toBe(1943262);
+    expect(f!.individualNet).toBe(-4367937);
+  });
+  it("필드 누락/형식 이상 → null(네이버 폴백 유지)", () => {
+    expect(parseKisInvestorFlow(null)).toBeNull();
+    expect(parseKisInvestorFlow({})).toBeNull();
+    expect(parseKisInvestorFlow({ stck_bsop_date: "20260618", frgn_ntby_qty: "x" })).toBeNull();
+  });
+});
+
+describe("supplyDemandFact — 개인 데이터 있으면 함께 표기(KIS)", () => {
+  it("개인 포함 시 라벨에 개인 방향 추가 + 출처 KIS", () => {
+    const f = supplyDemandFact({ date: "2026-06-18", foreignNet: 100, institutionNet: -50, individualNet: -30 });
+    expect(f.label).toContain("개인 순매도");
+    expect(f.source).toContain("KIS");
+  });
+  it("개인 없으면(네이버) 외인·기관만 + 출처 네이버", () => {
+    const f = supplyDemandFact({ date: "2026-06-18", foreignNet: 100, institutionNet: -50 });
+    expect(f.label).not.toContain("개인");
+    expect(f.source).toContain("네이버");
   });
 });

--- a/packages/fomo-core/src/supply-demand.ts
+++ b/packages/fomo-core/src/supply-demand.ts
@@ -18,6 +18,8 @@ export interface InvestorFlow {
   foreignNet: number;
   /** 기관 순매매량(주식 수, +매수 / -매도). */
   institutionNet: number;
+  /** 개인 순매매량(주식 수, +매수 / -매도). 네이버는 미제공(undefined), KIS Open API 는 제공. */
+  individualNet?: number;
 }
 
 /** 부호 붙은 정수만(콤마 제거). 등락률(+1.02%)은 % 동반이라 매칭되지 않는다. */
@@ -42,6 +44,34 @@ export function parseNaverInvestorFlow(html: string): InvestorFlow[] {
     out.push({ date, institutionNet: signed[0]!, foreignNet: signed[1]! });
   }
   return out;
+}
+
+/** YYYYMMDD → YYYY-MM-DD. */
+function dashDate(yyyymmdd: string): string {
+  return /^\d{8}$/.test(yyyymmdd)
+    ? `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`
+    : yyyymmdd;
+}
+
+/**
+ * KIS '주식현재가 투자자'(tr_id FHKST01010900) output 한 행 → InvestorFlow. 순수.
+ * KIS 는 개인까지 제공(네이버 한계 보완). 매일 cron 호출로 일별 누적.
+ *
+ * ⚠️ 필드명(stck_bsop_date / prsn·frgn·orgn _ntby_qty)은 KIS 명세 기준 **best-guess**.
+ *    앱키 발급 후 실제 응답 1회로 최종 확정 필요(아래 키만 맞추면 됨). 못 맞으면 null → 네이버 폴백 유지.
+ */
+export function parseKisInvestorFlow(
+  row: Record<string, unknown> | null | undefined
+): InvestorFlow | null {
+  if (!row) return null;
+  const num = (v: unknown) => Number(String(v ?? "").replace(/,/g, ""));
+  const date = dashDate(String(row["stck_bsop_date"] ?? "")); // TODO(키): 영업일자 필드 확인
+  const foreignNet = num(row["frgn_ntby_qty"]); // TODO(키): 외국인 순매수량
+  const institutionNet = num(row["orgn_ntby_qty"]); // TODO(키): 기관 순매수량
+  const individualNet = num(row["prsn_ntby_qty"]); // TODO(키): 개인 순매수량
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+  if (![foreignNet, institutionNet, individualNet].every(Number.isFinite)) return null;
+  return { date, foreignNet, institutionNet, individualNet };
 }
 
 /** 가장 최근(장 마감 확정) 1거래일 수급. 없으면 null(정직한 빈 값). */
@@ -70,10 +100,16 @@ function fmtShares(net: number): string {
 export function supplyDemandFact(flow: InvestorFlow): OfficialFact {
   const [, m, d] = flow.date.split("-");
   const md = `${Number(m)}/${Number(d)}`;
+  // 개인은 데이터가 있을 때만(KIS). 네이버 경로는 외국인·기관만.
+  const indivLabel = flow.individualNet !== undefined ? ` · 개인 ${netDirection(flow.individualNet)}` : "";
+  const indivDetail =
+    flow.individualNet !== undefined
+      ? `, 개인 ${fmtShares(flow.individualNet)} ${netDirection(flow.individualNet)}`
+      : "";
   return {
-    label: `수급 — 외국인 ${netDirection(flow.foreignNet)} · 기관 ${netDirection(flow.institutionNet)} (${md} 장마감)`,
-    detail: `외국인 ${fmtShares(flow.foreignNet)} ${netDirection(flow.foreignNet)}, 기관 ${fmtShares(flow.institutionNet)} ${netDirection(flow.institutionNet)} · ${flow.date} 장 마감 확정`,
-    source: "네이버 금융(KRX 확정)",
+    label: `수급 — 외국인 ${netDirection(flow.foreignNet)} · 기관 ${netDirection(flow.institutionNet)}${indivLabel} (${md} 장마감)`,
+    detail: `외국인 ${fmtShares(flow.foreignNet)} ${netDirection(flow.foreignNet)}, 기관 ${fmtShares(flow.institutionNet)} ${netDirection(flow.institutionNet)}${indivDetail} · ${flow.date} 장 마감 확정`,
+    source: flow.individualNet !== undefined ? "한국투자증권 KIS(KRX 확정)" : "네이버 금융(KRX 확정)",
     tier: "official-high",
   };
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -800,6 +800,7 @@ model SupplyDemandDaily {
   date           String // YYYY-MM-DD (장마감 확정 거래일)
   foreignNet     Float // 외국인 순매매량(주, +매수/-매도)
   institutionNet Float // 기관 순매매량(주, +매수/-매도)
+  individualNet  Float? // 개인 순매매량(주). KIS Open API 만 제공(네이버 경로는 null)
   createdAt      DateTime @default(now())
 
   @@unique([ticker, date])

--- a/scripts/supply-demand-collect.ts
+++ b/scripts/supply-demand-collect.ts
@@ -9,20 +9,24 @@
  */
 import { STOCK_VOCAB } from "@fomo/core";
 import { fetchSupplyDemand } from "../apps/web/lib/supply-demand";
+import { fetchKisInvestorFlow, kisEnabled } from "../apps/web/lib/kis";
 import { writeSupplyDemand } from "../apps/web/lib/supply-demand-store";
 
 const GAP_MS = 400; // 종목 간 간격(네이버 레이트 보호)
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 async function main() {
-  const targets = STOCK_VOCAB.filter((d) => d.naverCode); // 국내 상장만(네이버 종목 페이지)
+  const targets = STOCK_VOCAB.filter((d) => d.naverCode); // 국내 상장만
   const hasDb = !!process.env.DATABASE_URL;
-  console.log(`[supply-demand] 대상 ${targets.length}종목, DB=${hasDb ? "on" : "dry-run"}`);
+  const useKis = kisEnabled(); // 앱키 있으면 KIS(개인 포함), 없으면 네이버(외인·기관)
+  console.log(`[supply-demand] 대상 ${targets.length}종목, DB=${hasDb ? "on" : "dry-run"}, 소스=${useKis ? "KIS(개인 포함)" : "네이버"}`);
 
   let collected = 0;
   let saved = 0;
   for (const d of targets) {
-    const flows = await fetchSupplyDemand(d.naverCode!);
+    // KIS 우선(개인까지) → 실패/미설정 시 네이버 폴백(외인·기관). 둘 다 시점(기준일) 부착.
+    const kis = useKis ? await fetchKisInvestorFlow(d.naverCode!) : null;
+    const flows = kis ? [kis] : await fetchSupplyDemand(d.naverCode!);
     if (flows.length === 0) {
       console.warn(`  ✗ ${d.canonical}(${d.naverCode}): 수급 0(차단/형식변경?)`);
       await sleep(GAP_MS);


### PR DESCRIPTION
개선 ②(수급 정밀화) — 키 받기 전 **골격 전부 셋팅**. 키 없으면 네이버 폴백(동작 불변), 키 넣으면 KIS 자동 활성.

## 변경
- **lib/kis.ts**: OAuth 토큰 발급·캐시(24h) + 투자자매매동향(FHKST01010900). 키 없으면 null.
- **parseKisInvestorFlow**(순수): output→InvestorFlow(개인 포함). 필드명 best-guess(키 후 확정).
- **InvestorFlow.individualNet?** + **SupplyDemandDaily.individualNet?**(nullable) + store/read 확장.
- **collect**: KIS 우선 → 네이버 폴백.
- **supplyDemandFact**: 개인 데이터 있으면 '· 개인 순매수/도' + 출처 KIS.
- **.env.example** + 워크플로 secrets.
- 테스트 13건.

## 🔑 키 받은 후 (3스텝, 제가 처리)
1. Vercel/GitHub secrets 에 KIS_APP_KEY/SECRET
2. 실제 응답 1회로 `parseKisInvestorFlow` 필드명 확정(stck_bsop_date / prsn·frgn·orgn_ntby_qty)
3. SupplyDemandDaily.individualNet 컬럼 db push(추가형, dry-run 먼저)

## 안전
키 없는 현재: 전부 네이버 폴백, 점수·표시 그대로. typecheck·lint·build·test 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)