### PR TITLE
[codex] Guard autonomous agent workflows

### DIFF
--- a/.github/workflows/idea-proposal.yml
+++ b/.github/workflows/idea-proposal.yml
@@ -15,6 +15,10 @@ on:
         description: "실행할 에이전트 (all / pm / frontend / backend / designer / qa / cto / marketer / security / prompt_engineer) — 수동 폴백"
         required: false
         default: "all"
+      approval_token:
+        description: "자율기획 잠금 해제 토큰. SSOT_EXECUTION_ONLY 입력 시에만 실행"
+        required: false
+        default: ""
 
 concurrency:
   group: agent-council
@@ -38,6 +42,7 @@ permissions:
 jobs:
 
   prepare:
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' }}
     runs-on: ubuntu-latest
     outputs:
       feedback: ${{ steps.fetch.outputs.feedback }}
@@ -303,7 +308,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   pm:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'pm' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'pm') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -502,7 +507,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   frontend:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'frontend' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'frontend') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -691,7 +696,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   backend:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'backend' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'backend') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -846,7 +851,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   designer:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'designer' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'designer') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -1003,7 +1008,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   qa:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'qa' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'qa') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -1158,7 +1163,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   cto:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'cto' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'cto') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -1312,7 +1317,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   marketer:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'marketer' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'marketer') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -1500,7 +1505,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   security:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'security' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'security') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -1634,7 +1639,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   prompt_engineer:
     needs: [prepare]
-    if: ${{ github.event.inputs.agent == 'all' || github.event.inputs.agent == 'prompt_engineer' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && (github.event.inputs.agent == 'all' || github.event.inputs.agent == 'prompt_engineer') }}
     runs-on: ubuntu-latest
     outputs:
       proposal: ${{ steps.proposal.outputs.response }}
@@ -1794,7 +1799,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   score_and_filter:
     needs: [prepare, pm, frontend, backend, designer, qa, cto, marketer, security, prompt_engineer]
