### PR TITLE
feat: CEO brief #429 — 멘트·폴백·타이포·스켈레톤·테스트 개선

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -5,6 +5,7 @@ import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { KeywordHistory } from "@/components/KeywordHistory";
 import { LoginPage } from "@/components/LoginPage";
+import { FomoIndexSkeleton } from "@/components/SkeletonLoader";
 import type {
   FomoIndexResponse,
   TallyResponse,
@@ -73,27 +74,28 @@ export function HomeView({
           </button>
         </div>
 
-        {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}
+        {/* 시장 온도(FOMO Index) — 이슈 #412: 타이포그래피 위계 개선 + #409: 로딩 스켈레톤 */}
+        {!index && <FomoIndexSkeleton />}
         {index && !isFullFallback && (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-3">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <div className="flex items-baseline gap-2">
-              <span className="font-pixel text-xl leading-none" style={{ color }}>
+              <span className="font-pixel text-2xl font-bold leading-none" style={{ color }}>
                 {index.score}
               </span>
-              <span className="font-pixel text-[11px] text-muted">{index.state}</span>
+              <span className="font-pixel text-xs text-muted">{index.state}</span>
               {index.prevDayDelta !== 0 && (
                 <span className="font-pixel text-[11px]" style={{ color }}>
                   {index.prevDayDelta > 0
-                    ? `· 어제보다 ▲+${index.prevDayDelta}`
-                    : `· 어제보다 ▼${index.prevDayDelta}`}
+                    ? `▲+${index.prevDayDelta}`
+                    : `▼${index.prevDayDelta}`}
                 </span>
               )}
             </div>
           </div>
         )}
         {index && isFullFallback && (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-3">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <span className="font-pixel text-[11px] text-muted">데이터 수집 중…</span>
           </div>

--- a/apps/web/app/api/fomo/emotions/today/route.ts
+++ b/apps/web/app/api/fomo/emotions/today/route.ts
@@ -11,6 +11,7 @@ export function OPTIONS() {
 // GET /api/fomo/emotions/today — 오늘 감정 투표 집계 (비율 + 총 N명).
 // 정직한 숫자: total은 항상 실제 집계값. 0이어도 그대로.
 // fallback: true → 아직 투표 데이터 없음 (클라이언트에서 "집계 준비 중" 표시 기준).
+// 이슈 #425: 데이터 결측 시에도 안전한 구조화 응답 보장.
 export async function GET() {
   const date = kstDate();
   try {
@@ -19,9 +20,27 @@ export async function GET() {
     const ratios = Object.fromEntries(
       EMOTION_TYPES.map((e) => [e, total > 0 ? Math.round(((tally[e] ?? 0) / total) * 100) : 0])
     );
-    return corsJson({ date, total, counts, ratios, fallback: total === 0 });
+    return corsJson({
+      date,
+      total,
+      counts,
+      ratios,
+      fallback: total === 0,
+      confidence: total >= 50 ? "high" : total >= 10 ? "medium" : total > 0 ? "low" : "fallback",
+    });
   } catch (err) {
     console.warn("[fomo/emotions/today] error", err);
-    return corsJson({ error: "집계 조회 실패", code: "TALLY_ERROR" }, { status: 500 });
+    const fallbackCounts = Object.fromEntries(EMOTION_TYPES.map((e) => [e, 0]));
+    const fallbackRatios = Object.fromEntries(EMOTION_TYPES.map((e) => [e, 0]));
+    return corsJson({
+      date,
+      total: 0,
+      counts: fallbackCounts,
+      ratios: fallbackRatios,
+      fallback: true,
+      confidence: "fallback" as const,
+      error: "집계 조회 실패",
+      code: "TALLY_ERROR",
+    }, { status: 500 });
   }
 }

--- a/packages/fomo-core/__tests__/calculate.test.ts
+++ b/packages/fomo-core/__tests__/calculate.test.ts
@@ -149,3 +149,75 @@ describe("buildSummary — Heat 정보 + 정직한 숫자 (#428)", () => {
     expect(s).not.toMatch(/매수|매도|반드시|보장|폭락|급등/);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Heat 격리 — 개별 Heat 실패가 전체 파이프라인을 중단시키지 않음 (#415)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("computeFomoIndex — Heat 격리 견고성 (#415)", () => {
+  it("NaN 포함 시그널도 안전하게 처리", () => {
+    const idx = computeFomoIndex(
+      { market: { volumeChangePct: NaN, turnoverChangePct: NaN } },
+      "2026-06-11"
+    );
+    expect(Number.isNaN(idx.score)).toBe(false);
+    const m = idx.components.find((c) => c.key === "market")!;
+    expect(m.meta?.confidence).toBe("fallback");
+  });
+
+  it("whale에 빈 배열 → 0점, 다른 Heat 영향 없음", () => {
+    const idx = computeFomoIndex({ whale: [] }, "2026-06-11");
+    const w = idx.components.find((c) => c.key === "whale")!;
+    expect(w.score).toBe(0);
+    expect(idx.score).toBe(45); // 15+15+15+0
+  });
+
+  it("모든 Heat가 최대값일 때 100 초과하지 않음", () => {
+    const idx = computeFomoIndex(
+      {
+        market: { volumeChangePct: 200, turnoverChangePct: 200, searchChangePct: 200, etfInflowPct: 200 },
+        community: { mentionChangePct: 200, bullishRatio: 1.0 },
+        emotion: { fomo: 100, greed: 100 },
+        whale: [{ weight: 50 }],
+      },
+      "2026-06-11"
+    );
+    expect(idx.score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// heatContextLine — Heat 맥락 멘트 (#428)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { heatContextLine } from "../src/mascot-lines";
+
+describe("heatContextLine — Heat 기반 맥락 멘트 (#428)", () => {
+  it("상위 Heat 70%+ → '가장 뜨거워요' 포함", () => {
+    const line = heatContextLine([
+      { key: "market", score: 25, max: 30 },
+      { key: "community", score: 5, max: 30 },
+    ]);
+    expect(line).toContain("뜨거워요");
+  });
+
+  it("상위 Heat 30% 이하 → '조용한 흐름' 포함", () => {
+    const line = heatContextLine([
+      { key: "market", score: 5, max: 30 },
+      { key: "community", score: 3, max: 30 },
+    ]);
+    expect(line).toContain("조용한");
+  });
+
+  it("빈 배열 → '데이터를 모으고 있어요' 폴백", () => {
+    expect(heatContextLine([])).toContain("데이터를 모으고 있어요");
+  });
+
+  it("투자 조언·단정 표현 없음", () => {
+    const line = heatContextLine([
+      { key: "market", score: 20, max: 30 },
+      { key: "emotion", score: 25, max: 30 },
+    ]);
+    expect(line).not.toMatch(/매수|매도|반드시|보장|폭락|급등/);
+  });
+});

--- a/packages/fomo-core/src/mascot-lines.ts
+++ b/packages/fomo-core/src/mascot-lines.ts
@@ -47,6 +47,37 @@ export function marketSummary(state: FomoState): string {
   return MARKET_SUMMARY[state];
 }
 
+/**
+ * Heat 기반 맥락 한 줄 — 상위 Heat가 "왜 이런 온도인가"를 담담히 설명.
+ * buildSummary(숫자 옆)와 달리, 마스코트 멘트 블록 아래에 붙는 보조 맥락.
+ * 투자 조언·단정 ❌. 이슈 #428 Phase 1.
+ */
+const HEAT_CONTEXT_LABELS: Record<string, string> = {
+  market: "시장 거래",
+  community: "커뮤니티 관심",
+  emotion: "감정 투표",
+  whale: "대형 이벤트",
+};
+
+export function heatContextLine(
+  components: ReadonlyArray<{ key: string; score: number; max: number }>
+): string {
+  const sorted = [...components]
+    .filter((c) => c.max > 0)
+    .map((c) => ({
+      label: HEAT_CONTEXT_LABELS[c.key] ?? c.key,
+      pct: Math.round((c.score / c.max) * 100),
+    }))
+    .sort((a, b) => b.pct - a.pct);
+
+  if (sorted.length === 0) return "아직 데이터를 모으고 있어요.";
+
+  const top = sorted[0]!;
+  if (top.pct >= 70) return `${top.label}이 ${top.pct}%로 가장 뜨거워요.`;
+  if (top.pct <= 30) return `전반적으로 조용한 흐름이에요.`;
+  return `${top.label} ${top.pct}%가 오늘의 분위기를 이끌고 있어요.`;
+}
+
 export function mineLine(emotion: EmotionType): string {
   return MINE_LINES[emotion];
 }


### PR DESCRIPTION
## 구현 항목

- **#428 (Prompt Engineer)**: `heatContextLine()` 함수 추가 — 상위 Heat 비율 기반 맥락 멘트 생성 (`packages/fomo-core/src/mascot-lines.ts`). 70%+ → "가장 뜨거워요", 30%- → "조용한 흐름", 중간 → "분위기를 이끌고 있어요". 투자 조언·단정 금지.
- **#425 (Backend)**: `/api/fomo/emotions/today` API 에러 시 구조화 폴백 응답 반환 (빈 counts/ratios + `confidence: "fallback"` 필드). 정상 응답에도 `confidence` 레벨 추가 (high/medium/low/fallback).
- **#412 (Designer)**: FOMO Index 헤드라인 타이포그래피 강화 — `text-xl` → `text-2xl font-bold`, 패딩 조정 (`py-2.5` → `py-3`), 델타 표시 간결화.
- **#409 (PM)**: `FomoIndexSkeleton`을 `HomeView`에 연결 — `index`가 null(로딩 중)일 때 스켈레톤 UI 표시.
- **#413 (QA)**: Heat 격리 견고성 테스트 3건 + `heatContextLine` 테스트 4건 추가 (총 +7 테스트).

## 이미 구현 확인 (추가 변경 불필요)

- **#415 (CTO)**: `safeHeat()` 래퍼 + 4개 Heat 모듈 전부 try-catch 폴백 구현 완료.
- **#426 (Security)**: `session-hmac.ts` HMAC 서명/검증 + `vote/route.ts` 연동 완료.
- **#410 (Frontend)**: `FomoFace.tsx` — `React.memo` + 커스텀 비교 함수 적용 완료.

## 킬리스트 (미구현)

- **애니메이션 효과 (#374)**: 장식 폴리싱 금지 — 킬리스트 항목
- **가짜 데이터 테스트 (#378)**: 정직한 숫자 원칙 위반 — 킬리스트 항목

## 검증

- [x] lint 통과
- [x] typecheck 통과
- [x] build:web 통과
- [x] test 통과 (727 tests, 61 files)

## 참조
이슈: #429

---

## 👤 사용자 평가 (PR 검토 후 댓글로 평가해주세요)

이 PR의 구현 결과를 아래 명령어로 평가해주세요:

- 👍 만족스러운 경우: `/good`
- 👎 아쉬운 경우: `/bad [간단한 이유]`

평가는 에이전트들의 다음 사이클 제안 품질 개선에 반영됩니다.

🤖 Generated by CEO Brief Agent

---
_Generated by [Claude Code](https://claude.ai/code/session_018bYjPtKs8eHugM7datUGgh)_