### PR TITLE
feat(feed): 발견 피드 포모순위 밴드 정렬 + 일별 셔플 (척추 ④)

### DIFF
--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { sparklinePath, seriesIsUp, fomoCardView, computeFomoScore } from "@fomo/core";
+import { sparklinePath, seriesIsUp, fomoCardView, computeFomoScore, rankFeedByFomo } from "@fomo/core";
 import type { KeywordCard, SectorStock, StockSector, CardFrontSignals, FomoScoreResult, FomoCardView, FomoTone } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchSectorStocks, fetchKeywords, fetchStockFront, recordTaste } from "@/lib/fomoApi";
@@ -30,6 +30,26 @@ const EMPTY_FOMO = computeFomoScore({});
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
 type DeckStock = SectorStock & { reason?: string };
+
+/** 종목별 앞면 데이터(stock-front 응답 캐시). 포모 점수(척추)·스파크라인·가격. */
+type FrontEntry = {
+  signals: CardFrontSignals;
+  fomo: FomoScoreResult;
+  sparkline: number[];
+  priceText?: string;
+  changeText?: string;
+  changeDir?: "up" | "down" | "flat";
+};
+
+/** 오늘(KST) "YYYY-MM-DD" — 발견 정렬의 일별 셔플 시드(같은 날=같은 순서). */
+function kstDateSeed(): string {
+  try {
+    const kst = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+    return `${kst.getFullYear()}-${String(kst.getMonth() + 1).padStart(2, "0")}-${String(kst.getDate()).padStart(2, "0")}`;
+  } catch {
+    return "seed";
+  }
+}
 
 /**
  * 섹터 풀 + 그날 발굴 종목 병합(④). 발굴 근거(reason)를 풀 종목에 붙이고, 풀에 없던 발굴주는 추가.
@@ -255,30 +275,59 @@ interface SectorDeckProps {
 
 export function SectorStockDeck({ sector, loggedIn, onRequireLogin }: SectorDeckProps) {
   const [state, setState] = useState<
-    { kind: "loading" } | { kind: "error" } | { kind: "ready"; stocks: DeckStock[] }
+    | { kind: "loading" }
+    | { kind: "error" }
+    | { kind: "ready"; stocks: DeckStock[]; fronts: Record<string, FrontEntry> }
   >({ kind: "loading" });
 
   useEffect(() => {
     let alive = true;
     setState({ kind: "loading" });
-    // 풀(baseline 보장 — 빈 카드 방지) + 그날 발굴주(keywords) 병렬. 발굴 실패해도 풀로 진행.
-    Promise.all([
-      fetchSectorStocks(sector, true),
-      fetchKeywords().catch(() => null), // 발굴은 보강 — 실패 무시
-    ])
-      .then(([poolRes, kwRes]) => {
+    (async () => {
+      try {
+        // 풀(baseline 보장 — 빈 카드 방지) + 그날 발굴주(keywords) 병렬. 발굴 실패해도 풀로 진행.
+        const [poolRes, kwRes] = await Promise.all([
+          fetchSectorStocks(sector, true),
+          fetchKeywords().catch(() => null),
+        ]);
         if (!alive) return;
         if (!poolRes.stocks?.length) {
           setState({ kind: "error" });
           return;
         }
-        const stocks = mergeDiscovered(poolRes.stocks, kwRes?.cards ?? [], sector);
-        setState({ kind: "ready", stocks });
-      })
-      .catch((err) => {
+        const merged = mergeDiscovered(poolRes.stocks, kwRes?.cards ?? [], sector);
+
+        // ④ 발견 정렬 — 풀 종목 포모 점수를 미리 모아(서버 캐시로 방어) 밴드 정렬(💎 안 묻힘) + 일별 셔플.
+        const domestic = merged.filter((s) => s.naverCode);
+        const settled = await Promise.allSettled(domestic.map((s) => fetchStockFront(s.canonical)));
+        if (!alive) return;
+        const fronts: Record<string, FrontEntry> = {};
+        domestic.forEach((s, i) => {
+          const r = settled[i];
+          if (r && r.status === "fulfilled") {
+            const d = r.value;
+            fronts[s.canonical] = {
+              signals: d.signals,
+              fomo: d.fomo,
+              sparkline: d.sparkline,
+              ...(d.priceText ? { priceText: d.priceText } : {}),
+              ...(d.changeText ? { changeText: d.changeText } : {}),
+              ...(d.changeDir ? { changeDir: d.changeDir } : {}),
+            };
+          }
+        });
+        const order = rankFeedByFomo(
+          merged.map((s) => ({ key: s.canonical, label: fronts[s.canonical]?.fomo.label ?? "quiet" })),
+          { seed: kstDateSeed() }
+        );
+        const byKey = new Map(merged.map((s) => [s.canonical, s] as const));
+        const ranked = order.map((k) => byKey.get(k)).filter((s): s is DeckStock => !!s);
+        setState({ kind: "ready", stocks: ranked.length ? ranked : merged, fronts });
+      } catch (err) {
         console.warn("[SectorStockDeck] fetch failed", err);
         if (alive) setState({ kind: "error" });
-      });
+      }
+    })();
     return () => {
       alive = false;
     };
@@ -294,14 +343,22 @@ export function SectorStockDeck({ sector, loggedIn, onRequireLogin }: SectorDeck
         다른 섹터를 둘러봐 주세요.
       </div>
     );
-  return <SectorDeckInner stocks={state.stocks} loggedIn={loggedIn} onRequireLogin={onRequireLogin} />;
+  return (
+    <SectorDeckInner
+      stocks={state.stocks}
+      initialFronts={state.fronts}
+      loggedIn={loggedIn}
+      onRequireLogin={onRequireLogin}
+    />
+  );
 }
 
 function SectorDeckInner({
   stocks,
+  initialFronts,
   loggedIn,
   onRequireLogin,
-}: { stocks: DeckStock[] } & Omit<SectorDeckProps, "sector">) {
+}: { stocks: DeckStock[]; initialFronts?: Record<string, FrontEntry> } & Omit<SectorDeckProps, "sector">) {
   // 무한: 풀을 순환(modulo)해 끝나지 않는다(§7 "무한히 풀만큼").
   const [idx, setIdx] = useState(0);
   const [dx, setDx] = useState(0);
@@ -311,17 +368,8 @@ function SectorDeckInner({
   const startX = useRef(0);
   const moved = useRef(false);
 
-  // 앞면 FOMO 신호 — 도달하는 카드의 stock-front(가격·52주·라이브 수급 streak·시총순위·3개월 종가)를
-  // lazy 로 서버에서 조립해 받는다(비용 방어 §5). 캐시(canonical 키)로 재방문 즉시.
-  type FrontEntry = {
-    signals: CardFrontSignals;
-    fomo: FomoScoreResult;
-    sparkline: number[];
-    priceText?: string;
-    changeText?: string;
-    changeDir?: "up" | "down" | "flat";
-  };
-  const [front, setFront] = useState<Record<string, FrontEntry>>({});
+  // 앞면 FOMO 신호 — ④ 정렬 때 풀 전체를 이미 받아 seed(initialFronts). 빠진 종목만 도달 시 lazy 보강.
+  const [front, setFront] = useState<Record<string, FrontEntry>>(initialFronts ?? {});
   const inflight = useRef<Set<string>>(new Set());
 
   const at = (i: number) => stocks[((i % stocks.length) + stocks.length) % stocks.length]!;

--- a/packages/fomo-core/__tests__/fomo-score.test.ts
+++ b/packages/fomo-core/__tests__/fomo-score.test.ts
@@ -7,6 +7,7 @@ import {
   isLeadingSetup,
   fomoLabelTextsSafe,
   rankByScore,
+  rankFeedByFomo,
   isFrontHookSafe,
   C_WEIGHTS,
   type FomoScoreInputs,
@@ -217,6 +218,65 @@ describe("fomoCardView — 엔진 출력 → 카드(척추 ②, 단일 출처)",
       const h = fomoCardView(s, { sector: "반도체" }).headline;
       expect(isFrontHookSafe(h), `금칙어: ${h}`).toBe(true);
     }
+  });
+});
+
+describe("rankFeedByFomo — 발견 피드 밴드 정렬 + 일별 셔플(척추 ④)", () => {
+  const items = [
+    { key: "식는주", label: "cooling" as const },
+    { key: "조용주", label: "quiet" as const },
+    { key: "핫주", label: "hot" as const },
+    { key: "데우주", label: "warming" as const },
+    { key: "수급주", label: "incoming" as const }, // 💎
+    { key: "잠잠주", label: "silent" as const },
+  ];
+
+  it("밴드 순서 — 🔥/💎 상단, 식는중·silent 하단", () => {
+    const order = rankFeedByFomo(items, { seed: "2026-06-22" });
+    const band = (k: string) => order.indexOf(k);
+    // hot·incoming(💎) 이 warming·quiet·cooling·silent 보다 앞
+    expect(band("핫주")).toBeLessThan(band("데우주"));
+    expect(band("수급주")).toBeLessThan(band("데우주"));
+    expect(band("데우주")).toBeLessThan(band("조용주"));
+    expect(band("조용주")).toBeLessThan(band("식는주"));
+    expect(band("잠잠주")).toBe(order.length - 1); // silent 최하단
+  });
+
+  it("★핵심 — 💎(incoming, C 낮음)가 상위 밴드에 노출(바닥 안 가라앉음)", () => {
+    // 💎가 hot 과 같은 최상위 밴드(0) → 항상 상위 2개 안.
+    const order = rankFeedByFomo(items, { seed: "2026-06-22" });
+    expect(order.slice(0, 2)).toContain("수급주");
+    // 여러 시드에서도 늘 상위 밴드(데우는중보다 위)
+    for (const seed of ["a", "b", "2026-06-21", "x"]) {
+      const o = rankFeedByFomo(items, { seed });
+      expect(o.indexOf("수급주")).toBeLessThan(o.indexOf("데우주"));
+    }
+  });
+
+  it("일별 시드 결정성 — 같은 날 같은 순서, 다른 날 다른 순서", () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({ key: `q${i}`, label: "quiet" as const }));
+    expect(rankFeedByFomo(many, { seed: "2026-06-22" })).toEqual(rankFeedByFomo(many, { seed: "2026-06-22" }));
+    expect(rankFeedByFomo(many, { seed: "2026-06-22" })).not.toEqual(rankFeedByFomo(many, { seed: "2026-06-23" }));
+  });
+
+  it("콜드스타트(취향 없음) — 객관 밴드 순서로 안전", () => {
+    const order = rankFeedByFomo(items, { seed: "2026-06-22" });
+    expect(order[order.length - 1]).toBe("잠잠주"); // 억지로 상단에 안 올림
+  });
+
+  it("개인화 seam — rank 주입 시 밴드 내 그 순서(밴드는 유지)", () => {
+    const band0 = [
+      { key: "h1", label: "hot" as const },
+      { key: "h2", label: "hot" as const },
+      { key: "w1", label: "warming" as const },
+    ];
+    const order = rankFeedByFomo(band0, { seed: "x", rank: (k) => (k === "h2" ? 100 : 0) });
+    expect(order[0]).toBe("h2"); // 취향 점수 높은 게 밴드 내 위로
+    expect(order[order.length - 1]).toBe("w1"); // 밴드는 유지(warming 은 그대로 아래)
+  });
+
+  it("dropSilent — silent 제외", () => {
+    expect(rankFeedByFomo(items, { seed: "x", dropSilent: true })).not.toContain("잠잠주");
   });
 });
 

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -329,6 +329,63 @@ export interface RankResult {
   sector?: number;
 }
 
+// ── 발견 피드 정렬(척추 ④ — 밴드 + 일별 셔플. 💎 안 묻히게) ────────────────────
+/** 라벨 → 밴드(상단 0 → 하단 4). 🔥hot·💎incoming 은 같은 최상위 밴드(인터리브, §3). */
+const FEED_BAND: Record<FomoLabel, number> = {
+  hot: 0,
+  incoming: 0, // 💎 — C 낮아도 반드시 상위(순수 C 내림차순이면 바닥에 묻힘 → 금지)
+  warming: 1,
+  quiet: 2,
+  cooling: 3,
+  silent: 4,
+};
+
+export interface FeedRankItem {
+  key: string;
+  label: FomoLabel;
+}
+
+export interface FeedRankOptions {
+  /** 일별 셔플 시드 — 같은 날=같은 순서(캐시 안정), 다른 날=새 순서. 예 "2026-06-22"[, +유저]. */
+  seed: string;
+  /** 개인화 재정렬 seam(P3) — 밴드는 유지하고 밴드 *내* 순서만. 높을수록 위. 미주입 시 일별 셔플. */
+  rank?: (key: string) => number;
+  /** silent(진짜 조용) 제외 여부. 기본 false(최하단 유지). */
+  dropSilent?: boolean;
+}
+
+/** 결정적 문자열 해시(djb2) — 밴드 내 일별 셔플용. */
+function hashStr(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+/**
+ * 발견 피드 정렬 — 밴드(🔥/💎 상단 → 데우는중 → 조용 → 식는중 → silent 최하단) + 밴드 내 일별 결정적 셔플.
+ * ⚠️ 순수 C 내림차순 아님: 💎(조용한데 수급 선행)가 상위 밴드라 안 묻힌다(핵심 가치).
+ * 개인화(rank) 주입 시 밴드는 유지하고 밴드 내 순서만 취향대로(P3 seam). 순수·결정적.
+ */
+export function rankFeedByFomo(items: readonly FeedRankItem[], opts: FeedRankOptions): string[] {
+  const { seed, rank } = opts;
+  const pool = opts.dropSilent ? items.filter((it) => it.label !== "silent") : items;
+  return [...pool]
+    .sort((a, b) => {
+      const band = FEED_BAND[a.label] - FEED_BAND[b.label];
+      if (band !== 0) return band;
+      if (rank) {
+        const r = rank(b.key) - rank(a.key); // 밴드 내 개인화(취향 높을수록 위)
+        if (r !== 0) return r;
+      }
+      // 밴드 내 일별 셔플 — seed 를 XOR 로 섞는다(prefix 연결은 djb2 특성상 seed-독립 순서가 돼 안 됨).
+      const s = hashStr(seed);
+      const ha = (hashStr(a.key) ^ s) >>> 0;
+      const hb = (hashStr(b.key) ^ s) >>> 0;
+      return ha !== hb ? ha - hb : a.key < b.key ? -1 : 1; // 해시 동점도 결정적
+    })
+    .map((it) => it.key);
+}
+
 /**
  * 점수 내림차순 순위 — 시장 전체 + 섹터별. 동점은 key 사전순으로 결정적 tiebreak.
  * 포모 순위(score=C)·시총 순위(score=marketCap) 모두 이 함수로(척추 §3).


### PR DESCRIPTION
## 한 줄
척추 한 바퀴 닫힘 — 포모 점수가 **카드(②)·상세(③)·피드(④)**를 관통. 발견 피드를 포모 라벨 **밴드**로 정렬하되 **💎가 묻히지 않게**.

## 핵심 함정 회피
순수 C 내림차순으로 하면 **💎(C<60·L≥60, 조용한데 수급 선행)가 바닥**으로 가라앉아 발견 불가 → 우리 핵심 가치 상실. 그래서 **밴드 정렬**.

## 무엇을
- **`rankFeedByFomo`** (core 순수): 밴드(🔥hot·💎incoming **최상위 인터리브** → 데우는중 → 조용 → 식는중 → silent 최하단) + **밴드 내 일별 결정적 셔플**(seed XOR 해시). 같은 날=같은 순서(캐시 안정), 다른 날=신선. 개인화 `rank` seam(P3 — 밴드 유지, 밴드 내만).
- **`SectorStockDeck`**: 섹터 진입 시 풀 종목 `stock-front` 병렬 prefetch(서버 10분 캐시로 방어) → `rankFeedByFomo` 정렬 → 그 순서로 덱. front 맵 seed(개별 lazy fetch 절약). 시드=KST 날짜.

## 검증
- 로컬: 반도체 풀 — 현재 전부 quiet 밴드(수급 streak 미누적 L=0)라 **밴드 내 일별 셔플** 순서(코드스타트 대비 신선, 결정적). 💎/🔥 상단·silent 하단·일별 결정성은 **순수 테스트로 보장**(rankFeedByFomo 6 신규). 797 테스트, typecheck 클린.
- 💎 상단 노출은 수급 streak 누적되면 라이브로도 보임(테이블 갓 시작).

## 원칙
💎 안 묻힘 · 결정적(일별 시드) · 가짜 흥분 금지(밴드=실제 강도) · 정렬=주목 강도 순(품질 아님) · 새 소스/비용/DDL 없음.

## 후속 (P3)
개인화 재정렬(취향) — seam 열림(`rank` 미주입 시 객관 밴드). 헤더 포모순위 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)