-    if: always()
+    if: ${{ always() && github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1917,7 +1922,7 @@ jobs:
 
   ceo_brief:
     needs: [prepare, pm, frontend, backend, designer, qa, cto, marketer, security, prompt_engineer, score_and_filter]
-    if: always() && (github.event.inputs.agent == 'all' || github.event_name == 'schedule')
+    if: ${{ always() && github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' && github.event.inputs.agent == 'all' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/propose-northstar.yml
+++ b/.github/workflows/propose-northstar.yml
@@ -19,6 +19,10 @@ on:
         description: "출처 (예: slack/<thread>, weekly-cron)"
         required: false
         default: "manual"
+      approval_token:
+        description: "North Star 자율 제안 잠금 해제 토큰. SSOT_EXECUTION_ONLY 입력 시에만 실행"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -32,6 +36,7 @@ concurrency:
 
 jobs:
   propose:
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/propose-project.yml
+++ b/.github/workflows/propose-project.yml
@@ -4,6 +4,11 @@ name: Propose Projects (CEO)
 #   → PROJECT_ROADMAP.md 재생성 + 검토용 이슈 + Slack. 사람이 "제품 이해도"를 검토하고 1개 선택.
 on:
   workflow_dispatch:
+    inputs:
+      approval_token:
+        description: "자율 프로젝트 제안 잠금 해제 토큰. SSOT_EXECUTION_ONLY 입력 시에만 실행"
+        required: false
+        default: ""
 
 concurrency:
   group: propose-project
@@ -18,6 +23,7 @@ permissions:
 
 jobs:
   propose:
+    if: ${{ github.event.inputs.approval_token == 'SSOT_EXECUTION_ONLY' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/apps/web/__tests__/slack-natural-router.test.ts
+++ b/apps/web/__tests__/slack-natural-router.test.ts
@@ -30,8 +30,11 @@ describe("routeNaturalLanguage", () => {
     expect(routeNaturalLanguage("PR 뭐 있어?").confidence).toBe("low");
   });
 
-  it("프로젝트 자연어를 단계별 액션으로 라우팅", () => {
-    expect(routeNaturalLanguage("프로젝트 제안해줘").actions[0]).toEqual({ name: "propose_projects", payload: {} });
+  it("프로젝트 자율 제안은 실행하지 않고 LLM/안내 경로로 넘김", () => {
+    expect(routeNaturalLanguage("프로젝트 제안해줘").confidence).toBe("low");
+  });
+
+  it("사람이 지정한 프로젝트 단계는 액션으로 라우팅", () => {
     expect(routeNaturalLanguage("P1 시작하자").actions[0]).toEqual({ name: "select_project", payload: { id: "P1" } });
     expect(routeNaturalLanguage("P2 기획 승인").actions[0]).toEqual({ name: "approve_plan", payload: { id: "P2" } });
   });

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -333,8 +333,8 @@ ${runList || "(없음)"}
 액션 실행 규칙 (중요 — tool use):
 - CEO가 **명확히 실행을 지시**하면, 답변 끝에 단독 줄로 액션 토큰을 정확히 출력한다. 보통 1개, 단 "PR 머지 + 이슈 정리"처럼 벌크 정리는 merge_all·close_completed 를 함께(각각 단독 줄) 낼 수 있다.
 - 사용 가능한 액션:
-  \`[[ACTION:run_council]]\` — Agent Council(idea-proposal) 즉시 실행 ("의회 돌려", "제안 받아")
-  \`[[ACTION:propose_projects]]\` — CEO 에이전트가 제품 분석 → 프로젝트 후보 리스트 제안 ("프로젝트 제안해", "뭐부터 할지 제안해", "프로젝트 뽑아줘"). 사람이 검토 후 선택.
+  ~~\`[[ACTION:run_council]]\`~~ — 잠김. Agent Council/자율 제안 루프는 실행하지 않는다.
+  ~~\`[[ACTION:propose_projects]]\`~~ — 잠김. 에이전트가 새 제품 방향을 제안하지 않는다.
   \`[[ACTION:select_project]] {"id":"P1"}\` — 후보 중 활성 프로젝트 선택 ("P1 시작", "P2 프로젝트 하자"). 선택 시 **기획문서(PRD)** 를 먼저 작성(아직 분해 안 함).
   \`[[ACTION:approve_plan]] {"id":"P2"}\` — 기획문서 검토 후 승인 ("P2 기획 승인", "이 기획으로 개발 진행"). 승인 시 직군(기획/백엔드/프론트·UX/품질)별 하위 이슈로 분해.
   \`[[ACTION:implement_task]] {"issue":457}\` — 특정 프로젝트 하위 task 이슈를 실제 구현 → PR ("#457 개발해", "457 구현해", "이 이슈 개발"). 번호가 명시된 task 개발 지시.
@@ -365,11 +365,11 @@ ${runList || "(없음)"}
 - 둘 다 지시하면("머지하고 이슈도 닫아") merge_all + close_all 두 토큰을 각각 단독 줄로 출력한다.
 - **절대 "닫을 이슈가 없다/PR 번호가 올바르지 않다"고 지어내지 마라** — 벌크 토큰을 내면 시스템이 실제 열린 PR/이슈를 조회해 처리한다. close_all 은 이미 닫힌 게 아니면 반드시 무언가 닫는다.
 
-**톱다운 프로젝트 흐름 (3단계 — 단계마다 사람이 게이트)**:
-- ① "프로젝트 제안해", "뭐부터 할지 정리해" → \`[[ACTION:propose_projects]]\` (CEO가 제품 분석해 후보 리스트 제안).
-- ② "P2 시작", "P2 프로젝트 하자" → \`[[ACTION:select_project]] {"id":"P2"}\` (활성화 + **기획문서(PRD)** 작성. 아직 분해 안 함).
-- ③ 기획문서 검토 후 "P2 기획 승인", "이 기획으로 진행" → \`[[ACTION:approve_plan]] {"id":"P2"}\` (PRD 기준 직군별 하위 이슈 분해).
-- 이건 매일 잔 아이디어 run_council 과 다르다. 톱다운: 제안 → 선택 → 기획문서 → 승인 → 분해 → 격파.
+**톱다운 프로젝트 흐름 (사람이 방향 지정 — 단계마다 사람이 게이트)**:
+- "프로젝트 제안해", "뭐부터 할지 정리해" → 액션 토큰 금지. 자율기획은 잠겨 있으므로, SSOT 기준으로 “광혁이 프로젝트 방향을 지정하면 Pn 시작으로 받을 수 있다”고 안내한다.
+- "P2 시작", "P2 프로젝트 하자" → \`[[ACTION:select_project]] {"id":"P2"}\` (활성화 + **기획문서(PRD)** 작성. 아직 분해 안 함).
+- 기획문서 검토 후 "P2 기획 승인", "이 기획으로 진행" → \`[[ACTION:approve_plan]] {"id":"P2"}\` (PRD 기준 직군별 하위 이슈 분해).
+- 에이전트는 새 방향을 제안하지 않는다. 톱다운: 광혁 방향 지정 → 선택 → 기획문서 → 승인 → 분해 → 격파.
 
 - **순수 조회·요약·상태 확인·의견 질문**("브리핑 알려줘", "PR 뭐 있어", "상태 어때")에는 토큰을 내지 않는다.
 - merge/merge_all/close_completed/add_constraint 는 비가역·고영향 — CEO가 그 동작을 명시했을 때만. 정말 애매하면 토큰 없이 "구현을 시작할까요?"라고 한 번만 되묻는다(단, '개발/구현/진행' 동사가 있으면 되묻지 말고 바로 implement).
@@ -441,12 +441,10 @@ async function executeAction(
   try {
     switch (action.name) {
       case "run_council": {
-        await triggerWorkflow("idea-proposal.yml", { agent: "all" });
-        return "🗳️ *Agent Council 실행* — 잠시 후 제안 이슈들이 생성됩니다.";
+        return "🔒 *Agent Council은 잠겨 있습니다.* 자율 기획 루프는 FOMO Club SSOT 운영 방식과 맞지 않아 Slack에서 실행하지 않습니다. 필요한 작업은 `파이프라인 점검해`, `소스 후보 찾아줘`, `정합성 체크해`, 또는 특정 이슈 번호로 지시해 주세요.";
       }
       case "propose_projects": {
-        await triggerWorkflow("propose-project.yml", {});
-        return "🧭 *CEO 프로젝트 제안 생성 중* — 제품 정체성·OKR·현 상태를 분석해 프로젝트 후보를 제안합니다. 잠시 후 PROJECT_ROADMAP 갱신 + 검토 이슈(🧭 [CEO 프로젝트 제안])가 올라옵니다. 검토 후 \"P1 시작\"처럼 하나를 고르세요.";
+        return "🔒 *프로젝트 자율 제안은 잠겨 있습니다.* 에이전트가 새 방향을 제안하지 않도록 막았습니다. 광혁이 방향을 지정하면 `P1 시작`, `P1 기획 승인`, `#123 개발해`처럼 실행·검증 흐름만 처리합니다.";
       }
       case "select_project": {
         const id = typeof action.payload.id === "string" ? action.payload.id.trim().toUpperCase() : "";

--- a/apps/web/lib/slack/commands.ts
+++ b/apps/web/lib/slack/commands.ts
@@ -98,8 +98,9 @@ async function handleImplement(args: string): Promise<CommandResult> {
 }
 
 async function handleCouncil(): Promise<CommandResult> {
-  await triggerWorkflow("idea-proposal.yml", { agent: "all" });
-  return { text: "Daily Agent Council 워크플로우 트리거됨" };
+  return {
+    text: "🔒 Daily Agent Council은 잠겨 있습니다. 자율 기획 루프는 사용하지 않습니다. 대신 `/fomo pipeline`, `/fomo source`, `/fomo integrity` 또는 특정 이슈 개발 지시를 사용하세요.",
+  };
 }
 
 async function handleStatus(): Promise<CommandResult> {
@@ -192,7 +193,7 @@ async function handleHelp(): Promise<CommandResult> {
     text: [
       "*FOMO Club Agent 커맨드:*",
       "`/fomo implement {날짜}` — CEO Brief 자동 구현 트리거",
-      "`/fomo council` — Agent Council 수동 실행",
+      "`/fomo council` — 잠김: 자율기획 루프는 실행하지 않음",
       "`/fomo status` — 오픈 PR + CEO Brief + 실행 상태 요약",
       "`/fomo approve {이슈#}` — 이슈에 implement-approved 라벨 추가",
       "`/fomo merge {PR#}` — PR squash 머지",

--- a/apps/web/lib/slack/natural-router.ts
+++ b/apps/web/lib/slack/natural-router.ts
@@ -125,11 +125,7 @@ export function routeNaturalLanguage(input: string): NaturalRoute {
 
   // ── 톱다운 프로젝트 흐름 ─────────────────────────────────────
   if (/프로젝트.*(제안|뽑아|추천|정리)|뭐부터\s*할지.*(제안|정리)/i.test(text)) {
-    return route(
-      [{ name: "propose_projects", payload: {} }],
-      "🧭 프로젝트 후보 제안 요청으로 이해했어요. 자율 실행이 아니라 후보 리스트만 만들게요.",
-      "propose_projects",
-    );
+    return noRoute("autonomous-project-proposal-locked");
   }
 
   const pid = projectId(text);

--- a/docs/AGENT_ACTIONS_COST_AND_GUARDS.md
+++ b/docs/AGENT_ACTIONS_COST_AND_GUARDS.md
@@ -1,0 +1,20 @@
+# Agent Actions Cost and Guards
+
+FOMO Club의 GitHub Actions 에이전트 비용은 이 Codex 대화 토큰에서 나가지 않는다.
+
+## 비용/토큰 출처
+
+| 경로 | 주 사용 인증 | 비용/사용량이 잡히는 곳 |
+|---|---|---|
+| `auto-implement.yml`, `implement-task.yml` | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth/구독 또는 연결된 Anthropic 사용량 |
+| `idea-proposal.yml`, `propose-project.yml`, `project-kickoff.yml`, `project-decompose.yml`, `propose-northstar.yml`, `distill-constraints.yml` | GitHub `models: read`, `actions/ai-inference@v1` | GitHub Models/Actions 쪽 사용량 |
+| Slack 자유대화 | `GROQ_API_KEY` | Groq API 사용량 |
+| Codex 로컬 작업 | 현재 Codex 세션 | 이 대화의 Codex 토큰 |
+
+## 안전장치
+
+- 자율기획 계열 워크플로는 기본 실행되지 않는다.
+- `idea-proposal.yml`, `propose-project.yml`, `propose-northstar.yml`은 `approval_token=SSOT_EXECUTION_ONLY`가 없으면 job이 skip된다.
+- Slack에서는 `run_council`, `propose_projects` 액션을 실제 workflow dispatch로 연결하지 않는다.
+- 에이전트는 새 제품 방향을 제안하지 않고, 광혁이 지정한 방향 안에서 실행·검증·소스발굴·모니터링만 한다.
+- 실제 외부 소스 연동, prod DDL, 유료 서비스, 개인정보 처리 변경은 광혁 승인 후 별도 PR로만 진행한다.


### PR DESCRIPTION
## What changed
- Added explicit `approval_token=SSOT_EXECUTION_ONLY` gates to autonomous planning workflows:
  - `idea-proposal.yml`
  - `propose-project.yml`
  - `propose-northstar.yml`
- Updated Slack execution so `run_council` and `propose_projects` no longer dispatch autonomous planning workflows.
- Updated the Slack natural router so “프로젝트 제안해” is not treated as an executable action.
- Updated Slack prompt guidance to describe those actions as locked instead of available.
- Added `docs/AGENT_ACTIONS_COST_AND_GUARDS.md` documenting where GitHub Actions/Slack/Codex token usage is charged and what guards are active.

## Why
The user asked to prevent GitHub Actions autonomous planning from accidentally restarting, and asked where token usage is charged when GitHub Actions agents run. This makes the lock executable, not just a comment.

## Token/cost clarification
- `auto-implement.yml` / `implement-task.yml`: use `CLAUDE_CODE_OAUTH_TOKEN` via `anthropics/claude-code-action`, not this Codex session.
- `idea-proposal.yml` / `propose-project.yml` / `project-kickoff.yml` / `project-decompose.yml` / `propose-northstar.yml` / `distill-constraints.yml`: use GitHub Models (`actions/ai-inference@v1`, `models: read`).
- Slack free chat: uses `GROQ_API_KEY`.
- This Codex chat token is only for the current local/PR work.

## Validation
- `ruby -e "require 'yaml'; ..."` for guarded workflow parsing
- `npm test -- --run apps/web/__tests__/slack-natural-router.test.ts apps/web/__tests__/slack-actions.test.ts`
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`