### PR TITLE
feat(card): 앞면 후킹 — 그날 가장 센 객관 신호 한 줄 (PHASE0)

### DIFF
--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { KeywordCard, SectorStock, StockSector } from "@fomo/core";
+import { buildCardFrontHook, signalsFromBasics } from "@fomo/core";
+import type { KeywordCard, SectorStock, StockSector, CardFrontHook, CardFrontSignals } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
-import { fetchSectorStocks, fetchKeywords, recordTaste } from "@/lib/fomoApi";
+import { fetchSectorStocks, fetchKeywords, fetchStockBasics, recordTaste } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
 /**
@@ -79,8 +80,13 @@ const MARKET_LABEL: Record<string, string> = {
   COIN: "코인",
 };
 
-/** 종목 카드 앞면 — 이름 + 시장 라벨 + (발굴주면) 왜 보여줬나 근거(카피·국기 등 비주얼은 광혁). */
-function StockCardFace({ stock, progress }: { stock: DeckStock; progress?: string }) {
+/**
+ * 종목 카드 앞면 — 이름 + 시장 라벨 + 그날 가장 센 객관 신호 후킹(PHASE0 §4).
+ * 2행 헤드라인(가격>거래량>수급>뉴스>잠잠) · 3행 쉬운 번역 · 4행 균형(있으면). 점수·판정 없이 사실만.
+ * 비주얼 디테일(국기·리치 등)은 광혁 — 여기선 구조/문구만.
+ */
+function StockCardFace({ stock, hook, progress }: { stock: DeckStock; hook: CardFrontHook; progress?: string }) {
+  const quiet = hook.source === "quiet";
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2">
@@ -90,22 +96,37 @@ function StockCardFace({ stock, progress }: { stock: DeckStock; progress?: strin
       <p className="mt-3 font-pixel text-sm text-muted">
         {MARKET_LABEL[stock.market] ?? stock.market}
       </p>
-      {stock.reason ? (
-        <>
-          <p className="mt-4 font-pixel text-sm" style={{ color: UP }}>💡 주목해볼만한 종목</p>
-          <p className="mt-3 text-base leading-7 text-whiteout">{stock.reason}</p>
-        </>
-      ) : (
-        <p className="mt-6 text-lg leading-8 text-whiteout">
-          이 종목, 오늘 어떤 흐름인지 한번 볼까요?
-        </p>
+
+      {/* 2행 — 후킹(가장 센 객관 신호 1줄) */}
+      <p
+        className="mt-5 text-xl font-bold leading-8"
+        style={quiet ? { color: "#94A3B8" } : { color: UP }}
+      >
+        {hook.headline}
+      </p>
+      {/* 3행 — 쉬운 번역(사실 묘사) */}
+      {hook.translation && (
+        <p className="mt-2 text-base leading-7 text-whiteout">{hook.translation}</p>
       )}
+      {/* 4행 — 균형(반대 방향 사실, 있을 때만) */}
+      {hook.balance && <p className="mt-2 text-sm leading-6 text-muted">{hook.balance}</p>}
+
       <div className="mt-auto flex items-center justify-between pt-6">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
         {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
       </div>
     </div>
   );
+}
+
+/** 오늘(KST) "M/D" — 후킹 헤드라인 시점 라벨(§4 시점 명시). */
+function kstTodayLabel(): string {
+  try {
+    const kst = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+    return `${kst.getMonth() + 1}/${kst.getDate()}`;
+  } catch {
+    return "";
+  }
 }
 
 interface SectorDeckProps {
@@ -172,7 +193,32 @@ function SectorDeckInner({
   const startX = useRef(0);
   const moved = useRef(false);
 
+  // 앞면 후킹 신호 — 도달하는 카드의 baseline(가격·52주 등)을 lazy 로 불러 규칙기반 후킹(비용 방어 §5).
+  // 국내(naverCode) 종목만 가격 도출 — 없으면 발굴 근거/잠잠으로. 캐시(canonical 키)로 재방문 즉시.
+  const [signals, setSignals] = useState<Record<string, CardFrontSignals>>({});
+  const inflight = useRef<Set<string>>(new Set());
+  const asOf = useRef<string>(kstTodayLabel()).current;
+
   const at = (i: number) => stocks[((i % stocks.length) + stocks.length) % stocks.length]!;
+
+  const ensureSignals = useCallback(
+    (stock: DeckStock) => {
+      const key = stock.canonical;
+      if (!stock.naverCode || signals[key] || inflight.current.has(key)) return;
+      inflight.current.add(key);
+      fetchStockBasics(key)
+        .then((b) => setSignals((prev) => ({ ...prev, [key]: signalsFromBasics(b) })))
+        .catch((err) => console.warn("[SectorStockDeck] basics signal failed", key, err))
+        .finally(() => inflight.current.delete(key));
+    },
+    [signals]
+  );
+
+  const hookFor = (stock: DeckStock): CardFrontHook => {
+    const sig: CardFrontSignals = { ...(signals[stock.canonical] ?? {}), asOf };
+    if (stock.reason) sig.reason = stock.reason;
+    return buildCardFrontHook(sig);
+  };
 
   const flingNext = useCallback((dir: "left" | "right") => {
     if (prefersReducedMotion()) {
@@ -230,6 +276,12 @@ function SectorDeckInner({
     else setDx(0);
   };
 
+  // 보이는 카드(+다음 1장)의 신호를 미리 채운다 — 도달 종목만(비용 방어).
+  useEffect(() => {
+    ensureSignals(at(idx));
+    ensureSignals(at(idx + 1));
+  }, [idx, ensureSignals]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const top = at(idx);
   const topTransform = exiting
     ? `translateX(${exiting === "right" ? 140 : -140}%) rotate(${exiting === "right" ? 16 : -16}deg)`
@@ -255,7 +307,7 @@ function SectorDeckInner({
                 zIndex: 1,
               }}
             >
-              <StockCardFace stock={stock} />
+              <StockCardFace stock={stock} hook={hookFor(stock)} />
             </div>
           ))}
 
@@ -282,7 +334,7 @@ function SectorDeckInner({
           >
             ← 덜 관심
           </span>
-          <StockCardFace stock={top} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
+          <StockCardFace stock={top} hook={hookFor(top)} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
         </div>
       </div>
 

--- a/packages/fomo-core/__tests__/card-front-hook.test.ts
+++ b/packages/fomo-core/__tests__/card-front-hook.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCardFrontHook,
+  isFrontHookSafe,
+  signalsFromBasics,
+  FRONT_PRICE_PCT_MIN,
+  FRONT_VOLUME_RATIO_MIN,
+  FRONT_SUPPLY_STREAK_MIN,
+  type CardFrontSignals,
+  type StockBasics,
+} from "../src";
+
+describe("buildCardFrontHook — 카드 앞면 후킹(PHASE0 §3·§5)", () => {
+  it("우선순위: 가격 > 거래량 > 수급 > 뉴스 > 잠잠 (모두 있으면 가격)", () => {
+    const all: CardFrontSignals = {
+      changePct: 6.2,
+      volumeRatio: 3,
+      foreignNetStreak: 5,
+      reason: "원전 수주 기대로 묶임",
+    };
+    expect(buildCardFrontHook(all).source).toBe("price");
+    expect(buildCardFrontHook({ volumeRatio: 3, foreignNetStreak: 5, reason: "x 묶임" }).source).toBe("volume");
+    expect(buildCardFrontHook({ foreignNetStreak: 5, reason: "x 묶임" }).source).toBe("supply");
+    expect(buildCardFrontHook({ reason: "원전 수주 기대로 묶임" }).source).toBe("news");
+    expect(buildCardFrontHook({}).source).toBe("quiet");
+  });
+
+  it("가격 — ±3% 이상이면 헤드라인에 부호·숫자·시점", () => {
+    const up = buildCardFrontHook({ changePct: 6.23, asOf: "6/21" });
+    expect(up.source).toBe("price");
+    expect(up.headline).toBe("6/21 기준 +6.2%");
+    expect(up.translation).toContain("위쪽");
+
+    const down = buildCardFrontHook({ changePct: -4.1, asOf: "6/21" });
+    expect(down.headline).toBe("6/21 기준 -4.1%");
+    expect(down.translation).toContain("아래쪽");
+
+    const noDate = buildCardFrontHook({ changePct: 5 });
+    expect(noDate.headline).toBe("오늘 +5.0%");
+  });
+
+  it("가격 — 컷(±3%) 미달이면 가격 스킵 → 다음 우선순위(잠잠)", () => {
+    const small = buildCardFrontHook({ changePct: FRONT_PRICE_PCT_MIN - 0.5 });
+    expect(small.source).toBe("quiet");
+  });
+
+  it("가격 — 52주 신고가 부근은 컷과 무관하게 채택, 강한 등락과 결합", () => {
+    expect(buildCardFrontHook({ changePct: 0.4, near52WeekHigh: true }).headline).toContain("52주 신고가");
+    const both = buildCardFrontHook({ changePct: 7, near52WeekHigh: true, asOf: "6/21" });
+    expect(both.headline).toBe("6/21 기준 +7.0% · 52주 신고가 부근");
+  });
+
+  it("거래량 — 1.8배 이상만 채택, 미만은 스킵", () => {
+    expect(buildCardFrontHook({ volumeRatio: 2.4 }).headline).toBe("거래량 평소 2.4배");
+    expect(buildCardFrontHook({ volumeRatio: FRONT_VOLUME_RATIO_MIN - 0.1 }).source).toBe("quiet");
+  });
+
+  it("수급 — 3일 연속 이상만, 부호로 순매수/순매도", () => {
+    expect(buildCardFrontHook({ foreignNetStreak: 5 }).headline).toBe("외국인 5일째 순매수");
+    expect(buildCardFrontHook({ foreignNetStreak: -4 }).headline).toBe("외국인 4일째 순매도");
+    expect(buildCardFrontHook({ foreignNetStreak: FRONT_SUPPLY_STREAK_MIN - 1 }).source).toBe("quiet");
+  });
+
+  it("균형(4행) — 가격은 올랐는데 외국인은 빠지면 반대 사실 한 줄(억지 금지)", () => {
+    const conflict = buildCardFrontHook({ changePct: 6, foreignNetStreak: -5 });
+    expect(conflict.source).toBe("price");
+    expect(conflict.balance).toContain("외국인");
+    // 충돌 없으면 balance 없음
+    expect(buildCardFrontHook({ changePct: 6, foreignNetStreak: 5 }).balance).toBeUndefined();
+    expect(buildCardFrontHook({ changePct: 6 }).balance).toBeUndefined();
+  });
+
+  it("뉴스 — 근거를 헤드라인으로, 단 판정/추천 섞이면 잠잠으로 폴백(환각·판정 금지)", () => {
+    expect(buildCardFrontHook({ reason: "원전 수주 기대로 묶임" }).headline).toBe("원전 수주 기대로 묶임");
+    // 근거에 금칙(추천/예측)이 들어오면 채택 안 함
+    expect(buildCardFrontHook({ reason: "지금 매수 추천! 급등할 종목" }).source).toBe("quiet");
+  });
+
+  it("잠잠 — 신호 없으면 '오늘은 잠잠' + 회사 한 줄(있으면), 없으면 기본 문구", () => {
+    const withId = buildCardFrontHook({ identity: "모바일 메모리 설계 팹리스" });
+    expect(withId.source).toBe("quiet");
+    expect(withId.headline).toBe("오늘은 잠잠해요");
+    expect(withId.translation).toBe("모바일 메모리 설계 팹리스");
+    expect(buildCardFrontHook({}).translation).toContain("조용한");
+  });
+
+  it("결정적 — 같은 입력은 같은 출력(캐시·새로고침 안정)", () => {
+    const sig: CardFrontSignals = { changePct: 4.4, asOf: "6/21" };
+    expect(buildCardFrontHook(sig)).toEqual(buildCardFrontHook(sig));
+  });
+
+  it("금칙어 가드 — 어떤 채택 결과에도 점수·등급·추천·예측 어휘가 없다", () => {
+    const samples: CardFrontSignals[] = [
+      { changePct: 9.1, asOf: "6/21" },
+      { changePct: -7, foreignNetStreak: -6 },
+      { volumeRatio: 5 },
+      { foreignNetStreak: 8 },
+      { reason: "AI 데이터센터 수주로 묶임" },
+      { identity: "원전 기자재 전문" },
+      {},
+    ];
+    for (const s of samples) {
+      const h = buildCardFrontHook(s);
+      const joined = `${h.headline} ${h.translation} ${h.balance ?? ""}`;
+      // isFrontHookSafe 가 진짜 가드(순매수/순매도는 수급 사실로 허용) — 행동 지시·예측·점수·등급은 차단.
+      expect(isFrontHookSafe(joined), `금칙어: ${joined}`).toBe(true);
+      expect(joined).not.toMatch(/점수|등급|추천|유망|급등할|폭등/);
+    }
+  });
+});
+
+describe("signalsFromBasics — baseline(stock-basics) → 신호 도출", () => {
+  const base: StockBasics = { name: "테스트", metrics: [] };
+
+  it("등락률 — changeText 의 부호 포함 비율을 그대로(네이버 실제 포맷)", () => {
+    expect(signalsFromBasics({ ...base, changeText: "2,000 (0.55%)", changeDir: "up" }).changePct).toBe(0.55);
+    expect(signalsFromBasics({ ...base, changeText: "20,500 (-6.50%)", changeDir: "down" }).changePct).toBe(-6.5);
+    // 비율에 부호가 없는 드문 경우만 changeDir 로 보정.
+    expect(signalsFromBasics({ ...base, changeText: "1,500 (6.20%)", changeDir: "down" }).changePct).toBe(-6.2);
+  });
+
+  it("52주 신고가 — 현재가가 최고가의 98% 이상이면 부근", () => {
+    const near = signalsFromBasics({
+      ...base,
+      priceText: "99,000원",
+      metrics: [{ label: "최근 1년 최고가", value: "100,000원" }],
+    });
+    expect(near.near52WeekHigh).toBe(true);
+    const far = signalsFromBasics({
+      ...base,
+      priceText: "80,000원",
+      metrics: [{ label: "최근 1년 최고가", value: "100,000원" }],
+    });
+    expect(far.near52WeekHigh).toBe(false);
+  });
+
+  it("정체성 — 회사 개요 첫 구절(잠잠 보조)", () => {
+    const s = signalsFromBasics({ ...base, summary: "모바일 메모리 설계 팹리스. 2010년 설립." });
+    expect(s.identity).toBe("모바일 메모리 설계 팹리스");
+  });
+
+  it("데이터 없으면 빈 신호(환각 금지) → 잠잠으로 귀결", () => {
+    expect(buildCardFrontHook(signalsFromBasics(base)).source).toBe("quiet");
+  });
+
+  it("도출 신호로 후킹까지 — 강한 등락이면 가격 카드", () => {
+    const sig = signalsFromBasics({ ...base, changeText: "5,000 (5.10%)", changeDir: "up" });
+    sig.asOf = "6/21";
+    expect(buildCardFrontHook(sig).headline).toBe("6/21 기준 +5.1%");
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -1,0 +1,203 @@
+// PHASE0_CARD_FRONT_HOOK — 카드 앞면 후킹(순수부).
+//
+// 모든 종목 카드가 똑같은 "이 종목, 오늘 어떤 흐름인지 한번 볼까요?"(후킹 0) 대신,
+// 그날 그 종목의 *가장 센 객관 신호 한 줄 + 쉬운 번역 한 줄*로 교체한다.
+// 점수·등급·판정 없이 **사실(주목도)만**. 같은 입력=같은 출력(결정적 — 캐시·새로고침 안정).
+//
+// 신호 우선순위(§3, 위에서부터 데이터 있는 첫 신호):
+//   1) 가격 이벤트(등락 ≥±3% OR 52주 신고가 부근)  2) 거래량(평소 ≥1.8배)
+//   3) 수급(외인/기관 ≥3일 연속)  4) 뉴스/공시(발굴 근거)  5) (없음) 잠잠 + 회사 한 줄
+//
+// 비용방어(§5): 앞면 신호는 baseline 데이터로 **규칙 기반**(LLM 0, 싸게 항상). LLM 번역은 깊이 페이지 몫.
+
+import { isCommentSafe } from "./comment";
+import type { StockBasics } from "../stock-basics";
+
+/** 카드 앞면 후킹에 쓰는 신호 묶음 — 데이터 되는 것만 채운다(없으면 그 우선순위는 스킵). */
+export interface CardFrontSignals {
+  /** 등락률 %(부호 포함, 장 기준). 우선순위 1. */
+  changePct?: number;
+  /** 52주 신고가 부근/돌파. 우선순위 1 보강. */
+  near52WeekHigh?: boolean;
+  /** 평소 대비 거래량 배수. 우선순위 2(데이터 되면). */
+  volumeRatio?: number;
+  /** 외국인 연속 순매수(+)/순매도(−) 일수. 우선순위 3(데이터 되면). */
+  foreignNetStreak?: number;
+  /** 그날 그 종목이 묶인 근거(#560 발굴). 우선순위 4. */
+  reason?: string;
+  /** 회사 정체성 한 줄 — 잠잠 fallback 보조(있으면). */
+  identity?: string;
+  /** 시점 라벨 — 예 "6/21". 없으면 "오늘". */
+  asOf?: string;
+}
+
+/** 어느 신호가 채택됐는지(배지·테스트용). */
+export type CardFrontSource = "price" | "volume" | "supply" | "news" | "quiet";
+
+export interface CardFrontHook {
+  /** 2행 — 가장 센 객관 신호 1줄(숫자·시점 포함). */
+  headline: string;
+  /** 3행 — 쉬운 번역(사실 묘사, 판정 아님). 없으면 빈 문자열. */
+  translation: string;
+  /** 4행 — 반대 방향의 사실(있을 때만, 억지 금지). */
+  balance?: string;
+  /** 채택된 신호 종류. */
+  source: CardFrontSource;
+}
+
+// ── 임계값(§3, "가짜 흥분" 금지) ─────────────────────────────────────────────
+export const FRONT_PRICE_PCT_MIN = 3; // 등락 ≥ ±3%
+export const FRONT_VOLUME_RATIO_MIN = 1.8; // 거래량 평소 대비 ≥ 1.8배
+export const FRONT_SUPPLY_STREAK_MIN = 3; // 수급 ≥ 3일 연속
+
+// 판정·추천·예측 어휘는 isCommentSafe 로 거르고, 점수/등급류만 추가로 막는다(§5).
+const FRONT_JUDGMENT =
+  /점수|등급|[SAB]\s?급|최우수|유망|강력\s?매수|적극\s?매수|꼭\s?사|놓치면|지금\s?사/;
+
+/** 후킹 텍스트가 가드를 통과하는가(투자조언·예측·점수·등급 없음). */
+export function isFrontHookSafe(text: string): boolean {
+  // 순매수/순매도는 수급 '사실'(행동 지시 아님) — 가드의 매수/매도 부분일치에서 제외하고 검사.
+  const neutral = text.replace(/순매수|순매도/g, "수급");
+  return isCommentSafe(neutral) && !FRONT_JUDGMENT.test(neutral);
+}
+
+/** 등락률 → "+6.2%" / "-4.1%" / "0.0%". */
+function fmtPct(p: number): string {
+  const sign = p > 0 ? "+" : p < 0 ? "-" : "";
+  return `${sign}${Math.abs(p).toFixed(1)}%`;
+}
+
+function whenLabel(asOf?: string): string {
+  return asOf && asOf.trim() ? `${asOf.trim()} 기준` : "오늘";
+}
+
+function priceHook(sig: CardFrontSignals): CardFrontHook | null {
+  const pct = typeof sig.changePct === "number" && Number.isFinite(sig.changePct) ? sig.changePct : undefined;
+  const strong = pct !== undefined && Math.abs(pct) >= FRONT_PRICE_PCT_MIN;
+  if (!strong && !sig.near52WeekHigh) return null;
+  const when = whenLabel(sig.asOf);
+  let headline: string;
+  if (sig.near52WeekHigh && strong) headline = `${when} ${fmtPct(pct!)} · 52주 신고가 부근`;
+  else if (sig.near52WeekHigh) headline = `${when} 52주 신고가 부근`;
+  else headline = `${when} ${fmtPct(pct!)}`;
+
+  const up = (pct ?? 0) > 0 || (!!sig.near52WeekHigh && (pct ?? 0) >= 0);
+  const translation = sig.near52WeekHigh
+    ? "최근 1년 중 가장 높은 가격대에 시선이 모이는 중이에요."
+    : up
+      ? "오늘 가격이 위쪽으로 크게 움직였어요."
+      : "오늘 가격이 아래쪽으로 크게 움직였어요.";
+
+  // 균형(§4 4행): 가격은 올랐는데 외국인 수급은 반대면 한 줄로 알린다(억지 금지 — 데이터 있을 때만).
+  let balance: string | undefined;
+  const streak = sig.foreignNetStreak;
+  if (up && typeof streak === "number" && streak <= -FRONT_SUPPLY_STREAK_MIN)
+    balance = "다만 외국인 수급은 반대로 빠지는 중이에요.";
+  else if (!up && typeof streak === "number" && streak >= FRONT_SUPPLY_STREAK_MIN)
+    balance = "다만 외국인은 오히려 사 모으는 중이에요.";
+
+  return balance ? { headline, translation, balance, source: "price" } : { headline, translation, source: "price" };
+}
+
+function volumeHook(sig: CardFrontSignals): CardFrontHook | null {
+  const r = sig.volumeRatio;
+  if (typeof r !== "number" || !Number.isFinite(r) || r < FRONT_VOLUME_RATIO_MIN) return null;
+  return {
+    headline: `거래량 평소 ${r.toFixed(1)}배`,
+    translation: "평소보다 훨씬 많은 거래가 오갔어요.",
+    source: "volume",
+  };
+}
+
+function supplyHook(sig: CardFrontSignals): CardFrontHook | null {
+  const s = sig.foreignNetStreak;
+  if (typeof s !== "number" || !Number.isFinite(s) || Math.abs(s) < FRONT_SUPPLY_STREAK_MIN) return null;
+  const buy = s > 0;
+  return {
+    headline: `외국인 ${Math.abs(s)}일째 ${buy ? "순매수" : "순매도"}`,
+    translation: buy
+      ? "외국인 자금이 며칠째 꾸준히 들어오는 흐름이에요."
+      : "외국인 자금이 며칠째 빠져나가는 흐름이에요.",
+    source: "supply",
+  };
+}
+
+function newsHook(sig: CardFrontSignals): CardFrontHook | null {
+  const r = sig.reason?.trim();
+  if (!r) return null;
+  if (!isFrontHookSafe(r)) return null; // 근거에 판정/추천이 섞이면 채택 안 함 → 잠잠으로
+  return { headline: r, translation: "", source: "news" };
+}
+
+function quietHook(sig: CardFrontSignals): CardFrontHook {
+  const id = sig.identity?.trim();
+  return {
+    headline: "오늘은 잠잠해요",
+    translation: id || "큰 움직임 없이 조용한 하루예요.",
+    source: "quiet",
+  };
+}
+
+/**
+ * 카드 앞면 후킹 — 우선순위(가격>거래량>수급>뉴스>잠잠)대로 데이터 있는 첫 신호 채택.
+ * 순수·결정적. 채택된 줄이 가드(판정·추천·예측 금지)를 못 넘으면 잠잠으로 안전 폴백.
+ */
+export function buildCardFrontHook(sig: CardFrontSignals = {}): CardFrontHook {
+  const hook = priceHook(sig) || volumeHook(sig) || supplyHook(sig) || newsHook(sig) || quietHook(sig);
+  const joined = `${hook.headline} ${hook.translation} ${hook.balance ?? ""}`;
+  if (!isFrontHookSafe(joined)) return quietHook(sig);
+  return hook;
+}
+
+// ── baseline(stock-basics) → 신호 도출 (규칙 기반, 외부소스·LLM 0) ─────────────
+const numOf = (s: string | undefined): number | null => {
+  if (!s) return null;
+  const c = s.replace(/[^\d.-]/g, "");
+  if (!/\d/.test(c)) return null;
+  const n = Number(c);
+  return Number.isFinite(n) ? n : null;
+};
+
+/** 회사 개요 첫 구절만(잠잠 fallback 의 "회사 한 줄") — "동사는/당사는" 보일러플레이트 제거 후 너무 길면 자른다. */
+function firstClause(summary: string): string | undefined {
+  const head = summary
+    .trim()
+    .replace(/^(동사는|당사는|당사|동사)\s*/, "")
+    .split(/[.\n·]/)[0]
+    ?.trim();
+  if (!head) return undefined;
+  return head.length > 42 ? `${head.slice(0, 40)}…` : head;
+}
+
+/**
+ * stock-basics(네이버 baseline) → 카드 앞면 신호. 가격 이벤트(우선순위 1)와 잠잠 보조(정체성)만 채운다.
+ * 거래량·수급은 baseline 에 없어 미도출(P1) — 엔진 시그니처는 이미 열려 있다.
+ */
+export function signalsFromBasics(b: StockBasics): CardFrontSignals {
+  const out: CardFrontSignals = {};
+  if (b.changeText) {
+    // 네이버 등락 비율은 부호 포함 — 예 "8,500 (-2.34%)" / "2,000 (0.55%)". 부호를 그대로 쓴다.
+    const m = b.changeText.match(/\(\s*([+-]?[\d.]+)\s*%\s*\)/);
+    const raw = m?.[1];
+    if (raw) {
+      let pct = Number(raw);
+      // 비율에 부호가 없으면(드묾) changeDir 로 보정.
+      if (Number.isFinite(pct)) {
+        if (pct > 0 && b.changeDir === "down" && !/^[+-]/.test(raw)) pct = -pct;
+        out.changePct = pct;
+      }
+    }
+  }
+  const high = b.metrics.find((m) => m.label === "최근 1년 최고가")?.value;
+  const cur = b.priceText;
+  if (high && cur) {
+    const h = numOf(high);
+    const c = numOf(cur);
+    if (h && c && h > 0) out.near52WeekHigh = c >= h * 0.98; // 신고가의 98% 이상이면 "부근"
+  }
+  if (b.summary) {
+    const id = firstClause(b.summary);
+    if (id) out.identity = id;
+  }
+  return out;
+}

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -6,3 +6,4 @@ export * from "./community";
 export * from "./comment";
 export * from "./josa";
 export * from "./stocks";
+export * from "./card-front-hook";


### PR DESCRIPTION
## 한 줄
모든 종목 카드가 똑같던 **"이 종목, 오늘 어떤 흐름인지 한번 볼까요?"**(후킹 0)를 → 그날 그 종목의 **가장 센 객관 신호 한 줄 + 쉬운 번역 한 줄**로 교체. 점수·등급·판정 없이 **사실(주목도)만**.

## 무엇을
- **`buildCardFrontHook`** (`packages/fomo-core` 순수·결정적): 우선순위 **가격 > 거래량 > 수급 > 뉴스 > 잠잠** 중 데이터 있는 첫 신호 채택. 금칙어 가드(`isCommentSafe` + 점수/등급/추천). 같은 입력=같은 출력(캐시·새로고침 안정).
- **`signalsFromBasics`**: 네이버 baseline에서 가격 이벤트(등락률 *부호 포함* / 52주 신고가 부근) + 잠잠 보조(회사 정체성 한 줄) 규칙기반 도출. 외부소스·LLM 0.
- **`SectorStockDeck`**: 도달하는 카드의 basics를 lazy fetch(캐시) → 후킹 렌더(비용 방어 §5). `reason`/잠잠은 즉시, 가격은 도착 시 갱신. 시점 명시("M/D 기준"), 해요체, 균형(반대 방향 사실) 줄 지원.

## 범위 / 게이트
- 건드린 것: `card-front-hook.ts`(신규) + 배럴 + 테스트 + `SectorStockDeck.tsx`. **새 외부소스·비용·DDL 없음**(기존 네이버 baseline 경로 재사용) → 일반 PR.
- 거래량·수급(우선순위 2·3)은 baseline에 없어 엔진 **시그니처만** 열고 미연결 → **P1**(신호 배지·풀 티어링)에서 데이터 소싱.

## 검증
- 라이브 prod basics로 확인: **삼성전기 +3.2% · 네패스 -10.1% · 동진쎄미켐 -3.7% · 원익IPS -4.4%** → 가격 후킹 + 시점 + 번역. **삼성전자/SK하이닉스/리노공업** 등 ±3% 미만은 정직하게 **잠잠 + 회사 한 줄**.
- 741 테스트 통과(card-front-hook 16 신규), core/web typecheck 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)