### PR TITLE
[codex] secure password reset credentials

### DIFF
--- a/apps/web/__tests__/api/auth/password-reset-security.test.ts
+++ b/apps/web/__tests__/api/auth/password-reset-security.test.ts
@@ -1,0 +1,102 @@
+import bcrypt from "bcryptjs";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { debugMock, updateMock, findUniqueMock } = vi.hoisted(() => ({
+  debugMock: vi.fn(),
+  updateMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+}));
+
+vi.mock("../../../lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: findUniqueMock,
+      update: updateMock,
+    },
+  },
+}));
+
+vi.mock("../../../lib/logger", () => ({
+  createLogger: () => ({
+    debug: debugMock,
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { POST as requestReset } from "@/app/api/auth/forgot-password/route";
+import { POST as resetPassword } from "@/app/api/auth/reset-password/route";
+import { hashResetToken, tokenStore } from "../../../lib/passwordResetStore";
+
+function jsonRequest(path: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tokenStore.clear();
+  updateMock.mockResolvedValue({ id: "user-1" });
+});
+
+describe("password reset security", () => {
+  it("stores only a digest of the reset token and never logs the raw token", async () => {
+    findUniqueMock.mockResolvedValue({ id: "user-1" });
+
+    const response = await requestReset(
+      jsonRequest("/api/auth/forgot-password", { email: "USER@example.com" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(tokenStore.size).toBe(1);
+    const [storedKey] = tokenStore.keys();
+    expect(storedKey).toMatch(/^[a-f0-9]{64}$/);
+    expect(debugMock.mock.calls.some((call) => JSON.stringify(call).includes('"token"'))).toBe(false);
+  });
+
+  it("writes a bcrypt hash instead of a reversible password marker", async () => {
+    const rawToken = "reset-token-123";
+    const newPassword = "SecurePass123";
+    tokenStore.set(hashResetToken(rawToken), {
+      email: "user@example.com",
+      expiresAt: Date.now() + 60_000,
+      used: false,
+    });
+
+    const response = await resetPassword(
+      jsonRequest("/api/auth/reset-password", { token: rawToken, newPassword })
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledOnce();
+    const passwordHash = updateMock.mock.calls[0]?.[0]?.data?.passwordHash as string;
+    expect(passwordHash).not.toContain(newPassword);
+    expect(passwordHash).not.toMatch(/^hashed:/);
+    await expect(bcrypt.compare(newPassword, passwordHash)).resolves.toBe(true);
+    expect(tokenStore.size).toBe(0);
+  });
+
+  it("rejects passwords that exceed bcrypt's 72-byte input limit", async () => {
+    const rawToken = "long-password-token";
+    tokenStore.set(hashResetToken(rawToken), {
+      email: "user@example.com",
+      expiresAt: Date.now() + 60_000,
+      used: false,
+    });
+
+    const response = await resetPassword(
+      jsonRequest("/api/auth/reset-password", {
+        token: rawToken,
+        newPassword: `A1${"가".repeat(24)}`,
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/auth/forgot-password/route.ts
+++ b/apps/web/app/api/auth/forgot-password/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "../../../../lib/prisma";
 import { createLogger } from "../../../../lib/logger";
-import { tokenStore } from "../../../../lib/passwordResetStore";
+import { hashResetToken, tokenStore } from "../../../../lib/passwordResetStore";
 
 const log = createLogger("auth/forgot-password");
 
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
   for (const [k, v] of tokenStore) {
     if (v.email === email && !v.used) tokenStore.delete(k);
   }
-  tokenStore.set(token, { email, expiresAt, used: false });
+  tokenStore.set(hashResetToken(token), { email, expiresAt, used: false });
 
   log.info("password reset token issued", { email, expiresAt: new Date(expiresAt).toISOString() });
 
@@ -75,7 +75,5 @@ export async function POST(req: NextRequest) {
   // 프로덕션: 이메일에 아래 형태로 발송, 피싱 방지 문구 포함 필수.
   // "링크: https://fomo-club.com/reset-password?token=<token>"
   // "이 링크는 fomo-club.com 도메인에서만 유효합니다. 본인이 요청하지 않았다면 무시하세요."
-  log.debug("reset token (dev only — remove before prod)", { token });
-
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/app/api/auth/reset-password/route.ts
+++ b/apps/web/app/api/auth/reset-password/route.ts
@@ -1,15 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
 import { prisma } from "../../../../lib/prisma";
 import { createLogger } from "../../../../lib/logger";
-import { tokenStore } from "../../../../lib/passwordResetStore";
+import { hashResetToken, tokenStore } from "../../../../lib/passwordResetStore";
+import {
+  BCRYPT_MAX_PASSWORD_BYTES,
+  exceedsBcryptPasswordLimit,
+} from "../../../../lib/auth/passwordPolicy";
 
 const log = createLogger("auth/reset-password");
 
 const MIN_PASSWORD_LENGTH = 8;
+const BCRYPT_COST = 12;
 
 function validatePasswordStrength(password: string): string | null {
   if (password.length < MIN_PASSWORD_LENGTH) {
     return `비밀번호는 ${MIN_PASSWORD_LENGTH}자 이상이어야 합니다.`;
+  }
+  if (exceedsBcryptPasswordLimit(password)) {
+    return `비밀번호는 UTF-8 기준 ${BCRYPT_MAX_PASSWORD_BYTES}바이트 이하여야 합니다.`;
   }
   if (!/[A-Z]/.test(password)) return "대문자를 1자 이상 포함해야 합니다.";
   if (!/[0-9]/.test(password)) return "숫자를 1자 이상 포함해야 합니다.";
@@ -36,9 +45,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: passwordError }, { status: 400 });
   }
 
-  const entry = tokenStore.get(token);
+  const tokenKey = hashResetToken(token);
+  const entry = tokenStore.get(tokenKey);
   if (!entry) {
-    log.warn("reset-password: token not found", { token: token.slice(0, 8) + "..." });
+    log.warn("reset-password: token not found");
     return NextResponse.json({ error: "유효하지 않은 재설정 링크입니다." }, { status: 400 });
   }
 
@@ -48,7 +58,7 @@ export async function POST(req: NextRequest) {
   }
 
   if (Date.now() > entry.expiresAt) {
-    tokenStore.delete(token);
+    tokenStore.delete(tokenKey);
     log.warn("reset-password: token expired", { email: entry.email });
     return NextResponse.json({ error: "재설정 링크가 만료되었습니다. 다시 요청해주세요." }, { status: 400 });
   }
@@ -56,16 +66,15 @@ export async function POST(req: NextRequest) {
   // 1회 사용 즉시 만료 처리 (재사용 방지)
   entry.used = true;
 
-  // TODO: 프로덕션 전 bcryptjs 또는 argon2로 교체 필요.
-  // placeholder — 절대 프로덕션 사용 금지.
-  const passwordHash = `hashed:${newPassword}`;
+  // 로그인 경로와 동일한 bcrypt 포맷으로 저장한다. 원문은 DB·로그에 남기지 않는다.
+  const passwordHash = await bcrypt.hash(newPassword, BCRYPT_COST);
 
   await prisma.user.update({
     where: { email: entry.email },
     data: { passwordHash },
   });
 
-  tokenStore.delete(token);
+  tokenStore.delete(tokenKey);
   log.info("password reset successful", { email: entry.email });
 
   return NextResponse.json({ ok: true });

--- a/apps/web/app/api/fomo/auth/login/route.ts
+++ b/apps/web/app/api/fomo/auth/login/route.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcryptjs";
 import { prisma } from "../../../../../lib/prisma";
 import { corsJson, withCors } from "../../../../../lib/fomo";
 import { issueToken } from "@/lib/auth/jwt";
+import { exceedsBcryptPasswordLimit } from "@/lib/auth/passwordPolicy";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +25,9 @@ export async function POST(req: NextRequest) {
     const password = body.password ?? "";
     if (!email || !password) {
       return corsJson({ error: "이메일과 비밀번호를 입력해줘.", code: "MISSING" }, { status: 400 });
+    }
+    if (exceedsBcryptPasswordLimit(password)) {
+      return corsJson({ error: "이메일 또는 비밀번호가 맞지 않아.", code: "BAD_CREDENTIALS" }, { status: 401 });
     }
 
     const user = await prisma.user.findUnique({ where: { email } });

--- a/apps/web/app/api/fomo/auth/register/route.ts
+++ b/apps/web/app/api/fomo/auth/register/route.ts
@@ -3,6 +3,10 @@ import bcrypt from "bcryptjs";
 import { prisma } from "../../../../../lib/prisma";
 import { corsJson, withCors } from "../../../../../lib/fomo";
 import { issueToken } from "@/lib/auth/jwt";
+import {
+  BCRYPT_MAX_PASSWORD_BYTES,
+  exceedsBcryptPasswordLimit,
+} from "@/lib/auth/passwordPolicy";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +36,12 @@ export async function POST(req: NextRequest) {
     }
     if (password.length < MIN_PASSWORD) {
       return corsJson({ error: `비밀번호는 ${MIN_PASSWORD}자 이상이어야 해.`, code: "WEAK_PASSWORD" }, { status: 400 });
+    }
+    if (exceedsBcryptPasswordLimit(password)) {
+      return corsJson(
+        { error: `비밀번호는 UTF-8 기준 ${BCRYPT_MAX_PASSWORD_BYTES}바이트 이하여야 해.`, code: "WEAK_PASSWORD" },
+        { status: 400 }
+      );
     }
 
     const existing = await prisma.user.findUnique({ where: { email } });

--- a/apps/web/lib/auth/passwordPolicy.ts
+++ b/apps/web/lib/auth/passwordPolicy.ts
@@ -1,0 +1,6 @@
+/** bcrypt는 UTF-8 문자열의 첫 72바이트만 사용하므로 초과 입력을 명시적으로 거부한다. */
+export const BCRYPT_MAX_PASSWORD_BYTES = 72;
+
+export function exceedsBcryptPasswordLimit(password: string): boolean {
+  return Buffer.byteLength(password, "utf8") > BCRYPT_MAX_PASSWORD_BYTES;
+}

--- a/apps/web/lib/passwordResetStore.ts
+++ b/apps/web/lib/passwordResetStore.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto";
+
 /**
  * 임시 인메모리 비밀번호 재설정 토큰 저장소.
  * TODO: 프로덕션 배포 전 `PasswordResetToken` Prisma 모델로 교체.
@@ -5,7 +7,7 @@
  *   model PasswordResetToken {
  *     id        String    @id @default(cuid())
  *     email     String
- *     token     String    @unique
+ *     tokenHash String    @unique
  *     expiresAt DateTime
  *     usedAt    DateTime?
  *     createdAt DateTime  @default(now())
@@ -18,4 +20,10 @@ export interface ResetTokenEntry {
   used: boolean;
 }
 
+/** 원문 토큰은 메모리에도 보관하지 않는다. */
+export function hashResetToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+// key는 원문 토큰이 아니라 SHA-256 digest다.
 export const tokenStore = new Map<string, ResetTokenEntry>();


### PR DESCRIPTION
## 핵심 위험

운영 비밀번호 재설정 라우트가 `hashed:<원문 비밀번호>`를 DB에 저장해 사실상 평문 자격증명을 보관했고, 재설정 원문 토큰을 로그에 남겼습니다. DB 또는 로그 접근 시 계정 탈취로 이어질 수 있으며 bcrypt 로그인과도 호환되지 않았습니다.

## 변경 사항

- 재설정 비밀번호를 bcrypt cost 12로 단방향 해시
- 재설정 토큰은 SHA-256 digest만 메모리에 보관
- 원문 토큰 및 토큰 prefix 로그 제거
- bcrypt 72바이트 한계를 가입·로그인·재설정에 일관 적용
- 원문 비밀번호·토큰이 저장/로그되지 않는 회귀 테스트 추가

## 비침범

- 제품 화면·카드·프롬프트 변경 없음
- Prisma DDL·외부 서비스 변경 없음
- 다른 열린 제품 작업과 파일 중복 없음

## 검증

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` — 62 files, 725 tests
- `npm run build:web`
- `npm run build:fomo-web`
- 보안 회귀 테스트 3개 통과

## 후속 분리 권고

- Next.js 14.2.35는 `npm audit` High이며 Next.js 14가 EOL이므로 Next 15/16 마이그레이션을 별도 호환성 PR로 진행
- 인메모리 reset token/rate limit를 영속 저장소로 이전하고 실제 이메일 공급자 연동
- Slack signature malformed-input 및 관리 API 인증을 별도 보안 감사