### PR TITLE
feat(card): 포모 점수 → 카드 앞면 연결 (척추 ②, 단일 출처)

### DIFF
--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { buildCardFrontHook, sparklinePath, seriesIsUp } from "@fomo/core";
-import type { KeywordCard, SectorStock, StockSector, CardFrontHook, CardFrontSignals } from "@fomo/core";
+import { sparklinePath, seriesIsUp, fomoCardView, computeFomoScore } from "@fomo/core";
+import type { KeywordCard, SectorStock, StockSector, CardFrontSignals, FomoScoreResult, FomoCardView, FomoTone } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchSectorStocks, fetchKeywords, fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
@@ -24,6 +24,9 @@ const THRESHOLD = 90;
 const EXIT_MS = 320;
 const UP = "#FF5A36";
 const DOWN = "#64748B";
+
+/** 포모 점수 로드 전 placeholder(빈 입력 → silent·점수 보류). */
+const EMPTY_FOMO = computeFomoScore({});
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
 type DeckStock = SectorStock & { reason?: string };
@@ -80,9 +83,6 @@ const MARKET_LABEL: Record<string, string> = {
   COIN: "코인",
 };
 
-/** 강도별 헤드라인 색 — 강도 비례 톤(§3). high=코랄, medium=주황, calm=그레이. */
-const INTENSITY_COLOR: Record<string, string> = { high: UP, medium: "#F59E0B", calm: "#94A3B8" };
-
 /** 종목 로고 — 네이버 심볼 이미지(불러와지면), 실패 시 이니셜 원형 폴백. */
 function LogoBadge({ name, code }: { name: string; code?: string | undefined }) {
   const [failed, setFailed] = useState(false);
@@ -127,13 +127,24 @@ function Sparkline({ series }: { series: number[] }) {
 const DIR_COLOR: Record<string, string> = { up: UP, down: "#3B82F6", flat: "#94A3B8" };
 const DIR_MARK: Record<string, string> = { up: "▲", down: "▼", flat: "" };
 
+/** 포모 톤 → 색(강도 비례). hot=코랄·incoming=💎보라·warming=주황·calm=그레이·cooling=블루. */
+const TONE_COLOR: Record<FomoTone, string> = {
+  hot: UP,
+  incoming: "#A855F7",
+  warming: "#F59E0B",
+  calm: "#94A3B8",
+  cooling: "#3B82F6",
+};
+
 /**
- * 종목 카드 앞면(rev2): 정체성(로고+종목명+시장·시총순위) / 현재가 / 테마태그 / FOMO 후킹 / 스파크라인 / 재료.
- * 강도 비례 톤(§3) — 핫하면 세게, 조용하면 차분히. 점수·판정·예측 없음. 로고는 네이버 심볼(폴백 이니셜).
+ * 종목 카드 앞면 — 포모 점수(척추 ②, 단일 출처)로 점수·라벨·헤드라인·톤. 휴리스틱 대체.
+ * 정체성 / 현재가 / 포모점수+라벨 / 테마태그 / 헤드라인 / 스파크라인 / 재료. 점수=주목도(품질 아님), 예측 0.
  */
 function StockCardFace({
   stock,
-  hook,
+  view,
+  themeLabel,
+  catalysts,
   priceText,
   changeText,
   changeDir,
@@ -142,7 +153,9 @@ function StockCardFace({
   progress,
 }: {
   stock: DeckStock;
-  hook: CardFrontHook;
+  view: FomoCardView;
+  themeLabel?: string | undefined;
+  catalysts?: string[] | undefined;
   priceText?: string | undefined;
   changeText?: string | undefined;
   changeDir?: "up" | "down" | "flat" | undefined;
@@ -150,7 +163,7 @@ function StockCardFace({
   sparkline?: number[] | undefined;
   progress?: string | undefined;
 }) {
-  const color = INTENSITY_COLOR[hook.intensity] ?? "#94A3B8";
+  const tone = TONE_COLOR[view.tone] ?? "#94A3B8";
   return (
     <div className="flex h-full flex-col">
       {/* 1행 — 정체성: 로고 + 종목명 + 시장·시총순위 */}
@@ -168,7 +181,7 @@ function StockCardFace({
         </div>
       </div>
 
-      {/* 현재가 — 시총순위줄과 테마태그 사이(시장 readout, 후킹 아님) */}
+      {/* 현재가 — 시총순위줄과 포모 점수 사이(시장 readout, 후킹 아님) */}
       {priceText && (
         <div className="mt-3 flex items-baseline gap-2">
           <span className="text-lg font-bold text-whiteout">{priceText}</span>
@@ -180,34 +193,47 @@ function StockCardFace({
         </div>
       )}
 
-      {/* 2행 — 테마 태그 */}
-      {hook.themeLabel && (
+      {/* 포모 점수 + 라벨 (척추) — "포모 72 · 🔥 지금 한복판". 주목도 명시(품질 아님). */}
+      {view.scoreText && (
+        <div
+          className="mt-4 inline-flex w-fit items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm font-bold"
+          style={{ backgroundColor: `${tone}22`, color: tone }}
+        >
+          <span>{view.scoreText}</span>
+          <span className="opacity-70">·</span>
+          <span>
+            {view.emoji && <span aria-hidden>{view.emoji} </span>}
+            {view.badge}
+          </span>
+        </div>
+      )}
+
+      {/* 테마 태그 */}
+      {themeLabel && (
         <span
-          className="mt-4 inline-flex w-fit items-center rounded-full px-2.5 py-1 font-pixel text-xs"
+          className="mt-3 inline-flex w-fit items-center rounded-full px-2.5 py-1 font-pixel text-xs"
           style={{ backgroundColor: "rgba(255,90,54,0.12)", color: UP }}
         >
-          # {hook.themeLabel}
+          # {themeLabel}
         </span>
       )}
 
-      {/* 3행 — FOMO 후킹(강도 비례 톤) */}
-      <p className="mt-4 text-xl font-bold leading-8" style={{ color }}>
-        {hook.headline}
+      {/* 헤드라인 = 라벨 기반 한 줄(강도 비례 톤). 💎는 특별 강조. */}
+      <p className="mt-4 text-xl font-bold leading-8" style={{ color: tone }}>
+        {view.isLeading && <span aria-hidden>💎 </span>}
+        {view.headline}
       </p>
 
-      {/* 4행 — 미니 스파크라인(최근 3개월) */}
+      {/* 미니 스파크라인(최근 3개월) */}
       {sparkline && sparkline.length >= 2 && <Sparkline series={sparkline} />}
 
-      {/* 5행 — 다가오는 재료(구체·일정) */}
-      {hook.catalysts.length > 0 && (
+      {/* 다가오는 재료(있으면) */}
+      {catalysts && catalysts.length > 0 && (
         <ul className="mt-4 flex flex-col gap-1.5">
-          {hook.catalysts.map((c, i) => (
+          {catalysts.map((c, i) => (
             <li key={i} className="flex gap-2 text-sm leading-6 text-whiteout">
               <span aria-hidden style={{ color: UP }}>•</span>
-              <span>
-                {c.when && <span className="font-pixel text-muted">{c.when} · </span>}
-                {c.label}
-              </span>
+              <span>{c}</span>
             </li>
           ))}
         </ul>
@@ -219,16 +245,6 @@ function StockCardFace({
       </div>
     </div>
   );
-}
-
-/** 오늘(KST) "M/D" — 후킹 헤드라인 시점 라벨(§4 시점 명시). */
-function kstTodayLabel(): string {
-  try {
-    const kst = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
-    return `${kst.getMonth() + 1}/${kst.getDate()}`;
-  } catch {
-    return "";
-  }
 }
 
 interface SectorDeckProps {
@@ -299,6 +315,7 @@ function SectorDeckInner({
   // lazy 로 서버에서 조립해 받는다(비용 방어 §5). 캐시(canonical 키)로 재방문 즉시.
   type FrontEntry = {
     signals: CardFrontSignals;
+    fomo: FomoScoreResult;
     sparkline: number[];
     priceText?: string;
     changeText?: string;
@@ -306,7 +323,6 @@ function SectorDeckInner({
   };
   const [front, setFront] = useState<Record<string, FrontEntry>>({});
   const inflight = useRef<Set<string>>(new Set());
-  const asOf = useRef<string>(kstTodayLabel()).current;
 
   const at = (i: number) => stocks[((i % stocks.length) + stocks.length) % stocks.length]!;
 
@@ -321,6 +337,7 @@ function SectorDeckInner({
             ...prev,
             [key]: {
               signals: d.signals,
+              fomo: d.fomo,
               sparkline: d.sparkline,
               ...(d.priceText ? { priceText: d.priceText } : {}),
               ...(d.changeText ? { changeText: d.changeText } : {}),
@@ -334,17 +351,35 @@ function SectorDeckInner({
     [front]
   );
 
-  // 종목별 신호 조립 — 서버 신호(가격·52주·수급 streak·시총순위) + 테마 태그(섹터) + 발굴 근거(named catalyst).
-  const signalsFor = (stock: DeckStock): CardFrontSignals => {
-    const sig: CardFrontSignals = { ...(front[stock.canonical]?.signals ?? {}), asOf, themeLabel: stock.sector };
-    if (stock.reason) sig.catalysts = [{ label: stock.reason, kind: "news" }];
-    return sig;
+  // 카드 표현 — 포모 점수(척추, 단일 출처) → fomoCardView. 로드 전엔 EMPTY(근거 있으면 그게 헤드라인).
+  // 헤드라인으로 쓰인 근거는 재료 리스트에서 빼서 중복 방지.
+  const cardFor = (stock: DeckStock): { view: FomoCardView; catalysts: string[] } => {
+    const fomo = front[stock.canonical]?.fomo ?? EMPTY_FOMO;
+    const view = fomoCardView(fomo, { sector: stock.sector, ...(stock.reason ? { reason: stock.reason } : {}) });
+    const catalysts = stock.reason && view.headline !== stock.reason ? [stock.reason] : [];
+    return { view, catalysts };
   };
-  const hookFor = (stock: DeckStock): CardFrontHook => buildCardFrontHook(signalsFor(stock));
-  const sparkOf = (stock: DeckStock): number[] | undefined => front[stock.canonical]?.sparkline;
   const rankLabelFor = (stock: DeckStock): string | undefined => {
     const r = front[stock.canonical]?.signals.marketCapRank;
     return r ? `시총 ${r.rank}위` : undefined; // 시장명은 1행에 이미 있음(중복 방지)
+  };
+  const renderFace = (stock: DeckStock, progress?: string) => {
+    const { view, catalysts } = cardFor(stock);
+    const e = front[stock.canonical];
+    return (
+      <StockCardFace
+        stock={stock}
+        view={view}
+        catalysts={catalysts}
+        themeLabel={stock.sector}
+        priceText={e?.priceText}
+        changeText={e?.changeText}
+        changeDir={e?.changeDir}
+        rankLabel={rankLabelFor(stock)}
+        sparkline={e?.sparkline}
+        progress={progress}
+      />
+    );
   };
 
   const flingNext = useCallback((dir: "left" | "right") => {
@@ -434,7 +469,7 @@ function SectorDeckInner({
                 zIndex: 1,
               }}
             >
-              <StockCardFace stock={stock} hook={hookFor(stock)} priceText={front[stock.canonical]?.priceText} changeText={front[stock.canonical]?.changeText} changeDir={front[stock.canonical]?.changeDir} rankLabel={rankLabelFor(stock)} sparkline={sparkOf(stock)} />
+              {renderFace(stock)}
             </div>
           ))}
 
@@ -461,7 +496,7 @@ function SectorDeckInner({
           >
             ← 덜 관심
           </span>
-          <StockCardFace stock={top} hook={hookFor(top)} priceText={front[top.canonical]?.priceText} changeText={front[top.canonical]?.changeText} changeDir={front[top.canonical]?.changeDir} rankLabel={rankLabelFor(top)} sparkline={sparkOf(top)} progress={`${(idx % stocks.length) + 1} / ${stocks.length}`} />
+          {renderFace(top, `${(idx % stocks.length) + 1} / ${stocks.length}`)}
         </div>
       </div>
 

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -105,8 +105,10 @@ export const fetchStockBasics = (stock: string) =>
 
 /** 카드 앞면 FOMO 신호(rev2 후속) — baseline·라이브 수급 streak·시총순위·3개월 스파크라인. 도달 종목 lazy. */
 export type { CardFrontSignals } from "@fomo/core";
+export type { FomoScoreResult } from "@fomo/core";
 export interface StockFrontResponse {
   signals: import("@fomo/core").CardFrontSignals;
+  fomo: import("@fomo/core").FomoScoreResult;
   sparkline: number[];
   priceText?: string;
   changeText?: string;

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { computeFomoScore } from "@fomo/core";
 import { assembleStockFront, fetchMarketCapRankMap, type StockFrontData } from "../../../../lib/stock-front";
 
 /**
@@ -52,7 +53,9 @@ export async function GET(req: Request) {
     );
   } catch (err) {
     console.warn("[stock-front] failed", stock, (err as Error)?.message);
-    // 정직한 폴백 — 신호 없이도 카드는 잠잠으로 뜬다.
-    return withCors(NextResponse.json({ signals: {}, sparkline: [] } satisfies StockFrontData));
+    // 정직한 폴백 — 신호 없이도 카드는 잠잠(점수 보류)으로 뜬다.
+    return withCors(
+      NextResponse.json({ signals: {}, fomo: computeFomoScore({}), sparkline: [] } satisfies StockFrontData)
+    );
   }
 }

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -1,7 +1,14 @@
 // 카드 앞면 FOMO 신호 서버 조립 — PHASE0 rev2 후속(스파크라인·시총순위·라이브 수급).
 // baseline(가격·52주)·라이브 수급 streak·시총 순위·3개월 종가를 한 번에 모아 CardFrontSignals 로.
 // 외부소스는 네이버 금융(이미 쓰는 무료·무인증) — 새 비용·DDL 없음. 실패는 조용히 폴백(부분만 채움).
-import { resolveStock, signalsFromBasics, investorNetStreak, type CardFrontSignals } from "@fomo/core";
+import {
+  resolveStock,
+  signalsFromBasics,
+  investorNetStreak,
+  computeFomoScore,
+  type CardFrontSignals,
+  type FomoScoreResult,
+} from "@fomo/core";
 import { fetchStockBasics } from "./stock-basics";
 import { readSupplyDemandHistory } from "./supply-demand-store";
 
@@ -17,7 +24,8 @@ async function getJson(url: string): Promise<unknown> {
  * 네이버 siseJson(일봉) → 최근 N거래일 종가(오름차순, 오래된→최신). 스파크라인용.
  * 응답은 작은따옴표 의사 JSON + 헤더행(한글, EUC-KR) — 숫자 행만 정규식으로 안전 추출(인코딩 무관).
  */
-export async function fetchStockSparkline(code: string, calendarDays = 100): Promise<number[]> {
+/** 네이버 siseJson 일봉 → 최근 거래일 종가·거래량(오름차순). 스파크라인 + 거래량 회전·추세 산출용. */
+export async function fetchStockDaily(code: string, calendarDays = 100): Promise<{ closes: number[]; volumes: number[] }> {
   try {
     const ymd = (d: Date) =>
       `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}`;
@@ -25,22 +33,46 @@ export async function fetchStockSparkline(code: string, calendarDays = 100): Pro
     const start = new Date(end.getTime() - calendarDays * 86_400_000); // ~100일 ≈ 3개월 거래일
     const url = `https://api.finance.naver.com/siseJson.naver?symbol=${encodeURIComponent(code)}&requestType=1&startTime=${ymd(start)}&endTime=${ymd(end)}&timeframe=day`;
     const res = await fetch(url, { headers: UA, signal: AbortSignal.timeout(8000) });
-    if (!res.ok) return [];
+    if (!res.ok) return { closes: [], volumes: [] };
     const text = await res.text();
-    // 데이터 행: ["20260320", 350000, 355000, 348000, 352000, ...] — 날짜(따옴표),시,고,저,종,거래량,...
-    const rows: { date: string; close: number }[] = [];
-    const re = /\[\s*"?(\d{8})"?\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/g;
+    // 데이터 행: ["20260320", 시, 고, 저, 종, 거래량, ...] — 날짜(따옴표)·OHLC·거래량(idx5).
+    const rows: { date: string; close: number; volume: number }[] = [];
+    const re = /\[\s*"?(\d{8})"?\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(text)) !== null) {
       const close = Number(m[5]);
-      if (Number.isFinite(close)) rows.push({ date: m[1]!, close });
+      const volume = Number(m[6]);
+      if (Number.isFinite(close)) rows.push({ date: m[1]!, close, volume: Number.isFinite(volume) ? volume : 0 });
     }
     rows.sort((a, b) => (a.date < b.date ? -1 : 1)); // 오래된→최신
-    return rows.map((r) => r.close).slice(-66); // 최근 ~3개월
+    const recent = rows.slice(-66); // 최근 ~3개월
+    return { closes: recent.map((r) => r.close), volumes: recent.map((r) => r.volume) };
   } catch (err) {
-    console.warn("[stock-front] sparkline failed", code, (err as Error)?.message);
-    return [];
+    console.warn("[stock-front] daily failed", code, (err as Error)?.message);
+    return { closes: [], volumes: [] };
   }
+}
+
+/** 평소 대비 거래량 배수(거래량 회전) — 최신일 / 직전 ~20거래일 평균. 데이터 부족이면 undefined(가짜숫자 금지). */
+function volumeTurnover(volumes: number[]): number | undefined {
+  if (volumes.length < 6) return undefined;
+  const today = volumes[volumes.length - 1]!;
+  const prev = volumes.slice(-21, -1).filter((v) => v > 0);
+  if (prev.length < 5 || today <= 0) return undefined;
+  const avg = prev.reduce((a, b) => a + b, 0) / prev.length;
+  return avg > 0 ? today / avg : undefined;
+}
+
+/** 추세 강도 0~1 — *최근 ~1개월* 종가 변화폭(상·하 무관)을 15% 밴드로 정규화(현재 추세 세기).
+ *  3개월 누적은 강세장에서 거의 다 saturate 라 최근 창으로 차별화. 데이터 부족이면 undefined. */
+function trendStrength(closes: number[]): number | undefined {
+  if (closes.length < 2) return undefined;
+  const win = Math.min(closes.length, 21); // 최근 ~1개월 거래일
+  const start = closes[closes.length - win]!;
+  const last = closes[closes.length - 1]!;
+  if (start <= 0) return undefined;
+  const mag = Math.abs(last / start - 1) / 0.15;
+  return mag < 0 ? 0 : mag > 1 ? 1 : mag;
 }
 
 interface RankEntry {
@@ -79,8 +111,10 @@ export async function fetchMarketCapRankMap(): Promise<Record<string, RankEntry>
 }
 
 export interface StockFrontData {
-  /** 엔진(buildCardFrontHook)에 넣을 신호(가격·52주·수급 streak·시총순위·정체성). */
+  /** 엔진에 넣을 신호(가격·52주·수급 streak·시총순위·정체성). */
   signals: CardFrontSignals;
+  /** 포모 점수(척추) — C·L·라벨. 카드 점수/라벨/헤드라인의 단일 출처. */
+  fomo: FomoScoreResult;
   /** 최근 3개월 종가(스파크라인) — 없으면 빈 배열. */
   sparkline: number[];
   /** 현재가 — 예 "354,000원"(카드 1행 표기용). */
@@ -92,7 +126,8 @@ export interface StockFrontData {
 }
 
 /**
- * 한 종목의 카드 앞면 데이터 조립. baseline(가격·52주) + 라이브 수급 streak + 시총순위 + 스파크라인.
+ * 한 종목의 카드 앞면 데이터 조립 + 포모 점수 산출(척추 단일 출처).
+ * baseline(가격·52주) + 라이브 수급 streak + 거래량 회전·추세 + 시총순위 + 스파크라인 → computeFomoScore.
  * rankMap 은 비싸므로 호출부에서 받아 재사용(없으면 순위 생략).
  */
 export async function assembleStockFront(
@@ -101,12 +136,12 @@ export async function assembleStockFront(
 ): Promise<StockFrontData> {
   const def = resolveStock(stock);
   const code = def?.naverCode;
-  if (!code) return { signals: {}, sparkline: [] };
+  if (!code) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
 
-  const [basics, history, sparkline] = await Promise.all([
+  const [basics, history, daily] = await Promise.all([
     fetchStockBasics(stock).catch(() => null),
     readSupplyDemandHistory(code).catch(() => []),
-    fetchStockSparkline(code),
+    fetchStockDaily(code),
   ]);
 
   const signals: CardFrontSignals = basics ? signalsFromBasics(basics) : {};
@@ -120,9 +155,21 @@ export async function assembleStockFront(
   const rank = rankMap?.[code];
   if (rank) signals.marketCapRank = { scope: "market", market: rank.market, rank: rank.rank };
 
+  // ── 포모 점수(척추) — 거래량 회전·가격(등락·추세)·수급. 언급량·prevScore 는 후속(없으면 제외). ──
+  const volRatio = volumeTurnover(daily.volumes);
+  const trend = trendStrength(daily.closes);
+  const fomo = computeFomoScore({
+    ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
+    ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
+    ...(typeof trend === "number" ? { trendStrength: trend } : {}),
+    ...(typeof signals.foreignNetStreak === "number" ? { foreignNetStreak: signals.foreignNetStreak } : {}),
+    ...(typeof signals.institutionNetStreak === "number" ? { institutionNetStreak: signals.institutionNetStreak } : {}),
+  });
+
   return {
     signals,
-    sparkline,
+    fomo,
+    sparkline: daily.closes,
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),
     ...(basics?.changeDir ? { changeDir: basics.changeDir } : {}),

--- a/packages/fomo-core/__tests__/fomo-score.test.ts
+++ b/packages/fomo-core/__tests__/fomo-score.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   computeFomoScore,
+  fomoCardView,
   isLeadingSetup,
   fomoLabelTextsSafe,
   rankByScore,
@@ -116,6 +117,70 @@ describe("computeFomoScore — 포모 점수 엔진(§2)", () => {
       const t = computeFomoScore(l).labelText;
       expect(isFrontHookSafe(t), `금칙어: ${t}`).toBe(true);
       expect(t).not.toMatch(/점수|등급|추천|오를|사라|급등할/);
+    }
+  });
+});
+
+describe("fomoCardView — 엔진 출력 → 카드(척추 ②, 단일 출처)", () => {
+  it("점수·라벨이 엔진 결과와 정확히 일치(단일 출처)", () => {
+    const s = computeFomoScore({ volumeRatio: 3.5, changePct: 7, mentionScore: 90 });
+    const v = fomoCardView(s, { sector: "반도체" });
+    expect(v.scoreText).toBe(`포모 ${s.fomoScore}`);
+    expect(v.emoji).toBe("🔥");
+    expect(v.badge).toBe("지금 한복판");
+    expect(v.tone).toBe("hot");
+  });
+
+  it("💎 incoming 특별 취급 — isLeading + 특별 문구(reason 있어도 유지, 예측 0)", () => {
+    const s = computeFomoScore({
+      volumeRatio: 1.1,
+      foreignNetStreak: 5,
+      foreignNetRatio: 0.01,
+      institutionNetStreak: 5,
+      institutionNetRatio: 0.01,
+    });
+    const v = fomoCardView(s, { sector: "2차전지", reason: "수주 기대로 묶임" });
+    expect(s.label).toBe("incoming");
+    expect(v.isLeading).toBe(true);
+    expect(v.emoji).toBe("💎");
+    expect(v.headline).toContain("이미 움직였");
+    expect(v.headline).not.toMatch(/오를|될 것|상승할/);
+  });
+
+  it("강도 비례 톤 — 핫 세게(hot)·조용 차분(calm)·식는 중(cooling)", () => {
+    expect(fomoCardView(computeFomoScore({ volumeRatio: 3.5, mentionScore: 90 })).tone).toBe("hot");
+    expect(fomoCardView(computeFomoScore({ mentionScore: 10 })).tone).toBe("calm");
+    expect(fomoCardView(computeFomoScore({ volumeRatio: 3, mentionScore: 80, changePct: -7 })).tone).toBe("cooling");
+  });
+
+  it("근거(reason) 우선 — incoming 아닐 때 grounded 헤드라인", () => {
+    const s = computeFomoScore({ volumeRatio: 3.5, mentionScore: 90 }); // hot
+    expect(fomoCardView(s, { sector: "반도체", reason: "HBM4 공급계약 보도" }).headline).toBe("HBM4 공급계약 보도");
+  });
+
+  it("가드 위반 reason 은 폐기 → 라벨 헤드라인 폴백", () => {
+    const s = computeFomoScore({ volumeRatio: 3.5, mentionScore: 90 });
+    const v = fomoCardView(s, { sector: "반도체", reason: "지금 매수 추천! 급등할 종목" });
+    expect(v.headline).toBe("지금 반도체에서 가장 시선이 몰리는 자리예요");
+  });
+
+  it("데이터 0 → 점수 보류(빈 문자열), 라벨 silent", () => {
+    const v = fomoCardView(computeFomoScore({}));
+    expect(v.scoreText).toBe("");
+    expect(v.badge).toBe("조용");
+  });
+
+  it("금칙어 가드 — 모든 라벨 헤드라인에 예측·판정 0", () => {
+    const cases = [
+      computeFomoScore({ volumeRatio: 3.5, mentionScore: 90 }),
+      computeFomoScore({ foreignNetStreak: 5, foreignNetRatio: 0.01, institutionNetStreak: 5, institutionNetRatio: 0.01 }),
+      computeFomoScore({ mentionScore: 50, volumeRatio: 2 }),
+      computeFomoScore({ mentionScore: 10 }),
+      computeFomoScore({ volumeRatio: 3, mentionScore: 80, changePct: -7 }),
+    ];
+    for (const s of cases) {
+      const h = fomoCardView(s, { sector: "반도체" }).headline;
+      expect(isFrontHookSafe(h), `금칙어: ${h}`).toBe(true);
     }
   });
 });

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -199,6 +199,95 @@ export function fomoLabelTextsSafe(): boolean {
   return Object.values(LABEL_TEXT).every((t) => isFrontHookSafe(t));
 }
 
+// ── 카드 앞면 표현(척추 ② — 엔진 출력 → 카드. 단일 출처) ──────────────────────
+export type FomoTone = "hot" | "incoming" | "warming" | "calm" | "cooling";
+
+export interface FomoCardView {
+  /** 2행 점수 — "포모 72"(주목도 명시). 데이터 0이면 빈 문자열(보류). */
+  scoreText: string;
+  /** 라벨 이모지 — 🔥/💎(나머지 없음). */
+  emoji: string;
+  /** 짧은 상태 배지 — "지금 한복판"/"오기 직전"/"데우는 중"/"조용"/"식는 중". */
+  badge: string;
+  /** 4행 헤드라인 — 강도 비례·섹터 인지·근거 우선. 예측/판정 0. */
+  headline: string;
+  /** 톤(색·강조 매핑용). */
+  tone: FomoTone;
+  /** 💎 "오기 직전" 특별 취급 여부. */
+  isLeading: boolean;
+}
+
+const BADGE: Record<FomoLabel, string> = {
+  hot: "지금 한복판",
+  warming: "데우는 중",
+  incoming: "오기 직전",
+  quiet: "조용",
+  silent: "조용",
+  cooling: "식는 중",
+};
+const EMOJI: Record<FomoLabel, string> = {
+  hot: "🔥",
+  warming: "",
+  incoming: "💎",
+  quiet: "",
+  silent: "",
+  cooling: "",
+};
+const TONE: Record<FomoLabel, FomoTone> = {
+  hot: "hot",
+  warming: "warming",
+  incoming: "incoming",
+  quiet: "calm",
+  silent: "calm",
+  cooling: "cooling",
+};
+
+/**
+ * 포모 점수 → 카드 앞면 표현(점수·라벨·헤드라인·톤). 순수·결정적. 단일 출처(휴리스틱 대체).
+ * 헤드라인은 강도 비례·섹터 인지. 💎는 특별 문구(예측 금지 — "이미 움직였다"는 사실까지만).
+ * 근거(reason, 발굴 named)가 있으면 더 구체적이라 우선 — 단 💎는 특별 문구 유지, 가드 위반 reason 은 폐기.
+ */
+export function fomoCardView(score: FomoScoreResult, opts: { sector?: string; reason?: string } = {}): FomoCardView {
+  const { label } = score;
+  const sector = opts.sector?.trim();
+  const reason = opts.reason?.trim();
+  const isLeading = label === "incoming";
+
+  let headline: string;
+  if (isLeading) {
+    headline = "조용한데 외국인·기관이 이미 움직였어요 · 아직 사람들은 몰라요";
+  } else if (reason && isFrontHookSafe(reason)) {
+    headline = reason;
+  } else {
+    switch (label) {
+      case "hot":
+        headline = sector ? `지금 ${sector}에서 가장 시선이 몰리는 자리예요` : "지금 가장 시선이 몰리는 자리예요";
+        break;
+      case "warming":
+        headline = sector ? `${sector} 관심이 데워지는 중이에요` : "관심이 데워지는 중이에요";
+        break;
+      case "cooling":
+        headline = "한 물 가는 분위기예요";
+        break;
+      case "silent":
+        headline = "재료도 수급도 아직 조용해요";
+        break;
+      case "quiet":
+      default:
+        headline = "지금은 조용한 자리예요";
+    }
+  }
+
+  return {
+    scoreText: score.confidence > 0 ? `포모 ${score.fomoScore}` : "",
+    emoji: EMOJI[label],
+    badge: BADGE[label],
+    headline,
+    tone: TONE[label],
+    isLeading,
+  };
+}
+
 // ── 순위 (척추 §3) — 포모 순위·시총 순위 공통. 시장 전체 & 섹터 둘 다. 순수·결정적. ─────────
 export interface RankInput {
   key: string;


### PR DESCRIPTION
## 한 줄
#586 카드-로컬 휴리스틱을 **엔진(#591) 출력으로 교체** — 카드의 점수·라벨·헤드라인·톤이 전부 `FomoScoreResult` 단일 출처.

## 무엇을
- **`fomoCardView`** (core 순수): `FomoScoreResult` → `{scoreText "포모 72", emoji 🔥/💎, badge, headline, tone, isLeading}`. 강도 비례 톤. **💎 incoming 특별 문구**("이미 움직였다"는 사실까지만, 예측 0). 발굴 근거(named) 있으면 우선, 가드 위반 reason 폐기.
- **stock-front 데이터 배선**: `fetchStockDaily`(종가+거래량) → **거래량 회전**(volumeTurnover) + **추세 강도**(최근 ~1개월/15% 밴드) → `computeFomoScore`. 라이브 수급 streak = L 입력. 언급량·prevScore는 후속(없으면 제외, confidence 반영). **네이버 baseline 경로 — 새 외부소스·비용·DDL 없음**(게이트 ③ 무관).
- **카드**: "포모 점수 + 라벨" 행 추가(주목도 명시 — 품질 아님), 헤드라인=엔진 라벨 기반(휴리스틱 제거), 💎 보라 강조. 가격/로고/시총순위/스파크라인 유지. `buildCardFrontHook` 의존 제거(단일 출처 §6).

## 검증 (로컬 백엔드+프론트)
- 삼성전자 **포모 52 · 조용**, SK하이닉스 50·조용, 한미반도체 **78 · 식는 중**(고거래량+당일 하락), 리노공업 13·조용, 두산에너빌리티 16·조용 — 단일 출처 일치, 점수 차별화·라벨 타당. 스크린샷(삼성 로고+포모칩+가격+스파크라인).
- 💎 incoming은 수급 streak 누적되면 발화(엔진/뷰 단위테스트로 검증). 783 테스트(fomoCardView 7 신규), 3개 프로젝트 typecheck 클린.

## 후속 (이 PR 아님)
③ 상세 히어로 / ④ 발견 포모순위 정렬. 언급량(per-stock)·prevScore(방향) 입력 배선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)