### PR TITLE
[codex] Add deterministic Slack natural routing

### DIFF
--- a/.github/workflows/agent-ops.yml
+++ b/.github/workflows/agent-ops.yml
@@ -1,0 +1,142 @@
+name: Agent Ops Request
+
+# Slack 자연어 라우터가 실행하는 저비용 운영 접수 워크플로.
+# 실제 외부 소스 연동, prod DDL, 유료 서비스 호출은 하지 않는다.
+# 목적: source-discovery / integrity-checker / pipeline-monitor 작업을 이슈로 안정적으로 남긴다.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "source-discovery | integrity-checker | pipeline-monitor"
+        required: true
+      query:
+        description: "Slack 원문 요청"
+        required: false
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  create-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create agent ops issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ github.event.inputs.mode }}
+          QUERY: ${{ github.event.inputs.query }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          case "$MODE" in
+            source-discovery)
+              TITLE="🔎 [source-discovery] 소스 후보 발굴 요청"
+              LABELS="source-discovery,needs-ceo-review"
+              BODY=$(cat <<'EOF'
+          ## 목적
+          새로운 투자 정보 소스 후보를 찾는다.
+
+          ## 출력 형식
+          - 이름:
+          - URL:
+          - 유형:
+          - 접근 방식:
+          - 예상 가치:
+          - 리스크:
+          - 약관/로그인벽 여부:
+          - 추천 tier:
+          - 연동 우선순위:
+
+          ## 절대 규칙
+          - 제안만 한다.
+          - 실제 연동은 광혁 승인 후 별도 PR.
+          - 로그인벽/약관 리스크가 있으면 보류 또는 금지.
+          EOF
+          )
+              ;;
+            integrity-checker)
+              TITLE="🧪 [integrity-checker] 정합성 검수 요청"
+              LABELS="integrity-check,data-quality,needs-ceo-review"
+              BODY=$(cat <<'EOF'
+          ## 목적
+          수집된 정보가 진짜 판단 재료인지 검증한다.
+
+          ## 검수 항목
+          - 출처 신뢰도
+          - 발행 시점
+          - 원문과 요약의 일치
+          - 강세/약세 균형
+          - 커뮤니티 워딩 왜곡 여부
+          - 찌라시 가능성
+          - 투자조언/예측 표현 여부
+          - 💎 신호가 사실 관찰에 머무는지 여부
+
+          ## 출력
+          - 상태: 통과 / 수정 필요 / 폐기
+          - 문제 발견:
+          - 투자조언 리스크:
+          - 최종 판단:
+          EOF
+          )
+              ;;
+            pipeline-monitor)
+              TITLE="🛠 [pipeline-monitor] 파이프라인 점검 요청"
+              LABELS="pipeline-monitor,data-quality"
+              BODY=$(cat <<'EOF'
+          ## 목적
+          FOMO Club 데이터 파이프라인이 조용히 망가지는 것을 감시한다.
+
+          ## 감시 항목
+          - 수집량 급감
+          - 특정 소스 실패
+          - 빈 배열 증가
+          - fallback 비율 증가
+          - confidence 저하
+          - LLM 응축 실패
+          - API 응답 지연
+          - snapshot 생성 실패
+          - 카드 데이터가 mock/fallback으로만 채워지는 상황
+
+          ## 보고 형식
+          상태: 정상 / 주의 / 위험
+
+          수집:
+          - 뉴스:
+          - 커뮤니티:
+          - 수급:
+
+          품질:
+          - fallback 비율:
+          - confidence:
+          - 빈 카드:
+
+          다음 액션:
+          - 자동 복구 가능:
+          - PR 필요:
+          - 광혁 확인 필요:
+          EOF
+          )
+              ;;
+            *)
+              echo "Unsupported mode: $MODE" >&2
+              exit 1
+              ;;
+          esac
+
+          BODY="$BODY
+
+          ## Slack 요청 원문
+          ${QUERY:-"(원문 없음)"}
+
+          ## 실행 링크
+          ${RUN_URL}
+          "
+
+          # 라벨이 아직 없는 저장소에서도 실패하지 않게, 라벨 실패 시 무라벨 이슈로 폴백한다.
+          if ! gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "$LABELS"; then
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+          fi

