### PR TITLE
[codex] 브라우저 인증 토큰 HttpOnly 쿠키 전환

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { isAllowedProxyRequest, isTokenUnexpired, sanitizeAuthPayload } from "../lib/auth-proxy";
+
+const testDir = fileURLToPath(new URL(".", import.meta.url));
+
+function tokenWithExpiry(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+describe("FOMO Web browser auth security", () => {
+  it("removes the backend JWT before returning auth data to browser JavaScript", () => {
+    const original = { token: "secret-jwt", user: { id: "user-1" } };
+    const result = sanitizeAuthPayload(original);
+
+    expect(result.token).toBe("secret-jwt");
+    expect(result.payload).toEqual({ user: { id: "user-1" } });
+    expect(original.token).toBe("secret-jwt");
+  });
+
+  it("treats malformed and expired cookies as signed out", () => {
+    expect(isTokenUnexpired("not-a-token", 1_000)).toBe(false);
+    expect(isTokenUnexpired(tokenWithExpiry(999), 1_000)).toBe(false);
+    expect(isTokenUnexpired(tokenWithExpiry(1_001), 1_000)).toBe(true);
+  });
+
+  it("only proxies explicitly allowed authenticated routes and methods", () => {
+    expect(isAllowedProxyRequest("auth/login", "POST")).toBe(true);
+    expect(isAllowedProxyRequest("emotions/calendar", "GET")).toBe(true);
+    expect(isAllowedProxyRequest("account", "DELETE")).toBe(true);
+    expect(isAllowedProxyRequest("auth/login", "GET")).toBe(false);
+    expect(isAllowedProxyRequest("../runtime/state", "GET")).toBe(false);
+    expect(isAllowedProxyRequest("feed", "GET")).toBe(false);
+  });
+
+  it("does not write authentication credentials to localStorage or browser Authorization headers", () => {
+    const authSource = readFileSync(resolve(testDir, "../lib/auth.ts"), "utf8");
+    const apiSource = readFileSync(resolve(testDir, "../lib/fomoApi.ts"), "utf8");
+
+    expect(authSource).not.toContain("localStorage.setItem");
+    expect(apiSource).not.toContain("Authorization");
+    expect(apiSource).not.toContain("setToken(");
+  });
+
+  it("keeps CSP in report-only mode during the compatibility rollout", () => {
+    const config = readFileSync(resolve(testDir, "../next.config.mjs"), "utf8");
+
+    expect(config).toContain('key: "Content-Security-Policy"');
+    expect(config).toContain("Content-Security-Policy-Report-Only");
+    expect(config).toContain("object-src 'none'");
+    expect(config).toContain("https://t1.kakaocdn.net");
+  });
+});

--- a/apps/fomo-web/app/api/fomo/[...path]/route.ts
+++ b/apps/fomo-web/app/api/fomo/[...path]/route.ts
@@ -1,0 +1,125 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  AUTH_COOKIE_MAX_AGE_SECONDS,
+  AUTH_COOKIE_NAME,
+  isAllowedProxyRequest,
+  isTokenUnexpired,
+  sanitizeAuthPayload,
+} from "../../../../lib/auth-proxy";
+
+export const dynamic = "force-dynamic";
+
+const BACKEND_ORIGIN = (
+  process.env.FOMO_BACKEND_ORIGIN ??
+  process.env.NEXT_PUBLIC_FOMO_API_BASE ??
+  "https://fomo-club-backend.vercel.app"
+).replace(/\/$/, "");
+
+const AUTH_EXCHANGE_PATHS = new Set(["auth/login", "auth/register"]);
+const FORWARDED_RESPONSE_HEADERS = ["content-type", "retry-after"];
+
+function noStoreJson(body: unknown, init?: ResponseInit): NextResponse {
+  const response = NextResponse.json(body, init);
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}
+
+function clearAuthCookie(response: NextResponse): void {
+  response.cookies.set(AUTH_COOKIE_NAME, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    path: "/",
+    maxAge: 0,
+  });
+}
+
+async function proxy(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+  const { path } = await context.params;
+  const proxyPath = path.join("/");
+
+  if (!isAllowedProxyRequest(proxyPath, request.method)) {
+    return noStoreJson({ error: "Not found" }, { status: 404 });
+  }
+
+  if (proxyPath === "auth/logout" && request.method === "POST") {
+    const response = noStoreJson({ ok: true });
+    clearAuthCookie(response);
+    return response;
+  }
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+
+  if (proxyPath === "auth/session" && request.method === "GET") {
+    return noStoreJson({ authenticated: isTokenUnexpired(token) });
+  }
+
+  const upstreamUrl = new URL(
+    `/api/fomo/${path.map(encodeURIComponent).join("/")}${request.nextUrl.search}`,
+    BACKEND_ORIGIN
+  );
+  const headers = new Headers({ Accept: "application/json" });
+  const contentType = request.headers.get("content-type");
+  if (contentType) headers.set("Content-Type", contentType);
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+
+  try {
+    const init: RequestInit = {
+      method: request.method,
+      headers,
+      cache: "no-store",
+      redirect: "manual",
+      signal: AbortSignal.timeout(12_000),
+    };
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      init.body = await request.arrayBuffer();
+    }
+    const upstream = await fetch(upstreamUrl, init);
+
+    if (AUTH_EXCHANGE_PATHS.has(proxyPath)) {
+      const payload = await upstream.json().catch(() => null);
+      const sanitized = sanitizeAuthPayload(payload);
+      const response = noStoreJson(sanitized.payload, { status: upstream.status });
+
+      if (upstream.ok && sanitized.token) {
+        response.cookies.set(AUTH_COOKIE_NAME, sanitized.token, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "strict",
+          path: "/",
+          maxAge: AUTH_COOKIE_MAX_AGE_SECONDS,
+        });
+      }
+      return response;
+    }
+
+    const responseHeaders = new Headers({ "Cache-Control": "no-store" });
+    for (const name of FORWARDED_RESPONSE_HEADERS) {
+      const value = upstream.headers.get(name);
+      if (value) responseHeaders.set(name, value);
+    }
+
+    const response = new NextResponse(upstream.body, {
+      status: upstream.status,
+      headers: responseHeaders,
+    });
+    if (upstream.status === 401 || (proxyPath === "account" && request.method === "DELETE" && upstream.ok)) {
+      clearAuthCookie(response);
+    }
+    return response;
+  } catch (error) {
+    const timedOut = error instanceof Error && error.name === "TimeoutError";
+    return noStoreJson(
+      { error: timedOut ? "인증 서버 응답 시간이 초과되었습니다." : "인증 서버에 연결할 수 없습니다." },
+      { status: timedOut ? 504 : 502 }
+    );
+  }
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const DELETE = proxy;
+export const PATCH = proxy;

