### PR TITLE
fix(stock): 주목 종목 카드 전멸 버그 — 후보 fall-through

### DIFF
--- a/packages/fomo-core/__tests__/stock-extraction.test.ts
+++ b/packages/fomo-core/__tests__/stock-extraction.test.ts
@@ -174,6 +174,20 @@ describe("pickSurpriseStock — 의외의 추천 종목(대장주 말고 같이 
     expect(s?.canonical).toBe("한미반도체");
     expect(s?.reason).toBe("한미반도체, HBM 장비 수주로 급등"); // 약한 'N번 등장'이 아니라 실제 원문
   });
+  it("B 회귀 — 1순위 후보가 비교/리스트뿐이어도 차순위의 주어 헤드라인을 고른다(통째 null 금지)", () => {
+    // 한미반도체(코스닥=점수 1위)는 비교 헤드라인뿐 → 폐기되지만, 삼성전기(주어 헤드라인)가 살아남아야 함.
+    const items = [
+      ...mk(4, "삼성전자 강세"), // marquee 제외
+      { title: "하이닉스가 한미반도체 제쳤다" }, // 1순위 후보지만 비교(주어 아님)
+      { title: "[인기검색TOP5] 한미반도체, 삼성전자" }, // 한미반도체 리스트
+      { title: "삼성전기, AI 서버 수요 폭발에 실적 급증" }, // 주어 헤드라인 → 이게 선택돼야
+    ];
+    const s = pickSurpriseStock(items);
+    expect(s).not.toBeNull();
+    expect(s!.canonical).toBe("삼성전기");
+    expect(s!.reason).toContain("삼성전기");
+  });
+
   it("B — 비교/리스트 헤드라인뿐이면 약한 이유라 surprise 미노출(null)", () => {
     // 한미반도체가 비교 대상·인기검색 리스트로만 등장 → 주어 아님 → 폐기.
     const s = pickSurpriseStock([

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -266,19 +266,23 @@ export function pickSurpriseStock(
       a.s.mentions - b.s.mentions ||
       a.s.canonical.localeCompare(b.s.canonical)
   );
-  const top = scored[0]!;
-  // B — "왜 보여줬나" grounded 근거: 이 종목이 *주어*인 원문 한 줄만. 비교("하이닉스가 마이크론 제쳤다")·
-  //     리스트/인기검색("[인기검색TOP5] …")은 약한 이유라 폐기. 좋은 근거 없으면 surprise 자체를 안 띄움.
-  const reason = pickSurpriseReason(items, top.s.canonical);
-  if (!reason) return null; // 납득 가능한 이유 없음 → 노출 안 함(B: 약한 이유는 미노출)
-  return {
-    canonical: top.s.canonical,
-    market: top.s.market,
-    country: top.s.country,
-    mentions: top.s.mentions,
-    surprise: Math.round(top.surprise * 100) / 100,
-    reason,
-  };
+  // B — "왜 보여줬나" grounded 근거: 그 종목이 *주어*인 원문 한 줄만(비교·리스트는 폐기).
+  //     점수 1위만 보지 않고 **후보를 점수순으로 훑어 깨끗한 근거가 있는 첫 종목**을 고른다.
+  //     (1위 후보의 헤드라인이 비교/리스트뿐이어도, 차순위에 주어 헤드라인이 있으면 그걸 노출 — 종목 카드가
+  //      엉뚱하게 통째로 사라지던 버그 수정.) 어느 후보도 깨끗한 근거가 없을 때만 null(정직).
+  for (const { s, surprise } of scored) {
+    const reason = pickSurpriseReason(items, s.canonical);
+    if (!reason) continue;
+    return {
+      canonical: s.canonical,
+      market: s.market,
+      country: s.country,
+      mentions: s.mentions,
+      surprise: Math.round(surprise * 100) / 100,
+      reason,
+    };
+  }
+  return null;
 }
 
 /** 비교/리스트/인기검색 류 — 종목이 주어가 아닌 약한 헤드라인(노출 기준 미달). */


### PR DESCRIPTION
**증상**: 메인에 종목 카드가 하나도 안 뜸.

**원인**: `pickSurpriseStock`이 점수 1위 후보 1개만 reason(주어 헤드라인) 시도 → 그게 비교/리스트 헤드라인이면 통째로 null. 깨끗한 주어 헤드라인 가진 **차순위(삼성전기 'AI 서버發 수요 폭발')는 시도조차 안 됨**. B 주어-필터(#562) 강화 후 1위가 자주 비교/리스트라 surprise 사실상 전멸.

**수정**: 후보를 점수순으로 훑어 **깨끗한 근거가 있는 첫 종목** 선택. 모든 후보가 약할 때만 null. 라이브 재현: 반도체→삼성전기, AI→삼성전기 복구. 회귀 테스트 +1(708). typecheck·build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)