### PR TITLE
[codex] harden webhook verification and logs

### DIFF
--- a/apps/web/__tests__/logger-security.test.ts
+++ b/apps/web/__tests__/logger-security.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "../lib/logger";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("structured logger security", () => {
+  it("suppresses debug logs in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+
+    createLogger("security-test").debug("hidden", { token: "raw-token" });
+
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  it("redacts nested credentials while preserving non-sensitive context", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const output = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    createLogger("security-test").info("request", {
+      requestId: "req-1",
+      auth: {
+        authorization: "Bearer raw-token",
+        apiKey: "raw-api-key",
+        profile: { displayName: "Fomo" },
+      },
+    });
+
+    const entry = JSON.parse(String(output.mock.calls[0]?.[0]));
+    expect(entry.requestId).toBe("req-1");
+    expect(entry.auth.authorization).toBe("[REDACTED]");
+    expect(entry.auth.apiKey).toBe("[REDACTED]");
+    expect(entry.auth.profile.displayName).toBe("Fomo");
+  });
+});

--- a/apps/web/__tests__/slack-verify-security.test.ts
+++ b/apps/web/__tests__/slack-verify-security.test.ts
@@ -1,0 +1,45 @@
+import { createHmac } from "crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { verifySlackRequest } from "../lib/slack/verify";
+
+const SECRET = "test-slack-signing-secret-at-least-32-bytes";
+
+function sign(timestamp: string, body: string): string {
+  return `v0=${createHmac("sha256", SECRET).update(`v0:${timestamp}:${body}`).digest("hex")}`;
+}
+
+beforeEach(() => {
+  vi.stubEnv("SLACK_SIGNING_SECRET", SECRET);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("Slack request verification", () => {
+  it("accepts a correctly signed current request", () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const body = "command=%2Ffomo&text=status";
+
+    expect(verifySlackRequest(timestamp, body, sign(timestamp, body))).toBe(true);
+  });
+
+  it("fails closed without throwing for malformed signatures", () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+
+    expect(() => verifySlackRequest(timestamp, "body", "v0=short")).not.toThrow();
+    expect(verifySlackRequest(timestamp, "body", "v0=short")).toBe(false);
+    expect(verifySlackRequest(timestamp, "body", "not-a-signature")).toBe(false);
+  });
+
+  it("rejects stale, future, and non-numeric timestamps", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const stale = String(now - 301);
+    const future = String(now + 301);
+
+    expect(verifySlackRequest(stale, "body", sign(stale, "body"))).toBe(false);
+    expect(verifySlackRequest(future, "body", sign(future, "body"))).toBe(false);
+    expect(verifySlackRequest("NaN", "body", "v0=" + "0".repeat(64))).toBe(false);
+  });
+});

--- a/apps/web/lib/logger.ts
+++ b/apps/web/lib/logger.ts
@@ -13,13 +13,41 @@ interface LogEntry {
   [key: string]: unknown;
 }
 
+const SENSITIVE_KEY_RE = /(?:authorization|cookie|password|secret|token|api[-_]?key)/i;
+const MAX_CONTEXT_DEPTH = 6;
+
+function redactSensitive(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (depth > MAX_CONTEXT_DEPTH) return "[TRUNCATED]";
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitive(item, depth + 1, seen));
+  }
+
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message };
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      SENSITIVE_KEY_RE.test(key) ? "[REDACTED]" : redactSensitive(child, depth + 1, seen),
+    ])
+  );
+}
+
 function emit(level: LogLevel, service: string, msg: string, ctx?: Record<string, unknown>) {
+  // production debug 로그는 토큰·개인정보 노출면과 로그 비용만 늘리므로 출력하지 않는다.
+  if (level === "debug" && process.env.NODE_ENV === "production") return;
+
   const entry: LogEntry = {
     ts: new Date().toISOString(),
     level,
     service,
     msg,
-    ...ctx,
+    ...(ctx ? (redactSensitive(ctx) as Record<string, unknown>) : undefined),
   };
   const line = JSON.stringify(entry);
   if (level === "debug") console.debug(line);

--- a/apps/web/lib/slack/verify.ts
+++ b/apps/web/lib/slack/verify.ts
@@ -1,19 +1,28 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
-const SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
+const MAX_CLOCK_SKEW_SECONDS = 300;
+const SIGNATURE_RE = /^v0=[a-f0-9]{64}$/;
+const TIMESTAMP_RE = /^\d{10,}$/;
 
 export function verifySlackRequest(
   timestamp: string,
   body: string,
   signature: string
 ): boolean {
-  if (!SIGNING_SECRET) return false;
+  const signingSecret = process.env.SLACK_SIGNING_SECRET;
+  if (!signingSecret) return false;
 
-  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 300;
-  if (parseInt(timestamp) < fiveMinutesAgo) return false;
+  // 형식 검사를 먼저 해 timingSafeEqual의 길이 불일치 예외를 외부 입력이 유발하지 못하게 한다.
+  if (!SIGNATURE_RE.test(signature) || !TIMESTAMP_RE.test(timestamp)) return false;
+
+  const requestTime = Number(timestamp);
+  if (!Number.isSafeInteger(requestTime)) return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - requestTime) > MAX_CLOCK_SKEW_SECONDS) return false;
 
   const basestring = `v0:${timestamp}:${body}`;
-  const computed = `v0=${createHmac("sha256", SIGNING_SECRET).update(basestring).digest("hex")}`;
+  const computed = `v0=${createHmac("sha256", signingSecret).update(basestring).digest("hex")}`;
 
   return timingSafeEqual(Buffer.from(computed), Buffer.from(signature));
 }


### PR DESCRIPTION
## 변경 사항

- Slack signature 형식을 HMAC 비교 전에 검증해 malformed input의 `timingSafeEqual` 예외 차단
- timestamp를 숫자로 엄격 검증하고 과거·미래 5분 초과 요청 거부
- signing secret을 호출 시점에 읽어 런타임 회전과 테스트 격리 지원
- production debug 로그 출력 차단
- 중첩 context의 password/token/secret/authorization/cookie/API key 자동 redaction
- 순환·과도한 중첩 context 안전 처리

## 보안 효과

- 인증 전 외부 입력으로 webhook 500을 유발하는 경로 제거
- replay window를 Slack 공식 규칙과 동일하게 양방향 적용
- 운영 로그를 통한 credential 2차 유출 방지

## 비침범

- 제품 화면·카드·프롬프트 변경 없음
- DDL·외부 서비스·환경변수 변경 없음

## 검증

- Slack/로거 보안 회귀 테스트 5개
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` — 64 files, 730 tests
- `npm run build:web`
- `npm run build:fomo-web`

Reference: https://docs.slack.dev/authentication/verifying-requests-from-slack/