### PR TITLE
feat(stock): 종목 기본정보(바닥) 항상 표시 — 주가·개요·시총·재무 + 쉬운 번역

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useState } from "react";
 import { scoreToColor, cleanText, cleanQuote, communityWordings, type KeywordCard } from "@fomo/core";
-import { fetchThemeInsight, fetchStockInsight, recordTaste, type CondensedInsight } from "@/lib/fomoApi";
+import {
+  fetchThemeInsight,
+  fetchStockInsight,
+  fetchStockBasics,
+  recordTaste,
+  type CondensedInsight,
+  type StockBasics,
+} from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
 /**
@@ -303,6 +310,98 @@ export interface StockContext {
   fromTheme?: string;
 }
 
+/**
+ * 종목 기본 정보 블록(바닥) — 항상 렌더. 주가·회사개요·시총·핵심지표·연간 재무.
+ * "정확한 숫자 + 쉬운 라벨"(EPS→'한 주가 번 돈') 둘 다. 없는 값은 생략(가짜 금지), 추정치·출처 표기.
+ */
+function StockBasicsBlock({ basics }: { basics: StockBasics | null }) {
+  if (!basics) {
+    return (
+      <div className="space-y-2" aria-busy="true">
+        <div className="h-8 w-1/2 animate-pulse rounded bg-surface" />
+        <div className="h-14 animate-pulse rounded-lg border border-hairline bg-surface" />
+      </div>
+    );
+  }
+  const up = basics.changeDir === "up";
+  const down = basics.changeDir === "down";
+  const empty = !basics.priceText && basics.metrics.length === 0 && !basics.financials && !basics.summary;
+  return (
+    <section>
+      {basics.priceText && (
+        <div className="flex items-baseline gap-2">
+          <span className="font-pixel text-3xl text-whiteout">{basics.priceText}</span>
+          {basics.changeText && (
+            <span className="text-sm" style={up || down ? { color: up ? "#ff5a5f" : "#4f8cff" } : undefined}>
+              {up ? "▲" : down ? "▼" : ""} {basics.changeText}
+            </span>
+          )}
+        </div>
+      )}
+      {(basics.market || basics.marketCap || basics.sector) && (
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted">
+          {basics.market && <span>{basics.market}</span>}
+          {basics.marketCap && <span>시총 {basics.marketCap}</span>}
+          {basics.sector && <span>{cleanText(basics.sector)}</span>}
+        </div>
+      )}
+      {basics.summary && <p className="mt-3 text-sm leading-6 text-muted">{cleanText(basics.summary)}</p>}
+
+      {basics.metrics.length > 0 && (
+        <ul className="mt-4 grid grid-cols-2 gap-2">
+          {basics.metrics.map((m, i) => (
+            <li key={`m-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+              <span className="block text-[11px] text-muted">
+                {m.label}
+                {m.term ? <span className="text-muted/70"> · {m.term}</span> : null}
+              </span>
+              <span className="mt-0.5 block text-sm text-whiteout">{m.value}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {basics.financials && (
+        <div className="mt-5">
+          <p className="font-pixel text-sm text-whiteout">실적 흐름</p>
+          <div className="mt-2 overflow-x-auto">
+            <table className="w-full text-[12px]">
+              <thead>
+                <tr className="text-muted">
+                  <th className="py-1 text-left font-normal"> </th>
+                  {basics.financials.periods.map((p, i) => (
+                    <th key={`p-${i}`} className="px-2 py-1 text-right font-normal">
+                      {p.title}
+                      {p.estimate ? <span className="text-[10px]"> (E)</span> : null}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {basics.financials.rows.map((r, ri) => (
+                  <tr key={`r-${ri}`} className="border-t border-hairline">
+                    <td className="py-1.5 text-left text-muted">{r.label}</td>
+                    {r.values.map((v, vi) => (
+                      <td key={`v-${vi}`} className="px-2 py-1.5 text-right text-whiteout">{v}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-1 text-[10px] leading-4 text-muted">(E)=컨센서스 추정치 · 출처: 네이버 금융</p>
+        </div>
+      )}
+
+      {empty && (
+        <p className="text-sm leading-6 text-muted">
+          이 종목 기본 정보는 아직 연결 전이야(해외·신규 상장 등). 아래 흐름으로 봐줘.
+        </p>
+      )}
+    </section>
+  );
+}
+
 export function StockInsightView({
   stock,
   context,
@@ -314,11 +413,18 @@ export function StockInsightView({
 }) {
   const [insight, setInsight] = useState<CondensedInsight | null>(null);
   const [loading, setLoading] = useState(true);
+  // 기본 정보(바닥) — 원문 무관 객관 사실. 빠른 네이버 fetch라 해석(LLM)과 분리해 먼저 깐다.
+  const [basics, setBasics] = useState<StockBasics | null>(null);
 
   useEffect(() => {
     let alive = true;
     setLoading(true);
     setInsight(null);
+    setBasics(null);
+    // 기본 정보(빠름) + 이해 레이어(느림 LLM) 병렬 — 각자 도착하는 대로 표시(빈 화면 박멸).
+    fetchStockBasics(stock)
+      .then((r) => alive && setBasics(r))
+      .catch(() => alive && setBasics(null));
     fetchStockInsight(stock)
       .then((r) => alive && setInsight(r))
       .catch(() => alive && setInsight(null))
@@ -368,11 +474,15 @@ export function StockInsightView({
         </div>
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
+          {/* 바닥 — 기본 정보는 원문 무관 객관 사실이라 항상 먼저 깐다(빈 화면 박멸). */}
+          <StockBasicsBlock basics={basics} />
+
+          {/* 그 위 — 강세/약세 해석(원문 grounded, 있을 때만). LLM 이라 따로 로딩. */}
           {loading ? (
-            <FullPageLoading estimateMs={LOADING_PRESETS.stock.estimateMs} steps={LOADING_PRESETS.stock.steps} />
+            <p className="mt-7 text-sm leading-6 text-muted">강세·약세 관점을 읽고 있어…</p>
           ) : (
           <>
-          <section>
+          <section className="mt-7">
             <p className="font-pixel text-sm text-whiteout">왜 같이 움직였나</p>
             {/* 들어온 맥락(연관 근거) — stock-insight 가 부족해도 항상 보여준다(빈 화면 금지). */}
             {context?.reason && (

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -103,6 +103,13 @@ export const fetchStockInsight = (stock: string) =>
     `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`
   );
 
+/** 종목 기본 정보(바닥 — 주가·개요·시총·지표·재무). 항상 깔린다(원문 무관). */
+export type { StockBasics } from "@fomo/core";
+export const fetchStockBasics = (stock: string) =>
+  get<import("@fomo/core").StockBasics>(
+    `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}`
+  );
+
 export const fetchCalendar = (sessionId: string, month?: string) =>
   get<CalendarResponse>(
     `/api/fomo/emotions/calendar?sessionId=${encodeURIComponent(sessionId)}${month ? `&month=${month}` : ""}`

--- a/apps/web/app/api/fomo/stock-basics/route.ts
+++ b/apps/web/app/api/fomo/stock-basics/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import type { StockBasics } from "@fomo/core";
+import { withCors, kstDate } from "../../../../lib/fomo";
+import { fetchStockBasics } from "../../../../lib/stock-basics";
+
+/**
+ * 종목 기본 정보(바닥) API — STOCK_SCREEN_REDESIGN. 읽기 전용.
+ * 주가·회사개요·시총·핵심지표·연간 재무 = DB 객관 사실(원문 grounding 무관) → 항상 깔리는 바닥.
+ * (KST날짜, 종목) 캐시로 네이버 호출 절약. 정직: 없는 값은 omit(가짜 숫자 금지).
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+const REVALIDATE_S = 21_600; // 6h (가격은 약간 지연 허용 — 바닥 정보 안정성 우선, SWR)
+const inflight = new Map<string, Promise<StockBasics>>();
+
+async function getBasics(stock: string): Promise<StockBasics> {
+  const today = kstDate();
+  const key = `${today}:${stock}`;
+  const running = inflight.get(key);
+  if (running) return running;
+
+  const load = unstable_cache(
+    async () => fetchStockBasics(stock),
+    ["fomo-stock-basics", today, stock],
+    { revalidate: REVALIDATE_S }
+  );
+  const p = load().finally(() => inflight.delete(key));
+  inflight.set(key, p);
+  return p;
+}
+
+export async function GET(req: Request) {
+  const stock = new URL(req.url).searchParams.get("stock")?.trim();
+  if (!stock) {
+    return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
+  }
+  const payload = await getBasics(stock);
+  return withCors(
+    NextResponse.json(payload, {
+      headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=1800" },
+    })
+  );
+}

--- a/apps/web/lib/stock-basics.ts
+++ b/apps/web/lib/stock-basics.ts
@@ -1,0 +1,48 @@
+import { assembleStockBasics, resolveStock, type StockBasics } from "@fomo/core";
+
+/**
+ * 종목 기본 정보(바닥) 수집 — STOCK_SCREEN_REDESIGN §2.
+ * 출처: 네이버 금융 종목 API(m.stock.naver.com/api/stock/{code}/*) — 이미 쓰는 무료·무인증 출처.
+ *   · basic         → 주가·등락·시장
+ *   · integration   → 시총·PER/EPS/PBR/배당/52주
+ *   · finance/annual→ 회사개요·연간 매출/영업이익/순이익(추정치 구분)
+ * 종목명 → 코드: STOCK_VOCAB(resolveStock).naverCode 재사용. 코드 없으면(미국주 등) 기본만(정직).
+ * 파싱·번역은 fomo-core 순수부(assembleStockBasics). 여긴 fetch·조립만.
+ */
+
+const UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+
+async function getJson(url: string): Promise<unknown> {
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": UA, Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      console.warn("[stock-basics] non-OK", res.status, url);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.warn("[stock-basics] fetch failed", url, (err as Error)?.message);
+    return null;
+  }
+}
+
+/** 종목명으로 기본 정보. 코드 해석 실패(미등록/미국주) → name 만(빈 화면 대신 최소 보장). */
+export async function fetchStockBasics(stock: string): Promise<StockBasics> {
+  const def = resolveStock(stock);
+  const code = def?.naverCode;
+  if (!code) {
+    // 국내 코드 없음 → 네이버 종목 API 경로 없음. 정직하게 이름만(상위에서 수급/해석으로 보완).
+    return { name: def?.canonical ?? stock, metrics: [] };
+  }
+  const base = `https://m.stock.naver.com/api/stock/${encodeURIComponent(code)}`;
+  const [basic, integration, finance] = await Promise.all([
+    getJson(`${base}/basic`),
+    getJson(`${base}/integration`),
+    getJson(`${base}/finance/annual`),
+  ]);
+  return assembleStockBasics(def?.canonical ?? stock, basic, integration, finance);
+}

--- a/packages/fomo-core/__tests__/stock-basics.test.ts
+++ b/packages/fomo-core/__tests__/stock-basics.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseNaverStockBasic,
+  parseNaverTotalInfos,
+  parseNaverFinanceAnnual,
+  assembleStockBasics,
+  formatEok,
+} from "../src";
+
+describe("formatEok — 억원 → 친구 단위(조/억)", () => {
+  it("조 단위 변환", () => {
+    expect(formatEok("3,336,059")).toBe("333.6조"); // 삼성 매출 ≈ 333조
+    expect(formatEok("436,011")).toBe("43.6조");
+  });
+  it("억 단위 유지", () => {
+    expect(formatEok("4,360")).toBe("4,360억");
+  });
+  it("음수·결측 안전", () => {
+    expect(formatEok("-1,200")).toBe("-1,200억");
+    expect(formatEok("N/A")).toBeNull();
+  });
+});
+
+describe("parseNaverStockBasic — 주가·등락(객관 사실)", () => {
+  it("현재가·등락·시장·방향", () => {
+    const r = parseNaverStockBasic({
+      stockName: "삼성전자",
+      stockExchangeName: "코스피",
+      closePrice: "362,500",
+      fluctuationsRatio: "0.55",
+      compareToPreviousClosePrice: "2,000",
+    });
+    expect(r.priceText).toBe("362,500원");
+    expect(r.changeText).toContain("2,000");
+    expect(r.changeText).toContain("0.55%");
+    expect(r.changeDir).toBe("up");
+    expect(r.market).toBe("코스피");
+  });
+  it("하락 방향", () => {
+    expect(parseNaverStockBasic({ closePrice: "100", fluctuationsRatio: "-1.2", compareToPreviousClosePrice: "-5" }).changeDir).toBe("down");
+  });
+});
+
+describe("parseNaverTotalInfos — 시총·핵심지표(쉬운 라벨 + 정확 값 + 보조 용어)", () => {
+  const json = {
+    totalInfos: [
+      { key: "시총", value: "2,069조 5,826억" },
+      { key: "PER", value: "28.61배" },
+      { key: "EPS", value: "12,372원" },
+      { key: "PBR", value: "4.92배" },
+      { key: "52주 최고", value: "380,000" },
+      { key: "외인소진율", value: "47.62%" },
+    ],
+  };
+  it("시총 추출", () => {
+    expect(parseNaverTotalInfos(json).marketCap).toBe("2,069조 5,826억");
+  });
+  it("PER/EPS 는 쉬운 라벨 + 정확 값 + 보조 용어(term)", () => {
+    const m = parseNaverTotalInfos(json).metrics;
+    const per = m.find((x) => x.term === "PER");
+    const eps = m.find((x) => x.term === "EPS");
+    expect(per?.value).toBe("28.61배");
+    expect(eps?.label).toContain("번 돈"); // 쉬운 라벨
+    expect(eps?.value).toBe("12,372원"); // 정확 값
+  });
+  it("없는 지표는 채우지 않음(가짜 금지)", () => {
+    const m = parseNaverTotalInfos({ totalInfos: [{ key: "PER", value: "-" }] }).metrics;
+    expect(m.find((x) => x.term === "PER")).toBeUndefined(); // "-" 는 제외
+  });
+});
+
+describe("parseNaverFinanceAnnual — 연간 재무(추정치 구분, 결측 미채움)", () => {
+  const json = {
+    corporationSummary: "반도체와 디스플레이를 만드는 회사.",
+    financeInfo: {
+      trTitleList: [
+        { title: "2024.12.", key: "202412", isConsensus: "N" },
+        { title: "2025.12.", key: "202512", isConsensus: "N" },
+        { title: "2026.12.", key: "202612", isConsensus: "Y" },
+      ],
+      rowList: [
+        { title: "매출액", columns: { "202412": { value: "3,008,709" }, "202512": { value: "3,336,059" }, "202612": { value: "7,004,880" } } },
+        { title: "영업이익", columns: { "202412": { value: "327,259" }, "202512": { value: "436,011" }, "202612": { value: "3,631,658" } } },
+      ],
+    },
+  };
+  it("회사개요 + 매출/영업이익 행 + 친구단위 변환", () => {
+    const r = parseNaverFinanceAnnual(json);
+    expect(r.summary).toContain("반도체");
+    expect(r.financials?.rows.find((x) => x.label.includes("매출"))?.values[1]).toBe("333.6조");
+  });
+  it("추정 기간은 estimate=true", () => {
+    const r = parseNaverFinanceAnnual(json);
+    expect(r.financials?.periods[2]).toMatchObject({ title: "2026.12", estimate: true });
+    expect(r.financials?.periods[0].estimate).toBe(false);
+  });
+  it("재무 없으면 financials 생략(빈 객체에도 안전)", () => {
+    expect(parseNaverFinanceAnnual({}).financials).toBeUndefined();
+  });
+});
+
+describe("assembleStockBasics — 기본 정보는 항상(원문 무관), name 최소 보장", () => {
+  it("세 소스 합치고, 비어도 name + metrics 배열은 보장(빈 화면 박멸)", () => {
+    const b = assembleStockBasics("저스템", {}, {}, {});
+    expect(b.name).toBe("저스템");
+    expect(Array.isArray(b.metrics)).toBe(true); // 항상 배열(없으면 빈 배열)
+  });
+});

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./calendar";
 export * from "./insights";
 export * from "./sanitize";
 export * from "./supply-demand";
+export * from "./stock-basics";
 export * from "./banner";
 export * from "./markets";
 export * from "./mood-signals";

--- a/packages/fomo-core/src/stock-basics.ts
+++ b/packages/fomo-core/src/stock-basics.ts
@@ -1,0 +1,199 @@
+/**
+ * 종목 기본 정보(바닥) — STOCK_SCREEN_REDESIGN. 순수(네트워크 0).
+ *
+ * 인식 전환: 주가·시총·재무·회사개요는 *DB 객관 사실*이라 원문 grounding 대상이 아니다.
+ * 항상 깔리는 바닥. 강세/약세 "해석"만 원문 grounded(별도 레이어). 토스 구조와 동일.
+ *
+ * 여기 함수들은 네이버 금융 JSON(이미 쓰는 무료·무인증 출처)을 *파싱·번역*만 한다(fetch 는 apps/web).
+ * 정직 원칙: 없는 값은 omit(가짜 숫자 금지). 추정치는 estimate 플래그로 구분.
+ * "쉽게" 정체성: 정확한 숫자 + 친구 말투 번역(전문용어는 보조 라벨로만 — types.ts 전문용어 금지 존중).
+ */
+
+export interface StockMetric {
+  /** 쉬운 라벨(주력 표기) — 예 "한 주가 번 돈". */
+  label: string;
+  /** 정확한 값(숫자, 단위 포함) — 예 "12,372원". */
+  value: string;
+  /** 보조 용어(작게) — 예 "EPS". 초보는 label 을, 고급은 term 을 본다. */
+  term?: string;
+}
+
+export interface StockFinancialRow {
+  /** 쉬운 항목명 — 예 "벌어들인 돈(매출)". */
+  label: string;
+  /** 기간별 값(친구 단위로 포맷). periods 순서와 매칭. */
+  values: string[];
+}
+
+export interface StockFinancials {
+  periods: { title: string; estimate: boolean }[];
+  rows: StockFinancialRow[];
+}
+
+export interface StockBasics {
+  name: string;
+  /** 거래소/시장 — 예 "코스피". */
+  market?: string;
+  /** 현재가 — 예 "362,500원". */
+  priceText?: string;
+  /** 등락 — 예 "2,000 (0.55%)" (부호·색은 UI). */
+  changeText?: string;
+  changeDir?: "up" | "down" | "flat";
+  /** 시가총액 — 네이버 친구 표기 그대로 "2,069조 5,826억". */
+  marketCap?: string;
+  /** 섹터/산업명. */
+  sector?: string;
+  /** 회사 개요(1~2줄). */
+  summary?: string;
+  /** 핵심 지표(PER/EPS/PBR/배당/52주 등) — 쉬운 라벨 + 정확 값. */
+  metrics: StockMetric[];
+  /** 연간 재무(매출·영업이익·순이익 등). 없으면 undefined. */
+  financials?: StockFinancials;
+}
+
+const num = (s: string): number | null => {
+  const cleaned = String(s).replace(/[^\d.-]/g, "");
+  if (!/\d/.test(cleaned)) return null; // 숫자 없음("N/A"·"-") → null(0 으로 둔갑 금지)
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+};
+
+/** 억원 문자열("3,336,059") → 친구 단위("333.6조" / "4,360억"). 음수·결측 안전. */
+export function formatEok(value: string): string | null {
+  const n = num(value);
+  if (n === null) return null;
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  if (abs >= 10000) {
+    const jo = Math.round((abs / 10000) * 10) / 10; // 0.1조 단위 반올림
+    const joStr = Number.isInteger(jo) ? jo.toLocaleString() : jo.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+    return `${sign}${joStr}조`;
+  }
+  return `${sign}${Math.round(abs).toLocaleString()}억`;
+}
+
+/** 네이버 stock/{code}/basic → 주가·등락·시장. */
+export function parseNaverStockBasic(json: unknown): Partial<StockBasics> {
+  const d = (json ?? {}) as Record<string, unknown>;
+  const out: Partial<StockBasics> = {};
+  if (typeof d.stockName === "string") out.name = d.stockName;
+  if (typeof d.stockExchangeName === "string") out.market = d.stockExchangeName;
+  const close = d.closePrice;
+  if (typeof close === "string" && close.trim()) out.priceText = `${close}원`;
+  const ratio = d.fluctuationsRatio;
+  const change = d.compareToPreviousClosePrice ?? d.compareToPreviousPrice;
+  if (change !== undefined && change !== null && `${change}`.trim()) {
+    const r = ratio !== undefined && ratio !== null ? ` (${ratio}%)` : "";
+    out.changeText = `${`${change}`.replace(/^-/, "")}${r}`;
+  }
+  const code = typeof d.compareToPreviousClosePrice === "object" ? null : null; // (구조 변동 방어)
+  void code;
+  // 방향: code/부호 — compareToPreviousPrice 의 부호 또는 ratio 부호.
+  const rNum = num(`${ratio ?? ""}`);
+  const cNum = num(`${change ?? ""}`);
+  const basis = cNum ?? rNum;
+  out.changeDir = basis === null || basis === 0 ? "flat" : basis > 0 ? "up" : "down";
+  return out;
+}
+
+/** totalInfos 항목(key→value) 추출 + 핵심 지표를 쉬운 라벨로. */
+export function parseNaverTotalInfos(json: unknown): { marketCap?: string; metrics: StockMetric[] } {
+  const d = (json ?? {}) as Record<string, unknown>;
+  const infos = Array.isArray(d.totalInfos) ? (d.totalInfos as Record<string, unknown>[]) : [];
+  const by = new Map<string, string>();
+  for (const t of infos) {
+    const k = typeof t.key === "string" ? t.key : "";
+    const v = t.value;
+    if (k && (typeof v === "string" || typeof v === "number")) by.set(k, `${v}`);
+  }
+  const metrics: StockMetric[] = [];
+  const push = (key: string, label: string, term?: string) => {
+    const v = by.get(key);
+    if (v && v.trim() && v !== "-" && v !== "N/A") metrics.push(term ? { label, value: v, term } : { label, value: v });
+  };
+  // 쉬운 라벨 + 보조 용어(작게). 정확한 값은 네이버 표기 그대로.
+  push("PER", "지금 주가는 이익의", "PER"); // 값 "28.61배" → "이익의 28.61배 수준"
+  push("EPS", "한 주가 번 돈", "EPS");
+  push("PBR", "자산 가치 대비", "PBR");
+  push("배당수익률", "배당 수익률", "배당수익률");
+  push("주당배당금", "한 주당 배당금", "주당배당금");
+  push("52주 최고", "최근 1년 최고가");
+  push("52주 최저", "최근 1년 최저가");
+  push("외인소진율", "외국인이 가진 비율", "외인소진율");
+  const out: { marketCap?: string; metrics: StockMetric[] } = { metrics };
+  const cap = by.get("시총");
+  if (cap && cap.trim()) out.marketCap = cap;
+  return out;
+}
+
+/** finance/annual → 회사개요 + 연간 재무(매출·영업이익·순이익 중심, 추정치 구분). */
+export function parseNaverFinanceAnnual(json: unknown): {
+  summary?: string;
+  financials?: StockFinancials;
+} {
+  const d = (json ?? {}) as Record<string, unknown>;
+  const out: { summary?: string; financials?: StockFinancials } = {};
+  const cs = d.corporationSummary;
+  if (typeof cs === "string" && cs.trim()) out.summary = cs.trim();
+  else if (cs && typeof cs === "object") {
+    const t = (cs as Record<string, unknown>).summary ?? (cs as Record<string, unknown>).text;
+    if (typeof t === "string" && t.trim()) out.summary = t.trim();
+  }
+
+  const fi = (d.financeInfo ?? {}) as Record<string, unknown>;
+  const trList = Array.isArray(fi.trTitleList) ? (fi.trTitleList as Record<string, unknown>[]) : [];
+  const rowList = Array.isArray(fi.rowList) ? (fi.rowList as Record<string, unknown>[]) : [];
+  if (trList.length === 0 || rowList.length === 0) return out;
+
+  const periods = trList.map((t) => ({
+    title: typeof t.title === "string" ? t.title.replace(/\.$/, "") : "",
+    estimate: t.isConsensus === "Y",
+    key: typeof t.key === "string" ? t.key : "",
+  }));
+
+  // 쉬운 항목명(주력) — 네이버 원항목명은 보조. 매출·영업이익·순이익만(바닥 핵심).
+  const WANT: { match: string; label: string }[] = [
+    { match: "매출액", label: "벌어들인 돈(매출)" },
+    { match: "영업이익", label: "남긴 돈(영업이익)" },
+    { match: "당기순이익", label: "최종 이익(순이익)" },
+  ];
+  const rows: StockFinancialRow[] = [];
+  for (const want of WANT) {
+    const r = rowList.find((x) => typeof x.title === "string" && (x.title as string).includes(want.match));
+    if (!r) continue;
+    const cols = (r.columns ?? {}) as Record<string, { value?: string }>;
+    const values = periods.map((p) => {
+      const raw = cols[p.key]?.value;
+      return raw ? formatEok(raw) ?? raw : "—";
+    });
+    // 전부 결측이면 행 자체를 넣지 않는다(가짜로 안 채움).
+    if (values.some((v) => v !== "—")) rows.push({ label: want.label, values });
+  }
+  if (rows.length > 0) {
+    out.financials = { periods: periods.map((p) => ({ title: p.title, estimate: p.estimate })), rows };
+  }
+  return out;
+}
+
+/** 세 소스 파싱 결과를 StockBasics 로 합친다. name 은 최소 보장(없으면 fallback). */
+export function assembleStockBasics(
+  name: string,
+  basic: unknown,
+  integration: unknown,
+  financeAnnual: unknown
+): StockBasics {
+  const b = parseNaverStockBasic(basic);
+  const ti = parseNaverTotalInfos(integration);
+  const fa = parseNaverFinanceAnnual(financeAnnual);
+  return {
+    name: b.name || name,
+    ...(b.market ? { market: b.market } : {}),
+    ...(b.priceText ? { priceText: b.priceText } : {}),
+    ...(b.changeText ? { changeText: b.changeText } : {}),
+    ...(b.changeDir ? { changeDir: b.changeDir } : {}),
+    ...(ti.marketCap ? { marketCap: ti.marketCap } : {}),
+    ...(fa.summary ? { summary: fa.summary } : {}),
+    metrics: ti.metrics,
+    ...(fa.financials ? { financials: fa.financials } : {}),
+  };
+}


### PR DESCRIPTION
종목 화면 재설계(STOCK_SCREEN_REDESIGN). 순서 교정: **기본 정보(객관 사실) = 항상 깔리는 바닥**, 강세/약세 해석(원문 grounded) = 그 위 레이어. 원문 적어도 빈 화면 안 뜸.

## 데이터 소스 (승인됨)
네이버 금융 종목 API(이미 쓰는 무료·무인증) — `basic`(주가) / `integration`(시총·PER/EPS/PBR/배당/52주) / `finance/annual`(회사개요·매출/영업이익/순이익, 추정치 구분). **prod DDL 없음**(unstable_cache 6h).

## 변경
- `fomo-core/stock-basics.ts`(순수): `parseNaverStockBasic`/`TotalInfos`/`FinanceAnnual` + `assembleStockBasics` + `formatEok`(억→조). **정확 숫자 + 쉬운 라벨**(EPS→"한 주가 번 돈", PER→"이익의 N배") + 보조 용어. 없는 값 omit(가짜 금지), 추정치 `estimate` 플래그.
- `apps/web`: `lib/stock-basics.ts`(네이버 fetch, 코드=`resolveStock.naverCode` 재사용) + `/api/fomo/stock-basics` 라우트.
- `fomo-web`: `fetchStockBasics` + `StockBasicsBlock`(StockInsightView 에 항상 렌더, 해석과 **병렬 로드** — 기본정보 도착 즉시 표시, LLM 안 기다림). 구조: 기본정보(항상)→해석(있으면)→연관주.

## 원칙
기본정보=사실이라 항상 / 해석=grounded라 있을 때만. 시점·출처(네이버) 명시. 투자조언·단정 금지.

## 검증
테스트 +12 → **701 통과**(파서·formatEok·추정구분·결측 미채움·assemble 최소보장). typecheck·build:web·@fomo/web build green. ⚠️ 배포 후 prod 라이브 재확인(저스템·HLB 기본정보 항상 뜨는지). 미국주(naverCode 없음)는 기본정보 생략 — 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)