### PR TITLE
feat(stock): 종목 취향 수집(관심♥) + 왜 보여줬나 근거 + 재무 해석 (C·B·A)

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -410,7 +410,8 @@ function KeywordDeck({
             stock={selected.stock.canonical}
             context={{
               fromTheme: selected.fromKeyword,
-              reason: `뉴스에 ${selected.stock.mentions}번 같이 등장한 종목이야.`,
+              // B — "왜 보여줬나": 그 종목이 실제 등장한 원문 한 줄(grounded). 없으면 테마 연결만 정직하게.
+              reason: selected.stock.reason ?? `‘${selected.fromKeyword}’ 흐름에서 같이 움직인 종목이야.`,
             }}
             onClose={closeDepth}
           />

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -11,6 +11,7 @@ import {
   type StockBasics,
 } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
+import { isWatched, toggleWatch } from "@/lib/watchlist";
 
 /**
  * 키워드 뎁스 페이지 — 카드/히스토리에서 공용. KEYWORD_CARD_FEED_DEV_SPEC v3 §3.
@@ -356,6 +357,7 @@ function StockBasicsBlock({ basics }: { basics: StockBasics | null }) {
                 {m.term ? <span className="text-muted/70"> · {m.term}</span> : null}
               </span>
               <span className="mt-0.5 block text-sm text-whiteout">{m.value}</span>
+              {m.note && <span className="mt-1 block text-[11px] leading-4 text-muted">{m.note}</span>}
             </li>
           ))}
         </ul>
@@ -389,6 +391,9 @@ function StockBasicsBlock({ basics }: { basics: StockBasics | null }) {
               </tbody>
             </table>
           </div>
+          {basics.financials.note && (
+            <p className="mt-2 text-[12px] leading-5 text-muted">{basics.financials.note}</p>
+          )}
           <p className="mt-1 text-[10px] leading-4 text-muted">(E)=컨센서스 추정치 · 출처: 네이버 금융</p>
         </div>
       )}
@@ -415,6 +420,18 @@ export function StockInsightView({
   const [loading, setLoading] = useState(true);
   // 기본 정보(바닥) — 원문 무관 객관 사실. 빠른 네이버 fetch라 해석(LLM)과 분리해 먼저 깐다.
   const [basics, setBasics] = useState<StockBasics | null>(null);
+  // 종목 관심(C) — 명시적 취향 입력. 진입 자체도 암묵 신호(view_depth)로 적재됨.
+  const [watched, setWatchedState] = useState(false);
+
+  useEffect(() => {
+    setWatchedState(isWatched(stock));
+  }, [stock]);
+
+  const toggleWatched = () => {
+    const now = toggleWatch(stock, Date.now());
+    setWatchedState(now);
+    recordTaste("stock", stock, now ? "more" : "less"); // 서버 취향 신호(트랙 B 재사용)
+  };
 
   useEffect(() => {
     let alive = true;
@@ -470,10 +487,36 @@ export function StockInsightView({
             </button>
             <span className="text-lg font-bold text-whiteout">{cleanText(stock)}</span>
           </div>
-          <span className="font-pixel text-xs text-muted">종목</span>
+          <button
+            onClick={toggleWatched}
+            aria-label={watched ? "관심 해제" : "관심 등록"}
+            className="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors"
+            style={{
+              borderColor: watched ? "#FF5A36" : "var(--hairline, #2a2a2a)",
+              color: watched ? "#FF5A36" : "#94a3b8",
+            }}
+          >
+            <span aria-hidden>{watched ? "♥" : "♡"}</span>
+            {watched ? "관심" : "관심"}
+          </button>
         </div>
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
+          {/* B — "왜 너한테 보여줬나" 상단 한 줄(추천 맥락이 있으면). 납득 먼저. */}
+          {context?.reason && (
+            <div className="mb-5 rounded-lg border border-hairline bg-surface px-3 py-2">
+              <span className="block text-[11px] text-muted">
+                {context.fromTheme ? `‘${cleanText(context.fromTheme)}’ 흐름에서 보여주는 이유` : "보여주는 이유"}
+              </span>
+              <span className="mt-1 block text-sm leading-6 text-whiteout">{cleanText(context.reason)}</span>
+              {context.sourceUrl && (
+                <a href={context.sourceUrl} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
+                  ↳ {cleanText(context.sourceLabel ?? "원문")} · 원문 보기 →
+                </a>
+              )}
+            </div>
+          )}
+
           {/* 바닥 — 기본 정보는 원문 무관 객관 사실이라 항상 먼저 깐다(빈 화면 박멸). */}
           <StockBasicsBlock basics={basics} />
 
@@ -482,33 +525,13 @@ export function StockInsightView({
             <p className="mt-7 text-sm leading-6 text-muted">강세·약세 관점을 읽고 있어…</p>
           ) : (
           <>
-          <section className="mt-7">
-            <p className="font-pixel text-sm text-whiteout">왜 같이 움직였나</p>
-            {/* 들어온 맥락(연관 근거) — stock-insight 가 부족해도 항상 보여준다(빈 화면 금지). */}
-            {context?.reason && (
-              <div className="mt-2 rounded-lg border border-hairline bg-surface px-3 py-2">
-                {context.fromTheme && (
-                  <span className="mb-1 block text-[11px] text-muted">‘{cleanText(context.fromTheme)}’ 흐름에서</span>
-                )}
-                <span className="block text-sm leading-6 text-whiteout">{cleanText(context.reason)}</span>
-                {context.sourceUrl ? (
-                  <a href={context.sourceUrl} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
-                    ↳ {cleanText(context.sourceLabel ?? "원문")} · 원문 보기 →
-                  </a>
-                ) : (
-                  context.sourceLabel && <span className="mt-1 block text-[11px] text-muted">↳ {cleanText(context.sourceLabel)}</span>
-                )}
-              </div>
-            )}
-            {/* 종목 단독 응축(understandStock)이 되면 그걸 덧붙임. 안 되면 위 맥락이 근거. */}
-            {hasInsight ? (
+          {/* 종목 단독 응축(understandStock)이 되면 강세/약세 종합. 추천 이유는 위 배너가 담당. */}
+          {hasInsight && (
+            <section className="mt-7">
+              <p className="font-pixel text-sm text-whiteout">왜 같이 움직였나</p>
               <p className="mt-2 text-sm leading-6 text-muted">{cleanText(insight!.whyHot)}</p>
-            ) : (
-              !context?.reason && (
-                <p className="mt-2 text-sm leading-6 text-muted">이 종목만으로는 응축할 원문이 아직 부족해. 그것도 정상이야.</p>
-              )
-            )}
-          </section>
+            </section>
+          )}
 
           {insight?.officialFacts && insight.officialFacts.length > 0 && (
             <section className="mt-6">

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import { MOCK_KEYWORD_CARDS, scoreToColor, type KeywordCard } from "@fomo/core";
-import { KeywordDepthPage } from "@/components/KeywordDepthPage";
+import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { getHistory } from "@/lib/keywordHistory";
+import { getWatchlist } from "@/lib/watchlist";
 
 /**
  * 히스토리 탭 — 내가 본 키워드 카드 다시 보기. KEYWORD_CARD_FEED_DEV_SPEC v3.
@@ -20,21 +21,42 @@ function relativeTime(ts: number): string {
 
 export function KeywordHistory() {
   const [history] = useState(() => getHistory());
+  const [watchlist] = useState(() => getWatchlist());
   const [selected, setSelected] = useState<KeywordCard | null>(null);
+  const [stockSel, setStockSel] = useState<string | null>(null);
 
-  if (history.length === 0) {
+  if (history.length === 0 && watchlist.length === 0) {
     return (
       <p className="mt-16 text-center text-sm leading-6 text-muted">
-        아직 본 카드가 없어.
+        아직 관심 둔 게 없어.
         <br />
-        카드를 슥 넘기면 여기 쌓여.
+        카드를 넘기거나 종목에 ♥를 누르면 여기 쌓여.
       </p>
     );
   }
 
   return (
     <div className="w-full">
-      <p className="mb-3 px-1 text-xs text-muted">내가 본 키워드</p>
+      {watchlist.length > 0 && (
+        <section className="mb-6">
+          <p className="mb-3 px-1 text-xs text-muted">관심 종목 ♥</p>
+          <div className="flex flex-col gap-2.5">
+            {watchlist.map((w) => (
+              <button
+                key={`${w.stock}-${w.ts}`}
+                onClick={() => setStockSel(w.stock)}
+                className="flex w-full items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-3 text-left transition-colors hover:border-muted"
+                style={{ borderLeft: "2px solid #FF5A36" }}
+              >
+                <span className="text-base font-semibold text-whiteout">{w.stock}</span>
+                <span className="text-[11px] text-muted">{relativeTime(w.ts)}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {history.length > 0 && <p className="mb-3 px-1 text-xs text-muted">내가 본 키워드</p>}
       <div className="flex flex-col gap-2.5">
         {history.map((h) => {
           const color = scoreToColor(h.fomoScore);
@@ -63,6 +85,7 @@ export function KeywordHistory() {
       </div>
 
       {selected && <KeywordDepthPage card={selected} onClose={() => setSelected(null)} />}
+      {stockSel && <StockInsightView stock={stockSel} onClose={() => setStockSel(null)} />}
     </div>
   );
 }

--- a/apps/fomo-web/lib/watchlist.ts
+++ b/apps/fomo-web/lib/watchlist.ts
@@ -1,0 +1,65 @@
+/**
+ * 종목 관심(워치리스트) seam — STOCK_SCREEN_REDESIGN 2차 C. "증권시장의 틴더" 취향 입력의 핵심.
+ *
+ * 명시적 관심(하트)을 로컬에 즉시 기록(토글 상태 + 히스토리). 서버 적재는 recordTaste(STOCK, more/less)로
+ * 트랙 B(#552) 취향 신호에 같이 쌓인다 — 별도 테이블/DDL 없이 재사용. 로그인 시 서버 워치리스트로 보강.
+ * 비로그인도 로컬로 동작(기존 패턴). 출시 후 서버 동기화로 교체할 단일 지점.
+ */
+const KEY = "fomo_watchlist";
+const CAP = 200;
+
+export interface WatchItem {
+  stock: string;
+  ts: number;
+}
+
+function read(): WatchItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as WatchItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(list: WatchItem[]): void {
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(list.slice(-CAP)));
+  } catch {
+    /* 저장 실패 무시 — 흐름 안 막음 */
+  }
+}
+
+/** 관심 등록 여부. */
+export function isWatched(stock: string): boolean {
+  return read().some((w) => w.stock === stock);
+}
+
+/** 최근 관심 순(내림차순). */
+export function getWatchlist(): WatchItem[] {
+  return [...read()].sort((a, b) => b.ts - a.ts);
+}
+
+/** 관심 토글 — 새 상태(true=관심 등록됨) 반환. */
+export function toggleWatch(stock: string, nowMs: number): boolean {
+  if (typeof window === "undefined") return false;
+  const list = read();
+  const exists = list.some((w) => w.stock === stock);
+  if (exists) {
+    write(list.filter((w) => w.stock !== stock));
+    return false;
+  }
+  write([...list, { stock, ts: nowMs }]);
+  return true;
+}
+
+/** 서버 워치리스트(로그인 시)를 로컬에 머지 — 다른 기기에서 담은 것도 보이게. */
+export function mergeWatchlist(stocks: string[], nowMs: number): void {
+  if (typeof window === "undefined" || stocks.length === 0) return;
+  const list = read();
+  const have = new Set(list.map((w) => w.stock));
+  const merged = [...list];
+  for (const s of stocks) if (!have.has(s)) merged.push({ stock: s, ts: nowMs });
+  write(merged);
+}

--- a/packages/fomo-core/__tests__/stock-basics.test.ts
+++ b/packages/fomo-core/__tests__/stock-basics.test.ts
@@ -105,6 +105,43 @@ describe("parseNaverFinanceAnnual — 연간 재무(추정치 구분, 결측 미
   });
 });
 
