### PR TITLE
fix(stock): 저스템 종목코드 정정(잘못된 회사 데이터) + 회사개요 추출

### DIFF
--- a/packages/fomo-core/__tests__/stock-basics.test.ts
+++ b/packages/fomo-core/__tests__/stock-basics.test.ts
@@ -97,6 +97,12 @@ describe("parseNaverFinanceAnnual — 연간 재무(추정치 구분, 결측 미
   it("재무 없으면 financials 생략(빈 객체에도 안전)", () => {
     expect(parseNaverFinanceAnnual({}).financials).toBeUndefined();
   });
+  it("회사개요 dict(comment1/2/3) 형태도 합쳐서 추출", () => {
+    const r = parseNaverFinanceAnnual({
+      corporationSummary: { comment1: "1969년 설립된 전자 기업.", comment2: "메모리·파운드리 사업.", comment3: "" },
+    });
+    expect(r.summary).toBe("1969년 설립된 전자 기업. 메모리·파운드리 사업.");
+  });
 });
 
 describe("assembleStockBasics — 기본 정보는 항상(원문 무관), name 최소 보장", () => {

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -80,7 +80,7 @@ export const STOCK_VOCAB: readonly StockDef[] = [
   // 반도체 소부장/연관 — 발굴(discover)에서 자주 뜨는 실상장 종목(티커 검증된 것만 보강).
   { canonical: "삼성전기", aliases: ["삼성전기"], market: "KOSPI", country: "KR", naverCode: "009150" },
   { canonical: "DB하이텍", aliases: ["DB하이텍"], market: "KOSPI", country: "KR", naverCode: "000990" },
-  { canonical: "저스템", aliases: ["저스템"], market: "KOSDAQ", country: "KR", naverCode: "417180" },
+  { canonical: "저스템", aliases: ["저스템"], market: "KOSDAQ", country: "KR", naverCode: "417840" },
   { canonical: "네패스", aliases: ["네패스"], market: "KOSDAQ", country: "KR", naverCode: "033640" },
   { canonical: "원익IPS", aliases: ["원익IPS"], market: "KOSDAQ", country: "KR", naverCode: "240810" },
   { canonical: "동진쎄미켐", aliases: ["동진쎄미켐"], market: "KOSDAQ", country: "KR", naverCode: "005290" },

--- a/packages/fomo-core/src/stock-basics.ts
+++ b/packages/fomo-core/src/stock-basics.ts
@@ -136,8 +136,17 @@ export function parseNaverFinanceAnnual(json: unknown): {
   const cs = d.corporationSummary;
   if (typeof cs === "string" && cs.trim()) out.summary = cs.trim();
   else if (cs && typeof cs === "object") {
-    const t = (cs as Record<string, unknown>).summary ?? (cs as Record<string, unknown>).text;
-    if (typeof t === "string" && t.trim()) out.summary = t.trim();
+    // 네이버: corporationSummary = { comment1, comment2, comment3, ... } (회사개요 문장들).
+    const o = cs as Record<string, unknown>;
+    const comments = Object.keys(o)
+      .filter((k) => /^comment\d+$/.test(k))
+      .sort()
+      .map((k) => o[k])
+      .filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+    const joined = comments.length > 0 ? comments.join(" ") : "";
+    const fallback = typeof o.summary === "string" ? o.summary : typeof o.text === "string" ? o.text : "";
+    const s = (joined || fallback).trim();
+    if (s) out.summary = s;
   }
 
   const fi = (d.financeInfo ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
라이브 검증 중 발견: 저스템 naverCode `417180`은 실제로 **핑거스토리** → 다른 회사 재무가 뜨던 데이터 무결성 버그. 정답 `417840`으로 정정(네이버 stockName 교차검증). 추가 8개 코드 중 저스템만 오류, 나머지 전부 일치 확인.

회사개요: 네이버 `corporationSummary`가 `{comment1,comment2,comment3}` dict였음 → commentN 합쳐 추출. 테스트 13 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)