### PR TITLE
[codex] TA 사실층과 포모 튜닝 seam 추가

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -474,11 +474,11 @@ function DetailChart({ front }: { front: StockFrontResponse | null }) {
   const stroke = up ? "#FF5A36" : "#60A5FA";
   const lead = (front?.fomo.leadSignal ?? 0) >= 60;
   // 차트가 뒷받침하나 — 현재 상태 묘사만(예측 금지).
-  const note = lead && !up
+  const note = front?.taFact?.text ?? (lead && !up
     ? "차트는 아직 안 따라왔어요 — 수급이 가격보다 먼저 움직이는 자리예요."
     : up
       ? "이미 위로 올라온 자리예요(최근 3개월)."
-      : "최근 3개월은 차분한 흐름이에요.";
+      : "최근 3개월은 차분한 흐름이에요.");
   return (
     <section className="mt-7">
       <p className="font-pixel text-sm text-whiteout">차트가 받쳐주나</p>

--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { sparklinePath, seriesIsUp, fomoCardView, computeFomoScore, rankFeedByFomo } from "@fomo/core";
-import type { KeywordCard, SectorStock, StockSector, CardFrontSignals, FomoScoreResult, FomoCardView, FomoTone } from "@fomo/core";
+import type { KeywordCard, SectorStock, StockSector, CardFrontSignals, FomoScoreResult, FomoCardView, FomoTone, TaFact } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchSectorStocks, fetchKeywords, fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
@@ -35,6 +35,7 @@ type DeckStock = SectorStock & { reason?: string };
 type FrontEntry = {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
+  taFact?: TaFact;
   sparkline: number[];
   priceText?: string;
   changeText?: string;
@@ -170,6 +171,7 @@ function StockCardFace({
   changeDir,
   rankLabel,
   sparkline,
+  taFact,
   progress,
 }: {
   stock: DeckStock;
@@ -181,6 +183,7 @@ function StockCardFace({
   changeDir?: "up" | "down" | "flat" | undefined;
   rankLabel?: string | undefined;
   sparkline?: number[] | undefined;
+  taFact?: TaFact | undefined;
   progress?: string | undefined;
 }) {
   const tone = TONE_COLOR[view.tone] ?? "#94A3B8";
@@ -243,6 +246,14 @@ function StockCardFace({
         {view.isLeading && <span aria-hidden>💎 </span>}
         {view.headline}
       </p>
+
+      {taFact && (
+        <p className="mt-2 rounded-lg border border-hairline bg-black/10 px-3 py-2 text-sm leading-6 text-muted">
+          <span className="font-pixel text-[11px] text-whiteout">차트 사실</span>
+          <span className="mx-1.5 opacity-50">·</span>
+          {taFact.text}
+        </p>
+      )}
 
       {/* 미니 스파크라인(최근 3개월) */}
       {sparkline && sparkline.length >= 2 && <Sparkline series={sparkline} />}
@@ -309,6 +320,7 @@ export function SectorStockDeck({ sector, loggedIn, onRequireLogin }: SectorDeck
             fronts[s.canonical] = {
               signals: d.signals,
               fomo: d.fomo,
+              ...(d.taFact ? { taFact: d.taFact } : {}),
               sparkline: d.sparkline,
               ...(d.priceText ? { priceText: d.priceText } : {}),
               ...(d.changeText ? { changeText: d.changeText } : {}),
@@ -386,6 +398,7 @@ function SectorDeckInner({
             [key]: {
               signals: d.signals,
               fomo: d.fomo,
+              ...(d.taFact ? { taFact: d.taFact } : {}),
               sparkline: d.sparkline,
               ...(d.priceText ? { priceText: d.priceText } : {}),
               ...(d.changeText ? { changeText: d.changeText } : {}),
@@ -425,6 +438,7 @@ function SectorDeckInner({
         changeDir={e?.changeDir}
         rankLabel={rankLabelFor(stock)}
         sparkline={e?.sparkline}
+        taFact={e?.taFact}
         progress={progress}
       />
     );

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -106,9 +106,11 @@ export const fetchStockBasics = (stock: string) =>
 /** 카드 앞면 FOMO 신호(rev2 후속) — baseline·라이브 수급 streak·시총순위·3개월 스파크라인. 도달 종목 lazy. */
 export type { CardFrontSignals } from "@fomo/core";
 export type { FomoScoreResult } from "@fomo/core";
+export type { TaFact } from "@fomo/core";
 export interface StockFrontResponse {
   signals: import("@fomo/core").CardFrontSignals;
   fomo: import("@fomo/core").FomoScoreResult;
+  taFact?: import("@fomo/core").TaFact;
   sparkline: number[];
   priceText?: string;
   changeText?: string;

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -6,8 +6,12 @@ import {
   signalsFromBasics,
   investorNetStreak,
   computeFomoScore,
+  computeTechnicalAnalysis,
+  selectTaFact,
   type CardFrontSignals,
   type FomoScoreResult,
+  type DailyOhlcv,
+  type TaFact,
 } from "@fomo/core";
 import { fetchStockBasics } from "./stock-basics";
 import { readSupplyDemandHistory } from "./supply-demand-store";
@@ -24,8 +28,11 @@ async function getJson(url: string): Promise<unknown> {
  * 네이버 siseJson(일봉) → 최근 N거래일 종가(오름차순, 오래된→최신). 스파크라인용.
  * 응답은 작은따옴표 의사 JSON + 헤더행(한글, EUC-KR) — 숫자 행만 정규식으로 안전 추출(인코딩 무관).
  */
-/** 네이버 siseJson 일봉 → 최근 거래일 종가·거래량(오름차순). 스파크라인 + 거래량 회전·추세 산출용. */
-export async function fetchStockDaily(code: string, calendarDays = 100): Promise<{ closes: number[]; volumes: number[] }> {
+/** 네이버 siseJson 일봉 → 최근 거래일 OHLCV(오름차순). 스파크라인 + 거래량 회전 + TA 사실층 공용. */
+export async function fetchStockDaily(
+  code: string,
+  calendarDays = 420
+): Promise<{ candles: DailyOhlcv[]; closes: number[]; volumes: number[] }> {
   try {
     const ymd = (d: Date) =>
       `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, "0")}${String(d.getDate()).padStart(2, "0")}`;
@@ -33,23 +40,34 @@ export async function fetchStockDaily(code: string, calendarDays = 100): Promise
     const start = new Date(end.getTime() - calendarDays * 86_400_000); // ~100일 ≈ 3개월 거래일
     const url = `https://api.finance.naver.com/siseJson.naver?symbol=${encodeURIComponent(code)}&requestType=1&startTime=${ymd(start)}&endTime=${ymd(end)}&timeframe=day`;
     const res = await fetch(url, { headers: UA, signal: AbortSignal.timeout(8000) });
-    if (!res.ok) return { closes: [], volumes: [] };
+    if (!res.ok) return { candles: [], closes: [], volumes: [] };
     const text = await res.text();
     // 데이터 행: ["20260320", 시, 고, 저, 종, 거래량, ...] — 날짜(따옴표)·OHLC·거래량(idx5).
-    const rows: { date: string; close: number; volume: number }[] = [];
+    const rows: DailyOhlcv[] = [];
     const re = /\[\s*"?(\d{8})"?\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(text)) !== null) {
+      const open = Number(m[2]);
+      const high = Number(m[3]);
+      const low = Number(m[4]);
       const close = Number(m[5]);
       const volume = Number(m[6]);
-      if (Number.isFinite(close)) rows.push({ date: m[1]!, close, volume: Number.isFinite(volume) ? volume : 0 });
+      if ([open, high, low, close].every(Number.isFinite)) {
+        rows.push({
+          date: m[1]!,
+          open,
+          high,
+          low,
+          close,
+          volume: Number.isFinite(volume) ? volume : 0,
+        });
+      }
     }
-    rows.sort((a, b) => (a.date < b.date ? -1 : 1)); // 오래된→최신
-    const recent = rows.slice(-66); // 최근 ~3개월
-    return { closes: recent.map((r) => r.close), volumes: recent.map((r) => r.volume) };
+    rows.sort((a, b) => ((a.date ?? "") < (b.date ?? "") ? -1 : 1)); // 오래된→최신
+    return { candles: rows, closes: rows.map((r) => r.close), volumes: rows.map((r) => r.volume) };
   } catch (err) {
     console.warn("[stock-front] daily failed", code, (err as Error)?.message);
-    return { closes: [], volumes: [] };
+    return { candles: [], closes: [], volumes: [] };
   }
 }
 
@@ -115,6 +133,8 @@ export interface StockFrontData {
   signals: CardFrontSignals;
   /** 포모 점수(척추) — C·L·라벨. 카드 점수/라벨/헤드라인의 단일 출처. */
   fomo: FomoScoreResult;
+  /** TA 셀렉터가 고른 사실 1개 — 점수/진열이 아니라 카드·상세 보조 문맥. */
+  taFact?: TaFact;
   /** 최근 3개월 종가(스파크라인) — 없으면 빈 배열. */
   sparkline: number[];
   /** 현재가 — 예 "354,000원"(카드 1행 표기용). */
@@ -157,19 +177,24 @@ export async function assembleStockFront(
 
   // ── 포모 점수(척추) — 거래량 회전·가격(등락·추세)·수급. 언급량·prevScore 는 후속(없으면 제외). ──
   const volRatio = volumeTurnover(daily.volumes);
-  const trend = trendStrength(daily.closes);
+  const ta = computeTechnicalAnalysis(daily.candles);
+  const trend = ta.inputs.trendStrength ?? trendStrength(daily.closes);
   const fomo = computeFomoScore({
     ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
     ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
     ...(typeof trend === "number" ? { trendStrength: trend } : {}),
+    ...(ta.inputs.accumulationDivergence ? { accumulationDivergence: true } : {}),
+    ...(ta.inputs.bollingerSqueeze ? { bollingerSqueeze: true } : {}),
     ...(typeof signals.foreignNetStreak === "number" ? { foreignNetStreak: signals.foreignNetStreak } : {}),
     ...(typeof signals.institutionNetStreak === "number" ? { institutionNetStreak: signals.institutionNetStreak } : {}),
   });
+  const taFact = selectTaFact(fomo, ta);
 
   return {
     signals,
     fomo,
-    sparkline: daily.closes,
+    ...(taFact ? { taFact } : {}),
+    sparkline: daily.closes.slice(-66),
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),
     ...(basics?.changeDir ? { changeDir: basics.changeDir } : {}),

--- a/packages/fomo-core/__tests__/fomo-score.test.ts
+++ b/packages/fomo-core/__tests__/fomo-score.test.ts
@@ -122,12 +122,17 @@ describe("computeFomoScore — 포모 점수 엔진(§2)", () => {
     expect(empty.label).toBe("silent");
   });
 
-  it("매집 다이버전스 — 거래량↑·가격 평탄이면 L 보너스 + 플래그", () => {
+  it("매집 다이버전스 — 기본 off, 튜닝 플래그를 켜면 L 보너스 + 플래그", () => {
     const base = computeFomoScore({ volumeRatio: 2.5, changePct: 0.5, foreignNetStreak: 3 });
+    const tuned = computeFomoScore(
+      { volumeRatio: 2.5, changePct: 0.5, foreignNetStreak: 3 },
+      { accumulation: { enabled: true, leadBonus: 8 } }
+    );
     const noDiv = computeFomoScore({ volumeRatio: 2.5, changePct: 6, foreignNetStreak: 3 });
-    expect(base.inputs.accumulationDivergence).toBe(true);
+    expect(base.inputs.accumulationDivergence).toBeUndefined();
+    expect(tuned.inputs.accumulationDivergence).toBe(true);
     expect(noDiv.inputs.accumulationDivergence).toBeUndefined();
-    expect(base.leadSignal).toBeGreaterThan(noDiv.leadSignal);
+    expect(tuned.leadSignal).toBeGreaterThan(noDiv.leadSignal);
   });
 
   it("방향 — prevScore 대비 ↑/↓/flat", () => {

--- a/packages/fomo-core/__tests__/technical-analysis.test.ts
+++ b/packages/fomo-core/__tests__/technical-analysis.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeFomoScore,
+  computeTechnicalAnalysis,
+  isTaFactTextSafe,
+  selectTaFact,
+  type DailyOhlcv,
+} from "../src";
+
+function candles(closes: number[], volumes?: number[]): DailyOhlcv[] {
+  return closes.map((close, i) => ({
+    date: `202601${String((i % 28) + 1).padStart(2, "0")}`,
+    open: close,
+    high: close * 1.01,
+    low: close * 0.99,
+    close,
+    volume: volumes?.[i] ?? 1000,
+  }));
+}
+
+describe("technical analysis facts — OHLCV 사실층", () => {
+  it("같은 일봉 OHLCV 입력은 같은 TA snapshot을 만든다", () => {
+    const input = candles(Array.from({ length: 80 }, (_, i) => 100 + Math.sin(i / 3) * 2), Array.from({ length: 80 }, (_, i) => 1000 + i * 3));
+
+    expect(computeTechnicalAnalysis(input)).toEqual(computeTechnicalAnalysis(input));
+  });
+
+  it("평범한 종목은 TA fact를 표시하지 않는다", () => {
+    const input = candles(Array.from({ length: 80 }, () => 100), Array.from({ length: 80 }, () => 1000));
+    const ta = computeTechnicalAnalysis(input);
+
+    expect(ta.facts).toEqual([]);
+    expect(selectTaFact(computeFomoScore({ volumeRatio: 1.05, changePct: 0.1 }), ta)).toBeUndefined();
+  });
+
+  it("포모 incoming에는 매집/스퀴즈 확증 fact를 우선 선택한다", () => {
+    const closes = Array.from({ length: 80 }, (_, i) => 100 + i * 0.02);
+    const volumes = Array.from({ length: 80 }, (_, i) => (i < 79 ? 1200 : 3600));
+    const ta = computeTechnicalAnalysis(candles(closes, volumes));
+    const fomo = computeFomoScore({ foreignNetStreak: 5, foreignNetRatio: 0.01 });
+    const selected = selectTaFact(fomo, ta);
+
+    expect(selected?.kind).toBe("accumulation_divergence");
+    expect(selected?.role).toBe("confirmation");
+    expect(selected?.confidence).toBe("low");
+  });
+
+  it("수급은 강한데 RSI가 과열이면 균형 fact를 우선 선택한다", () => {
+    const closes = Array.from({ length: 80 }, (_, i) => 100 + i * 1.4);
+    const ta = computeTechnicalAnalysis(candles(closes));
+    const fomo = computeFomoScore({ foreignNetStreak: 5, foreignNetRatio: 0.01 });
+    const selected = selectTaFact(fomo, ta);
+
+    expect(selected?.kind).toBe("rsi_overbought");
+    expect(selected?.role).toBe("balance");
+  });
+
+  it("TA fact 문장은 다음 행동 암시 없이 원인+상태만 말한다", () => {
+    const cases = [
+      ...computeTechnicalAnalysis(candles(Array.from({ length: 80 }, (_, i) => 100 + i * 1.4))).facts,
+      ...computeTechnicalAnalysis(candles(Array.from({ length: 80 }, (_, i) => 160 - i * 1.2))).facts,
+      ...computeTechnicalAnalysis(candles(Array.from({ length: 80 }, (_, i) => 100 + i * 0.02), Array.from({ length: 80 }, (_, i) => 1000 + i * 12))).facts,
+    ];
+
+    expect(cases.length).toBeGreaterThan(0);
+    for (const fact of cases) {
+      expect(isTaFactTextSafe(fact.text), fact.text).toBe(true);
+      expect(fact.text).not.toMatch(/사라|팔아라|추천|오를|내릴|반등할|조정받/);
+    }
+  });
+
+  it("매집·스퀴즈 입력은 튜닝 플래그가 켜질 때만 L에 반영된다", () => {
+    const off = computeFomoScore({ accumulationDivergence: true, bollingerSqueeze: true });
+    const on = computeFomoScore(
+      { accumulationDivergence: true, bollingerSqueeze: true },
+      { accumulation: { enabled: true, leadBonus: 8 }, bollingerSqueeze: { enabled: true, leadBonus: 5 } }
+    );
+
+    expect(off.leadSignal).toBe(0);
+    expect(on.leadSignal).toBe(13);
+    expect(on.inputs.accumulationDivergence).toBe(true);
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -17,8 +17,10 @@ export const L_WEIGHTS = { foreign: 60, institution: 40 } as const;
 export const FOMO_THRESHOLDS = { hot: 80, warm: 60, quiet: 40, lead: 60 } as const;
 /** 정규화 기준점 — 거래량 3.5배=만점, 등락 8%=만점, 수급 5일연속·시총대비 1%=만점. */
 export const FOMO_NORM = { volTopX: 3.5, priceTopPct: 8, streakTopDays: 5, ratioTopPct: 0.01 } as const;
-/** 매집 다이버전스(§6.4 — 거래량↑·가격 평탄 = 조용히 담는 중). L 보너스 + 💎 보조 트리거. */
-export const ACCUMULATION = { enabled: true, volMin: 1.8, priceFlatMax: 2, leadBonus: 15 } as const;
+/** 매집 다이버전스(§6.4 — 거래량↑·가격 평탄 = 조용히 담는 중). 광혁 튜닝 전 기본 off. */
+export const ACCUMULATION = { enabled: false, volMin: 1.8, priceFlatMax: 2, leadBonus: 8 } as const;
+/** 볼린저 스퀴즈(§6.4 — 변동성 압축). L 보조 입력. 광혁 튜닝 전 기본 off. */
+export const BOLLINGER_SQUEEZE = { enabled: false, leadBonus: 5 } as const;
 /** 방향 — 어제(또는 3일 전) C 대비. flat 밴드 ±5, 강한 하락 = C 10↓ 또는 가격 -5%. */
 export const FOMO_DIRECTION = { flatBand: 5, strongDropDelta: 10, strongDropPct: -5 } as const;
 
@@ -41,11 +43,20 @@ export interface FomoScoreInputs {
   foreignNetRatio?: number; // 시총 대비 비중 0~1
   institutionNetStreak?: number;
   institutionNetRatio?: number;
+  /** TA 사실층 입력 — 거래량은 늘었는데 가격이 평탄한 매집형 다이버전스. */
+  accumulationDivergence?: boolean;
+  /** TA 사실층 입력 — 볼린저밴드 폭이 낮은 압축 상태. */
+  bollingerSqueeze?: boolean;
   // 방향
   /** 어제(또는 최근 3일) C — 방향 산출용. */
   prevScore?: number;
   /** 수급 기준일(시점 명시) — 예 "6/21". */
   asOf?: string;
+}
+
+export interface FomoScoreTuning {
+  accumulation?: Partial<typeof ACCUMULATION>;
+  bollingerSqueeze?: Partial<typeof BOLLINGER_SQUEEZE>;
 }
 
 export interface FomoScoreResult {
@@ -104,7 +115,9 @@ const LABEL_TEXT: Record<FomoLabel, string> = {
  * 포모 점수 산출 — C(현재 강도)·L(선행)·방향·상태 라벨. 순수·결정적.
  * 입력 없는 항목은 제외하고 가중치 재정규화 + confidence 반영(가짜숫자 금지).
  */
-export function computeFomoScore(input: FomoScoreInputs = {}): FomoScoreResult {
+export function computeFomoScore(input: FomoScoreInputs = {}, tuning: FomoScoreTuning = {}): FomoScoreResult {
+  const accumulation = { ...ACCUMULATION, ...tuning.accumulation };
+  const bollingerSqueeze = { ...BOLLINGER_SQUEEZE, ...tuning.bollingerSqueeze };
   const inputs: FomoScoreResult["inputs"] = {};
 
   // ── C — 현재 강도 ──
@@ -147,14 +160,18 @@ export function computeFomoScore(input: FomoScoreInputs = {}): FomoScoreResult {
 
   // 매집 다이버전스 — 거래량↑인데 가격 평탄 = 조용히 담는 중(거래량 논리 직계 선행 신호).
   const divergence =
-    ACCUMULATION.enabled &&
-    typeof input.volumeRatio === "number" &&
-    input.volumeRatio >= ACCUMULATION.volMin &&
-    typeof input.changePct === "number" &&
-    Math.abs(input.changePct) < ACCUMULATION.priceFlatMax;
+    accumulation.enabled &&
+    (input.accumulationDivergence === true ||
+      (typeof input.volumeRatio === "number" &&
+        input.volumeRatio >= accumulation.volMin &&
+        typeof input.changePct === "number" &&
+        Math.abs(input.changePct) < accumulation.priceFlatMax));
   if (divergence) {
     inputs.accumulationDivergence = true;
-    L = clamp100(L + ACCUMULATION.leadBonus);
+    L = clamp100(L + accumulation.leadBonus);
+  }
+  if (bollingerSqueeze.enabled && input.bollingerSqueeze === true) {
+    L = clamp100(L + bollingerSqueeze.leadBonus);
   }
 
   // ── 방향 ──

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -8,3 +8,4 @@ export * from "./josa";
 export * from "./stocks";
 export * from "./card-front-hook";
 export * from "./fomo-score";
+export * from "./technical-analysis";

--- a/packages/fomo-core/src/keyword-cards/technical-analysis.ts
+++ b/packages/fomo-core/src/keyword-cards/technical-analysis.ts
@@ -1,0 +1,274 @@
+import type { FomoScoreResult } from "./fomo-score";
+
+export interface DailyOhlcv {
+  date?: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export type TaFactKind =
+  | "accumulation_divergence"
+  | "bollinger_squeeze"
+  | "rsi_overbought"
+  | "rsi_oversold"
+  | "ma_bullish"
+  | "ma_bearish"
+  | "macd_bullish"
+  | "macd_bearish"
+  | "near_52w_high"
+  | "near_52w_low"
+  | "atr_expanded";
+
+export type TaFactRole = "confirmation" | "balance" | "event";
+export type TaConfidence = "high" | "low";
+
+export interface TaFact {
+  kind: TaFactKind;
+  role: TaFactRole;
+  confidence: TaConfidence;
+  text: string;
+}
+
+export interface TechnicalAnalysisSnapshot {
+  facts: TaFact[];
+  latest?: {
+    rsi14?: number;
+    macd?: number;
+    macdSignal?: number;
+    bollingerWidthPct?: number;
+    atrPct?: number;
+    closeTo52WeekHighPct?: number;
+    closeTo52WeekLowPct?: number;
+  };
+  inputs: {
+    accumulationDivergence?: boolean;
+    bollingerSqueeze?: boolean;
+    trendStrength?: number;
+  };
+}
+
+const ACTION_HINT =
+  /사라|팔아라|사세요|파세요|추천|매수|매도|들어가|진입|손절|익절|목표가|오른다|오를\s*(?:거|것|듯|전망|예정)|내린다|내릴\s*(?:거|것|듯)|반등할|조정받|급등할|폭등|폭락|떡상|떡락|가즈아/;
+
+export function isTaFactTextSafe(text: string): boolean {
+  const neutral = text.replace(/과매수|과매도/g, "상태").replace(/매집/g, "구조");
+  return !ACTION_HINT.test(neutral);
+}
+
+const num = (x: number | undefined): x is number => typeof x === "number" && Number.isFinite(x);
+const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+function sma(values: readonly number[], n: number): number | undefined {
+  if (values.length < n) return undefined;
+  const slice = values.slice(-n);
+  return slice.reduce((a, b) => a + b, 0) / n;
+}
+
+function std(values: readonly number[]): number {
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  const v = values.reduce((a, b) => a + (b - avg) ** 2, 0) / values.length;
+  return Math.sqrt(v);
+}
+
+function emaSeries(values: readonly number[], n: number): number[] {
+  if (values.length === 0) return [];
+  const k = 2 / (n + 1);
+  const out: number[] = [values[0]!];
+  for (let i = 1; i < values.length; i += 1) out.push(values[i]! * k + out[i - 1]! * (1 - k));
+  return out;
+}
+
+function rsi14(closes: readonly number[]): number | undefined {
+  if (closes.length < 15) return undefined;
+  let gain = 0;
+  let loss = 0;
+  for (let i = closes.length - 14; i < closes.length; i += 1) {
+    const d = closes[i]! - closes[i - 1]!;
+    if (d >= 0) gain += d;
+    else loss -= d;
+  }
+  if (gain === 0 && loss === 0) return 50;
+  if (loss === 0) return 100;
+  const rs = gain / loss;
+  return 100 - 100 / (1 + rs);
+}
+
+function macd(closes: readonly number[]): { macd: number; signal: number; prevMacd?: number; prevSignal?: number } | undefined {
+  if (closes.length < 35) return undefined;
+  const ema12 = emaSeries(closes, 12);
+  const ema26 = emaSeries(closes, 26);
+  const line = closes.map((_, i) => ema12[i]! - ema26[i]!);
+  const signal = emaSeries(line, 9);
+  const out: { macd: number; signal: number; prevMacd?: number; prevSignal?: number } = {
+    macd: line[line.length - 1]!,
+    signal: signal[signal.length - 1]!,
+  };
+  const prevMacd = line[line.length - 2];
+  const prevSignal = signal[signal.length - 2];
+  if (num(prevMacd)) out.prevMacd = prevMacd;
+  if (num(prevSignal)) out.prevSignal = prevSignal;
+  return out;
+}
+
+function bollingerWidths(closes: readonly number[]): number[] {
+  const out: number[] = [];
+  for (let i = 19; i < closes.length; i += 1) {
+    const win = closes.slice(i - 19, i + 1);
+    const mid = win.reduce((a, b) => a + b, 0) / win.length;
+    if (mid <= 0) continue;
+    out.push((4 * std(win) / mid) * 100);
+  }
+  return out;
+}
+
+function atrPct(candles: readonly DailyOhlcv[], n = 14): number | undefined {
+  if (candles.length < n + 1) return undefined;
+  const trs: number[] = [];
+  for (let i = candles.length - n; i < candles.length; i += 1) {
+    const c = candles[i]!;
+    const prev = candles[i - 1]!;
+    trs.push(Math.max(c.high - c.low, Math.abs(c.high - prev.close), Math.abs(c.low - prev.close)));
+  }
+  const close = candles[candles.length - 1]!.close;
+  if (close <= 0) return undefined;
+  return (trs.reduce((a, b) => a + b, 0) / n / close) * 100;
+}
+
+function obv(candles: readonly DailyOhlcv[]): number[] {
+  const out = [0];
+  for (let i = 1; i < candles.length; i += 1) {
+    const prev = candles[i - 1]!;
+    const cur = candles[i]!;
+    const dir = cur.close > prev.close ? 1 : cur.close < prev.close ? -1 : 0;
+    out.push(out[i - 1]! + dir * cur.volume);
+  }
+  return out;
+}
+
+function pushSafe(facts: TaFact[], fact: TaFact): void {
+  if (isTaFactTextSafe(fact.text)) facts.push(fact);
+}
+
+export function computeTechnicalAnalysis(candles: readonly DailyOhlcv[]): TechnicalAnalysisSnapshot {
+  const clean = candles.filter(
+    (c) => num(c.open) && num(c.high) && num(c.low) && num(c.close) && num(c.volume) && c.high >= c.low && c.close > 0
+  );
+  const facts: TaFact[] = [];
+  if (clean.length < 20) return { facts, inputs: {} };
+
+  const closes = clean.map((c) => c.close);
+  const volumes = clean.map((c) => c.volume);
+  const last = clean[clean.length - 1]!;
+  const ma20 = sma(closes, 20);
+  const ma60 = sma(closes, 60);
+  const ma120 = sma(closes, 120);
+  const rsi = rsi14(closes);
+  const macdNow = macd(closes);
+  const widths = bollingerWidths(closes);
+  const width = widths[widths.length - 1];
+  const widthAvg = widths.length >= 20 ? widths.slice(-20).reduce((a, b) => a + b, 0) / 20 : undefined;
+  const atr = atrPct(clean);
+  const atrPrev = clean.length >= 30 ? atrPct(clean.slice(0, -14)) : undefined;
+
+  const high52 = Math.max(...clean.slice(-260).map((c) => c.high));
+  const low52 = Math.min(...clean.slice(-260).map((c) => c.low));
+  const closeToHigh = high52 > 0 ? (last.close / high52) * 100 : undefined;
+  const closeToLow = low52 > 0 ? (last.close / low52) * 100 : undefined;
+
+  if (num(ma20) && num(ma60) && num(ma120)) {
+    if (ma20 > ma60 && ma60 > ma120)
+      pushSafe(facts, { kind: "ma_bullish", role: "event", confidence: "high", text: "20·60·120일선이 위쪽으로 정렬된 상태예요." });
+    if (ma20 < ma60 && ma60 < ma120)
+      pushSafe(facts, { kind: "ma_bearish", role: "event", confidence: "high", text: "20·60·120일선이 아래쪽으로 정렬된 상태예요." });
+  }
+
+  if (macdNow) {
+    const crossedUp = num(macdNow.prevMacd) && num(macdNow.prevSignal) && macdNow.prevMacd <= macdNow.prevSignal && macdNow.macd > macdNow.signal;
+    const crossedDown = num(macdNow.prevMacd) && num(macdNow.prevSignal) && macdNow.prevMacd >= macdNow.prevSignal && macdNow.macd < macdNow.signal;
+    if (crossedUp) pushSafe(facts, { kind: "macd_bullish", role: "event", confidence: "high", text: "MACD가 신호선 위에 올라선 상태예요." });
+    if (crossedDown) pushSafe(facts, { kind: "macd_bearish", role: "event", confidence: "high", text: "MACD가 신호선 아래에 놓인 상태예요." });
+  }
+
+  if (num(rsi) && rsi >= 70)
+    pushSafe(facts, { kind: "rsi_overbought", role: "balance", confidence: "high", text: "최근 상승 폭이 커 RSI가 천장 영역(과매수)이에요." });
+  if (num(rsi) && rsi <= 30)
+    pushSafe(facts, { kind: "rsi_oversold", role: "event", confidence: "high", text: "최근 낙폭이 가팔라 RSI가 바닥 영역(과매도)이에요." });
+
+  const squeeze = num(width) && num(widthAvg) && width < widthAvg * 0.65;
+  if (squeeze)
+    pushSafe(facts, { kind: "bollinger_squeeze", role: "confirmation", confidence: "high", text: "변동성 폭이 좁아져 차트가 압축된 상태예요." });
+
+  if (num(atr) && num(atrPrev) && atr >= atrPrev * 1.5)
+    pushSafe(facts, { kind: "atr_expanded", role: "event", confidence: "high", text: "하루 변동폭이 최근 평균보다 커진 상태예요." });
+
+  if (clean.length >= 120 && num(closeToHigh) && closeToHigh >= 99.5)
+    pushSafe(facts, { kind: "near_52w_high", role: "event", confidence: "high", text: "52주 고점권까지 올라온 상태예요." });
+  if (clean.length >= 120 && num(closeToLow) && closeToLow <= 105)
+    pushSafe(facts, { kind: "near_52w_low", role: "event", confidence: "high", text: "52주 저점권에 가까운 상태예요." });
+
+  const recent = clean.slice(-20);
+  const recentVolumes = volumes.slice(-20).filter((v) => v > 0);
+  const firstClose = recent[0]?.close;
+  const obvSeries = obv(clean);
+  const obvDelta = obvSeries[obvSeries.length - 1]! - obvSeries[Math.max(0, obvSeries.length - 21)]!;
+  const volumeAvg = recentVolumes.length ? recentVolumes.reduce((a, b) => a + b, 0) / recentVolumes.length : 0;
+  const priceFlat = num(firstClose) && firstClose > 0 && Math.abs(last.close / firstClose - 1) <= 0.03;
+  const volumeRising = last.volume > volumeAvg * 1.25;
+  const accumulation = !!priceFlat && volumeRising && obvDelta > 0;
+  if (accumulation)
+    pushSafe(facts, { kind: "accumulation_divergence", role: "confirmation", confidence: "low", text: "거래는 늘었는데 가격이 평탄해, 매집으로 보이는 구조예요." });
+
+  const trendStrength = num(ma20) ? clamp01(Math.abs(last.close / ma20 - 1) / 0.15) : undefined;
+  return {
+    facts,
+    latest: {
+      ...(num(rsi) ? { rsi14: Math.round(rsi * 10) / 10 } : {}),
+      ...(macdNow ? { macd: macdNow.macd, macdSignal: macdNow.signal } : {}),
+      ...(num(width) ? { bollingerWidthPct: Math.round(width * 10) / 10 } : {}),
+      ...(num(atr) ? { atrPct: Math.round(atr * 10) / 10 } : {}),
+      ...(num(closeToHigh) ? { closeTo52WeekHighPct: Math.round(closeToHigh * 10) / 10 } : {}),
+      ...(num(closeToLow) ? { closeTo52WeekLowPct: Math.round(closeToLow * 10) / 10 } : {}),
+    },
+    inputs: {
+      ...(accumulation ? { accumulationDivergence: true } : {}),
+      ...(squeeze ? { bollingerSqueeze: true } : {}),
+      ...(num(trendStrength) ? { trendStrength } : {}),
+    },
+  };
+}
+
+export function selectTaFact(fomo: FomoScoreResult, ta: TechnicalAnalysisSnapshot): TaFact | undefined {
+  const byKind = new Map(ta.facts.map((f) => [f.kind, f] as const));
+
+  if (fomo.label === "incoming") {
+    const confirm = byKind.get("accumulation_divergence") ?? byKind.get("bollinger_squeeze");
+    if (confirm) return { ...confirm, role: "confirmation" };
+  }
+
+  if (fomo.leadSignal >= 60) {
+    const balance = byKind.get("rsi_overbought");
+    if (balance) return { ...balance, role: "balance" };
+  }
+
+  for (const kind of [
+    "near_52w_high",
+    "bollinger_squeeze",
+    "rsi_overbought",
+    "rsi_oversold",
+    "accumulation_divergence",
+    "macd_bullish",
+    "macd_bearish",
+    "ma_bullish",
+    "ma_bearish",
+    "atr_expanded",
+    "near_52w_low",
+  ] as const) {
+    const fact = byKind.get(kind);
+    if (fact) return fact;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## 변경 내용

- 일봉 OHLCV 기반 TA 사실층을 `@fomo/core`에 추가했습니다.
- RSI, MACD, 이동평균 정렬, 볼린저 스퀴즈, ATR, OBV 기반 매집형 다이버전스, 52주 위치를 같은 OHLCV 파이프라인에서 계산합니다.
- TA selector가 카드/상세에 표시할 사실 1개만 고릅니다.
- `stock-front` 응답에 `taFact`를 추가하고 카드·상세의 보조 문맥으로 연결했습니다.
- 포모 점수 §6 튜닝값 중 매집/스퀴즈 L 보조 입력을 상수와 옵션으로 분리했습니다.
- 매집 다이버전스는 광혁 튜닝 전 기본 off로 변경했습니다.

## 원칙 준수

- 새 외부 소스, 새 서비스, DDL, 유료 기능 없음
- 기존 네이버 일봉 OHLCV 호출을 재사용하고 조회 기간만 52주 위치 계산 가능하게 확장
- TA는 독립 점수·랭킹으로 노출하지 않고 라벨된 사실 1개만 표시
- 예측·추천·다음 행동 암시 없이 현재 상태만 표현
- 데이터 부족 시 해당 지표는 제외

## 검증

- `npm test` — 69 files, 806 tests
- `npm run typecheck`
- `npm run lint`
- `npm run build:fomo-web`
- `npm run build:web`
- `npm run ci`

## 광혁 튜닝 포인트

- `ACCUMULATION.enabled`, `leadBonus`
- `BOLLINGER_SQUEEZE.enabled`, `leadBonus`
- 기존 C/L 가중치와 라벨 임계값
- 카드에서 TA fact의 노출 빈도와 문장 감각
