### PR TITLE
fix(stock): 주목종목 '왜 보여줬나' — 주어 헤드라인만(비교·리스트 폐기)

### DIFF
--- a/packages/fomo-core/__tests__/stock-extraction.test.ts
+++ b/packages/fomo-core/__tests__/stock-extraction.test.ts
@@ -165,7 +165,7 @@ describe("pickSurpriseStock — 의외의 추천 종목(대장주 말고 같이 
   it("종목 0이면 null", () => {
     expect(pickSurpriseStock([{ title: "금리 인상 우려" }])).toBeNull();
   });
-  it("B — '왜 보여줬나' grounded 근거(그 종목 등장 원문 한 줄)를 함께 반환", () => {
+  it("B — '왜 보여줬나' grounded 근거(그 종목이 주어인 원문 한 줄)를 함께 반환", () => {
     const s = pickSurpriseStock([
       { title: "삼성전자 강세" },
       { title: "삼성전자 또 신고가" },
@@ -173,6 +173,16 @@ describe("pickSurpriseStock — 의외의 추천 종목(대장주 말고 같이 
     ]);
     expect(s?.canonical).toBe("한미반도체");
     expect(s?.reason).toBe("한미반도체, HBM 장비 수주로 급등"); // 약한 'N번 등장'이 아니라 실제 원문
+  });
+  it("B — 비교/리스트 헤드라인뿐이면 약한 이유라 surprise 미노출(null)", () => {
+    // 한미반도체가 비교 대상·인기검색 리스트로만 등장 → 주어 아님 → 폐기.
+    const s = pickSurpriseStock([
+      { title: "삼성전자 강세" },
+      { title: "삼성전자 신고가" },
+      { title: "하이닉스가 한미반도체 제쳤다" }, // 비교(주어 아님)
+      { title: "[인기검색TOP5] 한미반도체, 삼성전자, SK하이닉스" }, // 리스트
+    ]);
+    expect(s).toBeNull();
   });
   // 회귀(prod 버그): 키워드로 좁힌 부분집합에선 비-marquee 종목이 1회만 등장하는 게 흔하다.
   // 기본 minMentions=2 였을 때 2+ 생존자가 전부 marquee라 제외 후 후보 0 → 항상 null(화면에 영영 안 뜸).

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -267,17 +267,45 @@ export function pickSurpriseStock(
       a.s.canonical.localeCompare(b.s.canonical)
   );
   const top = scored[0]!;
-  // B — "왜 보여줬나" grounded 근거: 이 종목이 실제로 등장한 원문 한 줄(제목 우선, 없으면 요약).
-  const hit = items.find((it) => stockMatchesText(top.s.canonical, `${it.title} ${it.summary ?? ""}`));
-  const reason = hit?.title?.trim();
+  // B — "왜 보여줬나" grounded 근거: 이 종목이 *주어*인 원문 한 줄만. 비교("하이닉스가 마이크론 제쳤다")·
+  //     리스트/인기검색("[인기검색TOP5] …")은 약한 이유라 폐기. 좋은 근거 없으면 surprise 자체를 안 띄움.
+  const reason = pickSurpriseReason(items, top.s.canonical);
+  if (!reason) return null; // 납득 가능한 이유 없음 → 노출 안 함(B: 약한 이유는 미노출)
   return {
     canonical: top.s.canonical,
     market: top.s.market,
     country: top.s.country,
     mentions: top.s.mentions,
     surprise: Math.round(top.surprise * 100) / 100,
-    ...(reason ? { reason } : {}),
+    reason,
   };
+}
+
+/** 비교/리스트/인기검색 류 — 종목이 주어가 아닌 약한 헤드라인(노출 기준 미달). */
+const WEAK_HEADLINE =
+  /(인기검색|특징주|급등주|급등 ?종목|상한가|TOP\s?\d|순위|총정리|모음|제쳤|제치|넘어섰|넘고|앞질|제외하고|\[[^\]]*\])/;
+
+/** surprise 종목의 "왜" 근거 한 줄 — 그 종목이 *주어*인 깨끗한 원문만(없으면 undefined). */
+function pickSurpriseReason(
+  items: readonly KeywordSourceItem[],
+  canonical: string
+): string | undefined {
+  const matched = items.filter((it) =>
+    stockMatchesText(canonical, `${it.title} ${it.summary ?? ""}`)
+  );
+  if (matched.length === 0) return undefined;
+  const norm = (s: string) => s.replace(/\s+/g, "");
+  const nc = norm(canonical);
+  // 1순위: 제목이 종목명으로 시작(주어) + 비교/리스트 아님.
+  const subjectFirst = matched.find(
+    (it) => norm(it.title).startsWith(nc) && !WEAK_HEADLINE.test(it.title)
+  );
+  if (subjectFirst) return subjectFirst.title.trim();
+  // 2순위: 종목명 포함 + 비교/리스트 아님(주어 추정).
+  const clean = matched.find((it) => !WEAK_HEADLINE.test(it.title));
+  if (clean) return clean.title.trim();
+  // 전부 비교/리스트 → 약한 이유뿐 → 폐기.
+  return undefined;
 }
 
 /** 종목명 → 정의(소스 매핑 등에 사용). 없으면 undefined. */


### PR DESCRIPTION
라이브에서 surprise reason 이 grounded 됐으나 약한 헤드라인이 셌음: "하이닉스가 마이크론 제쳤다"(비교), "[인기검색TOP5] …"(리스트) — B 가 없애려던 약한 이유. `pickSurpriseReason`: 종목이 **주어**인 깨끗한 원문만 채택, 비교/리스트/인기검색 폐기, 좋은 이유 없으면 surprise 미노출(B 기준). 테스트 707. typecheck·build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)