### PR TITLE
feat(track-b): 이메일+비번 로그인/가입 + 익명→유저 취향 연결 + 탈퇴 (Phase 2)

### DIFF
--- a/apps/fomo-web/app/privacy/page.tsx
+++ b/apps/fomo-web/app/privacy/page.tsx
@@ -1,0 +1,36 @@
+// 임시 최소 개인정보 처리방침 — 트랙 B(로그인=이메일 수집 시작) 게이트 충족용 초안.
+// ⚠️ 법적 효력 문구·약관 최종본은 광혁 직접 영역(법률 자문 후 교체). 여기는 "없이 수집 금지" 원칙을
+// 지키기 위한 최소 고지다.
+export const metadata = { title: "개인정보 처리방침 · FOMO Club" };
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-md px-6 py-10 text-whiteout">
+      <h1 className="font-pixel text-lg">개인정보 처리방침 (임시)</h1>
+      <p className="mt-2 text-[12px] text-muted">최종본은 준비 중이야. 아래는 현재 무엇을 모으는지에 대한 최소 고지.</p>
+
+      <section className="mt-6 space-y-4 text-sm leading-6 text-muted">
+        <div>
+          <p className="font-pixel text-whiteout">무엇을 모으나</p>
+          <p>이메일(로그인 식별용), 취향 신호(키워드·종목에 대한 관심/덜관심, 뎁스 열람·연관주 탭). 비밀번호는 해시로만 저장하고 원문은 보관하지 않아.</p>
+        </div>
+        <div>
+          <p className="font-pixel text-whiteout">왜 모으나</p>
+          <p>네 취향에 맞춘 피드(개인화)를 위해서야. 투자 조언이 아니라, 네가 어떤 주제에 관심 있는지 학습해 보여주는 용도.</p>
+        </div>
+        <div>
+          <p className="font-pixel text-whiteout">로그인 없이도</p>
+          <p>가입 없이 둘러볼 수 있어. 로그인은 취향을 기기 너머로 기억하기 위한 선택이야.</p>
+        </div>
+        <div>
+          <p className="font-pixel text-whiteout">보관과 삭제</p>
+          <p>탈퇴하면 계정과 취향 신호를 함께 삭제해. 제3자에게 팔거나 광고에 넘기지 않아.</p>
+        </div>
+        <div>
+          <p className="font-pixel text-whiteout">문의</p>
+          <p>choihenry0010@gmail.com</p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/fomo-web/components/AuthSheet.tsx
+++ b/apps/fomo-web/components/AuthSheet.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { registerEmail, loginEmail, logout, deleteAccount } from "@/lib/fomoApi";
+
+/**
+ * 최소 로그인/가입 시트 — 트랙 B. 이메일+비밀번호. 비로그인 둘러보기는 그대로, 로그인은 "취향 기억"용 선택.
+ * ⚠️ 화면·카피·약관 문구는 광혁 직접 영역 — 여기 텍스트/스타일은 임시(기능 우선).
+ * 로그인/가입 성공 시 fomoApi 가 토큰 저장 + 익명 취향 연결까지 처리한 뒤 onAuthed() 호출.
+ */
+export function AuthSheet({
+  loggedIn,
+  onClose,
+  onAuthed,
+}: {
+  loggedIn: boolean;
+  onClose: () => void;
+  onAuthed: () => void;
+}) {
+  const [mode, setMode] = useState<"login" | "register">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      if (mode === "register") await registerEmail(email, password);
+      else await loginEmail(email, password);
+      onAuthed();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "문제가 생겼어. 다시 시도해줘.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-end bg-black/70" onClick={onClose}>
+      <div
+        className="mx-auto w-full max-w-md rounded-t-2xl border-t border-hairline bg-surface p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {loggedIn ? (
+          // 로그인 상태 — 로그아웃 / 탈퇴(개인정보 삭제)
+          <div className="flex flex-col gap-3">
+            <p className="font-pixel text-sm text-whiteout">내 계정</p>
+            <button
+              onClick={() => {
+                logout();
+                onClose();
+                window.location.reload();
+              }}
+              className="rounded-lg border border-hairline px-4 py-3 text-sm text-whiteout"
+            >
+              로그아웃
+            </button>
+            <button
+              onClick={async () => {
+                if (!window.confirm("정말 탈퇴할래? 쌓인 취향 데이터도 함께 삭제돼.")) return;
+                try {
+                  await deleteAccount();
+                  onClose();
+                  window.location.reload();
+                } catch {
+                  setError("탈퇴 처리에 실패했어.");
+                }
+              }}
+              className="rounded-lg px-4 py-3 text-sm text-muted"
+            >
+              탈퇴(데이터 삭제)
+            </button>
+            {error && <p className="text-[12px] text-[#ff5a5f]">{error}</p>}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <p className="font-pixel text-sm text-whiteout">
+              {mode === "login" ? "로그인" : "가입"} · 취향을 기억해줄게
+            </p>
+            <input
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              placeholder="이메일"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="rounded-lg border border-hairline bg-black px-3 py-3 text-sm text-whiteout outline-none"
+            />
+            <input
+              type="password"
+              autoComplete={mode === "login" ? "current-password" : "new-password"}
+              placeholder="비밀번호 (8자 이상)"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && !busy && submit()}
+              className="rounded-lg border border-hairline bg-black px-3 py-3 text-sm text-whiteout outline-none"
+            />
+            {error && <p className="text-[12px] text-[#ff5a5f]">{error}</p>}
+            <button
+              onClick={submit}
+              disabled={busy}
+              className="rounded-lg bg-[#FF5A36] px-4 py-3 text-sm font-pixel text-white disabled:opacity-50"
+            >
+              {busy ? "처리 중…" : mode === "login" ? "로그인" : "가입하고 시작"}
+            </button>
+            <button
+              onClick={() => {
+                setMode(mode === "login" ? "register" : "login");
+                setError(null);
+              }}
+              className="text-[12px] text-muted"
+            >
+              {mode === "login" ? "처음이야? 가입하기" : "이미 계정이 있어? 로그인"}
+            </button>
+            <p className="text-[11px] leading-5 text-muted">
+              가입하면 <a href="/privacy" target="_blank" className="underline">개인정보 처리방침</a>에 동의하는 거야.
+              취향 신호(관심/덜관심·열람)만 모으고, 언제든 탈퇴 시 전부 삭제돼.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { KeywordHistory } from "@/components/KeywordHistory";
+import { AuthSheet } from "@/components/AuthSheet";
 import type {
   FomoIndexResponse,
   TallyResponse,
@@ -24,6 +25,8 @@ type Tab = "card" | "history";
 
 export function HomeView({
   index,
+  loggedIn,
+  onLoggedIn,
 }: {
   index: FomoIndexResponse | null;
   tally: TallyResponse | null;
@@ -39,6 +42,7 @@ export function HomeView({
   onLoggedIn: () => void;
 }) {
   const [tab, setTab] = useState<Tab>("card");
+  const [authOpen, setAuthOpen] = useState(false);
   const color = index ? scoreToColor(index.score) : undefined;
 
   /**
@@ -58,9 +62,15 @@ export function HomeView({
   return (
     <>
       <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-20 pt-4">
-        {/* 상단 얇은 띠: 로고 */}
-        <div className="flex items-center">
+        {/* 상단 얇은 띠: 로고 + 로그인(취향 기억) */}
+        <div className="flex items-center justify-between">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
+          <button
+            onClick={() => setAuthOpen(true)}
+            className="text-xs text-muted transition-colors hover:text-whiteout"
+          >
+            {loggedIn ? "내 계정" : "로그인"}
+          </button>
         </div>
 
         {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}
@@ -101,6 +111,10 @@ export function HomeView({
           <TabButton active={tab === "history"} onClick={() => setTab("history")} label="히스토리" />
         </div>
       </nav>
+
+      {authOpen && (
+        <AuthSheet loggedIn={loggedIn} onClose={() => setAuthOpen(false)} onAuthed={onLoggedIn} />
+      )}
     </>
   );
 }

--- a/apps/fomo-web/lib/auth.ts
+++ b/apps/fomo-web/lib/auth.ts
@@ -1,6 +1,6 @@
-// 로그인 토큰 보관. 타로 인증 백엔드가 발급한 JWT를 localStorage에 저장하고
+// 로그인 토큰 보관. FOMO Club 인증(/api/fomo/auth/*)이 발급한 JWT를 localStorage에 저장하고
 // Authorization: Bearer 로 fomo API에 보낸다(크로스오리진이라 쿠키 대신 Bearer).
-// docs/IDENTITY_AND_MILESTONES.md §M2 — 캘린더(기록) 영속화는 가입자만.
+// 트랙 B — 로그인하면 취향 신호가 유저별로 서버에 쌓인다(가입 전 익명 sessionId 도 로그인 시 연결).
 const TOKEN_KEY = "fomo_token";
 
 export function getToken(): string | null {

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -9,7 +9,7 @@ import type {
   MoodSignal,
   ScoredArticle,
 } from "@fomo/core";
-import { getToken, setToken } from "@/lib/auth";
+import { getToken, setToken, clearToken } from "@/lib/auth";
 import { getSessionId } from "@/lib/session";
 
 export type { BannerItem } from "@fomo/core";
@@ -183,4 +183,57 @@ export function recordTaste(
     body: JSON.stringify({ subjectType, subject, signal, sessionId: getSessionId() }),
     keepalive: true, // 화면 전환/언마운트 중에도 전송 보장
   }).catch((err) => console.warn("[recordTaste] failed", err));
+}
+
+// ── 트랙 B: 이메일+비밀번호 인증 ────────────────────────────────────────────
+// 비로그인 둘러보기는 그대로 유지 — 로그인은 "취향을 기억"하기 위한 선택. 로그인/가입 직후
+// 익명 sessionId 로 쌓인 취향을 내 계정으로 연결(linkTaste)해 가입 전 학습이 끊기지 않게 한다.
+
+/** 익명 sessionId 취향 신호 → 내 계정 연결(로그인 직후 1회). 실패해도 흐름 안 막음. */
+async function linkTaste(): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/api/fomo/taste/link`, {
+      method: "POST",
+      headers: authHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ sessionId: getSessionId() }),
+    });
+  } catch (err) {
+    console.warn("[linkTaste] failed", err);
+  }
+}
+
+async function authPost(path: string, email: string, password: string): Promise<LoginResponse> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  const data = (await res.json().catch(() => ({}))) as Partial<LoginResponse> & { error?: string };
+  if (!res.ok || !data.token) throw new Error(data.error || `auth ${res.status}`);
+  setToken(data.token);
+  await linkTaste(); // 가입 전 익명 취향을 계정으로 이어붙임
+  return data as LoginResponse;
+}
+
+/** 이메일+비밀번호 가입 → JWT 저장 + 익명 취향 연결. */
+export const registerEmail = (email: string, password: string) =>
+  authPost("/api/fomo/auth/register", email, password);
+
+/** 이메일+비밀번호 로그인 → JWT 저장 + 익명 취향 연결. */
+export const loginEmail = (email: string, password: string) =>
+  authPost("/api/fomo/auth/login", email, password);
+
+/** 로그아웃 — 토큰만 제거(서버 상태 없음). */
+export function logout(): void {
+  clearToken();
+}
+
+/** 탈퇴 — 계정·취향 신호 삭제(서버 CASCADE) 후 토큰 제거. */
+export async function deleteAccount(): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/fomo/account`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`delete ${res.status}`);
+  clearToken();
 }

