### PR TITLE
feat(card): FOMO 강도 모델로 앞면 후킹 재설계 (PHASE0 rev2)

### DIFF
--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -85,35 +85,96 @@ const MARKET_LABEL: Record<string, string> = {
  * 2행 헤드라인(가격>거래량>수급>뉴스>잠잠) · 3행 쉬운 번역 · 4행 균형(있으면). 점수·판정 없이 사실만.
  * 비주얼 디테일(국기·리치 등)은 광혁 — 여기선 구조/문구만.
  */
-function StockCardFace({ stock, hook, progress }: { stock: DeckStock; hook: CardFrontHook; progress?: string }) {
-  const quiet = hook.source === "quiet";
+/** 강도별 헤드라인 색 — 강도 비례 톤(§3). high=코랄, medium=주황, calm=그레이. */
+const INTENSITY_COLOR: Record<string, string> = { high: UP, medium: "#F59E0B", calm: "#94A3B8" };
+
+/** 로고 폴백 — 종목명 첫 글자 원형(외부 이미지는 후속, 게이트). */
+function InitialBadge({ name }: { name: string }) {
+  const ch = name.trim().slice(0, 1) || "·";
+  return (
+    <span
+      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-base font-bold text-white"
+      style={{ backgroundColor: "rgba(255,90,54,0.18)", color: UP }}
+      aria-hidden
+    >
+      {ch}
+    </span>
+  );
+}
+
+/**
+ * 종목 카드 앞면 — FOMO 후킹 구조(rev2 §4): 정체성 / 테마태그 / 후킹 / 다가오는 재료 / baseline.
+ * 강도에 비례한 톤(§3) — 핫한 종목은 세게, 조용한 종목은 차분하게. 점수·판정·예측 없음.
+ * 로고 이미지·미니차트·시총순위는 후속(배포 복구 후 서버 페치) — 지금은 이니셜/태그/텍스트 골격.
+ */
+function StockCardFace({
+  stock,
+  hook,
+  changePct,
+  progress,
+}: {
+  stock: DeckStock;
+  hook: CardFrontHook;
+  changePct?: number | undefined;
+  progress?: string | undefined;
+}) {
+  const color = INTENSITY_COLOR[hook.intensity] ?? "#94A3B8";
+  // 6행 baseline(위생) — 헤드라인이 이미 등락을 말하는 가격/quiet 앵글은 생략(중복 방지).
+  const showBaseline = ["named", "dday", "big", "surprise"].includes(hook.angle) && typeof changePct === "number";
+  const baseline = showBaseline
+    ? `오늘 ${changePct! > 0 ? "+" : changePct! < 0 ? "-" : ""}${Math.abs(changePct!).toFixed(1)}%`
+    : undefined;
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-2">
-        <span className="text-2xl font-bold text-whiteout">{stock.canonical}</span>
-        {stock.marquee && <span className="text-xl" aria-hidden>⭐</span>}
+      {/* 1행 — 정체성: 로고(이니셜) + 종목명 + 시장 */}
+      <div className="flex items-center gap-2.5">
+        <InitialBadge name={stock.canonical} />
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-2xl font-bold text-whiteout">{stock.canonical}</span>
+            {stock.marquee && <span className="text-base" aria-hidden>⭐</span>}
+          </div>
+          <span className="font-pixel text-xs text-muted">{MARKET_LABEL[stock.market] ?? stock.market}</span>
+        </div>
       </div>
-      <p className="mt-3 font-pixel text-sm text-muted">
-        {MARKET_LABEL[stock.market] ?? stock.market}
-      </p>
 
-      {/* 2행 — 후킹(가장 센 객관 신호 1줄) */}
-      <p
-        className="mt-5 text-xl font-bold leading-8"
-        style={quiet ? { color: "#94A3B8" } : { color: UP }}
-      >
+      {/* 2행 — 테마 태그 */}
+      {hook.themeLabel && (
+        <span
+          className="mt-4 inline-flex w-fit items-center rounded-full px-2.5 py-1 font-pixel text-xs"
+          style={{ backgroundColor: "rgba(255,90,54,0.12)", color: UP }}
+        >
+          # {hook.themeLabel}
+        </span>
+      )}
+
+      {/* 3행 — FOMO 후킹(강도 비례 톤) */}
+      <p className="mt-4 text-xl font-bold leading-8" style={{ color }}>
         {hook.headline}
       </p>
-      {/* 3행 — 쉬운 번역(사실 묘사) */}
-      {hook.translation && (
-        <p className="mt-2 text-base leading-7 text-whiteout">{hook.translation}</p>
-      )}
-      {/* 4행 — 균형(반대 방향 사실, 있을 때만) */}
-      {hook.balance && <p className="mt-2 text-sm leading-6 text-muted">{hook.balance}</p>}
 
-      <div className="mt-auto flex items-center justify-between pt-6">
-        <span className="font-pixel text-[11px] text-muted">더보기 →</span>
-        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+      {/* 5행 — 다가오는 재료(구체·일정) */}
+      {hook.catalysts.length > 0 && (
+        <ul className="mt-4 flex flex-col gap-1.5">
+          {hook.catalysts.map((c, i) => (
+            <li key={i} className="flex gap-2 text-sm leading-6 text-whiteout">
+              <span aria-hidden style={{ color: UP }}>•</span>
+              <span>
+                {c.when && <span className="font-pixel text-muted">{c.when} · </span>}
+                {c.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-auto pt-6">
+        {/* 6행 — baseline(위생 요소, 후킹 아님) */}
+        {baseline && <p className="font-pixel text-[11px] text-muted">{baseline}</p>}
+        <div className="mt-2 flex items-center justify-between">
+          <span className="font-pixel text-[11px] text-muted">더보기 →</span>
+          {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+        </div>
       </div>
     </div>
   );
@@ -214,11 +275,15 @@ function SectorDeckInner({
     [signals]
   );
 
-  const hookFor = (stock: DeckStock): CardFrontHook => {
-    const sig: CardFrontSignals = { ...(signals[stock.canonical] ?? {}), asOf };
-    if (stock.reason) sig.reason = stock.reason;
-    return buildCardFrontHook(sig);
+  // 종목별 신호 조립 — basics(가격·52주) + 테마 태그(섹터) + 발굴 근거(named catalyst).
+  // 라이브 수급 streak·거래량·시총순위·일정은 후속(서버 페치, 배포 복구 후) — 엔진은 채워지면 자동 반영.
+  const signalsFor = (stock: DeckStock): CardFrontSignals => {
+    const sig: CardFrontSignals = { ...(signals[stock.canonical] ?? {}), asOf, themeLabel: stock.sector };
+    if (stock.reason) sig.catalysts = [{ label: stock.reason, kind: "news" }];
+    return sig;
   };
+  const hookFor = (stock: DeckStock): CardFrontHook => buildCardFrontHook(signalsFor(stock));
+  const pctOf = (stock: DeckStock): number | undefined => signals[stock.canonical]?.changePct;
 
   const flingNext = useCallback((dir: "left" | "right") => {
     if (prefersReducedMotion()) {
@@ -307,7 +372,7 @@ function SectorDeckInner({
                 zIndex: 1,
               }}
             >
-              <StockCardFace stock={stock} hook={hookFor(stock)} />
+              <StockCardFace stock={stock} hook={hookFor(stock)} changePct={pctOf(stock)} />
             </div>
           ))}
 
@@ -334,7 +399,7 @@ function SectorDeckInner({
           >
             ← 덜 관심
           </span>
-          <StockCardFace stock={top} hook={hookFor(top)} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
+          <StockCardFace stock={top} hook={hookFor(top)} changePct={pctOf(top)} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
         </div>
       </div>
 

--- a/apps/web/lib/supply-demand-store.ts
+++ b/apps/web/lib/supply-demand-store.ts
@@ -61,3 +61,26 @@ export async function readLatestSupplyDemand(ticker: string): Promise<InvestorFl
     return null;
   }
 }
+
+/** 한 종목의 최근 N거래일 수급(최신순). 연속 순매수/순매도(streak) 계산용. 테이블 미생성이면 빈 배열. */
+export async function readSupplyDemandHistory(
+  ticker: string,
+  days = 20
+): Promise<InvestorFlow[]> {
+  try {
+    const rows = await prisma.supplyDemandDaily.findMany({
+      where: { ticker },
+      orderBy: { date: "desc" },
+      take: Math.max(1, Math.min(days, 60)),
+    });
+    return rows.map((row) => ({
+      date: row.date,
+      foreignNet: row.foreignNet,
+      institutionNet: row.institutionNet,
+      ...(row.individualNet != null ? { individualNet: row.individualNet } : {}),
+    }));
+  } catch (err) {
+    console.warn("[supply-demand-store] history read skipped (table missing?)", (err as Error)?.message);
+    return [];
+  }
+}

--- a/packages/fomo-core/__tests__/card-front-hook.test.ts
+++ b/packages/fomo-core/__tests__/card-front-hook.test.ts
@@ -3,109 +3,105 @@ import {
   buildCardFrontHook,
   isFrontHookSafe,
   signalsFromBasics,
-  FRONT_PRICE_PCT_MIN,
-  FRONT_VOLUME_RATIO_MIN,
-  FRONT_SUPPLY_STREAK_MIN,
   type CardFrontSignals,
+  type FomoCatalyst,
   type StockBasics,
 } from "../src";
 
-describe("buildCardFrontHook — 카드 앞면 후킹(PHASE0 §3·§5)", () => {
-  it("우선순위: 가격 > 거래량 > 수급 > 뉴스 > 잠잠 (모두 있으면 가격)", () => {
-    const all: CardFrontSignals = {
-      changePct: 6.2,
-      volumeRatio: 3,
+describe("buildCardFrontHook rev2 — FOMO 강도 모델(§2·§3)", () => {
+  it("최고 강도 앵글 선택 — 수급 연속(사회적 증거 ★최강)이 테마보다 위", () => {
+    const h = buildCardFrontHook({
       foreignNetStreak: 5,
-      reason: "원전 수주 기대로 묶임",
-    };
-    expect(buildCardFrontHook(all).source).toBe("price");
-    expect(buildCardFrontHook({ volumeRatio: 3, foreignNetStreak: 5, reason: "x 묶임" }).source).toBe("volume");
-    expect(buildCardFrontHook({ foreignNetStreak: 5, reason: "x 묶임" }).source).toBe("supply");
-    expect(buildCardFrontHook({ reason: "원전 수주 기대로 묶임" }).source).toBe("news");
-    expect(buildCardFrontHook({}).source).toBe("quiet");
+      institutionNetStreak: 4,
+      themeProminenceRank: 2,
+      themeLabel: "AI 메모리",
+    });
+    expect(h.angle).toBe("social");
+    expect(h.headline).toContain("담는 중");
+    expect(h.intensity).toBe("high");
   });
 
-  it("가격 — ±3% 이상이면 헤드라인에 부호·숫자·시점", () => {
-    const up = buildCardFrontHook({ changePct: 6.23, asOf: "6/21" });
-    expect(up.source).toBe("price");
-    expect(up.headline).toBe("6/21 기준 +6.2%");
-    expect(up.translation).toContain("위쪽");
-
-    const down = buildCardFrontHook({ changePct: -4.1, asOf: "6/21" });
-    expect(down.headline).toBe("6/21 기준 -4.1%");
-    expect(down.translation).toContain("아래쪽");
-
-    const noDate = buildCardFrontHook({ changePct: 5 });
-    expect(noDate.headline).toBe("오늘 +5.0%");
+  it("고정 우선순위 아님 — 수급 없고 테마 1위면 '판이 큼' 앵글", () => {
+    const h = buildCardFrontHook({ themeProminenceRank: 1, themeLabel: "원전 슈퍼사이클" });
+    expect(h.angle).toBe("big");
+    expect(h.headline).toContain("원전 슈퍼사이클");
+    expect(h.headline).toContain("1위");
   });
 
-  it("가격 — 컷(±3%) 미달이면 가격 스킵 → 다음 우선순위(잠잠)", () => {
-    const small = buildCardFrontHook({ changePct: FRONT_PRICE_PCT_MIN - 0.5 });
-    expect(small.source).toBe("quiet");
+  it("D-day — 임박 일정이 있으면 강하게(지금 봐야)", () => {
+    const cat: FomoCatalyst[] = [{ label: "2분기 실적 발표", when: "7월 말", kind: "schedule" }];
+    const h = buildCardFrontHook({ catalysts: cat, themeProminenceRank: 3 });
+    expect(h.angle).toBe("dday");
+    expect(h.headline).toContain("7월 말");
+    expect(h.headline).toContain("2분기 실적 발표");
   });
 
-  it("가격 — 52주 신고가 부근은 컷과 무관하게 채택, 강한 등락과 결합", () => {
-    expect(buildCardFrontHook({ changePct: 0.4, near52WeekHigh: true }).headline).toContain("52주 신고가");
-    const both = buildCardFrontHook({ changePct: 7, near52WeekHigh: true, asOf: "6/21" });
-    expect(both.headline).toBe("6/21 기준 +7.0% · 52주 신고가 부근");
+  it("의외성 — 가격 조용한데 테마 큰 인지 갭", () => {
+    const h = buildCardFrontHook({ changePct: 0.4, themeProminenceRank: 2, themeLabel: "HBM" });
+    expect(["surprise", "big"]).toContain(h.angle);
   });
 
-  it("거래량 — 1.8배 이상만 채택, 미만은 스킵", () => {
-    expect(buildCardFrontHook({ volumeRatio: 2.4 }).headline).toBe("거래량 평소 2.4배");
-    expect(buildCardFrontHook({ volumeRatio: FRONT_VOLUME_RATIO_MIN - 0.1 }).source).toBe("quiet");
+  it("강도 비례 톤(§3) — 약한 신호는 calm, 강한 신호는 high", () => {
+    expect(buildCardFrontHook({ near52WeekHigh: true }).intensity).not.toBe("high");
+    expect(buildCardFrontHook({ foreignNetStreak: 6, volumeRatio: 3 }).intensity).toBe("high");
   });
 
-  it("수급 — 3일 연속 이상만, 부호로 순매수/순매도", () => {
-    expect(buildCardFrontHook({ foreignNetStreak: 5 }).headline).toBe("외국인 5일째 순매수");
-    expect(buildCardFrontHook({ foreignNetStreak: -4 }).headline).toBe("외국인 4일째 순매도");
-    expect(buildCardFrontHook({ foreignNetStreak: FRONT_SUPPLY_STREAK_MIN - 1 }).source).toBe("quiet");
+  it("조용한 종목 — '잠잠'으로 끝내지 않고 다음 재료를 보여준다", () => {
+    const withNext = buildCardFrontHook({
+      catalysts: [{ label: "신제품 출시 컨퍼런스", when: "8월", kind: "schedule" }],
+    });
+    expect(withNext.angle).toBe("dday"); // 일정이 있으면 차분해도 그걸 후킹
+    const trulyQuiet = buildCardFrontHook({});
+    expect(trulyQuiet.angle).toBe("quiet");
+    expect(trulyQuiet.intensity).toBe("calm");
+    expect(trulyQuiet.headline).toContain("지켜볼 재료가 아직 없어요"); // 솔직
   });
 
-  it("균형(4행) — 가격은 올랐는데 외국인은 빠지면 반대 사실 한 줄(억지 금지)", () => {
-    const conflict = buildCardFrontHook({ changePct: 6, foreignNetStreak: -5 });
-    expect(conflict.source).toBe("price");
-    expect(conflict.balance).toContain("외국인");
-    // 충돌 없으면 balance 없음
-    expect(buildCardFrontHook({ changePct: 6, foreignNetStreak: 5 }).balance).toBeUndefined();
-    expect(buildCardFrontHook({ changePct: 6 }).balance).toBeUndefined();
+  it("데이터 없는 앵글은 후보에서 제외(환각 금지)", () => {
+    // 거래량/수급/테마 전무 → 가격만 약함 → quiet
+    expect(buildCardFrontHook({ changePct: 1.2 }).angle).toBe("quiet");
+    // 컷 미달 수급은 social 후보에서 빠짐
+    expect(buildCardFrontHook({ foreignNetStreak: 2 }).angle).toBe("quiet");
   });
 
-  it("뉴스 — 근거를 헤드라인으로, 단 판정/추천 섞이면 잠잠으로 폴백(환각·판정 금지)", () => {
-    expect(buildCardFrontHook({ reason: "원전 수주 기대로 묶임" }).headline).toBe("원전 수주 기대로 묶임");
-    // 근거에 금칙(추천/예측)이 들어오면 채택 안 함
-    expect(buildCardFrontHook({ reason: "지금 매수 추천! 급등할 종목" }).source).toBe("quiet");
+  it("다가오는 재료 — 익명 '재료' 금지, 구체/일정만, 일정 우선 정렬, 최대 3개", () => {
+    const cats: FomoCatalyst[] = [
+      { label: "재료", kind: "news" }, // 익명 → 제거
+      { label: "HBM4 공급계약 보도", when: "6/18", kind: "news" },
+      { label: "외국인 3주째 순매수", kind: "flow" },
+      { label: "2분기 실적", when: "7/25", kind: "schedule" },
+      { label: "AI 테마 묶임", kind: "theme" },
+    ];
+    const h = buildCardFrontHook({ themeProminenceRank: 1, themeLabel: "AI", catalysts: cats });
+    expect(h.catalysts.length).toBe(3);
+    expect(h.catalysts.every((c) => c.label !== "재료")).toBe(true);
+    expect(h.catalysts[0]!.kind).toBe("schedule"); // 일정 먼저
   });
 
-  it("잠잠 — 신호 없으면 '오늘은 잠잠' + 회사 한 줄(있으면), 없으면 기본 문구", () => {
-    const withId = buildCardFrontHook({ identity: "모바일 메모리 설계 팹리스" });
-    expect(withId.source).toBe("quiet");
-    expect(withId.headline).toBe("오늘은 잠잠해요");
-    expect(withId.translation).toBe("모바일 메모리 설계 팹리스");
-    expect(buildCardFrontHook({}).translation).toContain("조용한");
-  });
-
-  it("결정적 — 같은 입력은 같은 출력(캐시·새로고침 안정)", () => {
-    const sig: CardFrontSignals = { changePct: 4.4, asOf: "6/21" };
+  it("결정적 — 같은 입력은 같은 앵글·같은 카피", () => {
+    const sig: CardFrontSignals = { foreignNetStreak: 4, themeProminenceRank: 2, themeLabel: "방산" };
     expect(buildCardFrontHook(sig)).toEqual(buildCardFrontHook(sig));
   });
 
-  it("금칙어 가드 — 어떤 채택 결과에도 점수·등급·추천·예측 어휘가 없다", () => {
+  it("금칙어 가드 — 어떤 앵글 결과에도 예측·판정·점수·등급 어휘가 없다", () => {
     const samples: CardFrontSignals[] = [
-      { changePct: 9.1, asOf: "6/21" },
-      { changePct: -7, foreignNetStreak: -6 },
-      { volumeRatio: 5 },
-      { foreignNetStreak: 8 },
-      { reason: "AI 데이터센터 수주로 묶임" },
-      { identity: "원전 기자재 전문" },
+      { foreignNetStreak: 8, volumeRatio: 5 },
+      { themeProminenceRank: 1, themeLabel: "2차전지" },
+      { catalysts: [{ label: "FDA 승인 심사", when: "9월", kind: "schedule" }] },
+      { changePct: 0.2, themeProminenceRank: 2, themeLabel: "코인" },
       {},
     ];
     for (const s of samples) {
       const h = buildCardFrontHook(s);
-      const joined = `${h.headline} ${h.translation} ${h.balance ?? ""}`;
-      // isFrontHookSafe 가 진짜 가드(순매수/순매도는 수급 사실로 허용) — 행동 지시·예측·점수·등급은 차단.
+      const joined = `${h.headline} ${h.catalysts.map((c) => c.label).join(" ")}`;
       expect(isFrontHookSafe(joined), `금칙어: ${joined}`).toBe(true);
-      expect(joined).not.toMatch(/점수|등급|추천|유망|급등할|폭등/);
+      expect(joined).not.toMatch(/점수|등급|추천|유망|급등할|폭등|사라|오를 것/);
     }
+  });
+
+  it("예측 섞인 named catalyst 는 헤드라인 채택 안 함(가드)", () => {
+    const h = buildCardFrontHook({ catalysts: [{ label: "급등할 거란 전망", kind: "news" }] });
+    expect(h.angle).not.toBe("named");
   });
 });
 
@@ -115,37 +111,27 @@ describe("signalsFromBasics — baseline(stock-basics) → 신호 도출", () =>
   it("등락률 — changeText 의 부호 포함 비율을 그대로(네이버 실제 포맷)", () => {
     expect(signalsFromBasics({ ...base, changeText: "2,000 (0.55%)", changeDir: "up" }).changePct).toBe(0.55);
     expect(signalsFromBasics({ ...base, changeText: "20,500 (-6.50%)", changeDir: "down" }).changePct).toBe(-6.5);
-    // 비율에 부호가 없는 드문 경우만 changeDir 로 보정.
     expect(signalsFromBasics({ ...base, changeText: "1,500 (6.20%)", changeDir: "down" }).changePct).toBe(-6.2);
   });
 
   it("52주 신고가 — 현재가가 최고가의 98% 이상이면 부근", () => {
-    const near = signalsFromBasics({
-      ...base,
-      priceText: "99,000원",
-      metrics: [{ label: "최근 1년 최고가", value: "100,000원" }],
-    });
-    expect(near.near52WeekHigh).toBe(true);
-    const far = signalsFromBasics({
-      ...base,
-      priceText: "80,000원",
-      metrics: [{ label: "최근 1년 최고가", value: "100,000원" }],
-    });
-    expect(far.near52WeekHigh).toBe(false);
+    expect(
+      signalsFromBasics({ ...base, priceText: "99,000원", metrics: [{ label: "최근 1년 최고가", value: "100,000원" }] })
+        .near52WeekHigh
+    ).toBe(true);
+    expect(
+      signalsFromBasics({ ...base, priceText: "80,000원", metrics: [{ label: "최근 1년 최고가", value: "100,000원" }] })
+        .near52WeekHigh
+    ).toBe(false);
   });
 
-  it("정체성 — 회사 개요 첫 구절(잠잠 보조)", () => {
-    const s = signalsFromBasics({ ...base, summary: "모바일 메모리 설계 팹리스. 2010년 설립." });
-    expect(s.identity).toBe("모바일 메모리 설계 팹리스");
+  it("정체성 — '동사는' 보일러플레이트 제거한 첫 구절", () => {
+    expect(signalsFromBasics({ ...base, summary: "동사는 모바일 메모리 설계 팹리스. 2010년 설립." }).identity).toBe(
+      "모바일 메모리 설계 팹리스"
+    );
   });
 
-  it("데이터 없으면 빈 신호(환각 금지) → 잠잠으로 귀결", () => {
-    expect(buildCardFrontHook(signalsFromBasics(base)).source).toBe("quiet");
-  });
-
-  it("도출 신호로 후킹까지 — 강한 등락이면 가격 카드", () => {
-    const sig = signalsFromBasics({ ...base, changeText: "5,000 (5.10%)", changeDir: "up" });
-    sig.asOf = "6/21";
-    expect(buildCardFrontHook(sig).headline).toBe("6/21 기준 +5.1%");
+  it("데이터 없으면 빈 신호(환각 금지) → 차분 카드로 귀결", () => {
+    expect(buildCardFrontHook(signalsFromBasics(base)).angle).toBe("quiet");
   });
 });

--- a/packages/fomo-core/__tests__/supply-demand.test.ts
+++ b/packages/fomo-core/__tests__/supply-demand.test.ts
@@ -4,7 +4,29 @@ import {
   latestInvestorFlow,
   supplyDemandFact,
   parseKisInvestorFlow,
+  investorNetStreak,
+  type InvestorFlow,
 } from "../src/supply-demand";
+
+describe("investorNetStreak — 연속 순매수/순매도(사회적 증거 레버)", () => {
+  const f = (date: string, foreignNet: number, institutionNet: number): InvestorFlow => ({
+    date,
+    foreignNet,
+    institutionNet,
+  });
+  it("최신일부터 같은 부호가 이어지는 길이(순매수=+/순매도=−)", () => {
+    const flows = [f("2026-06-21", 100, -50), f("2026-06-20", 80, -10), f("2026-06-19", 30, 5), f("2026-06-18", -10, -20)];
+    const s = investorNetStreak(flows);
+    expect(s.foreign).toBe(3); // +,+,+ 후 끊김
+    expect(s.institution).toBe(-2); // -,- 후 +로 끊김
+  });
+  it("입력 순서 무관(결정적), 보합이면 끊김, 비면 0", () => {
+    expect(investorNetStreak([]).foreign).toBe(0);
+    expect(investorNetStreak([f("2026-06-21", 0, 5), f("2026-06-20", 10, 5)]).foreign).toBe(0); // 최신 보합
+    const a = investorNetStreak([f("2026-06-19", 1, 1), f("2026-06-21", 1, 1), f("2026-06-20", 1, 1)]);
+    expect(a.foreign).toBe(3);
+  });
+});
 
 // 네이버 frgn.naver 실제 행 구조(2행) — 날짜·종가·전일비·등락률·거래량·기관·외국인·보유주수·보유율.
 // 기관/외국인만 부호(+/-) 동반. 등락률(+1.02%)은 % 라 순매매로 안 잡혀야 한다.

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -1,152 +1,279 @@
-// PHASE0_CARD_FRONT_HOOK — 카드 앞면 후킹(순수부).
+// PHASE0_CARD_HOOK (rev2) — 카드 앞면 FOMO 후킹(순수부).
 //
-// 모든 종목 카드가 똑같은 "이 종목, 오늘 어떤 흐름인지 한번 볼까요?"(후킹 0) 대신,
-// 그날 그 종목의 *가장 센 객관 신호 한 줄 + 쉬운 번역 한 줄*로 교체한다.
-// 점수·등급·판정 없이 **사실(주목도)만**. 같은 입력=같은 출력(결정적 — 캐시·새로고침 안정).
+// 진짜 후킹 = "남들은 이미 움직이는데 / 곧 결판나고 / 판이 큰데 나만 모른다"를 그 강도만큼 번역한 한 줄
+// + 다가오는 재료(지켜볼 거리). 가격·거래량 readout 은 baseline(증권앱 다 있음) — 후킹 아님(rev1 폐기 사유).
 //
-// 신호 우선순위(§3, 위에서부터 데이터 있는 첫 신호):
-//   1) 가격 이벤트(등락 ≥±3% OR 52주 신고가 부근)  2) 거래량(평소 ≥1.8배)
-//   3) 수급(외인/기관 ≥3일 연속)  4) 뉴스/공시(발굴 근거)  5) (없음) 잠잠 + 회사 한 줄
+// FOMO 강도 모델(§2): 후보 앵글마다 5개 레버를 얼마나 치는지로 점수를 매기고 최고 앵글을 헤드라인으로.
+//   1) 사회적 증거 ★최강 — 외인·기관 연속 순매수, 거래량 급증 ("남들 이미 움직임")
+//   2) D-day 임박 — 실적·승인 등 임박 일정 ("지금 봐야")
+//   3) 판이 큼 — 테마 주목도 상위 ("터지면 큰 거")
+//   4) 구체·이름 — named catalyst ("재료" 익명 금지)
+//   5) 의외성 — 조용한데 사실 큰 게 옴 (인지 갭)
 //
-// 비용방어(§5): 앞면 신호는 baseline 데이터로 **규칙 기반**(LLM 0, 싸게 항상). LLM 번역은 깊이 페이지 몫.
+// 절대 원칙(§3·§6): 강도에 비례한 톤(전 카드 "지금 핫!" 금지). 예측("오를 것/사라") 금지 —
+//   누가 이미 움직였나(사실) + 뭐가 임박했나(일정)로만. 점수·등급·판정 금지. 같은 입력=같은 출력.
 
 import { isCommentSafe } from "./comment";
 import type { StockBasics } from "../stock-basics";
 
-/** 카드 앞면 후킹에 쓰는 신호 묶음 — 데이터 되는 것만 채운다(없으면 그 우선순위는 스킵). */
+/** 다가오는 재료 한 항목(§4 5행) — 구체·일정. 익명 "재료" 금지. */
+export interface FomoCatalyst {
+  /** 무엇 — 구체 명시("2분기 실적 발표", "HBM 공급계약 보도"). */
+  label: string;
+  /** 언제/시점 — "7월 말", "6/18"(있으면). */
+  when?: string;
+  kind: "schedule" | "news" | "flow" | "theme";
+}
+
+/** 카드 앞면 후킹에 쓰는 신호 묶음 — 데이터 되는 것만 채운다(없으면 그 레버는 0). */
 export interface CardFrontSignals {
-  /** 등락률 %(부호 포함, 장 기준). 우선순위 1. */
-  changePct?: number;
-  /** 52주 신고가 부근/돌파. 우선순위 1 보강. */
-  near52WeekHigh?: boolean;
-  /** 평소 대비 거래량 배수. 우선순위 2(데이터 되면). */
-  volumeRatio?: number;
-  /** 외국인 연속 순매수(+)/순매도(−) 일수. 우선순위 3(데이터 되면). */
+  // ── 레버 1: 사회적 증거 ──
+  /** 외국인 연속 순매수(+)/순매도(−) 일수. */
   foreignNetStreak?: number;
-  /** 그날 그 종목이 묶인 근거(#560 발굴). 우선순위 4. */
-  reason?: string;
-  /** 회사 정체성 한 줄 — 잠잠 fallback 보조(있으면). */
+  /** 기관 연속 순매수(+)/순매도(−) 일수. */
+  institutionNetStreak?: number;
+  /** 평소 대비 거래량 배수. */
+  volumeRatio?: number;
+  /** 등락률 %(부호 포함). 사회적 증거의 결과(보강). */
+  changePct?: number;
+  /** 52주 신고가 부근/돌파. */
+  near52WeekHigh?: boolean;
+  // ── 레버 3: 판이 큼 ──
+  /** 그날 테마 주목도 순위(1=최고). 키워드 엔진 fomoScore 기반. */
+  themeProminenceRank?: number;
+  /** 테마 라벨(2행 태그·헤드라인) — 예 "AI 메모리 슈퍼사이클". */
+  themeLabel?: string;
+  // ── 레버 2·4: D-day·named catalyst ──
+  /** 다가오는 재료(구체·일정). 비어도 됨. */
+  catalysts?: readonly FomoCatalyst[];
+  // ── 컨텍스트(후킹 아님) ──
+  /** 시총 순위(1행) — 예 { scope:"market", market:"코스피", rank:1 }. */
+  marketCapRank?: { scope: "market" | "sector"; market?: string; rank: number };
+  /** 회사 정체성 한 줄(잠잠 보조 — rev2 에선 거의 안 씀). */
   identity?: string;
   /** 시점 라벨 — 예 "6/21". 없으면 "오늘". */
   asOf?: string;
 }
 
-/** 어느 신호가 채택됐는지(배지·테스트용). */
-export type CardFrontSource = "price" | "volume" | "supply" | "news" | "quiet";
+/** 채택된 FOMO 앵글(§2 레버). */
+export type FomoAngle = "social" | "dday" | "big" | "named" | "surprise" | "quiet";
+/** 카드 세기 — 강도 비례 톤·시각 강조용(§3). */
+export type FomoIntensity = "high" | "medium" | "calm";
 
 export interface CardFrontHook {
-  /** 2행 — 가장 센 객관 신호 1줄(숫자·시점 포함). */
+  /** 3행 — FOMO 강도 최고 앵글 한 줄(구체 명시·시점·해요체). */
   headline: string;
-  /** 3행 — 쉬운 번역(사실 묘사, 판정 아님). 없으면 빈 문자열. */
-  translation: string;
-  /** 4행 — 반대 방향의 사실(있을 때만, 억지 금지). */
-  balance?: string;
-  /** 채택된 신호 종류. */
-  source: CardFrontSource;
+  /** 카드 세기(시각 강조·정렬용). */
+  intensity: FomoIntensity;
+  /** 채택된 앵글. */
+  angle: FomoAngle;
+  /** 5행 — 다가오는 재료(구체·일정, 익명 금지). 없으면 빈 배열. */
+  catalysts: FomoCatalyst[];
+  /** 2행 — 테마 태그(있으면). */
+  themeLabel?: string;
 }
 
-// ── 임계값(§3, "가짜 흥분" 금지) ─────────────────────────────────────────────
-export const FRONT_PRICE_PCT_MIN = 3; // 등락 ≥ ±3%
-export const FRONT_VOLUME_RATIO_MIN = 1.8; // 거래량 평소 대비 ≥ 1.8배
-export const FRONT_SUPPLY_STREAK_MIN = 3; // 수급 ≥ 3일 연속
+// ── 임계값·가중치(§8.1 광혁 튜닝 대상) ───────────────────────────────────────
+export const FRONT_SOCIAL_STREAK_MIN = 3; // 연속 ≥3일
+export const FRONT_VOLUME_RATIO_MIN = 1.8; // 거래량 ≥1.8배
+export const FRONT_PRICE_PCT_MIN = 3; // 등락 ≥±3%
+export const FRONT_THEME_TOP = 3; // 테마 주목도 상위 N
 
-// 판정·추천·예측 어휘는 isCommentSafe 로 거르고, 점수/등급류만 추가로 막는다(§5).
+const WEIGHT = {
+  socialStreakPerDay: 5, // 연속일수당(상한 적용)
+  socialStreakCap: 25,
+  socialVolume: 16,
+  social52High: 11,
+  socialPrice: 8,
+  dday: 28, // 임박 일정(가장 셈 — "지금 봐야")
+  themeRank: [0, 30, 22, 15] as const, // rank 1→30, 2→22, 3→15
+  named: 14,
+  surprise: 18,
+} as const;
+
+const HIGH_AT = 24;
+const MEDIUM_AT = 12;
+
+function intensityOf(score: number): FomoIntensity {
+  return score >= HIGH_AT ? "high" : score >= MEDIUM_AT ? "medium" : "calm";
+}
+
+// 판정·추천·예측 어휘는 isCommentSafe 로 거르고, 점수/등급류만 추가로 막는다.
 const FRONT_JUDGMENT =
   /점수|등급|[SAB]\s?급|최우수|유망|강력\s?매수|적극\s?매수|꼭\s?사|놓치면|지금\s?사/;
 
 /** 후킹 텍스트가 가드를 통과하는가(투자조언·예측·점수·등급 없음). */
 export function isFrontHookSafe(text: string): boolean {
-  // 순매수/순매도는 수급 '사실'(행동 지시 아님) — 가드의 매수/매도 부분일치에서 제외하고 검사.
+  // 순매수/순매도는 수급 '사실'(행동 지시 아님) — 가드의 매수/매도 부분일치에서 제외.
   const neutral = text.replace(/순매수|순매도/g, "수급");
   return isCommentSafe(neutral) && !FRONT_JUDGMENT.test(neutral);
 }
 
-/** 등락률 → "+6.2%" / "-4.1%" / "0.0%". */
 function fmtPct(p: number): string {
   const sign = p > 0 ? "+" : p < 0 ? "-" : "";
   return `${sign}${Math.abs(p).toFixed(1)}%`;
 }
-
 function whenLabel(asOf?: string): string {
   return asOf && asOf.trim() ? `${asOf.trim()} 기준` : "오늘";
 }
 
-function priceHook(sig: CardFrontSignals): CardFrontHook | null {
-  const pct = typeof sig.changePct === "number" && Number.isFinite(sig.changePct) ? sig.changePct : undefined;
-  const strong = pct !== undefined && Math.abs(pct) >= FRONT_PRICE_PCT_MIN;
-  if (!strong && !sig.near52WeekHigh) return null;
-  const when = whenLabel(sig.asOf);
-  let headline: string;
-  if (sig.near52WeekHigh && strong) headline = `${when} ${fmtPct(pct!)} · 52주 신고가 부근`;
-  else if (sig.near52WeekHigh) headline = `${when} 52주 신고가 부근`;
-  else headline = `${when} ${fmtPct(pct!)}`;
-
-  const up = (pct ?? 0) > 0 || (!!sig.near52WeekHigh && (pct ?? 0) >= 0);
-  const translation = sig.near52WeekHigh
-    ? "최근 1년 중 가장 높은 가격대에 시선이 모이는 중이에요."
-    : up
-      ? "오늘 가격이 위쪽으로 크게 움직였어요."
-      : "오늘 가격이 아래쪽으로 크게 움직였어요.";
-
-  // 균형(§4 4행): 가격은 올랐는데 외국인 수급은 반대면 한 줄로 알린다(억지 금지 — 데이터 있을 때만).
-  let balance: string | undefined;
-  const streak = sig.foreignNetStreak;
-  if (up && typeof streak === "number" && streak <= -FRONT_SUPPLY_STREAK_MIN)
-    balance = "다만 외국인 수급은 반대로 빠지는 중이에요.";
-  else if (!up && typeof streak === "number" && streak >= FRONT_SUPPLY_STREAK_MIN)
-    balance = "다만 외국인은 오히려 사 모으는 중이에요.";
-
-  return balance ? { headline, translation, balance, source: "price" } : { headline, translation, source: "price" };
+interface Scored {
+  angle: FomoAngle;
+  score: number;
+  headline: string;
 }
 
-function volumeHook(sig: CardFrontSignals): CardFrontHook | null {
-  const r = sig.volumeRatio;
-  if (typeof r !== "number" || !Number.isFinite(r) || r < FRONT_VOLUME_RATIO_MIN) return null;
+/** 사회적 증거(레버 1) — 외인·기관 연속, 거래량 급증, 신고가. */
+function scoreSocial(s: CardFrontSignals): Scored | null {
+  let score = 0;
+  const parts: string[] = [];
+  const fs = s.foreignNetStreak ?? 0;
+  const is = s.institutionNetStreak ?? 0;
+  // 같은 방향(둘 다 순매수 or 둘 다 순매도)일 때 가장 강함.
+  const strongStreak = Math.abs(fs) >= FRONT_SOCIAL_STREAK_MIN || Math.abs(is) >= FRONT_SOCIAL_STREAK_MIN;
+  if (strongStreak) {
+    const both = fs >= FRONT_SOCIAL_STREAK_MIN && is >= FRONT_SOCIAL_STREAK_MIN;
+    const bothSell = fs <= -FRONT_SOCIAL_STREAK_MIN && is <= -FRONT_SOCIAL_STREAK_MIN;
+    const n = Math.max(Math.abs(fs), Math.abs(is));
+    score += Math.min(n * WEIGHT.socialStreakPerDay, WEIGHT.socialStreakCap);
+    if (both) parts.push(`외국인·기관 ${n}일째 담는 중`);
+    else if (bothSell) parts.push(`외국인·기관 ${n}일째 파는 중`);
+    else if (Math.abs(fs) >= Math.abs(is)) parts.push(`외국인 ${Math.abs(fs)}일째 ${fs > 0 ? "순매수" : "순매도"} 중`);
+    else parts.push(`기관 ${Math.abs(is)}일째 ${is > 0 ? "순매수" : "순매도"} 중`);
+  }
+  const vr = s.volumeRatio;
+  if (typeof vr === "number" && vr >= FRONT_VOLUME_RATIO_MIN) {
+    score += WEIGHT.socialVolume;
+    parts.push(`거래량 평소 ${vr.toFixed(1)}배`);
+  }
+  if (s.near52WeekHigh) {
+    score += WEIGHT.social52High;
+    if (!strongStreak && !(typeof vr === "number" && vr >= FRONT_VOLUME_RATIO_MIN))
+      parts.push("52주 신고가 부근까지 올라왔어요");
+  }
+  const pct = s.changePct;
+  if (typeof pct === "number" && Math.abs(pct) >= FRONT_PRICE_PCT_MIN) {
+    score += WEIGHT.socialPrice;
+    // 가격 단독이면 readout 이 아니라 '움직임' 문장으로(§rev2: 숫자 한 줄=baseline, 후킹 아님).
+    if (parts.length === 0) parts.push(`오늘 ${fmtPct(pct)} 크게 움직였어요`);
+  }
+  if (score <= 0 || parts.length === 0) return null;
+  return { angle: "social", score, headline: parts.slice(0, 2).join(" · ") };
+}
+
+/** D-day 임박(레버 2) — 가장 가까운 일정 catalyst. */
+function scoreDday(s: CardFrontSignals): Scored | null {
+  const sched = (s.catalysts ?? []).find((c) => c.kind === "schedule");
+  if (!sched) return null;
+  const when = sched.when ? `${sched.when} · ` : "";
+  return { angle: "dday", score: WEIGHT.dday, headline: `${when}${sched.label} 임박했어요` };
+}
+
+/** 판이 큼(레버 3) — 테마 주목도 상위. */
+function scoreBig(s: CardFrontSignals): Scored | null {
+  const rank = s.themeProminenceRank;
+  if (!rank || rank < 1 || rank > FRONT_THEME_TOP) return null;
+  const w = WEIGHT.themeRank[rank] ?? 0;
+  if (w <= 0) return null;
+  const theme = s.themeLabel?.trim();
+  const headline = theme ? `${theme} · 오늘 주목도 ${rank}위 테마예요` : `오늘 주목도 ${rank}위 테마 한복판이에요`;
+  return { angle: "big", score: w, headline };
+}
+
+/** 구체·이름(레버 4) — named 뉴스 catalyst. */
+function scoreNamed(s: CardFrontSignals): Scored | null {
+  const named = (s.catalysts ?? []).find((c) => c.kind === "news" && c.label.trim());
+  if (!named) return null;
+  if (!isFrontHookSafe(named.label)) return null;
+  const when = named.when ? `${named.when} · ` : "";
+  return { angle: "named", score: WEIGHT.named, headline: `${when}${named.label}` };
+}
+
+/** 의외성(레버 5) — 가격은 조용한데 테마/재료는 큰 인지 갭. */
+function scoreSurprise(s: CardFrontSignals): Scored | null {
+  const quietPrice = !(typeof s.changePct === "number" && Math.abs(s.changePct) >= FRONT_PRICE_PCT_MIN);
+  const bigTheme = !!s.themeProminenceRank && s.themeProminenceRank <= FRONT_THEME_TOP;
+  const named = (s.catalysts ?? []).some((c) => c.kind === "news");
+  if (!quietPrice || (!bigTheme && !named)) return null;
+  const theme = s.themeLabel?.trim();
+  const headline = theme
+    ? `조용해 보여도 ${theme} 한복판에 있어요`
+    : "조용해 보여도 큰 흐름 안에 있어요";
+  return { angle: "surprise", score: WEIGHT.surprise, headline };
+}
+
+/** 다 약할 때 — 차분하게, 다음 재료를 보여준다(§3: "잠잠"으로 끝내지 말 것). */
+function quietHook(s: CardFrontSignals): CardFrontHook {
+  const next = (s.catalysts ?? [])[0];
+  const catalysts = dedupeCatalysts(s.catalysts ?? []);
+  if (next) {
+    const when = next.when ? `${next.when} · ` : "";
+    return {
+      headline: `지금은 조용한 자리예요 · 다음은 ${when}${next.label}`,
+      intensity: "calm",
+      angle: "quiet",
+      catalysts,
+      ...(s.themeLabel ? { themeLabel: s.themeLabel } : {}),
+    };
+  }
   return {
-    headline: `거래량 평소 ${r.toFixed(1)}배`,
-    translation: "평소보다 훨씬 많은 거래가 오갔어요.",
-    source: "volume",
+    headline: "지금은 조용한 자리예요 · 지켜볼 재료가 아직 없어요",
+    intensity: "calm",
+    angle: "quiet",
+    catalysts,
+    ...(s.themeLabel ? { themeLabel: s.themeLabel } : {}),
   };
 }
 
-function supplyHook(sig: CardFrontSignals): CardFrontHook | null {
-  const s = sig.foreignNetStreak;
-  if (typeof s !== "number" || !Number.isFinite(s) || Math.abs(s) < FRONT_SUPPLY_STREAK_MIN) return null;
-  const buy = s > 0;
-  return {
-    headline: `외국인 ${Math.abs(s)}일째 ${buy ? "순매수" : "순매도"}`,
-    translation: buy
-      ? "외국인 자금이 며칠째 꾸준히 들어오는 흐름이에요."
-      : "외국인 자금이 며칠째 빠져나가는 흐름이에요.",
-    source: "supply",
-  };
-}
-
-function newsHook(sig: CardFrontSignals): CardFrontHook | null {
-  const r = sig.reason?.trim();
-  if (!r) return null;
-  if (!isFrontHookSafe(r)) return null; // 근거에 판정/추천이 섞이면 채택 안 함 → 잠잠으로
-  return { headline: r, translation: "", source: "news" };
-}
-
-function quietHook(sig: CardFrontSignals): CardFrontHook {
-  const id = sig.identity?.trim();
-  return {
-    headline: "오늘은 잠잠해요",
-    translation: id || "큰 움직임 없이 조용한 하루예요.",
-    source: "quiet",
-  };
+/** 재료 정리 — 일정 먼저, 그다음 뉴스·수급·테마. 익명/중복 제거. 최대 3개. */
+function dedupeCatalysts(list: readonly FomoCatalyst[]): FomoCatalyst[] {
+  const order: Record<FomoCatalyst["kind"], number> = { schedule: 0, news: 1, flow: 2, theme: 3 };
+  const seen = new Set<string>();
+  const out: FomoCatalyst[] = [];
+  for (const c of [...list].sort((a, b) => order[a.kind] - order[b.kind])) {
+    const label = c.label?.trim();
+    if (!label || label === "재료" || seen.has(label)) continue; // 익명 "재료" 금지
+    seen.add(label);
+    out.push(c.when ? { ...c, label } : { ...c, label });
+    if (out.length >= 3) break;
+  }
+  return out;
 }
 
 /**
- * 카드 앞면 후킹 — 우선순위(가격>거래량>수급>뉴스>잠잠)대로 데이터 있는 첫 신호 채택.
- * 순수·결정적. 채택된 줄이 가드(판정·추천·예측 금지)를 못 넘으면 잠잠으로 안전 폴백.
+ * 카드 앞면 FOMO 후킹 — 5개 레버 점수 합이 가장 높은 앵글을 헤드라인으로(고정 우선순위 아님).
+ * 강도 비례 톤. 순수·결정적. 채택된 줄이 가드(예측·판정·추천 금지)를 못 넘으면 차분 폴백.
  */
 export function buildCardFrontHook(sig: CardFrontSignals = {}): CardFrontHook {
-  const hook = priceHook(sig) || volumeHook(sig) || supplyHook(sig) || newsHook(sig) || quietHook(sig);
-  const joined = `${hook.headline} ${hook.translation} ${hook.balance ?? ""}`;
-  if (!isFrontHookSafe(joined)) return quietHook(sig);
-  return hook;
+  const candidates = [
+    scoreSocial(sig),
+    scoreDday(sig),
+    scoreBig(sig),
+    scoreNamed(sig),
+    scoreSurprise(sig),
+  ].filter((c): c is Scored => c !== null && isFrontHookSafe(c.headline));
+
+  if (candidates.length === 0) return quietHook(sig);
+
+  // 점수 내림차순, 동점이면 앵글 우선순위(사회적 증거 > D-day > 판 > 이름 > 의외성)로 결정적.
+  const rank: Record<FomoAngle, number> = { social: 0, dday: 1, big: 2, named: 3, surprise: 4, quiet: 5 };
+  candidates.sort((a, b) => b.score - a.score || rank[a.angle] - rank[b.angle]);
+  const top = candidates[0]!;
+
+  // 헤드라인으로 쓴 catalyst(named/dday)는 아래 재료 리스트에서 빼서 중복 노출 방지.
+  const all = dedupeCatalysts(sig.catalysts ?? []);
+  const catalysts =
+    top.angle === "named" || top.angle === "dday"
+      ? all.filter((c) => !top.headline.includes(c.label))
+      : all;
+
+  return {
+    headline: top.headline,
+    intensity: intensityOf(top.score),
+    angle: top.angle,
+    catalysts,
+    ...(sig.themeLabel ? { themeLabel: sig.themeLabel } : {}),
+  };
 }
 
 // ── baseline(stock-basics) → 신호 도출 (규칙 기반, 외부소스·LLM 0) ─────────────
@@ -158,7 +285,7 @@ const numOf = (s: string | undefined): number | null => {
   return Number.isFinite(n) ? n : null;
 };
 
-/** 회사 개요 첫 구절만(잠잠 fallback 의 "회사 한 줄") — "동사는/당사는" 보일러플레이트 제거 후 너무 길면 자른다. */
+/** 회사 개요 첫 구절만 — "동사는/당사는" 보일러플레이트 제거 후 길면 자른다. */
 function firstClause(summary: string): string | undefined {
   const head = summary
     .trim()
@@ -170,18 +297,17 @@ function firstClause(summary: string): string | undefined {
 }
 
 /**
- * stock-basics(네이버 baseline) → 카드 앞면 신호. 가격 이벤트(우선순위 1)와 잠잠 보조(정체성)만 채운다.
- * 거래량·수급은 baseline 에 없어 미도출(P1) — 엔진 시그니처는 이미 열려 있다.
+ * stock-basics(네이버 baseline) → 카드 앞면 신호 일부. 가격 이벤트(등락률·52주)와 정체성만 채운다.
+ * 거래량·수급·테마·재료는 다른 소스에서 합쳐 넣는다(엔진 시그니처는 열려 있음).
  */
 export function signalsFromBasics(b: StockBasics): CardFrontSignals {
   const out: CardFrontSignals = {};
   if (b.changeText) {
-    // 네이버 등락 비율은 부호 포함 — 예 "8,500 (-2.34%)" / "2,000 (0.55%)". 부호를 그대로 쓴다.
+    // 네이버 등락 비율은 부호 포함 — 예 "8,500 (-2.34%)". 부호를 그대로 쓴다.
     const m = b.changeText.match(/\(\s*([+-]?[\d.]+)\s*%\s*\)/);
     const raw = m?.[1];
     if (raw) {
       let pct = Number(raw);
-      // 비율에 부호가 없으면(드묾) changeDir 로 보정.
       if (Number.isFinite(pct)) {
         if (pct > 0 && b.changeDir === "down" && !/^[+-]/.test(raw)) pct = -pct;
         out.changePct = pct;
@@ -193,7 +319,7 @@ export function signalsFromBasics(b: StockBasics): CardFrontSignals {
   if (high && cur) {
     const h = numOf(high);
     const c = numOf(cur);
-    if (h && c && h > 0) out.near52WeekHigh = c >= h * 0.98; // 신고가의 98% 이상이면 "부근"
+    if (h && c && h > 0) out.near52WeekHigh = c >= h * 0.98;
   }
   if (b.summary) {
     const id = firstClause(b.summary);

--- a/packages/fomo-core/src/supply-demand.ts
+++ b/packages/fomo-core/src/supply-demand.ts
@@ -81,6 +81,39 @@ export function latestInvestorFlow(flows: readonly InvestorFlow[]): InvestorFlow
   return [...flows].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))[0]!;
 }
 
+/** 연속 순매수/순매도 일수(최신일부터, 같은 부호가 이어지는 길이). 순매수=+, 순매도=−, 보합/없음=0. */
+export interface InvestorStreak {
+  /** 외국인 연속 일수(+순매수/−순매도). */
+  foreign: number;
+  /** 기관 연속 일수(+순매수/−순매도). */
+  institution: number;
+}
+
+function streakOf(sortedDescNets: number[]): number {
+  const first = sortedDescNets.find((n) => n !== 0);
+  if (first === undefined) return 0;
+  const dir = first > 0 ? 1 : -1;
+  let n = 0;
+  for (const net of sortedDescNets) {
+    if (net === 0) break; // 보합이면 연속 끊김
+    if (Math.sign(net) !== dir) break;
+    n++;
+  }
+  return dir * n;
+}
+
+/**
+ * 일별 수급 → 외국인·기관 연속 순매수/순매도 일수(사회적 증거 레버용). 최신일부터 같은 방향이 이어지는 길이.
+ * 데이터가 적으면(누적 전) 그만큼만 — 정직(환각 금지). 결정적.
+ */
+export function investorNetStreak(flows: readonly InvestorFlow[]): InvestorStreak {
+  const desc = [...flows].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+  return {
+    foreign: streakOf(desc.map((f) => f.foreignNet)),
+    institution: streakOf(desc.map((f) => f.institutionNet)),
+  };
+}
+
 import type { OfficialFact } from "./theme-understanding/types";
 
 function netDirection(net: number): string {


### PR DESCRIPTION
## 한 줄
rev1(가격·거래량 readout 한 줄)을 폐기 — 그건 baseline. 진짜 후킹 = **"남들 이미 움직이는데 / 곧 결판나고 / 판이 큰데 나만 모른다"**를 그 강도만큼 번역한 한 줄 + 다가오는 재료.

## 무엇을 (Tier A 골격 + 수급 인프라 — §10 (a)+병행)
- **`buildCardFrontHook` 재작성**: 5개 레버(사회적증거★·D-day·판이큼·named·의외성) 점수 합이 가장 높은 앵글을 헤드라인으로 — **고정 우선순위 아님**. **강도 비례 톤**(high/medium/calm): 핫하면 세게, 조용하면 차분히(`"지켜볼 재료가 아직 없어요"` 솔직). 예측·판정·점수 **금칙어 가드**. 결정적.
- **다가오는 재료**: 구체·일정만, 익명 `"재료"` 금지, 일정 우선 정렬, 헤드라인 중복 제거.
- **수급 인프라**(둘 다 병행): `investorNetStreak`(연속 순매수/순매도, core) + `readSupplyDemandHistory`(store). **SupplyDemandDaily prod DDL 푸시 완료** → 크론 누적 시작(streak 쌓이면 사회적 증거 레버 자동 가동).
- **카드 UI 6행**: 이니셜 로고 + 테마 색태그 + FOMO 후킹 + 재료 리스트 + baseline(위생). 강도별 색.

## 결정 반영 (광혁)
①둘 다 병행 ②시각요소 — 로고=이니셜 폴백(외부이미지 게이트), 스파크라인/시총순위는 후속 ③시총=시장 전체(랭킹 소스 필요→후속) ④구체 명시형 톤.

## 검증 (로컬, 라이브 prod 데이터)
- 삼성전기 → 발굴근거 후킹 + `오늘 +3.2%` baseline / 네패스 → `오늘 -10.1% 크게 움직였어요` / 삼성전자·SK하이닉스 → 조용한 자리(정직). 중복 노출 0.
- 752 테스트(엔진 15·streak 2 신규), core/web typecheck 클린.

## ⚠️ 후속 (배포 복구 후 — 새 서버 페치 필요, 지금은 검증·반영 불가)
- 3개월 **스파크라인**(naver `siseJson`) — 카드 중앙 공백을 채움.
- **시총 순위**(시장 전체 랭킹 리스트 페치+캐시) — 1행.
- **라이브 수급 streak** 연결(누적 며칠 후) + **실적 일정 D-day**(naver `irScheduleInfo`).
- 엔진은 시그니처가 열려 있어 데이터 채워지면 자동 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)