### PR TITLE
[codex] BFF 경로 레이트 리밋 추가

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -1,11 +1,16 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { isAllowedProxyRequest, isTokenUnexpired, sanitizeAuthPayload } from "../lib/auth-proxy";
+import { consumeRateLimit, getClientIp, resetRateLimitStore } from "../lib/request-rate-limit";
 
 const testDir = fileURLToPath(new URL(".", import.meta.url));
+
+afterEach(() => {
+  resetRateLimitStore();
+});
 
 function tokenWithExpiry(exp: number): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
@@ -54,5 +59,38 @@ describe("FOMO Web browser auth security", () => {
     expect(config).toContain("Content-Security-Policy-Report-Only");
     expect(config).toContain("object-src 'none'");
     expect(config).toContain("https://t1.kakaocdn.net");
+  });
+
+  it("rate limits repeated auth attempts per client IP", () => {
+    const now = 1_000;
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const result = consumeRateLimit("auth/login", "203.0.113.10", now);
+      expect(result.allowed).toBe(true);
+    }
+
+    const blocked = consumeRateLimit("auth/login", "203.0.113.10", now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+
+    const otherIp = consumeRateLimit("auth/login", "203.0.113.11", now);
+    expect(otherIp.allowed).toBe(true);
+  });
+
+  it("shares session checks by IP but isolates mutations by path", () => {
+    const now = 2_000;
+
+    const session = Array.from({ length: 60 }, () => consumeRateLimit("auth/session", "198.51.100.7", now));
+    expect(session.every((result) => result.allowed)).toBe(true);
+    expect(consumeRateLimit("auth/session", "198.51.100.7", now).allowed).toBe(false);
+
+    const vote = Array.from({ length: 30 }, () => consumeRateLimit("emotions/vote", "198.51.100.7", now));
+    expect(vote.every((result) => result.allowed)).toBe(true);
+    expect(consumeRateLimit("taste", "198.51.100.7", now).allowed).toBe(true);
+  });
+
+  it("normalizes the first forwarded IP and falls back safely", () => {
+    expect(getClientIp("198.51.100.7, 10.0.0.1")).toBe("198.51.100.7");
+    expect(getClientIp(null)).toBe("unknown");
   });
 });

--- a/apps/fomo-web/app/api/fomo/[...path]/route.ts
+++ b/apps/fomo-web/app/api/fomo/[...path]/route.ts
@@ -8,6 +8,7 @@ import {
   isTokenUnexpired,
   sanitizeAuthPayload,
 } from "../../../../lib/auth-proxy";
+import { consumeRateLimit } from "../../../../lib/request-rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +43,19 @@ async function proxy(request: NextRequest, context: { params: Promise<{ path: st
 
   if (!isAllowedProxyRequest(proxyPath, request.method)) {
     return noStoreJson({ error: "Not found" }, { status: 404 });
+  }
+
+  const rateLimit = consumeRateLimit(proxyPath, request.headers.get("x-forwarded-for"));
+  if (!rateLimit.allowed) {
+    return noStoreJson(
+      { error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(rateLimit.retryAfterSeconds),
+        },
+      }
+    );
   }
 
   if (proxyPath === "auth/logout" && request.method === "POST") {

--- a/apps/fomo-web/lib/request-rate-limit.ts
+++ b/apps/fomo-web/lib/request-rate-limit.ts
@@ -1,0 +1,75 @@
+type LimitWindow = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitRule = {
+  limit: number;
+  windowMs: number;
+  scope: "ip" | "ip-path";
+};
+
+type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  retryAfterSeconds: number;
+};
+
+const bucketStore = new Map<string, LimitWindow>();
+
+const DEFAULT_RULE: RateLimitRule = { limit: 90, windowMs: 60_000, scope: "ip-path" };
+
+const RULES: Array<{ match: RegExp; rule: RateLimitRule }> = [
+  { match: /^auth\/(login|register)$/, rule: { limit: 5, windowMs: 10 * 60_000, scope: "ip-path" } },
+  { match: /^auth\/session$/, rule: { limit: 60, windowMs: 60_000, scope: "ip" } },
+  { match: /^auth\/logout$/, rule: { limit: 20, windowMs: 60_000, scope: "ip" } },
+  { match: /^(emotions\/vote|taste|taste\/link|emotions\/link|challenges|account)$/, rule: { limit: 30, windowMs: 60_000, scope: "ip-path" } },
+];
+
+function resolveRule(path: string): RateLimitRule {
+  return RULES.find((entry) => entry.match.test(path))?.rule ?? DEFAULT_RULE;
+}
+
+export function getClientIp(forwardedFor: string | null): string {
+  return (
+    forwardedFor
+      ?.split(",")[0]
+      ?.trim()
+      ?.slice(0, 128) || "unknown"
+  );
+}
+
+export function consumeRateLimit(path: string, forwardedFor: string | null, now = Date.now()): RateLimitResult {
+  const rule = resolveRule(path);
+  const ip = getClientIp(forwardedFor);
+  const bucketKey = rule.scope === "ip" ? ip : `${ip}:${path}`;
+  const current = bucketStore.get(bucketKey);
+
+  if (!current || current.resetAt <= now) {
+    bucketStore.set(bucketKey, { count: 1, resetAt: now + rule.windowMs });
+    return {
+      allowed: true,
+      remaining: Math.max(rule.limit - 1, 0),
+      retryAfterSeconds: Math.ceil(rule.windowMs / 1000),
+    };
+  }
+
+  if (current.count >= rule.limit) {
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterSeconds: Math.max(Math.ceil((current.resetAt - now) / 1000), 1),
+    };
+  }
+
+  current.count += 1;
+  return {
+    allowed: true,
+    remaining: Math.max(rule.limit - current.count, 0),
+    retryAfterSeconds: Math.max(Math.ceil((current.resetAt - now) / 1000), 1),
+  };
+}
+
+export function resetRateLimitStore(): void {
+  bucketStore.clear();
+}


### PR DESCRIPTION
## What changed
- add in-memory rate limits for the fomo-web BFF auth and mutation routes
- return 429 with Retry-After when repeated requests exceed the route budget
- add security regression tests for IP normalization and route-specific throttling

## Why
- the browser auth hardening removed token exposure, but the same-origin BFF still allowed unbounded repeated attempts on login and write endpoints
- this reduces brute-force and spam pressure without touching product UI or business logic

## Validation
- npm test -- --run apps/fomo-web/__tests__/browser-auth-security.test.ts
- npm run lint
- npm run typecheck
- npm run build:fomo-web