### PR TITLE
feat(card): 스파크라인·시총순위·라이브 수급 서버 신호 연결 (PHASE0 rev2 후속)

### DIFF
--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { buildCardFrontHook, signalsFromBasics } from "@fomo/core";
+import { buildCardFrontHook, sparklinePath, seriesIsUp } from "@fomo/core";
 import type { KeywordCard, SectorStock, StockSector, CardFrontHook, CardFrontSignals } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
-import { fetchSectorStocks, fetchKeywords, fetchStockBasics, recordTaste } from "@/lib/fomoApi";
+import { fetchSectorStocks, fetchKeywords, fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 
 /**
@@ -107,15 +107,33 @@ function InitialBadge({ name }: { name: string }) {
  * 강도에 비례한 톤(§3) — 핫한 종목은 세게, 조용한 종목은 차분하게. 점수·판정·예측 없음.
  * 로고 이미지·미니차트·시총순위는 후속(배포 복구 후 서버 페치) — 지금은 이니셜/태그/텍스트 골격.
  */
+/** 3개월 종가 스파크라인 — 인라인 SVG(라이브러리 없음). 추세색: 상승=코랄/하락=블루. */
+function Sparkline({ series }: { series: number[] }) {
+  const paths = sparklinePath(series, 300, 44);
+  if (!paths) return null;
+  const up = seriesIsUp(series);
+  const stroke = up ? UP : "#60A5FA";
+  return (
+    <svg viewBox="0 0 300 44" preserveAspectRatio="none" className="mt-4 h-11 w-full" aria-hidden>
+      <path d={paths.area} fill={stroke} opacity={0.1} />
+      <path d={paths.line} fill="none" stroke={stroke} strokeWidth={1.5} strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 function StockCardFace({
   stock,
   hook,
   changePct,
+  rankLabel,
+  sparkline,
   progress,
 }: {
   stock: DeckStock;
   hook: CardFrontHook;
   changePct?: number | undefined;
+  rankLabel?: string | undefined;
+  sparkline?: number[] | undefined;
   progress?: string | undefined;
 }) {
   const color = INTENSITY_COLOR[hook.intensity] ?? "#94A3B8";
@@ -134,7 +152,10 @@ function StockCardFace({
             <span className="truncate text-2xl font-bold text-whiteout">{stock.canonical}</span>
             {stock.marquee && <span className="text-base" aria-hidden>⭐</span>}
           </div>
-          <span className="font-pixel text-xs text-muted">{MARKET_LABEL[stock.market] ?? stock.market}</span>
+          <span className="font-pixel text-xs text-muted">
+            {MARKET_LABEL[stock.market] ?? stock.market}
+            {rankLabel && <span> · {rankLabel}</span>}
+          </span>
         </div>
       </div>
 
@@ -152,6 +173,9 @@ function StockCardFace({
       <p className="mt-4 text-xl font-bold leading-8" style={{ color }}>
         {hook.headline}
       </p>
+
+      {/* 4행 — 미니 스파크라인(최근 3개월) */}
+      {sparkline && sparkline.length >= 2 && <Sparkline series={sparkline} />}
 
       {/* 5행 — 다가오는 재료(구체·일정) */}
       {hook.catalysts.length > 0 && (
@@ -254,36 +278,40 @@ function SectorDeckInner({
   const startX = useRef(0);
   const moved = useRef(false);
 
-  // 앞면 후킹 신호 — 도달하는 카드의 baseline(가격·52주 등)을 lazy 로 불러 규칙기반 후킹(비용 방어 §5).
-  // 국내(naverCode) 종목만 가격 도출 — 없으면 발굴 근거/잠잠으로. 캐시(canonical 키)로 재방문 즉시.
-  const [signals, setSignals] = useState<Record<string, CardFrontSignals>>({});
+  // 앞면 FOMO 신호 — 도달하는 카드의 stock-front(가격·52주·라이브 수급 streak·시총순위·3개월 종가)를
+  // lazy 로 서버에서 조립해 받는다(비용 방어 §5). 캐시(canonical 키)로 재방문 즉시.
+  const [front, setFront] = useState<Record<string, { signals: CardFrontSignals; sparkline: number[] }>>({});
   const inflight = useRef<Set<string>>(new Set());
   const asOf = useRef<string>(kstTodayLabel()).current;
 
   const at = (i: number) => stocks[((i % stocks.length) + stocks.length) % stocks.length]!;
 
-  const ensureSignals = useCallback(
+  const ensureFront = useCallback(
     (stock: DeckStock) => {
       const key = stock.canonical;
-      if (!stock.naverCode || signals[key] || inflight.current.has(key)) return;
+      if (!stock.naverCode || front[key] || inflight.current.has(key)) return;
       inflight.current.add(key);
-      fetchStockBasics(key)
-        .then((b) => setSignals((prev) => ({ ...prev, [key]: signalsFromBasics(b) })))
-        .catch((err) => console.warn("[SectorStockDeck] basics signal failed", key, err))
+      fetchStockFront(key)
+        .then((d) => setFront((prev) => ({ ...prev, [key]: { signals: d.signals, sparkline: d.sparkline } })))
+        .catch((err) => console.warn("[SectorStockDeck] stock-front failed", key, err))
         .finally(() => inflight.current.delete(key));
     },
-    [signals]
+    [front]
   );
 
-  // 종목별 신호 조립 — basics(가격·52주) + 테마 태그(섹터) + 발굴 근거(named catalyst).
-  // 라이브 수급 streak·거래량·시총순위·일정은 후속(서버 페치, 배포 복구 후) — 엔진은 채워지면 자동 반영.
+  // 종목별 신호 조립 — 서버 신호(가격·52주·수급 streak·시총순위) + 테마 태그(섹터) + 발굴 근거(named catalyst).
   const signalsFor = (stock: DeckStock): CardFrontSignals => {
-    const sig: CardFrontSignals = { ...(signals[stock.canonical] ?? {}), asOf, themeLabel: stock.sector };
+    const sig: CardFrontSignals = { ...(front[stock.canonical]?.signals ?? {}), asOf, themeLabel: stock.sector };
     if (stock.reason) sig.catalysts = [{ label: stock.reason, kind: "news" }];
     return sig;
   };
   const hookFor = (stock: DeckStock): CardFrontHook => buildCardFrontHook(signalsFor(stock));
-  const pctOf = (stock: DeckStock): number | undefined => signals[stock.canonical]?.changePct;
+  const pctOf = (stock: DeckStock): number | undefined => front[stock.canonical]?.signals.changePct;
+  const sparkOf = (stock: DeckStock): number[] | undefined => front[stock.canonical]?.sparkline;
+  const rankLabelFor = (stock: DeckStock): string | undefined => {
+    const r = front[stock.canonical]?.signals.marketCapRank;
+    return r ? `시총 ${r.rank}위` : undefined; // 시장명은 1행에 이미 있음(중복 방지)
+  };
 
   const flingNext = useCallback((dir: "left" | "right") => {
     if (prefersReducedMotion()) {
@@ -343,9 +371,9 @@ function SectorDeckInner({
 
   // 보이는 카드(+다음 1장)의 신호를 미리 채운다 — 도달 종목만(비용 방어).
   useEffect(() => {
-    ensureSignals(at(idx));
-    ensureSignals(at(idx + 1));
-  }, [idx, ensureSignals]); // eslint-disable-line react-hooks/exhaustive-deps
+    ensureFront(at(idx));
+    ensureFront(at(idx + 1));
+  }, [idx, ensureFront]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const top = at(idx);
   const topTransform = exiting
@@ -372,7 +400,7 @@ function SectorDeckInner({
                 zIndex: 1,
               }}
             >
-              <StockCardFace stock={stock} hook={hookFor(stock)} changePct={pctOf(stock)} />
+              <StockCardFace stock={stock} hook={hookFor(stock)} changePct={pctOf(stock)} rankLabel={rankLabelFor(stock)} sparkline={sparkOf(stock)} />
             </div>
           ))}
 
@@ -399,7 +427,7 @@ function SectorDeckInner({
           >
             ← 덜 관심
           </span>
-          <StockCardFace stock={top} hook={hookFor(top)} changePct={pctOf(top)} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
+          <StockCardFace stock={top} hook={hookFor(top)} changePct={pctOf(top)} rankLabel={rankLabelFor(top)} sparkline={sparkOf(top)} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
         </div>
       </div>
 

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -110,6 +110,15 @@ export const fetchStockBasics = (stock: string) =>
     `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}`
   );
 
+/** 카드 앞면 FOMO 신호(rev2 후속) — baseline·라이브 수급 streak·시총순위·3개월 스파크라인. 도달 종목 lazy. */
+export type { CardFrontSignals } from "@fomo/core";
+export interface StockFrontResponse {
+  signals: import("@fomo/core").CardFrontSignals;
+  sparkline: number[];
+}
+export const fetchStockFront = (stock: string) =>
+  get<StockFrontResponse>(`/api/fomo/stock-front?stock=${encodeURIComponent(stock)}`);
+
 /** 섹터 → 종목 풀(섹터구조 ②). 콜드스타트 노출 순. baseline=true 면 baseline 보장(국내) 종목만. */
 export type { StockSector, SectorStock } from "@fomo/core";
 export interface SectorStocksResponse {

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { assembleStockFront, fetchMarketCapRankMap, type StockFrontData } from "../../../../lib/stock-front";
+
+/**
+ * 카드 앞면 FOMO 신호 — PHASE0 rev2 후속. baseline(가격·52주) + 라이브 수급 streak + 시총순위 + 스파크라인.
+ * 덱이 도달 종목에 lazy 로 부른다(비용 방어). 응축은 buildCardFrontHook(@fomo/core)가 클라에서.
+ * 순수 데이터(LLM 0) — 네이버 금융 + 수급 누적 테이블. 일 단위 캐시(가격은 장중 갱신 위해 짧게).
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+const REVALIDATE_S = 600; // 10분 — 가격·수급은 자주 안 변함, 캐시로 비용 방어
+
+/** 시총 순위 맵 — 하루 1회만 새로(랭킹은 장중 거의 불변, 무거운 페치). */
+async function getRankMap(): Promise<Record<string, { market: string; rank: number }>> {
+  const load = unstable_cache(async () => fetchMarketCapRankMap(), ["fomo-marketcap-rank", cacheVersion(), kstDate()], {
+    revalidate: 60 * 60 * 12,
+  });
+  return load();
+}
+
+async function getFront(stock: string): Promise<StockFrontData> {
+  const today = kstDate();
+  const load = unstable_cache(
+    async () => {
+      const rankMap = await getRankMap().catch(() => ({}));
+      return assembleStockFront(stock, rankMap);
+    },
+    ["fomo-stock-front", cacheVersion(), today, stock],
+    { revalidate: REVALIDATE_S }
+  );
+  return load();
+}
+
+export async function GET(req: Request) {
+  const stock = new URL(req.url).searchParams.get("stock")?.trim();
+  if (!stock) {
+    return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
+  }
+  try {
+    const data = await getFront(stock);
+    return withCors(
+      NextResponse.json(data, {
+        headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400" },
+      })
+    );
+  } catch (err) {
+    console.warn("[stock-front] failed", stock, (err as Error)?.message);
+    // 정직한 폴백 — 신호 없이도 카드는 잠잠으로 뜬다.
+    return withCors(NextResponse.json({ signals: {}, sparkline: [] } satisfies StockFrontData));
+  }
+}

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -1,0 +1,118 @@
+// 카드 앞면 FOMO 신호 서버 조립 — PHASE0 rev2 후속(스파크라인·시총순위·라이브 수급).
+// baseline(가격·52주)·라이브 수급 streak·시총 순위·3개월 종가를 한 번에 모아 CardFrontSignals 로.
+// 외부소스는 네이버 금융(이미 쓰는 무료·무인증) — 새 비용·DDL 없음. 실패는 조용히 폴백(부분만 채움).
+import { resolveStock, signalsFromBasics, investorNetStreak, type CardFrontSignals } from "@fomo/core";
+import { fetchStockBasics } from "./stock-basics";
+import { readSupplyDemandHistory } from "./supply-demand-store";
+
+const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
+
+async function getJson(url: string): Promise<unknown> {
+  const res = await fetch(url, { headers: UA, signal: AbortSignal.timeout(8000) });
+  if (!res.ok) throw new Error(`${url} ${res.status}`);
+  return res.json();
+}
+
+/**
+ * 네이버 siseJson(일봉) → 최근 N거래일 종가(오름차순, 오래된→최신). 스파크라인용.
+ * 응답은 작은따옴표 의사 JSON + 헤더행(한글, EUC-KR) — 숫자 행만 정규식으로 안전 추출(인코딩 무관).
+ */
+export async function fetchStockSparkline(code: string, calendarDays = 100): Promise<number[]> {
+  try {
+    const ymd = (d: Date) =>
+      `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}`;
+    const end = new Date();
+    const start = new Date(end.getTime() - calendarDays * 86_400_000); // ~100일 ≈ 3개월 거래일
+    const url = `https://api.finance.naver.com/siseJson.naver?symbol=${encodeURIComponent(code)}&requestType=1&startTime=${ymd(start)}&endTime=${ymd(end)}&timeframe=day`;
+    const res = await fetch(url, { headers: UA, signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return [];
+    const text = await res.text();
+    // 데이터 행: ["20260320", 350000, 355000, 348000, 352000, ...] — 날짜(따옴표),시,고,저,종,거래량,...
+    const rows: { date: string; close: number }[] = [];
+    const re = /\[\s*"?(\d{8})"?\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const close = Number(m[5]);
+      if (Number.isFinite(close)) rows.push({ date: m[1]!, close });
+    }
+    rows.sort((a, b) => (a.date < b.date ? -1 : 1)); // 오래된→최신
+    return rows.map((r) => r.close).slice(-66); // 최근 ~3개월
+  } catch (err) {
+    console.warn("[stock-front] sparkline failed", code, (err as Error)?.message);
+    return [];
+  }
+}
+
+interface RankEntry {
+  market: string;
+  rank: number;
+}
+
+async function fetchMarketRanks(naverMarket: "KOSPI" | "KOSDAQ", label: string, pages = 3, pageSize = 100): Promise<Record<string, RankEntry>> {
+  const out: Record<string, RankEntry> = {};
+  for (let page = 1; page <= pages; page++) {
+    try {
+      const d = (await getJson(
+        `https://m.stock.naver.com/api/stocks/marketValue/${naverMarket}?page=${page}&pageSize=${pageSize}`
+      )) as { stocks?: { itemCode?: string }[] };
+      const stocks = d.stocks ?? [];
+      if (stocks.length === 0) break;
+      stocks.forEach((s, i) => {
+        if (s.itemCode) out[s.itemCode] = { market: label, rank: (page - 1) * pageSize + i + 1 };
+      });
+      if (stocks.length < pageSize) break;
+    } catch (err) {
+      console.warn("[stock-front] rank page failed", naverMarket, page, (err as Error)?.message);
+      break;
+    }
+  }
+  return out;
+}
+
+/** 시총 순위 맵(코스피+코스닥 상위) — itemCode → {시장, 순위}. 호출부에서 일 단위 캐시. */
+export async function fetchMarketCapRankMap(): Promise<Record<string, RankEntry>> {
+  const [kospi, kosdaq] = await Promise.all([
+    fetchMarketRanks("KOSPI", "코스피", 3),
+    fetchMarketRanks("KOSDAQ", "코스닥", 3),
+  ]);
+  return { ...kospi, ...kosdaq };
+}
+
+export interface StockFrontData {
+  /** 엔진(buildCardFrontHook)에 넣을 신호(가격·52주·수급 streak·시총순위·정체성). */
+  signals: CardFrontSignals;
+  /** 최근 3개월 종가(스파크라인) — 없으면 빈 배열. */
+  sparkline: number[];
+}
+
+/**
+ * 한 종목의 카드 앞면 데이터 조립. baseline(가격·52주) + 라이브 수급 streak + 시총순위 + 스파크라인.
+ * rankMap 은 비싸므로 호출부에서 받아 재사용(없으면 순위 생략).
+ */
+export async function assembleStockFront(
+  stock: string,
+  rankMap?: Record<string, RankEntry>
+): Promise<StockFrontData> {
+  const def = resolveStock(stock);
+  const code = def?.naverCode;
+  if (!code) return { signals: {}, sparkline: [] };
+
+  const [basics, history, sparkline] = await Promise.all([
+    fetchStockBasics(stock).catch(() => null),
+    readSupplyDemandHistory(code).catch(() => []),
+    fetchStockSparkline(code),
+  ]);
+
+  const signals: CardFrontSignals = basics ? signalsFromBasics(basics) : {};
+
+  if (history.length > 0) {
+    const streak = investorNetStreak(history);
+    if (streak.foreign !== 0) signals.foreignNetStreak = streak.foreign;
+    if (streak.institution !== 0) signals.institutionNetStreak = streak.institution;
+  }
+
+  const rank = rankMap?.[code];
+  if (rank) signals.marketCapRank = { scope: "market", market: rank.market, rank: rank.rank };
+
+  return { signals, sparkline };
+}


### PR DESCRIPTION
## 한 줄
rev2 FOMO 엔진의 빈 시그니처(시총순위·수급 streak)를 **실데이터**로 채우고, 카드 중앙 검은 공백을 **3개월 스파크라인**으로.

## 무엇을
- **`apps/web/lib/stock-front.ts`** (신규) — 네이버 금융(기존 무료·무인증) 서버 조립:
  - `fetchStockSparkline` — `siseJson` 3개월 일봉 종가(startTime/endTime, 날짜 따옴표 파싱).
  - `fetchMarketCapRankMap` — 코스피·코스닥 시총 랭킹(itemCode→순위), 12h 캐시.
  - `assembleStockFront` — basics(가격·52주) + **라이브 수급 streak**(`readSupplyDemandHistory`+`investorNetStreak`) + 시총순위 + 스파크라인 → `CardFrontSignals`.
- **`/api/fomo/stock-front`** (신규) — 도달 종목 lazy, `unstable_cache`(10분).
- **`SectorStockDeck`** — `fetchStockBasics`→`fetchStockFront`. 1행 **시총순위**, 4행 **인라인 SVG 스파크라인**(`sparklinePath`/`seriesIsUp` 재사용, 추세색).

## 검증 (로컬 백엔드 + 프론트)
- 시총순위: 삼성전자 **코스피 시총 1위**, SK하이닉스 2위, 삼성전기 5위, 네패스 **코스닥 126위**.
- 스파크라인: 66 종가 렌더(우상향 추세 코랄). 검은 공백 제거(스크린샷).
- 수급 streak: `SupplyDemandDaily` 누적되면 자동(테이블 prod 푸시 완료, 크론 누적 중).
- 752 테스트, 3개 프로젝트 typecheck 클린.

## 제외 (소스 없음 — 환각 금지)
- 실적 D-day(레버 2): 네이버 `integration.irScheduleInfo` 가 `null` → 신뢰할 소스 없어 제외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)