### PR TITLE
[codex] BFF 교차 출처 변경 요청 차단

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { isAllowedProxyRequest, isTokenUnexpired, sanitizeAuthPayload } from "../lib/auth-proxy";
+import { isTrustedRequestOrigin } from "../lib/request-origin";
 import { consumeRateLimit, getClientIp, resetRateLimitStore } from "../lib/request-rate-limit";
 
 const testDir = fileURLToPath(new URL(".", import.meta.url));
@@ -41,6 +42,44 @@ describe("FOMO Web browser auth security", () => {
     expect(isAllowedProxyRequest("auth/login", "GET")).toBe(false);
     expect(isAllowedProxyRequest("../runtime/state", "GET")).toBe(false);
     expect(isAllowedProxyRequest("feed", "GET")).toBe(false);
+  });
+
+  it("allows state-changing requests only from the current web origin", () => {
+    const requestUrl = new URL("https://fomo.club/api/fomo/taste");
+    const sameOriginHeaders = new Headers({
+      origin: "https://fomo.club",
+      host: "fomo.club",
+    });
+
+    expect(isTrustedRequestOrigin("POST", sameOriginHeaders, requestUrl)).toBe(true);
+    expect(
+      isTrustedRequestOrigin(
+        "POST",
+        new Headers({ origin: "https://attacker.example", host: "fomo.club" }),
+        requestUrl
+      )
+    ).toBe(false);
+    expect(isTrustedRequestOrigin("DELETE", new Headers({ host: "fomo.club" }), requestUrl)).toBe(false);
+  });
+
+  it("uses forwarded host and protocol behind the deployment proxy", () => {
+    const internalUrl = new URL("http://internal:3000/api/fomo/emotions/vote");
+    const headers = new Headers({
+      origin: "https://preview.fomo.club",
+      host: "internal:3000",
+      "x-forwarded-host": "preview.fomo.club",
+      "x-forwarded-proto": "https",
+    });
+
+    expect(isTrustedRequestOrigin("PATCH", headers, internalUrl)).toBe(true);
+    expect(isTrustedRequestOrigin("GET", new Headers(), internalUrl)).toBe(true);
+  });
+
+  it("rejects opaque and malformed mutation origins", () => {
+    const requestUrl = new URL("https://fomo.club/api/fomo/auth/logout");
+
+    expect(isTrustedRequestOrigin("POST", new Headers({ origin: "null" }), requestUrl)).toBe(false);
+    expect(isTrustedRequestOrigin("POST", new Headers({ origin: "not a url" }), requestUrl)).toBe(false);
   });
 
   it("does not write authentication credentials to localStorage or browser Authorization headers", () => {

--- a/apps/fomo-web/app/api/fomo/[...path]/route.ts
+++ b/apps/fomo-web/app/api/fomo/[...path]/route.ts
@@ -8,6 +8,7 @@ import {
   isTokenUnexpired,
   sanitizeAuthPayload,
 } from "../../../../lib/auth-proxy";
+import { isTrustedRequestOrigin } from "../../../../lib/request-origin";
 import { consumeRateLimit } from "../../../../lib/request-rate-limit";
 
 export const dynamic = "force-dynamic";
@@ -43,6 +44,10 @@ async function proxy(request: NextRequest, context: { params: Promise<{ path: st
 
   if (!isAllowedProxyRequest(proxyPath, request.method)) {
     return noStoreJson({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!isTrustedRequestOrigin(request.method, request.headers, request.nextUrl)) {
+    return noStoreJson({ error: "허용되지 않은 요청 출처입니다." }, { status: 403 });
   }
 
   const rateLimit = consumeRateLimit(proxyPath, request.headers.get("x-forwarded-for"));

--- a/apps/fomo-web/lib/request-origin.ts
+++ b/apps/fomo-web/lib/request-origin.ts
@@ -1,0 +1,50 @@
+const STATE_CHANGING_METHODS = new Set(["POST", "PATCH", "DELETE"]);
+
+function firstHeaderValue(value: string | null): string | null {
+  const first = value?.split(",", 1)[0]?.trim();
+  return first || null;
+}
+
+function toOrigin(protocol: string, host: string): string | null {
+  try {
+    return new URL(`${protocol}://${host}`).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isStateChangingMethod(method: string): boolean {
+  return STATE_CHANGING_METHODS.has(method.toUpperCase());
+}
+
+export function isTrustedRequestOrigin(
+  method: string,
+  headers: Headers,
+  requestUrl: URL
+): boolean {
+  if (!isStateChangingMethod(method)) return true;
+
+  const originHeader = headers.get("origin");
+  if (!originHeader || originHeader === "null") return false;
+
+  let requestOrigin: string;
+  try {
+    requestOrigin = new URL(originHeader).origin;
+  } catch {
+    return false;
+  }
+
+  const trustedOrigins = new Set<string>([requestUrl.origin]);
+  const forwardedProto = firstHeaderValue(headers.get("x-forwarded-proto"));
+  const protocol = forwardedProto ?? requestUrl.protocol.replace(":", "");
+
+  for (const hostHeader of [headers.get("x-forwarded-host"), headers.get("host")]) {
+    const host = firstHeaderValue(hostHeader);
+    if (!host) continue;
+
+    const origin = toOrigin(protocol, host);
+    if (origin) trustedOrigins.add(origin);
+  }
+
+  return trustedOrigins.has(requestOrigin);
+}


### PR DESCRIPTION
## 변경 내용

- Fomo Web BFF의 `POST`, `PATCH`, `DELETE` 요청에 동일 출처 검증을 추가했습니다.
- 외부, 누락, `null`, 비정상 Origin은 백엔드 전달 전에 403으로 차단합니다.
- Vercel/프리뷰 등 리버스 프록시의 forwarded host/protocol을 지원합니다.
- 교차 출처 요청이 rate-limit 카운터를 소모하기 전에 차단되도록 검증 순서를 배치했습니다.

## 이유와 영향

HttpOnly 인증 쿠키는 브라우저가 자동 전송하므로 별도 출처 검증이 없으면 CSRF 공격 표면이 남습니다. 이번 변경으로 외부 사이트가 로그인, 취향, 감정 투표, 계정 변경·삭제 요청을 대신 보내는 경로를 차단합니다. 화면 및 제품 로직 변경은 없습니다.

## 검증

- `npm test -- --run apps/fomo-web/__tests__/browser-auth-security.test.ts` (11 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run build:fomo-web`