--- a/apps/web/__tests__/slack-actions.test.ts
+++ b/apps/web/__tests__/slack-actions.test.ts
@@ -113,7 +113,7 @@ describe("log_feedback 액션", () => {
 
 describe("액션 집합", () => {
   it("KNOWN_ACTIONS 에 7개 포함", () => {
-    for (const a of ["run_council", "implement", "merge", "approve", "comment", "add_constraint", "log_feedback"]) {
+    for (const a of ["run_council", "implement", "merge", "approve", "comment", "add_constraint", "log_feedback", "pipeline_check", "source_discovery", "integrity_check"]) {
       expect(KNOWN_ACTIONS.has(a)).toBe(true);
     }
   });

--- a/apps/web/__tests__/slack-natural-router.test.ts
+++ b/apps/web/__tests__/slack-natural-router.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { routeNaturalLanguage } from "@/lib/slack/natural-router";
+
+function names(text: string) {
+  return routeNaturalLanguage(text).actions.map((action) => action.name);
+}
+
+describe("routeNaturalLanguage", () => {
+  it("파이프라인 점검 요청을 pipeline_check로 라우팅", () => {
+    const r = routeNaturalLanguage("파이프라인 점검해. fallback 비율도 봐줘");
+    expect(r.confidence).toBe("high");
+    expect(r.actions).toEqual([
+      { name: "pipeline_check", payload: { query: "파이프라인 점검해. fallback 비율도 봐줘" } },
+    ]);
+  });
+
+  it("소스 후보 발굴 요청을 source_discovery로 라우팅", () => {
+    expect(names("소스 후보 찾아줘. 한국 개인투자자 커뮤니티 중심으로")).toEqual(["source_discovery"]);
+    expect(names("source candidate research 해줘")).toEqual(["source_discovery"]);
+  });
+
+  it("정합성/금칙어 검수 요청을 integrity_check로 라우팅", () => {
+    expect(names("정합성 체크해. 투자조언 표현도 같이 봐줘")).toEqual(["integrity_check"]);
+    expect(names("grounding 검증해줘")).toEqual(["integrity_check"]);
+  });
+
+  it("조회/상태 질문은 실행하지 않음", () => {
+    expect(routeNaturalLanguage("파이프라인 상태 알려줘").confidence).toBe("low");
+    expect(routeNaturalLanguage("개발됐어?").confidence).toBe("low");
+    expect(routeNaturalLanguage("PR 뭐 있어?").confidence).toBe("low");
+  });
+
+  it("프로젝트 자연어를 단계별 액션으로 라우팅", () => {
+    expect(routeNaturalLanguage("프로젝트 제안해줘").actions[0]).toEqual({ name: "propose_projects", payload: {} });
+    expect(routeNaturalLanguage("P1 시작하자").actions[0]).toEqual({ name: "select_project", payload: { id: "P1" } });
+    expect(routeNaturalLanguage("P2 기획 승인").actions[0]).toEqual({ name: "approve_plan", payload: { id: "P2" } });
+  });
+
+  it("특정 이슈 개발과 일반 개발을 구분", () => {
+    expect(routeNaturalLanguage("#457 개발해").actions[0]).toEqual({ name: "implement_task", payload: { issue: 457 } });
+    expect(routeNaturalLanguage("다음 작업 개발 진행해").actions[0]).toEqual({ name: "implement", payload: {} });
+  });
+
+  it("PR 머지와 이슈 닫기를 안전하게 분류", () => {
+    expect(routeNaturalLanguage("PR #602 머지해").actions[0]).toEqual({ name: "merge", payload: { pr: 602 } });
+    expect(routeNaturalLanguage("이상 없으면 PR 전부 머지").actions[0]).toEqual({ name: "merge_all", payload: {} });
+    expect(routeNaturalLanguage("완료된 이슈 닫아").actions[0]).toEqual({ name: "close_completed", payload: {} });
+    expect(routeNaturalLanguage("이슈 전부 닫아").actions[0]).toEqual({ name: "close_all", payload: {} });
+  });
+
+  it("머지하고 이슈 닫아 같은 복합 지시를 두 액션으로 라우팅", () => {
+    expect(routeNaturalLanguage("이상 없으면 PR 머지하고 이슈도 닫아").actions).toEqual([
+      { name: "merge_all", payload: {} },
+      { name: "close_all", payload: {} },
+    ]);
+  });
+});

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -22,6 +22,7 @@ import {
   getTodayAutoPRs,
 } from "@/lib/slack/github";
 import { classifyIntent, truncate } from "@/lib/slack/intent";
+import { routeNaturalLanguage } from "@/lib/slack/natural-router";
 import { resolveAgent, axisIdentity, axisHeader } from "@/lib/slack/agents";
 import {
   isCeoDecisionThread,
@@ -152,6 +153,25 @@ async function handleAgentChat(
   rootThreadTs: string | undefined,
   currentMsgTs: string
 ) {
+  const naturalRoute = routeNaturalLanguage(question);
+  if (naturalRoute.confidence === "high" && naturalRoute.actions.length > 0) {
+    const axis = resolveAgent(question);
+    const identity = axisIdentity(axis);
+    const header = axisHeader(axis);
+    try {
+      let reply = naturalRoute.reply;
+      for (const action of naturalRoute.actions) {
+        reply += "\n\n" + (await executeAction(action, channel, rootThreadTs || threadTs));
+      }
+      if (header) reply = `${header}\n${reply}`;
+      await postMessage(channel, reply, threadTs, identity);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await postMessage(channel, `❌ 자연어 라우팅 실패: ${msg}`, threadTs, identity).catch(() => {});
+    }
+    return;
+  }
+
   // Groq (무료, OpenAI-compat) — console.groq.com에서 무료 발급
   const GROQ_API_KEY = process.env.GROQ_API_KEY;
   const AI_URL = "https://api.groq.com/openai/v1/chat/completions";
@@ -445,6 +465,21 @@ async function executeAction(
         if (!Number.isInteger(issue) || issue <= 0) return "⚠️ implement_task: 이슈 번호가 올바르지 않아 실행하지 않았습니다.";
         await triggerWorkflow("implement-task.yml", { issue: String(issue) });
         return `🚀 *#${issue} 구현 시작* — Claude Code 가 이슈 스펙대로 구현 후 PR을 올립니다(수 분). CI 후 리뷰/머지하세요. (Prisma·보안 변경은 자동 머지 차단)`;
+      }
+      case "pipeline_check": {
+        const query = typeof action.payload.query === "string" ? action.payload.query : "";
+        await triggerWorkflow("agent-ops.yml", { mode: "pipeline-monitor", query });
+        return "🛠️ *pipeline-monitor 접수* — 파이프라인 점검 작업 이슈를 생성합니다. Slack에는 링크 중심으로 후속 보고하세요.";
+      }
+      case "source_discovery": {
+        const query = typeof action.payload.query === "string" ? action.payload.query : "";
+        await triggerWorkflow("agent-ops.yml", { mode: "source-discovery", query });
+        return "🔎 *source-discovery 접수* — 소스 후보 리포트 작업 이슈를 생성합니다. 실제 연동은 광혁 승인 전까지 하지 않습니다.";
+      }
+      case "integrity_check": {
+        const query = typeof action.payload.query === "string" ? action.payload.query : "";
+        await triggerWorkflow("agent-ops.yml", { mode: "integrity-checker", query });
+        return "🧪 *integrity-checker 접수* — 정합성 검수 작업 이슈를 생성합니다. 투자조언·근거·강세/약세 균형을 우선 확인합니다.";
       }
       case "implement": {
         const raw = action.payload.date;

--- a/apps/web/lib/slack/actions.ts
+++ b/apps/web/lib/slack/actions.ts
@@ -18,6 +18,9 @@ export type ActionName =
   | "select_project"
   | "approve_plan"
   | "implement_task"
+  | "pipeline_check"
+  | "source_discovery"
+  | "integrity_check"
   | "implement"
   | "merge"
   | "merge_all"
@@ -34,6 +37,9 @@ export const KNOWN_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
   "select_project",
   "approve_plan",
   "implement_task",
+  "pipeline_check",
+  "source_discovery",
+  "integrity_check",
   "implement",
   "merge",
   "merge_all",
@@ -56,6 +62,9 @@ export const HIGH_IMPACT_ACTIONS: ReadonlySet<string> = new Set<ActionName>([
   "select_project",
   "approve_plan",
   "implement_task",
+  "pipeline_check",
+  "source_discovery",
+  "integrity_check",
 ]);
 
 export interface ParsedAction {

--- a/apps/web/lib/slack/commands.ts
+++ b/apps/web/lib/slack/commands.ts
@@ -15,10 +15,36 @@ interface CommandResult {
 type CommandHandler = (args: string, userId: string) => Promise<CommandResult>;
 
 // GitHub API 다중 호출 등 3초 초과 가능성 있는 커맨드
-export const SLOW_COMMANDS = new Set(["status", "implement", "council", "merge", "constraints"]);
+export const SLOW_COMMANDS = new Set([
+  "status",
+  "implement",
+  "council",
+  "merge",
+  "constraints",
+  "pipeline",
+  "source",
+  "integrity",
+  "파이프라인",
+  "소스",
+  "정합성",
+]);
 
 // 알려진 커맨드 목록 — events/route.ts에서 chat vs command 분기에 사용
-export const KNOWN_COMMANDS = new Set(["implement", "council", "status", "approve", "merge", "help", "constraints"]);
+export const KNOWN_COMMANDS = new Set([
+  "implement",
+  "council",
+  "status",
+  "approve",
+  "merge",
+  "help",
+  "constraints",
+  "pipeline",
+  "source",
+  "integrity",
+  "파이프라인",
+  "소스",
+  "정합성",
+]);
 
 const commands: Record<string, CommandHandler> = {
   implement: handleImplement,
@@ -27,6 +53,12 @@ const commands: Record<string, CommandHandler> = {
   approve: handleApprove,
   merge: handleMerge,
   constraints: handleConstraints,
+  pipeline: handlePipeline,
+  source: handleSourceDiscovery,
+  integrity: handleIntegrityCheck,
+  파이프라인: handlePipeline,
+  소스: handleSourceDiscovery,
+  정합성: handleIntegrityCheck,
   help: handleHelp,
 };
 
@@ -117,6 +149,21 @@ async function handleMerge(args: string): Promise<CommandResult> {
   return { text: `PR #${prNum} 머지 완료 (squash)` };
 }
 
+async function handlePipeline(args: string): Promise<CommandResult> {
+  await triggerWorkflow("agent-ops.yml", { mode: "pipeline-monitor", query: args });
+  return { text: "🛠️ pipeline-monitor 작업 이슈 생성을 요청했습니다. 수집량·fallback·confidence·빈 카드 기준으로 점검합니다." };
+}
+
+async function handleSourceDiscovery(args: string): Promise<CommandResult> {
+  await triggerWorkflow("agent-ops.yml", { mode: "source-discovery", query: args });
+  return { text: "🔎 source-discovery 작업 이슈 생성을 요청했습니다. 실제 연동은 하지 않고 후보·리스크·tier만 보고합니다." };
+}
+
+async function handleIntegrityCheck(args: string): Promise<CommandResult> {
+  await triggerWorkflow("agent-ops.yml", { mode: "integrity-checker", query: args });
+  return { text: "🧪 integrity-checker 작업 이슈 생성을 요청했습니다. 원문 grounding·tier·금칙어·강세/약세 균형을 검수합니다." };
+}
+
 interface ActiveConstraint {
   rule: string;
   scope: string[];
@@ -150,6 +197,9 @@ async function handleHelp(): Promise<CommandResult> {
       "`/fomo approve {이슈#}` — 이슈에 implement-approved 라벨 추가",
       "`/fomo merge {PR#}` — PR squash 머지",
       "`/fomo constraints` — 현재 등록된 standing constraints 목록",
+      "`/fomo pipeline {요청}` — pipeline-monitor 점검 이슈 생성",
+      "`/fomo source {요청}` — source-discovery 소스 후보 리포트 이슈 생성",
+      "`/fomo integrity {요청}` — integrity-checker 정합성 검수 이슈 생성",
       "`/fomo help` — 이 도움말",
       "",
       "*직군 에이전트와 대화:*",

--- a/apps/web/lib/slack/natural-router.ts
+++ b/apps/web/lib/slack/natural-router.ts
@@ -1,0 +1,195 @@
+import type { ParsedAction } from "./actions";
+
+export type NaturalRouteConfidence = "high" | "low";
+
+export interface NaturalRoute {
+  confidence: NaturalRouteConfidence;
+  actions: ParsedAction[];
+  reply: string;
+  reason: string;
+}
+
+const PROJECT_ID_RE = /\bP\s*(\d+)\b/i;
+const HASH_NUMBER_RE = /#\s*(\d+)/;
+const STANDALONE_NUMBER_RE = /(?:^|\s)(\d{2,6})(?:\s|$)/;
+
+function compact(text: string): string {
+  return text
+    .replace(/<@[A-Z0-9]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasAny(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function projectId(text: string): string | null {
+  const match = text.match(PROJECT_ID_RE);
+  return match?.[1] ? `P${match[1]}` : null;
+}
+
+function numberIn(text: string): number | null {
+  const hash = text.match(HASH_NUMBER_RE)?.[1];
+  const raw = hash ?? text.match(STANDALONE_NUMBER_RE)?.[1];
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+function route(actions: ParsedAction[], reply: string, reason: string): NaturalRoute {
+  return { confidence: "high", actions, reply, reason };
+}
+
+function noRoute(reason: string): NaturalRoute {
+  return { confidence: "low", actions: [], reply: "", reason };
+}
+
+const ASK_ONLY = [
+  /어때\??$/,
+  /알려\s*줘/,
+  /보여\s*줘/,
+  /요약/,
+  /설명/,
+  /뭐\s*(야|임|있)/,
+  /상태/,
+  /됐(어|나|니)\??/,
+  /진행\s*(상황|상태)/,
+];
+
+const EXEC_VERBS = [
+  /해\s*줘/,
+  /해라/,
+  /해\b/,
+  /하자/,
+  /시작/,
+  /진행/,
+  /돌려/,
+  /실행/,
+  /체크/,
+  /점검/,
+  /찾아/,
+  /발굴/,
+  /승인/,
+  /머지/,
+  /닫아/,
+  /클로즈/,
+  /정리/,
+];
+
+function isLikelyExecution(text: string): boolean {
+  return hasAny(text, EXEC_VERBS) && !/하지\s*마|말아|스킵|보류/.test(text);
+}
+
+function isAskOnly(text: string): boolean {
+  return hasAny(text, ASK_ONLY) && !isLikelyExecution(text);
+}
+
+/**
+ * Slack 자연어를 LLM 호출 전에 안전한 액션으로 분류한다.
+ * - 확실한 실행 지시만 high confidence 로 반환한다.
+ * - 조회/상태/요약 질문은 low confidence 로 두어 기존 Agent Chat 이 답하게 한다.
+ * - 고영향 액션은 대상 번호/프로젝트 id가 없으면 실행하지 않는다.
+ */
+export function routeNaturalLanguage(input: string): NaturalRoute {
+  const text = compact(input);
+  if (!text) return noRoute("empty");
+  if (isAskOnly(text)) return noRoute("ask-only");
+
+  const lower = text.toLowerCase();
+
+  // ── 새 에이전트 운영 3종 ──────────────────────────────────────
+  if (/(파이프라인|pipeline).*(점검|체크|확인|봐|모니터|monitor)/i.test(text)) {
+    return route(
+      [{ name: "pipeline_check", payload: { query: text } }],
+      "🛠️ 파이프라인 점검 요청으로 이해했어요. `pipeline-monitor` 작업 이슈를 만들고 실행 로그를 남길게요.",
+      "pipeline_check",
+    );
+  }
+
+  if (/소스.*(후보|찾아|발굴|리서치|조사)|source.*(discover|candidate|research)/i.test(text)) {
+    return route(
+      [{ name: "source_discovery", payload: { query: text } }],
+      "🔎 소스 후보 발굴 요청으로 이해했어요. 실제 연동은 하지 않고 후보 리포트 작업 이슈만 만들게요.",
+      "source_discovery",
+    );
+  }
+
+  if (/(정합성|무결성|integrity|grounding|그라운딩).*(체크|검수|확인|봐|검증)|금칙어.*(체크|검수)|투자조언.*(체크|검수)/i.test(text)) {
+    return route(
+      [{ name: "integrity_check", payload: { query: text } }],
+      "🧪 정합성 검수 요청으로 이해했어요. `integrity-checker` 작업 이슈를 만들고 금칙어·근거·균형 기준으로 보게 할게요.",
+      "integrity_check",
+    );
+  }
+
+  // ── 톱다운 프로젝트 흐름 ─────────────────────────────────────
+  if (/프로젝트.*(제안|뽑아|추천|정리)|뭐부터\s*할지.*(제안|정리)/i.test(text)) {
+    return route(
+      [{ name: "propose_projects", payload: {} }],
+      "🧭 프로젝트 후보 제안 요청으로 이해했어요. 자율 실행이 아니라 후보 리스트만 만들게요.",
+      "propose_projects",
+    );
+  }
+
+  const pid = projectId(text);
+  if (pid && /(기획|prd).*(승인|오케이|ok|진행)|승인.*(기획|prd)/i.test(text)) {
+    return route(
+      [{ name: "approve_plan", payload: { id: pid } }],
+      `✅ ${pid} 기획 승인으로 이해했어요. PRD 기준으로 하위 task 분해를 실행할게요.`,
+      "approve_plan",
+    );
+  }
+
+  if (pid && /(시작|하자|킥오프|착수|선택)/i.test(text)) {
+    return route(
+      [{ name: "select_project", payload: { id: pid } }],
+      `🗺️ ${pid} 프로젝트 시작으로 이해했어요. 먼저 기획문서(PRD) 이슈를 만들게요.`,
+      "select_project",
+    );
+  }
+
+  // ── 구현/개발 ────────────────────────────────────────────────
+  const n = numberIn(text);
+  if (/(개발|구현|작업).*(해|진행|시작|착수)|진행해|만들어\s*줘/i.test(text)) {
+    if (n && /#?\s*\d{2,6}/.test(text)) {
+      return route(
+        [{ name: "implement_task", payload: { issue: n } }],
+        `🚀 #${n} 이슈 구현 요청으로 이해했어요. 해당 task 구현 워크플로를 실행할게요.`,
+        "implement_task",
+      );
+    }
+    return route(
+      [{ name: "implement", payload: {} }],
+      "🚀 개발 실행 요청으로 이해했어요. 오늘 기준 auto-implement를 실행할게요.",
+      "implement",
+    );
+  }
+
+  // ── PR 머지 / 이슈 정리 ──────────────────────────────────────
+  const actions: ParsedAction[] = [];
+  const wantsMerge = /(pr|pull request|풀리퀘|피알)?.*(머지|merge)|(머지|merge).*(pr|풀리퀘|피알)/i.test(text);
+  const wantsCloseIssue = /(이슈|issue).*(닫아|클로즈|close|정리)|닫아.*(이슈|issue)|클로즈.*(이슈|issue)/i.test(text);
+
+  if (wantsMerge) {
+    const prNumber = n;
+    const all = /(전부|전체|다|모두|남은|이상\s*없|문제\s*없)/i.test(text);
+    if (prNumber && !all) actions.push({ name: "merge", payload: { pr: prNumber } });
+    else actions.push({ name: "merge_all", payload: {} });
+  }
+
+  if (wantsCloseIssue) {
+    const completedOnly = /(완료|끝난|해결|머지된|merged)/i.test(text);
+    actions.push({ name: completedOnly ? "close_completed" : "close_all", payload: {} });
+  }
+
+  if (actions.length > 0) {
+    return route(
+      actions,
+      `🧹 정리 요청으로 이해했어요. ${actions.map((a) => `\`${a.name}\``).join(" + ")} 액션을 실행할게요.`,
+      "merge-or-close",
+    );
+  }
+
+  return noRoute("no-confident-route");
+}


### PR DESCRIPTION
## What changed
- Added a deterministic Slack natural-language router that runs before the LLM for clear execution requests.
- Routes natural Korean/English requests for:
  - `파이프라인 점검해` → `pipeline_check`
  - `소스 후보 찾아줘` → `source_discovery`
  - `정합성 체크해` → `integrity_check`
  - `P1 시작`, `P2 기획 승인`, `#457 개발해`, PR merge, issue close flows
- Keeps status/summary questions as non-executing low-confidence routes, so “개발됐어?” and “파이프라인 상태 알려줘” do not accidentally trigger workflows.
- Added `/fomo pipeline`, `/fomo source`, `/fomo integrity` slash command aliases.
- Added `agent-ops.yml`, a low-cost workflow that creates operational issues for `source-discovery`, `integrity-checker`, and `pipeline-monitor` without touching product code, external paid services, prod DDL, or source integrations.
- Added tests for the natural router and action registry.

## Why
Slack previously relied heavily on LLM-generated `[[ACTION]]` tokens. That made commands brittle when the user used natural phrasing. This adds a deterministic intent layer for high-confidence execution commands and leaves ambiguous/read-only questions to the existing chat path.

## Safety
- Clear execution verbs are required for actions.
- Read-only/status questions do not execute.
- New agent ops actions create issues only; they do not integrate sources or modify production data.
- Existing high-impact merge/close/implement actions remain routed through the existing executor.

## Validation
- `npm test -- --run apps/web/__tests__/slack-natural-router.test.ts apps/web/__tests__/slack-actions.test.ts apps/web/__tests__/slack-intent.test.ts`
- `ruby -e "require 'yaml'; %w[.github/workflows/agent-ops.yml .github/workflows/auto-implement.yml].each { |f| YAML.load_file(f) }"`
- `git diff --check`
- `npm run typecheck`
- `npm run build:web`
- `npm run lint`
- `npm test`