### PR TITLE
[codex] add FOMO social share metadata

### DIFF
--- a/apps/fomo-web/app/layout.tsx
+++ b/apps/fomo-web/app/layout.tsx
@@ -2,8 +2,23 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "FOMO Club",
-  description: "투자자들이 \"나만 그런 게 아니구나\"를 확인하는 공간. FOMO Index는 감정 체감 지표이며 투자 조언이 아닙니다.",
+  title: {
+    default: "FOMO Club",
+    template: "%s | FOMO Club",
+  },
+  description: "스와이프로 투자 취향을 학습해 오늘의 테마와 종목을 쉽게 매칭하는 피드.",
+  openGraph: {
+    type: "website",
+    locale: "ko_KR",
+    siteName: "FOMO Club",
+    title: "FOMO Club — 내 취향 투자 피드",
+    description: "오늘 볼 만한 시장 테마와 종목을 넘겨 보고, 내 취향에 맞는 투자 정보를 쉽게 발견하세요.",
+  },
+  twitter: {
+    card: "summary",
+    title: "FOMO Club — 내 취향 투자 피드",
+    description: "오늘 볼 만한 시장 테마와 종목을 넘겨 보고, 내 취향에 맞는 투자 정보를 쉽게 발견하세요.",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## 변경
- FOMO web 기본 description을 현재 취향 매칭 제품 정의로 갱신했습니다.
- Open Graph와 Twitter summary 메타데이터를 추가했습니다.

## 범위 제한
- `apps/fomo-web/app/layout.tsx`의 정적 metadata만 변경
- components, 화면 렌더링, 프롬프트, 제품 로직 변경 없음
- 공식 도메인이 없어 canonical URL은 설정하지 않음
- 승인된 OG 이미지 자산이 없어 이미지도 임의 생성하지 않음

## 검증
- `npm run build:fomo-web` 성공
- build 이후 `npm run typecheck:fomo-web` 성공
- `git diff --check`