### PR TITLE
hotfix(card): "한 물 가는 분위기"(쇠퇴 판정) 제거 + 가드 구멍 막기

### DIFF
--- a/packages/fomo-core/__tests__/fomo-score.test.ts
+++ b/packages/fomo-core/__tests__/fomo-score.test.ts
@@ -44,6 +44,26 @@ describe("fomoWhy / confidenceGrade — 상세 포모 해부(척추 ③)", () =>
     expect(confidenceGrade(0.45)).toBe("근거 보통");
     expect(confidenceGrade(0.2)).toBe("근거 약함");
   });
+
+  // HOTFIX 회귀 — "한 물 가는 분위기"(쇠퇴 판정) 제거 + 가드 구멍 막힘.
+  it("가드 구멍 — '한 물 가는 분위기예요'는 이제 거부(false)", () => {
+    expect(isFrontHookSafe("한 물 가는 분위기예요")).toBe(false);
+    expect(isFrontHookSafe("한물 갔어요")).toBe(false);
+    expect(isFrontHookSafe("끝물이에요")).toBe(false);
+  });
+  it("정상 카피('분위기' 정상 사용)는 통과 — 과금지 아님", () => {
+    expect(isFrontHookSafe("관심이 데워지는 분위기예요")).toBe(true);
+    expect(fomoLabelTextsSafe()).toBe(true); // 새 cooling 카피 포함 전부 통과
+  });
+  it("cooling 경로(라벨·fomoWhy·카드 헤드라인)에 '한물'/'한 물' 없음", () => {
+    const cooling = computeFomoScore({ volumeRatio: 3, mentionScore: 80, changePct: -7 });
+    expect(cooling.label).toBe("cooling");
+    const texts = [cooling.labelText, fomoWhy(cooling), fomoCardView(cooling, { sector: "반도체" }).headline];
+    for (const t of texts) {
+      expect(t).not.toMatch(/한\s?물|한물|끝물/);
+      expect(isFrontHookSafe(t), `cooling 텍스트 가드 통과: ${t}`).toBe(true);
+    }
+  });
 });
 
 describe("computeFomoScore — 포모 점수 엔진(§2)", () => {

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -98,9 +98,10 @@ function intensityOf(score: number): FomoIntensity {
   return score >= HIGH_AT ? "high" : score >= MEDIUM_AT ? "medium" : "calm";
 }
 
-// 판정·추천·예측 어휘는 isCommentSafe 로 거르고, 점수/등급류만 추가로 막는다.
+// 판정·추천·예측 어휘는 isCommentSafe 로 거르고, 점수/등급류 + has-been(쇠퇴 판정) 관용구를 추가로 막는다.
+// ⚠️ "분위기" 자체는 금지 금물(데워지는 분위기 등 정상) — verdict 관용구만 정밀 타깃.
 const FRONT_JUDGMENT =
-  /점수|등급|[SAB]\s?급|최우수|유망|강력\s?매수|적극\s?매수|꼭\s?사|놓치면|지금\s?사/;
+  /점수|등급|[SAB]\s?급|최우수|유망|강력\s?매수|적극\s?매수|꼭\s?사|놓치면|지금\s?사|한\s?물\s?(?:가|간|갔|지)|끝물|한물/;
 
 /** 후킹 텍스트가 가드를 통과하는가(투자조언·예측·점수·등급 없음). */
 export function isFrontHookSafe(text: string): boolean {

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -97,7 +97,7 @@ const LABEL_TEXT: Record<FomoLabel, string> = {
   incoming: "조용한데 외국인·기관은 이미 들어오는 중이에요",
   quiet: "지금은 조용한 자리예요",
   silent: "재료도 수급도 아직 조용해요",
-  cooling: "한 물 가는 분위기예요",
+  cooling: "모였던 관심이 식는 중이에요",
 };
 
 /**
@@ -208,7 +208,7 @@ export function fomoWhy(s: FomoScoreResult): string {
   if (i.accumulationDivergence)
     return "거래는 느는데 가격은 잠잠해요 — 누군가 조용히 담는 모양새예요.";
   if (s.label === "cooling")
-    return "거래는 많지만 가격이 빠지면서 한 물 가는 분위기예요.";
+    return "거래는 많은데 가격은 빠지고 있어요 — 모였던 관심이 식는 흐름이에요.";
   const vol = i.volume ?? 0;
   const price = i.price ?? 0;
   const mention = i.mention ?? 0;
@@ -294,7 +294,7 @@ export function fomoCardView(score: FomoScoreResult, opts: { sector?: string; re
         headline = sector ? `${sector} 관심이 데워지는 중이에요` : "관심이 데워지는 중이에요";
         break;
       case "cooling":
-        headline = "한 물 가는 분위기예요";
+        headline = "모였던 관심이 식는 중이에요";
         break;
       case "silent":
         headline = "재료도 수급도 아직 조용해요";


### PR DESCRIPTION
## 🚨 긴급 핫픽스
프로덕션 카드 `cooling` 라벨에 하락 **판정** 워딩 "한 물 가는 분위기예요" 노출 — "한물 가다"=쇠퇴 verdict, 예측·판정 금지 원칙 위반(리딩방급). 더 심각: 가드가 이 문구를 **통과**시킴(구멍).

## 고침
- **cooling 워딩 3곳** → 사실·중립(주목이 식는 사실이지 종목 끝났다는 판정 아님):
  - 라벨/카드 헤드라인: `"모였던 관심이 식는 중이에요"`
  - fomoWhy: `"거래는 많은데 가격은 빠지고 있어요 — 모였던 관심이 식는 흐름이에요."`
  - 나머지 라벨(hot/warming/💎/quiet/silent) 불변.
- **가드 강화(근본)**: `FRONT_JUDGMENT` 에 has-been 관용구 추가 — `한물/한 물 가·간·갔·지/끝물`. ⚠️ "분위기"는 금지 안 함(데워지는 분위기 등 정상) — verdict 관용구만 정밀 타깃.

## 회귀 테스트 (핵심)
- `isFrontHookSafe("한 물 가는 분위기예요")` → **false**(구멍 막힘 직접 검증).
- 정상 "관심이 데워지는 분위기예요" → true(과금지 아님), `fomoLabelTextsSafe()` 여전히 true.
- cooling 경로(라벨·fomoWhy·카드 헤드라인) 출력에 "한물"/"한 물" 0. 800 테스트.

## 스윕
라이브 헤드라인 경로(fomo-score.ts·card-front-hook.ts)에 다른 방향-판정 워딩 없음 확인. mock·emotion-translation 등 레거시는 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)