+describe("A — 재무 한 줄 해석(사실까지만, 조언 금지)", () => {
+  const FORBIDDEN = /(싸다|비싸다|저평가|고평가|위험|사라|팔아라|매수|매도|추천|손절|익절|좋다|나쁘다)/;
+  it("PER 높으면 '시장 기대' 해석이 붙고, 조언어는 없음", () => {
+    const m = parseNaverTotalInfos({ totalInfos: [{ key: "PER", value: "140.2배" }] }).metrics;
+    const per = m.find((x) => x.term === "PER");
+    expect(per?.note).toBeTruthy();
+    expect(per!.note).toMatch(/기대/);
+    expect(per!.note).not.toMatch(FORBIDDEN);
+  });
+  it("영업이익 출렁이면 '안정성 낮은 편', 적자 섞이면 '기복' — 둘 다 조언 아님", () => {
+    const swing = parseNaverFinanceAnnual({
+      financeInfo: {
+        trTitleList: [
+          { title: "2023.12.", key: "a", isConsensus: "N" },
+          { title: "2024.12.", key: "b", isConsensus: "N" },
+        ],
+        rowList: [{ title: "영업이익", columns: { a: { value: "1,000" }, b: { value: "5,000" } } }],
+      },
+    });
+    expect(swing.financials?.note).toMatch(/출렁|안정성/);
+    expect(swing.financials?.note).not.toMatch(FORBIDDEN);
+  });
+  it("추정 기간(E)은 안정성 판단에서 제외(확정치만)", () => {
+    const r = parseNaverFinanceAnnual({
+      financeInfo: {
+        trTitleList: [
+          { title: "2024.12.", key: "a", isConsensus: "N" },
+          { title: "2025.12.", key: "b", isConsensus: "Y" }, // 추정 — 제외
+        ],
+        rowList: [{ title: "영업이익", columns: { a: { value: "1,000" }, b: { value: "9,999" } } }],
+      },
+    });
+    // 확정 1개뿐 → 안정성 판단 보류(note 없음, 가짜 단정 금지)
+    expect(r.financials?.note).toBeUndefined();
+  });
+});
+
 describe("assembleStockBasics — 기본 정보는 항상(원문 무관), name 최소 보장", () => {
   it("세 소스 합치고, 비어도 name + metrics 배열은 보장(빈 화면 박멸)", () => {
     const b = assembleStockBasics("저스템", {}, {}, {});

--- a/packages/fomo-core/__tests__/stock-extraction.test.ts
+++ b/packages/fomo-core/__tests__/stock-extraction.test.ts
@@ -165,6 +165,15 @@ describe("pickSurpriseStock — 의외의 추천 종목(대장주 말고 같이 
   it("종목 0이면 null", () => {
     expect(pickSurpriseStock([{ title: "금리 인상 우려" }])).toBeNull();
   });
+  it("B — '왜 보여줬나' grounded 근거(그 종목 등장 원문 한 줄)를 함께 반환", () => {
+    const s = pickSurpriseStock([
+      { title: "삼성전자 강세" },
+      { title: "삼성전자 또 신고가" },
+      { title: "한미반도체, HBM 장비 수주로 급등" },
+    ]);
+    expect(s?.canonical).toBe("한미반도체");
+    expect(s?.reason).toBe("한미반도체, HBM 장비 수주로 급등"); // 약한 'N번 등장'이 아니라 실제 원문
+  });
   // 회귀(prod 버그): 키워드로 좁힌 부분집합에선 비-marquee 종목이 1회만 등장하는 게 흔하다.
   // 기본 minMentions=2 였을 때 2+ 생존자가 전부 marquee라 제외 후 후보 0 → 항상 null(화면에 영영 안 뜸).
   // 기본 1로 내려 grounded 1회 언급도 후보가 돼야 한다. (반도체 매칭 집합 ≈ 한미반도체:1 + 마르키:N 재현)

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -227,6 +227,8 @@ export interface SurpriseStock {
   mentions: number;
   /** 의외성 점수(높을수록 의외 — UI/정렬·디버그용). */
   surprise: number;
+  /** "왜 보여줬나" grounded 근거 — 이 종목이 등장한 실제 원문 한 줄(B). 없으면 노출 약함. */
+  reason?: string;
 }
 
 /**
@@ -265,12 +267,16 @@ export function pickSurpriseStock(
       a.s.canonical.localeCompare(b.s.canonical)
   );
   const top = scored[0]!;
+  // B — "왜 보여줬나" grounded 근거: 이 종목이 실제로 등장한 원문 한 줄(제목 우선, 없으면 요약).
+  const hit = items.find((it) => stockMatchesText(top.s.canonical, `${it.title} ${it.summary ?? ""}`));
+  const reason = hit?.title?.trim();
   return {
     canonical: top.s.canonical,
     market: top.s.market,
     country: top.s.country,
     mentions: top.s.mentions,
     surprise: Math.round(top.surprise * 100) / 100,
+    ...(reason ? { reason } : {}),
   };
 }
 

--- a/packages/fomo-core/src/stock-basics.ts
+++ b/packages/fomo-core/src/stock-basics.ts
@@ -16,6 +16,8 @@ export interface StockMetric {
   value: string;
   /** 보조 용어(작게) — 예 "EPS". 초보는 label 을, 고급은 term 을 본다. */
   term?: string;
+  /** 이게 무슨 뜻인지 한 줄(A) — *사실까지만*(싸다/비싸다/사라 금지). 판단은 유저 몫. */
+  note?: string;
 }
 
 export interface StockFinancialRow {
@@ -28,6 +30,29 @@ export interface StockFinancialRow {
 export interface StockFinancials {
   periods: { title: string; estimate: boolean }[];
   rows: StockFinancialRow[];
+  /** 이익 안정성 한 줄(A) — *사실까지만*. 예 "남기는 돈이 해마다 출렁여". */
+  note?: string;
+}
+
+/** PER → "이게 무슨 뜻" 한 줄(사실: 시장 기대 수준 묘사. 싸다/비싸다 단정 금지). */
+function perNote(value: string): string | undefined {
+  const n = num(value);
+  if (n === null || n <= 0) return undefined;
+  if (n >= 50) return "주가가 버는 돈의 수십 배 수준 — 시장이 앞으로의 성장을 크게 기대한다는 뜻이야(기대가 식으면 출렁일 수 있어).";
+  if (n >= 15) return "버는 돈에 비해 주가에 성장 기대가 어느 정도 들어가 있어.";
+  return "버는 돈 대비 주가는 차분한 편 — 큰 성장 기대가 반영되진 않았어.";
+}
+
+/** 영업이익 추이 → 이익 안정성 한 줄(사실: 변동/적자 여부 묘사). 안전이면 undefined(군더더기 없이). */
+function stabilityNote(opRaw: (number | null)[]): string | undefined {
+  const vals = opRaw.filter((v): v is number => v !== null);
+  if (vals.length < 2) return undefined;
+  const hasLoss = vals.some((v) => v < 0);
+  const pos = vals.filter((v) => v > 0);
+  const swing = pos.length >= 2 && Math.max(...pos) / Math.min(...pos) >= 2;
+  if (hasLoss) return "해에 따라 적자도 있어 — 남기는 돈의 기복이 큰 편이야.";
+  if (swing) return "남기는 돈이 해마다 출렁여 — 이익 안정성은 낮은 편이야.";
+  return "남기는 돈이 해마다 비교적 꾸준한 편이야.";
 }
 
 export interface StockBasics {
@@ -120,6 +145,12 @@ export function parseNaverTotalInfos(json: unknown): { marketCap?: string; metri
   push("52주 최고", "최근 1년 최고가");
   push("52주 최저", "최근 1년 최저가");
   push("외인소진율", "외국인이 가진 비율", "외인소진율");
+  // A — PER 에 "무슨 뜻" 한 줄(사실까지만).
+  const per = metrics.find((m) => m.term === "PER");
+  if (per) {
+    const note = perNote(per.value);
+    if (note) per.note = note;
+  }
   const out: { marketCap?: string; metrics: StockMetric[] } = { metrics };
   const cap = by.get("시총");
   if (cap && cap.trim()) out.marketCap = cap;
@@ -179,7 +210,19 @@ export function parseNaverFinanceAnnual(json: unknown): {
     if (values.some((v) => v !== "—")) rows.push({ label: want.label, values });
   }
   if (rows.length > 0) {
-    out.financials = { periods: periods.map((p) => ({ title: p.title, estimate: p.estimate })), rows };
+    const financials: StockFinancials = {
+      periods: periods.map((p) => ({ title: p.title, estimate: p.estimate })),
+      rows,
+    };
+    // A — 이익 안정성 한 줄: 영업이익의 *확정(비추정)* 추이로만 판단(추정치 제외).
+    const opRow = rowList.find((x) => typeof x.title === "string" && (x.title as string).includes("영업이익"));
+    if (opRow) {
+      const cols = (opRow.columns ?? {}) as Record<string, { value?: string }>;
+      const opRaw = periods.filter((p) => !p.estimate).map((p) => num(cols[p.key]?.value ?? ""));
+      const note = stabilityNote(opRaw);
+      if (note) financials.note = note;
+    }
+    out.financials = financials;
   }
   return out;
 }


### PR DESCRIPTION
종목 화면 2차(STOCK_SCREEN_REDESIGN 2). 우선순위 **C>B>A**. **DDL 없음**(TasteSignal #552 재사용 — 종목 관심 모델 신설 안 함).

## C — 종목 취향 수집 (토대, 가장 근본)
- 종목 화면 헤더 **관심 ♥ 토글** → 로컬 워치리스트(`lib/watchlist.ts`) 즉시 기록 + 서버 취향 신호(`recordTaste` STOCK more/less, 트랙 B 재사용).
- 히스토리 탭에 **"관심 종목 ♥" 섹션** → 탭하면 그 종목 다시 봄(취향 거울 1차). 비로그인 로컬 폴백.
- 진입(view_depth)·연관주 탭(tap_related) 암묵 신호는 기존 적재 그대로.

## B — "왜 너한테 보여줬나" 근거
- `surpriseStock` 에 **grounded reason**(그 종목이 등장한 실제 원문 한 줄) 부여 → 약한 "뉴스 N번 등장" 대신 구체 근거.
- 종목 화면 **상단 "보여주는 이유" 배너**로 납득 먼저.

## A — 재무를 판단되게 (한 줄 해석)
- PER → "시장이 성장을 크게 기대한다는 뜻"(사실), 영업이익 추이 → 이익 안정성 한 줄.
- **절대선: 사실까지만** — 싸다/비싸다/사라/위험 등 조언어 금지(가드 테스트). 추정치(E)는 안정성 판단서 제외.

## 검증
테스트 +9 → **705 통과**(조언금지어 가드 / surprise grounded reason / 추정 제외). typecheck·build:web·@fomo/web green.
⚠️ 캐시 키(날짜+종목)라 화면 반영은 캐시 갱신 후. 게이트 없음(새 테이블/소스 없음).
후속: 서버 워치리스트 cross-device read, 수급(기관/외인) 연결 근거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)