### PR TITLE
[codex] gate main on FOMO web build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test
+        run: npm test -- --reporter=dot
+
   build-api:
     runs-on: ubuntu-latest
     needs: [resolve-ref, repo-checks]
@@ -129,15 +132,37 @@ jobs:
       - name: Build web workspace
         run: npm --workspace @trading/web run build
 
+  build-fomo-web:
+    runs-on: ubuntu-latest
+    needs: [resolve-ref, repo-checks]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.ref || '' }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build FOMO web workspace
+        run: npm run build:fomo-web
+
   # ── Phase 3: CI 성공 시 auto-merge 트리거 ──────────────────────
   # workflow_run 이벤트는 2단계 전파 불가 → 명시적 dispatch
   dispatch-auto-merge:
-    needs: [resolve-ref, repo-checks, build-api, build-web]
+    needs: [resolve-ref, repo-checks, build-api, build-web, build-fomo-web]
     if: |
       always() &&
       needs.repo-checks.result == 'success' &&
       needs.build-api.result == 'success' &&
       needs.build-web.result == 'success' &&
+      needs.build-fomo-web.result == 'success' &&
       needs.resolve-ref.outputs.ref != '' &&
       startsWith(needs.resolve-ref.outputs.ref, 'agent/ceo-brief-')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 변경
- 기존 CI의 repo checks에 전체 Vitest 실행을 추가했습니다.
- 주력 `apps/fomo-web` 프로덕션 빌드 job을 추가했습니다.
- 자동 머지 dispatch가 FOMO web 빌드 성공도 요구하도록 연결했습니다.

## 이유
기존 CI는 레거시 `apps/web`과 API만 빌드하고, 주력 FOMO web 빌드 및 707개 테스트를 실행하지 않아 화면 트랙 변경을 보호하지 못했습니다.

## 영향
제품·화면·카피 로직 변경 없이 CI 게이트만 강화합니다.

## 검증
- `npm test -- --reporter=dot` — 59 files, 707 tests passed
- `npm run build:fomo-web` — production build passed
- `git diff --check`