--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -5,7 +5,7 @@ import { FEATURE_EMOTION_VOTE, type EmotionType } from "@fomo/core";
 import { EmotionGate } from "@/components/EmotionGate";
 import { HomeView } from "@/components/HomeView";
 import { getSessionId } from "@/lib/session";
-import { isLoggedIn } from "@/lib/auth";
+import { hasSession } from "@/lib/auth";
 import {
   fetchIndex,
   fetchToday,
@@ -48,7 +48,7 @@ export default function Home() {
 
   // 로그인 상태는 클라에서만 확정(SSR 불일치 방지).
   useEffect(() => {
-    setLoggedIn(isLoggedIn());
+    void hasSession().then(setLoggedIn);
   }, []);
 
   // 뉴스 피드는 외부 RSS 다중 수집이라 느릴 수 있다 — 스플래시를 막지 않고 별도로 로드.

--- a/apps/fomo-web/components/LoginPage.tsx
+++ b/apps/fomo-web/components/LoginPage.tsx
@@ -55,10 +55,14 @@ export function LoginPage({
             <div className="flex flex-col gap-3">
               <p className="text-sm leading-6 text-muted">로그인 상태예요. 취향이 계정에 기억되고 있어요.</p>
               <button
-                onClick={() => {
-                  logout();
-                  onClose();
-                  window.location.reload();
+                onClick={async () => {
+                  try {
+                    await logout();
+                    onClose();
+                    window.location.reload();
+                  } catch {
+                    setError("로그아웃 처리에 실패했어요.");
+                  }
                 }}
                 className="rounded-lg border border-hairline px-4 py-3 text-sm text-whiteout"
               >

--- a/apps/fomo-web/lib/auth-proxy.ts
+++ b/apps/fomo-web/lib/auth-proxy.ts
@@ -1,0 +1,48 @@
+export const AUTH_COOKIE_NAME = "fomo_access_token";
+export const AUTH_COOKIE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+
+const ALLOWED_PROXY_REQUESTS = new Map<string, ReadonlySet<string>>([
+  ["auth/login", new Set(["POST"])],
+  ["auth/register", new Set(["POST"])],
+  ["auth/logout", new Set(["POST"])],
+  ["auth/session", new Set(["GET"])],
+  ["emotions/calendar", new Set(["GET"])],
+  ["emotions/link", new Set(["POST"])],
+  ["emotions/vote", new Set(["POST"])],
+  ["taste", new Set(["POST"])],
+  ["taste/link", new Set(["POST"])],
+  ["account", new Set(["DELETE"])],
+  ["challenges", new Set(["GET", "POST"])],
+]);
+
+export function isAllowedProxyRequest(path: string, method: string): boolean {
+  return ALLOWED_PROXY_REQUESTS.get(path)?.has(method.toUpperCase()) === true;
+}
+
+export function sanitizeAuthPayload(payload: unknown): {
+  payload: unknown;
+  token: string | null;
+} {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { payload, token: null };
+  }
+
+  const record = payload as Record<string, unknown>;
+  const token = typeof record.token === "string" && record.token ? record.token : null;
+  const { token: _removed, ...safePayload } = record;
+  return { payload: safePayload, token };
+}
+
+/** UI 상태용 만료 검사. 실제 인증·서명 검증은 백엔드가 수행한다. */
+export function isTokenUnexpired(token: string | undefined, now = Date.now()): boolean {
+  if (!token) return false;
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString()) as { exp?: unknown };
+    return typeof payload.exp === "number" && payload.exp > now;
+  } catch {
+    return false;
+  }
+}

--- a/apps/fomo-web/lib/auth.ts
+++ b/apps/fomo-web/lib/auth.ts
@@ -1,23 +1,27 @@
-// 로그인 토큰 보관. FOMO Club 인증(/api/fomo/auth/*)이 발급한 JWT를 localStorage에 저장하고
-// Authorization: Bearer 로 fomo API에 보낸다(크로스오리진이라 쿠키 대신 Bearer).
-// 트랙 B — 로그인하면 취향 신호가 유저별로 서버에 쌓인다(가입 전 익명 sessionId 도 로그인 시 연결).
-const TOKEN_KEY = "fomo_token";
+// 인증 토큰은 BFF의 HttpOnly 쿠키에만 보관한다.
+// 브라우저 JavaScript는 토큰을 읽거나 쓰지 않고 세션 존재 여부만 같은 출처 API로 확인한다.
+const LEGACY_TOKEN_KEY = "fomo_token";
 
-export function getToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return window.localStorage.getItem(TOKEN_KEY);
-}
-
-export function setToken(token: string): void {
+export function clearLegacyBrowserToken(): void {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(TOKEN_KEY, token);
+  window.localStorage.removeItem(LEGACY_TOKEN_KEY);
 }
 
-export function clearToken(): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.removeItem(TOKEN_KEY);
-}
+export async function hasSession(): Promise<boolean> {
+  if (typeof window === "undefined") return false;
 
-export function isLoggedIn(): boolean {
-  return !!getToken();
+  // 이전 버전의 JavaScript-readable JWT를 남기지 않는다. 보안을 위해 기존 사용자는 재로그인한다.
+  clearLegacyBrowserToken();
+
+  try {
+    const response = await fetch("/api/fomo/auth/session", {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    if (!response.ok) return false;
+    const data = (await response.json()) as { authenticated?: boolean };
+    return data.authenticated === true;
+  } catch {
+    return false;
+  }
 }

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -9,7 +9,6 @@ import type {
   MoodSignal,
   ScoredArticle,
 } from "@fomo/core";
-import { getToken, setToken, clearToken } from "@/lib/auth";
 import { getSessionId } from "@/lib/session";
 
 export type { BannerItem } from "@fomo/core";
@@ -17,12 +16,6 @@ export type { BannerItem } from "@fomo/core";
 const API_BASE =
   process.env.NEXT_PUBLIC_FOMO_API_BASE?.replace(/\/$/, "") ||
   "https://fomo-club-backend.vercel.app";
-
-/** 로그인 토큰이 있으면 Authorization 헤더를 붙인다(없으면 익명). */
-function authHeaders(extra?: Record<string, string>): Record<string, string> {
-  const token = getToken();
-  return { ...extra, ...(token ? { Authorization: `Bearer ${token}` } : {}) };
-}
 
 export interface FomoIndexResponse {
   date: string;
@@ -50,7 +43,7 @@ export interface CalendarResponse {
 }
 
 async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, { cache: "no-store", headers: authHeaders() });
+  const res = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
   if (!res.ok) throw new Error(`GET ${path} ${res.status}`);
   return res.json() as Promise<T>;
 }
@@ -122,18 +115,25 @@ export const fetchSectorStocks = (sector: string, baselineOnly = false) =>
   );
 
 export const fetchCalendar = (sessionId: string, month?: string) =>
-  get<CalendarResponse>(
+  getPrivate<CalendarResponse>(
     `/api/fomo/emotions/calendar?sessionId=${encodeURIComponent(sessionId)}${month ? `&month=${month}` : ""}`
   );
+
+async function getPrivate<T>(path: string): Promise<T> {
+  const res = await fetch(path, { cache: "no-store", credentials: "same-origin" });
+  if (!res.ok) throw new Error(`GET ${path} ${res.status}`);
+  return res.json() as Promise<T>;
+}
 
 export async function postVote(
   sessionId: string,
   emotion: string,
   voice?: { situationKey: string; resolveKey: string }
 ): Promise<TallyResponse & { mine: string }> {
-  const res = await fetch(`${API_BASE}/api/fomo/emotions/vote`, {
+  const res = await fetch("/api/fomo/emotions/vote", {
     method: "POST",
-    headers: authHeaders({ "Content-Type": "application/json" }),
+    headers: { "Content-Type": "application/json" },
+    credentials: "same-origin",
     body: JSON.stringify({ sessionId, emotion, source: "web", ...voice }),
   });
   if (!res.ok) throw new Error(`vote ${res.status}`);
@@ -151,32 +151,31 @@ export interface VoiceItem {
 export const fetchVoices = () => get<{ date: string; items: VoiceItem[] }>("/api/fomo/voices");
 
 interface LoginResponse {
-  token: string;
   user: { id: string; displayName: string | null; isNew: boolean };
 }
 
 /**
- * 카카오 access_token으로 로그인 → JWT 저장 후 반환.
+ * 카카오 access_token으로 로그인 → BFF가 JWT를 HttpOnly 쿠키에 저장한 뒤 안전한 사용자 정보만 반환.
  * [보관] 감정 캘린더(FEATURE_HISTORY_TAB) 가입 흐름 전용 — 현재 flag OFF라 미사용.
  * 인증 백엔드(`/api/fomo/auth/login`)는 감정 모델 복원 시 함께 복원한다.
  */
 export async function loginKakao(accessToken: string): Promise<LoginResponse> {
-  const res = await fetch(`${API_BASE}/api/fomo/auth/login`, {
+  const res = await fetch("/api/fomo/auth/login", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ provider: "KAKAO", identityToken: accessToken }),
   });
   if (!res.ok) throw new Error(`login ${res.status}`);
   const data = (await res.json()) as LoginResponse;
-  if (data.token) setToken(data.token);
   return data;
 }
 
 /** 로그인 직후 익명 sessionId 기록을 내 계정으로 연결(가입 전 감정 보존). */
 export async function linkSession(sessionId: string): Promise<{ linked: number }> {
-  const res = await fetch(`${API_BASE}/api/fomo/emotions/link`, {
+  const res = await fetch("/api/fomo/emotions/link", {
     method: "POST",
-    headers: authHeaders({ "Content-Type": "application/json" }),
+    headers: { "Content-Type": "application/json" },
+    credentials: "same-origin",
     body: JSON.stringify({ sessionId }),
   });
   if (!res.ok) throw new Error(`link ${res.status}`);
@@ -184,7 +183,7 @@ export async function linkSession(sessionId: string): Promise<{ linked: number }
 }
 
 // ── 트랙 B: 취향 학습 적재 ──────────────────────────────────────────────────
-// 스와이프(관심/덜관심)·깊이 신호(뎁스 열람/연관주 탭)를 서버에 쌓는다. 로그인이면 Bearer 로 유저별,
+// 스와이프(관심/덜관심)·깊이 신호(뎁스 열람/연관주 탭)를 서버에 쌓는다. 로그인 쿠키가 있으면 BFF가 유저별,
 // 아니면 익명 sessionId 로(익명 적재 먼저). fire-and-forget — 실패해도 스와이프 흐름을 막지 않는다.
 export type TasteSubjectType = "theme" | "stock";
 export type TasteSignalKind = "more" | "less" | "view_depth" | "tap_related";
@@ -195,9 +194,10 @@ export function recordTaste(
   signal: TasteSignalKind
 ): void {
   if (typeof window === "undefined" || !subject) return;
-  void fetch(`${API_BASE}/api/fomo/taste`, {
+  void fetch("/api/fomo/taste", {
     method: "POST",
-    headers: authHeaders({ "Content-Type": "application/json" }),
+    headers: { "Content-Type": "application/json" },
+    credentials: "same-origin",
     body: JSON.stringify({ subjectType, subject, signal, sessionId: getSessionId() }),
     keepalive: true, // 화면 전환/언마운트 중에도 전송 보장
   }).catch((err) => console.warn("[recordTaste] failed", err));
@@ -210,9 +210,10 @@ export function recordTaste(
 /** 익명 sessionId 취향 신호 → 내 계정 연결(로그인 직후 1회). 실패해도 흐름 안 막음. */
 async function linkTaste(): Promise<void> {
   try {
-    await fetch(`${API_BASE}/api/fomo/taste/link`, {
+    await fetch("/api/fomo/taste/link", {
       method: "POST",
-      headers: authHeaders({ "Content-Type": "application/json" }),
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
       body: JSON.stringify({ sessionId: getSessionId() }),
     });
   } catch (err) {
@@ -221,14 +222,14 @@ async function linkTaste(): Promise<void> {
 }
 
 async function authPost(path: string, email: string, password: string): Promise<LoginResponse> {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "same-origin",
     body: JSON.stringify({ email, password }),
   });
   const data = (await res.json().catch(() => ({}))) as Partial<LoginResponse> & { error?: string };
-  if (!res.ok || !data.token) throw new Error(data.error || `auth ${res.status}`);
-  setToken(data.token);
+  if (!res.ok || !data.user) throw new Error(data.error || `auth ${res.status}`);
   await linkTaste(); // 가입 전 익명 취향을 계정으로 이어붙임
   return data as LoginResponse;
 }
@@ -241,17 +242,17 @@ export const registerEmail = (email: string, password: string) =>
 export const loginEmail = (email: string, password: string) =>
   authPost("/api/fomo/auth/login", email, password);
 
-/** 로그아웃 — 토큰만 제거(서버 상태 없음). */
-export function logout(): void {
-  clearToken();
+/** 로그아웃 — BFF의 HttpOnly 쿠키를 만료시킨다. */
+export async function logout(): Promise<void> {
+  const res = await fetch("/api/fomo/auth/logout", { method: "POST", credentials: "same-origin" });
+  if (!res.ok) throw new Error(`logout ${res.status}`);
 }
 
 /** 탈퇴 — 계정·취향 신호 삭제(서버 CASCADE) 후 토큰 제거. */
 export async function deleteAccount(): Promise<void> {
-  const res = await fetch(`${API_BASE}/api/fomo/account`, {
+  const res = await fetch("/api/fomo/account", {
     method: "DELETE",
-    headers: authHeaders(),
+    credentials: "same-origin",
   });
   if (!res.ok) throw new Error(`delete ${res.status}`);
-  clearToken();
 }

--- a/apps/fomo-web/next.config.mjs
+++ b/apps/fomo-web/next.config.mjs
@@ -4,14 +4,34 @@ import { fileURLToPath } from "node:url";
 
 const monorepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-// 베이스라인 보안 헤더 (P3-2) — 전역 적용. 앱을 깨지 않는 무해한 것만:
-// 클릭재킹(XFO)·MIME 스니핑(nosniff)·리퍼러 유출·미사용 브라우저 API 차단.
-// CSP는 라이브 카카오 SDK/팝업 흐름을 깰 위험이 있어 별도 검증 라운드로 보류.
+// 베이스라인 보안 헤더 (P3-2) — 전역 적용.
+// 정적 CSP 안전 지침은 즉시 강제하고, 외부 SDK 관련 전체 정책은 Report-Only로 호환성을 관찰한다.
 const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  {
+    key: "Content-Security-Policy",
+    value: "base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'",
+  },
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "frame-ancestors 'none'",
+      "form-action 'self'",
+      "script-src 'self' 'unsafe-inline' https://t1.kakaocdn.net",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https://fomo-club-backend.vercel.app https://kauth.kakao.com https://kapi.kakao.com",
+      "frame-src https://kauth.kakao.com https://accounts.kakao.com",
+      "upgrade-insecure-requests",
+    ].join("; "),
+  },
 ];
 
 const nextConfig = {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: [
       "packages/**/__tests__/**/*.test.ts",
       "apps/web/__tests__/**/*.test.ts",
+      "apps/fomo-web/__tests__/**/*.test.ts",
       "apps/fomo-club/tests/**/*.e2e.ts",
       "scripts/**/__tests__/**/*.test.ts",
     ],


### PR DESCRIPTION
## 변경 요약
- 브라우저 `localStorage` JWT 저장과 클라이언트 Authorization 헤더 생성을 제거
- FOMO Web same-origin BFF가 인증 토큰을 `HttpOnly; Secure; SameSite=Strict` 쿠키로 보관
- 인증이 필요한 요청만 BFF를 사용하고 공개 GET은 기존 backend/CDN 경로를 유지
- BFF 프록시 경로와 HTTP 메서드를 화이트리스트로 제한
- 12초 upstream timeout, 인증 응답에서 JWT 제거, 401/로그아웃/탈퇴 시 쿠키 만료
- 기존 localStorage JWT는 첫 진입 시 삭제(기존 로그인 사용자는 1회 재로그인)
- 안전한 CSP 지침은 강제 적용하고 전체 Kakao 호환 정책은 Report-Only로 배포
- 보안 회귀 테스트 5개 추가

## 보안 효과
- XSS 발생 시 JavaScript가 장기 JWT를 읽어가는 공격 경로 차단
- 브라우저에서 인증 토큰이 API 응답·localStorage·Authorization 헤더로 노출되지 않음
- BFF를 임의 backend 프록시로 악용하는 경로 차단
- object/embed, 외부 base URI, framing, 외부 form action 차단

## 검증
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` — 66 files / 740 tests
- `npm run build:api`
- `npm run build:web`
- `npm run build:fomo-web`
- 로컬 HTTP: session `Cache-Control: no-store`, logout `Set-Cookie: HttpOnly; SameSite=Strict; Max-Age=0`, CSP 헤더 확인

## 비용·운영 영향
- 신규 외부 서비스·유료 도구·환경변수·prod DDL 없음
- 공개 데이터 요청은 BFF를 거치지 않아 기존 캐시/속도 유지
- 화면 카피·스타일·추천 로직 변경 없음