### PR TITLE
feat: CEO Brief #429 — 8개 실행 항목 구현

### DIFF
--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -76,7 +76,12 @@ export default function Home() {
       fetchFeed(),
     ]).then(([i, t, b, c, v, f]) => {
       if (i.status === "fulfilled") setIndex(i.value);
-      if (t.status === "fulfilled") setTally(t.value);
+      // #425: 감정 투표 데이터 폴백 — 실패/빈값 시 중립 기본값(정직한 숫자: votes=0 명시)
+      setTally(
+        t.status === "fulfilled" && t.value.total > 0
+          ? t.value
+          : { date: new Date().toISOString().slice(0, 10), total: 0, counts: {}, ratios: {} },
+      );
       if (b.status === "fulfilled") {
         setBanner(b.value.items);
         setMarkets(b.value.markets ?? []);

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -73,27 +73,41 @@ export function HomeView({
           </button>
         </div>
 
-        {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}
-        {index && !isFullFallback && (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+        {/* 시장 온도(FOMO Index) — #412 타이포그래피 위계 강화 + #409 스켈레톤 폴백 */}
+        {!index && (
+          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-3">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
-            <div className="flex items-baseline gap-2">
-              <span className="font-pixel text-xl leading-none" style={{ color }}>
-                {index.score}
-              </span>
-              <span className="font-pixel text-[11px] text-muted">{index.state}</span>
-              {index.prevDayDelta !== 0 && (
-                <span className="font-pixel text-[11px]" style={{ color }}>
-                  {index.prevDayDelta > 0
-                    ? `· 어제보다 ▲+${index.prevDayDelta}`
-                    : `· 어제보다 ▼${index.prevDayDelta}`}
-                </span>
-              )}
+            <div className="flex items-center gap-2">
+              <div className="h-7 w-10 animate-pulse rounded bg-elevated" />
+              <div className="h-3 w-16 animate-pulse rounded bg-elevated" />
             </div>
           </div>
         )}
+        {index && !isFullFallback && (
+          <div className="mt-3 flex flex-col gap-1.5 rounded-xl border border-hairline bg-surface px-4 py-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted">오늘의 시장 온도</span>
+              <div className="flex items-baseline gap-2">
+                <span className="font-pixel text-2xl font-bold leading-none" style={{ color }}>
+                  {index.score}
+                </span>
+                <span className="font-pixel text-xs text-muted">{index.state}</span>
+                {index.prevDayDelta !== 0 && (
+                  <span className="font-pixel text-[11px]" style={{ color }}>
+                    {index.prevDayDelta > 0
+                      ? `▲+${index.prevDayDelta}`
+                      : `▼${index.prevDayDelta}`}
+                  </span>
+                )}
+              </div>
+            </div>
+            {index.aiSummary && (
+              <p className="text-xs leading-relaxed text-muted">{index.aiSummary}</p>
+            )}
+          </div>
+        )}
         {index && isFullFallback && (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-3">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <span className="font-pixel text-[11px] text-muted">데이터 수집 중…</span>
           </div>

--- a/apps/fomo-web/lib/session-integrity.ts
+++ b/apps/fomo-web/lib/session-integrity.ts
@@ -1,0 +1,58 @@
+/**
+ * 익명 세션 무결성 검증 (#426).
+ * 클라이언트가 세션 ID + HMAC 서명을 함께 전송하면,
+ * 서버(BFF proxy)에서 서명을 검증하여 위변조된 요청을 거부한다.
+ * HMAC secret 이 없으면 검증을 건너뛴다(개발 환경 호환).
+ */
+
+const HMAC_SECRET = process.env.FOMO_SESSION_HMAC_SECRET ?? "";
+
+async function hmacSign(data: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(data));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function signSessionId(sessionId: string): Promise<string> {
+  if (!HMAC_SECRET) return "";
+  return hmacSign(sessionId, HMAC_SECRET);
+}
+
+export async function verifySessionSignature(
+  sessionId: string,
+  signature: string,
+): Promise<boolean> {
+  if (!HMAC_SECRET) return true;
+  if (!signature) return false;
+  const expected = await hmacSign(sessionId, HMAC_SECRET);
+  if (expected.length !== signature.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < expected.length; i++) {
+    mismatch |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+export interface SessionValidationResult {
+  valid: boolean;
+  reason?: "missing_session" | "missing_signature" | "invalid_signature";
+}
+
+export function validateSessionFormat(sessionId: string | undefined): SessionValidationResult {
+  if (!sessionId || typeof sessionId !== "string" || sessionId.length === 0) {
+    return { valid: false, reason: "missing_session" };
+  }
+  if (sessionId.length > 128) {
+    return { valid: false, reason: "invalid_signature" };
+  }
+  return { valid: true };
+}

--- a/packages/fomo-core/__tests__/calculate.test.ts
+++ b/packages/fomo-core/__tests__/calculate.test.ts
@@ -149,3 +149,105 @@ describe("buildSummary — Heat 정보 + 정직한 숫자 (#428)", () => {
     expect(s).not.toMatch(/매수|매도|반드시|보장|폭락|급등/);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #413 추가 회귀 테스트 — 경계값·부분 조합·Heat 격리
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("computeFomoIndex — 경계값 시나리오 (#413)", () => {
+  it("market만 극단값일 때 다른 Heat는 독립적으로 산출", () => {
+    const idx = computeFomoIndex(
+      { market: { volumeChangePct: 999, turnoverChangePct: 999, searchChangePct: 999, etfInflowPct: 999 } },
+      "2026-06-22",
+    );
+    const market = idx.components.find((c) => c.key === "market")!;
+    const community = idx.components.find((c) => c.key === "community")!;
+    expect(market.score).toBe(30);
+    expect(community.meta?.confidence).toBe("fallback");
+  });
+
+  it("emotion 투표가 bullish 쏠림일 때 score > 중립", () => {
+    const idx = computeFomoIndex(
+      { emotion: { fomo: 50, greed: 30, fear: 5, regret: 5, conviction: 10 } },
+      "2026-06-22",
+    );
+    const emotion = idx.components.find((c) => c.key === "emotion")!;
+    expect(emotion.score).toBeGreaterThan(15);
+    expect(emotion.meta?.confidence).not.toBe("fallback");
+  });
+
+  it("emotion 투표가 bearish 쏠림일 때 score < 중립", () => {
+    const idx = computeFomoIndex(
+      { emotion: { fear: 50, regret: 30, fomo: 5, greed: 5, conviction: 10 } },
+      "2026-06-22",
+    );
+    const emotion = idx.components.find((c) => c.key === "emotion")!;
+    expect(emotion.score).toBeLessThan(15);
+  });
+
+  it("whale 이벤트가 max 초과해도 10 이하로 clamp", () => {
+    const idx = computeFomoIndex(
+      { whale: [{ weight: 100 }, { weight: 200 }] },
+      "2026-06-22",
+    );
+    const whale = idx.components.find((c) => c.key === "whale")!;
+    expect(whale.score).toBeLessThanOrEqual(10);
+  });
+
+  it("모든 소스가 정상이면 fallbackCount === 0", () => {
+    const idx = computeFomoIndex(
+      {
+        market: { volumeChangePct: 10, turnoverChangePct: 5, searchChangePct: 20, etfInflowPct: 3 },
+        community: { mentionChangePct: 15, bullishRatio: 0.6 },
+        emotion: { fomo: 10, fear: 5, greed: 3, regret: 2, conviction: 8 },
+        whale: [{ weight: 3 }],
+      },
+      "2026-06-22",
+    );
+    for (const c of idx.components) {
+      expect(c.meta?.confidence).not.toBe("fallback");
+    }
+  });
+
+  it("date 필드가 반환 결과에 그대로 전달된다", () => {
+    const idx = computeFomoIndex({}, "2099-12-31");
+    expect(idx.date).toBe("2099-12-31");
+  });
+
+  it("4개 컴포넌트가 항상 반환된다", () => {
+    const idx = computeFomoIndex({}, "2026-06-22");
+    expect(idx.components).toHaveLength(4);
+    const keys = idx.components.map((c) => c.key).sort();
+    expect(keys).toEqual(["community", "emotion", "market", "whale"]);
+  });
+});
+
+describe("개별 Heat — confidence 레벨 정확성 (#413)", () => {
+  it("marketHeat: 4개 소스 모두 제공 → high", () => {
+    const h = marketHeat({ volumeChangePct: 10, turnoverChangePct: 5, searchChangePct: 20, etfInflowPct: 3 });
+    expect(h.meta?.confidence).toBe("high");
+    expect(h.meta?.sourcesAvailable).toBe(4);
+  });
+
+  it("marketHeat: 1개 소스만 → low", () => {
+    const h = marketHeat({ volumeChangePct: 10 });
+    expect(h.meta?.confidence).toBe("low");
+    expect(h.meta?.sourcesAvailable).toBe(1);
+  });
+
+  it("communityHeat: mentionChangePct + bullishRatio → medium", () => {
+    const h = communityHeat({ mentionChangePct: 10, bullishRatio: 0.5 });
+    expect(h.meta?.confidence).toBe("medium");
+    expect(h.meta?.sourcesAvailable).toBe(2);
+  });
+
+  it("emotionHeat: 50+ 투표 → high", () => {
+    const h = emotionHeat({ fomo: 20, fear: 15, greed: 10, regret: 5, conviction: 5 });
+    expect(h.meta?.confidence).toBe("high");
+  });
+
+  it("emotionHeat: 10~49 투표 → medium", () => {
+    const h = emotionHeat({ fomo: 5, fear: 5 });
+    expect(h.meta?.confidence).toBe("medium");
+  });
+});

--- a/packages/fomo-core/__tests__/heat-logger.test.ts
+++ b/packages/fomo-core/__tests__/heat-logger.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Heat 구조화 로거 테스트 (#415).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { logHeatError, logHeatWarning, drainLogBuffer, peekLogBuffer } from "../src/index-engine/logger";
+
+beforeEach(() => {
+  drainLogBuffer();
+});
+
+describe("logHeatError", () => {
+  it("에러를 구조화해 버퍼에 적재", () => {
+    logHeatError("marketHeat", "test error", new Error("boom"));
+    const entries = peekLogBuffer();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.level).toBe("ERROR");
+    expect(entries[0]!.heatKey).toBe("marketHeat");
+    expect(entries[0]!.fallbackUsed).toBe(true);
+    expect(entries[0]!.error).toBe("boom");
+    expect(entries[0]!.timestamp).toBeTruthy();
+  });
+
+  it("Error 외 타입도 문자열로 저장", () => {
+    logHeatError("whaleHeat", "non-error", 42);
+    expect(peekLogBuffer()[0]!.error).toBe("42");
+  });
+});
+
+describe("logHeatWarning", () => {
+  it("WARNING 레벨로 적재, fallbackUsed=false", () => {
+    logHeatWarning("communityHeat", "partial data");
+    const entries = peekLogBuffer();
+    expect(entries[0]!.level).toBe("WARNING");
+    expect(entries[0]!.fallbackUsed).toBe(false);
+  });
+});
+
+describe("drainLogBuffer", () => {
+  it("버퍼를 비우고 반환", () => {
+    logHeatError("a", "x", null);
+    logHeatWarning("b", "y");
+    const drained = drainLogBuffer();
+    expect(drained).toHaveLength(2);
+    expect(peekLogBuffer()).toHaveLength(0);
+  });
+});

--- a/packages/fomo-core/__tests__/mascot-lines.test.ts
+++ b/packages/fomo-core/__tests__/mascot-lines.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { marketLine, marketSummary, mineLine, restorativeLine, isCalmDay, personalLine } from "../src/mascot-lines";
+import { marketLine, marketSummary, mineLine, restorativeLine, isCalmDay, personalLine, indexAwareMarketLine } from "../src/mascot-lines";
 import { EMOTION_TYPES } from "../src/types";
 
 const STATES = ["무관심", "관망", "관심", "FOMO", "광기"] as const;
@@ -36,6 +36,36 @@ describe("포모 멘트 — 담담한 솔직함 (lovable + regulation)", () => {
     // 가짜 긍정이 아니라 사실 인정 + 위로 — 표본 점검
     expect(mineLine("fear")).toContain("괜찮");
     expect(marketLine("FOMO")).toContain("다들"); // 혼자 아님 톤(2인칭 지목 없이 · 해요체)
+  });
+});
+
+describe("indexAwareMarketLine — Heat 근거 포함 멘트 (#428)", () => {
+  it("상위 2개 Heat 비율이 괄호 안에 포함된다", () => {
+    const components = [
+      { key: "market", score: 24, max: 30 },
+      { key: "community", score: 9, max: 30 },
+      { key: "emotion", score: 20, max: 30 },
+      { key: "whale", score: 3, max: 10 },
+    ];
+    const line = indexAwareMarketLine("관심", components);
+    expect(line).toContain("시장 80%");
+    expect(line).toContain("감정");
+    expect(line).toContain("%");
+  });
+
+  it("components 빈 배열이면 기본 marketLine 반환", () => {
+    expect(indexAwareMarketLine("무관심", [])).toBe(marketLine("무관심"));
+  });
+
+  it("금칙 표현 없음", () => {
+    const components = [
+      { key: "market", score: 30, max: 30 },
+      { key: "emotion", score: 30, max: 30 },
+    ];
+    for (const s of STATES) {
+      const line = indexAwareMarketLine(s, components);
+      expect(line).not.toMatch(FORBIDDEN);
+    }
   });
 });
 

--- a/packages/fomo-core/src/index-engine/communityHeat.ts
+++ b/packages/fomo-core/src/index-engine/communityHeat.ts
@@ -14,6 +14,7 @@
 
 import type { HeatComponent } from "../types";
 import type { CommunitySignals, RedditSignal, HeatMeta, HeatConfidence } from "./types";
+import { logHeatError } from "./logger";
 
 export const COMMUNITY_HEAT_MAX = 30;
 const NEUTRAL = COMMUNITY_HEAT_MAX / 2;
@@ -125,7 +126,7 @@ export function communityHeat(signals: CommunitySignals = {}): HeatComponent {
 
     return { key: "community", score: clamp(score), max: COMMUNITY_HEAT_MAX, meta };
   } catch (err) {
-    console.warn("[fomo-core/communityHeat] unexpected error, using fallback", err);
+    logHeatError("communityHeat", "산출 실패, 폴백 사용", err);
     return {
       key: "community",
       score: NEUTRAL,

--- a/packages/fomo-core/src/index-engine/emotionHeat.ts
+++ b/packages/fomo-core/src/index-engine/emotionHeat.ts
@@ -8,6 +8,7 @@
 
 import type { HeatComponent } from "../types";
 import type { EmotionTally, HeatMeta, HeatConfidence } from "./types";
+import { logHeatError } from "./logger";
 
 export const EMOTION_HEAT_MAX = 30;
 const NEUTRAL = EMOTION_HEAT_MAX / 2;
@@ -61,7 +62,7 @@ export function emotionHeat(tally: EmotionTally = {}): HeatComponent {
 
     return { key: "emotion", score: clamp(score), max: EMOTION_HEAT_MAX, meta };
   } catch (err) {
-    console.warn("[fomo-core/emotionHeat] unexpected error, using fallback", err);
+    logHeatError("emotionHeat", "산출 실패, 폴백 사용", err);
     return {
       key: "emotion",
       score: NEUTRAL,

--- a/packages/fomo-core/src/index-engine/logger.ts
+++ b/packages/fomo-core/src/index-engine/logger.ts
@@ -1,0 +1,56 @@
+/**
+ * FOMO Index 파이프라인 구조화 에러 로깅 (#415).
+ * Heat 산출 실패 시 원인·폴백 여부·타임스탬프를 구조화해 남긴다.
+ * console.warn 을 직접 호출하던 패턴 대신 이 유틸로 통일 — 운영 시 Slack/로그 수집기 연동 가능.
+ */
+
+export type HeatLogLevel = "ERROR" | "WARNING";
+
+export interface HeatLogEntry {
+  level: HeatLogLevel;
+  heatKey: string;
+  message: string;
+  fallbackUsed: boolean;
+  timestamp: string;
+  error?: string;
+}
+
+const logBuffer: HeatLogEntry[] = [];
+
+export function logHeatError(
+  heatKey: string,
+  message: string,
+  err: unknown,
+  fallbackUsed = true,
+): void {
+  const entry: HeatLogEntry = {
+    level: "ERROR",
+    heatKey,
+    message,
+    fallbackUsed,
+    timestamp: new Date().toISOString(),
+    error: err instanceof Error ? err.message : String(err),
+  };
+  logBuffer.push(entry);
+  console.warn(`[fomo-core/${heatKey}] ${message}`, err);
+}
+
+export function logHeatWarning(heatKey: string, message: string): void {
+  const entry: HeatLogEntry = {
+    level: "WARNING",
+    heatKey,
+    message,
+    fallbackUsed: false,
+    timestamp: new Date().toISOString(),
+  };
+  logBuffer.push(entry);
+  console.warn(`[fomo-core/${heatKey}] ${message}`);
+}
+
+export function drainLogBuffer(): HeatLogEntry[] {
+  return logBuffer.splice(0, logBuffer.length);
+}
+
+export function peekLogBuffer(): readonly HeatLogEntry[] {
+  return logBuffer;
+}

--- a/packages/fomo-core/src/index-engine/marketHeat.ts
+++ b/packages/fomo-core/src/index-engine/marketHeat.ts
@@ -7,6 +7,7 @@
 
 import type { HeatComponent } from "../types";
 import type { MarketSignals, HeatMeta, HeatConfidence } from "./types";
+import { logHeatError } from "./logger";
 
 export const MARKET_HEAT_MAX = 30;
 const NEUTRAL = MARKET_HEAT_MAX / 2; // 데이터 미비 시 중립값(인위적 과열/과냉 방지)
@@ -54,7 +55,7 @@ export function marketHeat(signals: MarketSignals = {}): HeatComponent {
 
     return { key: "market", score: clamp(score), max: MARKET_HEAT_MAX, meta };
   } catch (err) {
-    console.warn("[fomo-core/marketHeat] unexpected error, using fallback", err);
+    logHeatError("marketHeat", "산출 실패, 폴백 사용", err);
     return {
       key: "market",
       score: NEUTRAL,

--- a/packages/fomo-core/src/index-engine/whaleHeat.ts
+++ b/packages/fomo-core/src/index-engine/whaleHeat.ts
@@ -8,6 +8,7 @@
 
 import type { HeatComponent } from "../types";
 import type { WhaleEvent, HeatMeta } from "./types";
+import { logHeatError } from "./logger";
 
 export const WHALE_HEAT_MAX = 10;
 
@@ -28,7 +29,7 @@ export function whaleHeat(events: WhaleEvent[] = []): HeatComponent {
 
     return { key: "whale", score: clamp(Math.round(sum)), max: WHALE_HEAT_MAX, meta };
   } catch (err) {
-    console.warn("[fomo-core/whaleHeat] unexpected error, using fallback", err);
+    logHeatError("whaleHeat", "산출 실패, 폴백 사용", err);
     return {
       key: "whale",
       score: 0,

--- a/packages/fomo-core/src/index.ts
+++ b/packages/fomo-core/src/index.ts
@@ -25,6 +25,7 @@ export * from "./index-engine/whaleHeat";
 export * from "./index-engine/calculate";
 export * from "./index-engine/summary";
 export * from "./index-engine/health";
+export * from "./index-engine/logger";
 export * from "./index-engine/community";
 export * from "./index-engine/whaleEvents";
 export * from "./index-engine/naverFetcher";

--- a/packages/fomo-core/src/mascot-lines.ts
+++ b/packages/fomo-core/src/mascot-lines.ts
@@ -30,6 +30,40 @@ export function marketLine(state: FomoState): string {
   return MARKET_LINES[state];
 }
 
+const HEAT_LABELS: Record<string, string> = {
+  market: "시장",
+  community: "커뮤니티",
+  emotion: "감정",
+  whale: "고래",
+};
+
+/**
+ * Index 근거를 포함한 마켓 멘트 (#428).
+ * 상위 2개 Heat의 기여도를 담담히 곁들여 "왜 이런 분위기인지" 3초 이내 이해를 돕는다.
+ * components 가 비어 있거나 max=0 이면 기본 marketLine 으로 폴백.
+ */
+export function indexAwareMarketLine(
+  state: FomoState,
+  components: ReadonlyArray<{ key: string; score: number; max: number }>,
+): string {
+  const base = MARKET_LINES[state];
+  if (components.length === 0) return base;
+
+  const topHeats = [...components]
+    .filter((c) => c.max > 0)
+    .map((c) => ({
+      label: HEAT_LABELS[c.key] ?? c.key,
+      pct: Math.round((c.score / c.max) * 100),
+    }))
+    .sort((a, b) => b.pct - a.pct)
+    .slice(0, 2);
+
+  if (topHeats.length === 0) return base;
+
+  const heatHint = topHeats.map((h) => `${h.label} ${h.pct}%`).join(", ");
+  return `${base} (${heatHint})`;
+}
+
 /**
  * FOMO Index 한 줄 요약 — "3초 안에" 지금 온도를 직관적으로 잡게 하는 짧은 글.
  * 마스코트의 위로 멘트(marketLine)와 달리, 숫자 옆에서 지표의 의미만 담담히 옮긴다.


### PR DESCRIPTION
## CEO Brief #429 실행 결과 (2026-06-22)

### 구현 항목 (8개)

| 이슈 | 항목 | 상태 |
|------|------|------|
| #428 | `indexAwareMarketLine` — 상위 2개 Heat 비율 포함 멘트 | ✅ 신규 구현 |
| #426 | `session-integrity.ts` — HMAC 기반 세션 서명/검증 | ✅ 신규 구현 |
| #425 | tally 폴백 — 실패/빈값 시 중립 기본값 (정직한 숫자) | ✅ 구현 |
| #415 | 구조화 Heat 로거 — `logHeatError`/`logHeatWarning` + 4개 Heat 모듈 통합 | ✅ 신규 구현 |
| #413 | 회귀 테스트 — 경계값·confidence 레벨 12건 추가 | ✅ 테스트 추가 |
| #412 | 타이포그래피 위계 강화 — score `text-2xl font-bold` + `aiSummary` 노출 | ✅ 구현 |
| #410 | `FomoFace` React.memo 최적화 | ✅ 기구현 확인 (변경 불필요) |
| #409 | 스켈레톤 폴백 + fullFallback 분기 | ✅ 구현 |

### 킬리스트 (미구현 — 의도적 제외)

| 이슈 | 항목 | 사유 |
|------|------|------|
| #374 | 애니메이션 효과 | CEO 킬리스트 |
| #378 | 가짜 데이터 테스트 | CEO 킬리스트 |

### 검증 체크리스트

- [x] `npm run lint` — 통과
- [x] `npm run typecheck` — 통과
- [x] `npm run build:web` — 통과
- [x] `npm run test` — 819 tests passed

### 변경 파일 (13개)

**신규 파일 (3)**
- `packages/fomo-core/src/index-engine/logger.ts` — Heat 구조화 로거
- `packages/fomo-core/__tests__/heat-logger.test.ts` — 로거 테스트
- `apps/fomo-web/lib/session-integrity.ts` — HMAC 세션 검증

**수정 파일 (10)**
- `packages/fomo-core/src/mascot-lines.ts` — `indexAwareMarketLine` 추가
- `packages/fomo-core/src/index-engine/marketHeat.ts` — 구조화 로거 연동
- `packages/fomo-core/src/index-engine/communityHeat.ts` — 구조화 로거 연동
- `packages/fomo-core/src/index-engine/emotionHeat.ts` — 구조화 로거 연동
- `packages/fomo-core/src/index-engine/whaleHeat.ts` — 구조화 로거 연동
- `packages/fomo-core/src/index.ts` — logger export 추가
- `apps/fomo-web/app/page.tsx` — tally 폴백 로직
- `apps/fomo-web/components/HomeView.tsx` — 스켈레톤·타이포·aiSummary·fullFallback
- `packages/fomo-core/__tests__/calculate.test.ts` — 경계값·confidence 회귀 12건
- `packages/fomo-core/__tests__/mascot-lines.test.ts` — indexAwareMarketLine 테스트

### 참조

- CEO Brief: #429
- 정체성 기준: `docs/PRODUCT_TRUTH.md` (정직한 숫자 원칙)

---

> **광혁 평가 영역** — 아래 항목은 자동 검증 불가, PO 검수 필요:
> - [ ] 멘트 톤앤매너 (담담한 솔직함)
> - [ ] Heat 비율 표기의 직관성
> - [ ] 스켈레톤/fullFallback UX 적절성

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHsXpCoUJF47seSan1fWsf)_