--- a/apps/web/app/api/fomo/account/route.ts
+++ b/apps/web/app/api/fomo/account/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "../../../../lib/prisma";
+import { corsJson, withCors } from "../../../../lib/fomo";
+import { extractBearerToken, verifyToken } from "@/lib/auth/jwt";
+
+export const dynamic = "force-dynamic";
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+// 트랙 B — 탈퇴(개인정보 게이트 최소 동작). 유저 삭제 시 TasteSignal 은 FK ON DELETE CASCADE 로 함께 삭제.
+// 처리방침의 "탈퇴 시 데이터 삭제" 약속을 코드로 보장.
+export async function DELETE(req: NextRequest) {
+  const userId = verifyToken(extractBearerToken(req.headers.get("authorization")) ?? "");
+  if (!userId) {
+    return corsJson({ error: "로그인이 필요해.", code: "NO_TOKEN" }, { status: 401 });
+  }
+  try {
+    await prisma.user.delete({ where: { id: userId } });
+    return corsJson({ ok: true });
+  } catch (err) {
+    console.warn("[fomo/account] delete error", err);
+    return corsJson({ error: "탈퇴 처리에 실패했어.", code: "DELETE_ERROR" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/fomo/auth/login/route.ts
+++ b/apps/web/app/api/fomo/auth/login/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "../../../../../lib/prisma";
+import { corsJson, withCors } from "../../../../../lib/fomo";
+import { issueToken } from "@/lib/auth/jwt";
+
+export const dynamic = "force-dynamic";
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+// 트랙 B — 이메일+비밀번호 로그인. 소셜은 추후 provider 분기로 확장(User.authProvider 그릇 준비됨).
+// 보안: 이메일 존재 여부를 노출하지 않게 실패 메시지를 통일(계정 열거 방지).
+interface Body {
+  email?: string;
+  password?: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as Body;
+    const email = body.email?.trim().toLowerCase();
+    const password = body.password ?? "";
+    if (!email || !password) {
+      return corsJson({ error: "이메일과 비밀번호를 입력해줘.", code: "MISSING" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    const ok = user?.passwordHash ? await bcrypt.compare(password, user.passwordHash) : false;
+    if (!user || !ok) {
+      return corsJson({ error: "이메일 또는 비밀번호가 맞지 않아.", code: "BAD_CREDENTIALS" }, { status: 401 });
+    }
+
+    const token = issueToken(user.id);
+    return corsJson({ token, user: { id: user.id, displayName: user.displayName, isNew: false } });
+  } catch (err) {
+    console.warn("[fomo/auth/login] error", err);
+    return corsJson({ error: "로그인에 실패했어. 잠시 후 다시 시도해줘.", code: "LOGIN_ERROR" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/fomo/auth/register/route.ts
+++ b/apps/web/app/api/fomo/auth/register/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "../../../../../lib/prisma";
+import { corsJson, withCors } from "../../../../../lib/fomo";
+import { issueToken } from "@/lib/auth/jwt";
+
+export const dynamic = "force-dynamic";
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+// 트랙 B — 이메일+비밀번호 가입. JWT(issueToken)·User.passwordHash 재사용.
+// 소셜 로그인 확장성: User.authProvider/authProviderId 필드가 이미 있어, 추후 구글/카카오는
+// 별도 분기(provider 경로)로 같은 User 그릇에 얹는다 — 지금은 email+password 만.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD = 8;
+
+interface Body {
+  email?: string;
+  password?: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as Body;
+    const email = body.email?.trim().toLowerCase();
+    const password = body.password ?? "";
+
+    if (!email || !EMAIL_RE.test(email)) {
+      return corsJson({ error: "올바른 이메일을 입력해줘.", code: "BAD_EMAIL" }, { status: 400 });
+    }
+    if (password.length < MIN_PASSWORD) {
+      return corsJson({ error: `비밀번호는 ${MIN_PASSWORD}자 이상이어야 해.`, code: "WEAK_PASSWORD" }, { status: 400 });
+    }
+
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return corsJson({ error: "이미 가입된 이메일이야. 로그인해줘.", code: "EMAIL_TAKEN" }, { status: 409 });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({ data: { email, passwordHash } });
+    const token = issueToken(user.id);
+
+    return corsJson({ token, user: { id: user.id, displayName: user.displayName, isNew: true } });
+  } catch (err) {
+    console.warn("[fomo/auth/register] error", err);
+    return corsJson({ error: "가입에 실패했어. 잠시 후 다시 시도해줘.", code: "REGISTER_ERROR" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/fomo/taste/link/route.ts
+++ b/apps/web/app/api/fomo/taste/link/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "../../../../../lib/prisma";
+import { corsJson, withCors } from "../../../../../lib/fomo";
+import { extractBearerToken, verifyToken } from "@/lib/auth/jwt";
+
+export const dynamic = "force-dynamic";
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+interface LinkBody {
+  sessionId?: string;
+}
+
+// 트랙 B — 로그인 직후 익명 sessionId 로 쌓인 취향 신호를 내 계정으로 연결(가입 전 학습 보존).
+// emotions/link 와 동형. 아직 주인 없는(userId null) 행만 연결 — 이미 다른 유저에 묶인 건 안 건드림.
+export async function POST(req: NextRequest) {
+  const userId = verifyToken(extractBearerToken(req.headers.get("authorization")) ?? "");
+  if (!userId) {
+    return corsJson({ error: "로그인이 필요해.", code: "NO_TOKEN" }, { status: 401 });
+  }
+  try {
+    const body = (await req.json().catch(() => ({}))) as LinkBody;
+    const sessionId = body.sessionId?.trim();
+    if (!sessionId) {
+      return corsJson({ error: "sessionId 필요", code: "MISSING_SESSION" }, { status: 400 });
+    }
+    const result = await prisma.tasteSignal.updateMany({
+      where: { sessionId, userId: null },
+      data: { userId, sessionId: null },
+    });
+    return corsJson({ ok: true, linked: result.count });
+  } catch (err) {
+    console.warn("[fomo/taste/link] error", err);
+    return corsJson({ error: "연결 실패", code: "LINK_ERROR" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
트랙 B 토대 2/2 — **로그인 작동 + 유저별 취향 적재 완성**. 비로그인 둘러보기 불변, 스와이프 UX 불변.

## 변경
**apps/web (인증 — `issueToken`/`bcryptjs`/`User` 재사용, 새 프레임워크 X)**
- `POST /api/fomo/auth/register` — 이메일+비번(≥8) 가입, bcrypt 해시, JWT.
- `POST /api/fomo/auth/login` — bcrypt 검증, JWT. 계정 열거 방지(실패 메시지 통일).
- `POST /api/fomo/taste/link` — 로그인 직후 익명 `sessionId` 취향을 `userId`로 연결(`emotions/link` 동형).
- `DELETE /api/fomo/account` — 탈퇴 → User 삭제, `TasteSignal` CASCADE.

**apps/fomo-web**
- `fomoApi`: `registerEmail`/`loginEmail`(성공 시 `setToken`+`linkTaste` 자동), `logout`, `deleteAccount`.
- `AuthSheet`: 최소 로그인/가입/계정 시트. **화면·카피·약관은 임시(광혁 영역)**.
- HomeView 헤더 로그인/내 계정 버튼(기존 `loggedIn`/`onLoggedIn` 재사용).
- `/privacy`: 임시 최소 처리방침(법적 최종본 광혁) — "없이 수집 금지" 충족.

## 설계 메모
- **소셜 확장성 유지**: `User.authProvider`/`authProviderId` 그릇 그대로 → 추후 구글/카카오는 provider 분기로 같은 User에 얹음(이번엔 email+password).

## 검증
- typecheck · `build:web`(auth 4라우트 빌드) · `@fomo/web` build(/privacy) green.
- ⚠️ 로그인 자체는 `User` 테이블이라 **배포 즉시 작동**(머지 후 prod 스모크 예정). taste 적재/연결 라이브는 **prod DDL(TasteSignal) 적용 후** — 광혁: `npx prisma db push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)