### PR TITLE
fix(cache): Data Cache 키에 배포 버전 — 배포 즉시 반영

### DIFF
--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import type { KeywordCard, KeywordConfidence } from "@fomo/core";
-import { withCors, kstDate } from "../../../../lib/fomo";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { computeKeywordCards } from "../../../../lib/keyword-pipeline";
 import { readKeywordSnapshot } from "../../../../lib/keyword-snapshot";
 
@@ -47,7 +47,7 @@ async function computeLive(date: string): Promise<KeywordsPayload> {
   try {
     const load = unstable_cache(
       async () => await computeKeywordCards(),
-      ["fomo-keywords-live", date],
+      ["fomo-keywords-live", cacheVersion(), date],
       { revalidate: 1800 }
     );
     const { cards, confidence } = await load();

--- a/apps/web/app/api/fomo/stock-basics/route.ts
+++ b/apps/web/app/api/fomo/stock-basics/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import type { StockBasics } from "@fomo/core";
-import { withCors, kstDate } from "../../../../lib/fomo";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { fetchStockBasics } from "../../../../lib/stock-basics";
 
 /**
@@ -27,7 +27,7 @@ async function getBasics(stock: string): Promise<StockBasics> {
 
   const load = unstable_cache(
     async () => fetchStockBasics(stock),
-    ["fomo-stock-basics", today, stock],
+    ["fomo-stock-basics", cacheVersion(), today, stock],
     { revalidate: REVALIDATE_S }
   );
   const p = load().finally(() => inflight.delete(key));

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, stockDef, supplyDemandFact, type CondensedInsight } from "@fomo/core";
-import { withCors, kstDate } from "../../../../lib/fomo";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { understandStock } from "../../../../lib/theme-understanding";
 import { readLatestSupplyDemand } from "../../../../lib/supply-demand-store";
 
@@ -31,7 +31,7 @@ async function getInsight(stock: string): Promise<CondensedInsight> {
 
   const load = unstable_cache(
     async () => condenseThemeInsight(await understandStock(stock)),
-    ["fomo-stock-insight", today, stock],
+    ["fomo-stock-insight", cacheVersion(), today, stock],
     { revalidate: REVALIDATE_S }
   );
 

--- a/apps/web/app/api/fomo/theme-insight/route.ts
+++ b/apps/web/app/api/fomo/theme-insight/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, type CondensedInsight } from "@fomo/core";
-import { withCors, kstDate } from "../../../../lib/fomo";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { understandTheme } from "../../../../lib/theme-understanding";
 
 /**
@@ -39,7 +39,7 @@ async function getInsight(theme: string): Promise<CondensedInsight> {
 
   const load = unstable_cache(
     async () => condenseThemeInsight(await understandTheme(theme)),
-    ["fomo-theme-insight", today, theme],
+    ["fomo-theme-insight", cacheVersion(), today, theme],
     { revalidate: REVALIDATE_S }
   );
 

--- a/apps/web/lib/fomo.ts
+++ b/apps/web/lib/fomo.ts
@@ -22,6 +22,15 @@ export function kstDate(offsetDays = 0): string {
 }
 
 /**
+ * 배포 버전 토큰 — Vercel Data Cache(unstable_cache) 키에 넣어 *배포마다 캐시 무효화*.
+ * unstable_cache 는 배포로 자동 무효화되지 않아, 코드/로직 수정이 (날짜+종목) 캐시 TTL(수h) 전까지
+ * 화면에 안 떴다(반복 이슈). 커밋 SHA 를 키에 더해, 새 배포 = 새 키 = 즉시 재산출. (로컬은 "dev".)
+ */
+export function cacheVersion(): string {
+  return (process.env.VERCEL_GIT_COMMIT_SHA || "dev").slice(0, 8);
+}
+
+/**
  * KST 시간대 슬롯 — 뎁스 인사이트 캐시 키에 넣어 하루를 4구간으로 나눈다.
  * 같은 슬롯 안에선 캐시 고정(깜빡임 방지), 슬롯이 바뀌면 새 키 → 그날 최신 뉴스로 재산출.
  *   dawn(~09) · morning(09~13, 장 시작) · afternoon(13~16, 장 마감 전후) · evening(16~, 마감 후)


### PR DESCRIPTION
Vercel `unstable_cache`는 배포로 무효화 안 되고 키가 (날짜+종목)이라, 코드 수정이 캐시 TTL(수h)/익일 전까지 화면에 안 떴다(저스템 정정·MLCC·재무 해석 라이브 검증이 매번 막힌 근본 원인). `cacheVersion()`=`VERCEL_GIT_COMMIT_SHA` 8자를 4개 캐시 키(stock-basics/stock-insight/theme-insight/keywords)에 주입 → 새 배포=새 키=즉시 재산출. 순수 인프라, 게이트 없음. typecheck·build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)