### PR TITLE
[codex] Fix agent issue automation no-op success

### DIFF
--- a/.github/workflows/agent-ops.yml
+++ b/.github/workflows/agent-ops.yml
@@ -38,11 +38,12 @@ jobs:
           gh label create "ssot-sync" --repo "$REPO" --force --color "5319e7" --description "SSOT/document synchronization" >/dev/null 2>&1 || true
           gh label create "needs-ceo-review" --repo "$REPO" --force --color "d93f0b" --description "Requires Gwanghyuk review/approval" >/dev/null 2>&1 || true
           gh label create "data-quality" --repo "$REPO" --force --color "c2e0c6" --description "Data quality, confidence, fallback, grounding" >/dev/null 2>&1 || true
+          gh label create "task" --repo "$REPO" --force --color "bfd4f2" --description "Implementable task issue" >/dev/null 2>&1 || true
 
           case "$MODE" in
             source-discovery)
               TITLE="🔎 [source-discovery] 소스 후보 발굴 요청"
-              LABELS="source-discovery,needs-ceo-review"
+              LABELS="source-discovery,needs-ceo-review,task"
               BODY=$(cat <<'EOF'
           ## 목적
           새로운 투자 정보 소스 후보를 찾는다.
@@ -67,7 +68,7 @@ jobs:
               ;;
             integrity-checker)
               TITLE="🧪 [integrity-checker] 정합성 검수 요청"
-              LABELS="integrity-check,data-quality,needs-ceo-review"
+              LABELS="integrity-check,data-quality,needs-ceo-review,task"
               BODY=$(cat <<'EOF'
           ## 목적
           수집된 정보가 진짜 판단 재료인지 검증한다.
@@ -92,7 +93,7 @@ jobs:
               ;;
             pipeline-monitor)
               TITLE="🛠 [pipeline-monitor] 파이프라인 점검 요청"
-              LABELS="pipeline-monitor,data-quality"
+              LABELS="pipeline-monitor,data-quality,task"
               BODY=$(cat <<'EOF'
           ## 목적
           FOMO Club 데이터 파이프라인이 조용히 망가지는 것을 감시한다.

--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -16,6 +16,9 @@ on:
       brief_date:
         description: "CEO Brief 날짜 (YYYY-MM-DD, 기본: 오늘)"
         required: false
+      issue:
+        description: "직접 구현할 이슈 번호 (있으면 brief_date보다 우선)"
+        required: false
       model:
         description: "Claude 모델 (비우면 vars.CLAUDE_MODEL → 기본 claude-opus-4-8)"
         required: false
@@ -52,11 +55,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # ── 1. 오늘 CEO Brief 이슈 가져오기 ───────────────────────
-      - name: Fetch CEO Brief
+      # ── 1. 구현 대상 이슈 가져오기 ────────────────────────────
+      - name: Fetch target issue
         id: brief
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.inputs.issue }}
         run: |
           if [ -n "${{ github.event.inputs.brief_date }}" ]; then
             TODAY="${{ github.event.inputs.brief_date }}"
@@ -65,18 +69,31 @@ jobs:
           fi
           echo "today=$TODAY" >> "$GITHUB_OUTPUT"
 
-          BRIEF_JSON=$(gh issue list \
-            --label "ceo-brief" \
-            --state open \
-            --limit 5 \
-            --json number,title,body \
-            --repo "${{ github.repository }}" | \
-            jq "[.[] | select(.title | contains(\"$TODAY\"))] | .[0]")
+          if [ -n "$ISSUE" ]; then
+            BRIEF_JSON=$(gh issue view "$ISSUE" \
+              --json number,title,body,state \
+              --repo "${{ github.repository }}" 2>/dev/null || echo "")
+            if [ -z "$BRIEF_JSON" ] || [ "$(printf '%s' "$BRIEF_JSON" | jq -r '.state')" != "OPEN" ]; then
+              echo "found=false" >> "$GITHUB_OUTPUT"
+              echo "❌ 구현 대상 이슈 #$ISSUE 를 찾지 못했거나 이미 닫혔습니다."
+              exit 1
+            fi
+            echo "target_kind=issue" >> "$GITHUB_OUTPUT"
+          else
+            BRIEF_JSON=$(gh issue list \
+              --label "ceo-brief" \
+              --state open \
+              --limit 5 \
+              --json number,title,body \
+              --repo "${{ github.repository }}" | \
+              jq "[.[] | select(.title | contains(\"$TODAY\"))] | .[0]")
+            echo "target_kind=ceo-brief" >> "$GITHUB_OUTPUT"
+          fi
 
           if [ -z "$BRIEF_JSON" ] || [ "$BRIEF_JSON" = "null" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️ $TODAY 날짜의 CEO Brief 이슈를 찾지 못했습니다."
-            exit 0
+            echo "❌ $TODAY 날짜의 CEO Brief 이슈를 찾지 못했습니다. PR을 만들지 못했으므로 실패 처리합니다."
+            exit 1
           fi
 
           echo "found=true" >> "$GITHUB_OUTPUT"
@@ -210,14 +227,18 @@ jobs:
           BRIEF_NUMBER: ${{ steps.brief.outputs.number }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
-            echo "변경사항 없음 — PR 생성 건너뜀"
-            exit 0
+            echo "❌ 변경사항 없음 — PR을 만들지 못했으므로 실패 처리"
+            exit 1
           fi
 
           TITLE=$(head -1 /tmp/impl-title.txt 2>/dev/null | xargs)
           [ -z "$TITLE" ] && TITLE="CEO Brief 구현"
 
-          BRANCH="agent/ceo-brief-${TODAY}"
+          if [ "${{ steps.brief.outputs.target_kind }}" = "issue" ]; then
+            BRANCH="agent/issue-${BRIEF_NUMBER}"
+          else
+            BRANCH="agent/ceo-brief-${TODAY}"
+          fi
           git config user.name "fomo-agent[bot]"
           git config user.email "fomo-agent[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
@@ -275,7 +296,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TODAY: ${{ steps.brief.outputs.today }}
         run: |
-          BRANCH="agent/ceo-brief-${TODAY}"
+          if [ "${{ steps.brief.outputs.target_kind }}" = "issue" ]; then
+            BRANCH="agent/issue-${{ steps.brief.outputs.number }}"
+          else
+            BRANCH="agent/ceo-brief-${TODAY}"
+          fi
           PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' --repo "${{ github.repository }}" 2>/dev/null || echo "")
           if [ -n "$PR_NUM" ]; then
             gh issue comment "${{ steps.brief.outputs.number }}" \

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -65,9 +65,9 @@ jobs:
             --jq '.[0]')
 
           if [ -z "$PR" ] || [ "$PR" = "null" ]; then
-            echo "⚠️ 브랜치 $BRANCH 에 연결된 오픈 PR 없음. 건너뜁니다."
+            echo "❌ 브랜치 $BRANCH 에 연결된 오픈 PR 없음. 실제 머지 대상이 없으므로 실패 처리합니다."
             echo "pr_number=" >> "$GITHUB_OUTPUT"
-            exit 0
+            exit 1
           fi
 
           PR_NUMBER=$(echo "$PR" | jq -r '.number')
@@ -161,7 +161,7 @@ jobs:
             LABELS=$(gh issue view "$N" --repo "$REPO" --json labels \
               -q '[.labels[].name] | join(",")' 2>/dev/null || echo "")
             case ",$LABELS," in
-              *,agent-council,*)
+              *,agent-council,*|*,task,*|*,pipeline-monitor,*|*,source-discovery,*|*,integrity-check,*|*,ssot-sync,*)
                 STATE=$(gh issue view "$N" --repo "$REPO" --json state -q .state 2>/dev/null || echo "")
                 if [ "$STATE" = "OPEN" ]; then
                   echo "  close #$N (PR #$PR_NUMBER 로 해결)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
       needs.build-web.result == 'success' &&
       needs.build-fomo-web.result == 'success' &&
       needs.resolve-ref.outputs.ref != '' &&
-      startsWith(needs.resolve-ref.outputs.ref, 'agent/ceo-brief-')
+      (startsWith(needs.resolve-ref.outputs.ref, 'agent/ceo-brief-') ||
+       startsWith(needs.resolve-ref.outputs.ref, 'agent/task-') ||
+       startsWith(needs.resolve-ref.outputs.ref, 'agent/issue-'))
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/implement-task.yml
+++ b/.github/workflows/implement-task.yml
@@ -52,11 +52,17 @@ jobs:
           set -uo pipefail
           DATA=$(gh issue view "$NUM" --repo "${{ github.repository }}" --json number,title,body,labels,state 2>/dev/null || echo "")
           if [ -z "$DATA" ] || [ "$(printf '%s' "$DATA" | jq -r '.state')" != "OPEN" ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"; echo "이슈 #$NUM 없음/닫힘"; exit 0
+            echo "found=false" >> "$GITHUB_OUTPUT"; echo "이슈 #$NUM 없음/닫힘"; exit 1
           fi
-          IS_TASK=$(printf '%s' "$DATA" | jq -r '[.labels[].name] | index("task") != null')
-          if [ "$IS_TASK" != "true" ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"; echo "이슈 #$NUM 은 task 라벨이 아님 — 중단"; exit 0
+          IS_IMPLEMENTABLE=$(printf '%s' "$DATA" | jq -r '[.labels[].name] as $l | (
+            ($l | index("task") != null) or
+            ($l | index("pipeline-monitor") != null) or
+            ($l | index("source-discovery") != null) or
+            ($l | index("integrity-check") != null) or
+            ($l | index("ssot-sync") != null)
+          )')
+          if [ "$IS_IMPLEMENTABLE" != "true" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"; echo "이슈 #$NUM 은 구현 가능한 작업 라벨(task/agent ops)이 아님 — 중단"; exit 1
           fi
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "title=$(printf '%s' "$DATA" | jq -r '.title')" >> "$GITHUB_OUTPUT"
@@ -199,7 +205,7 @@ jobs:
           if [ -z "$(git status --porcelain)" ]; then
             echo "변경사항 없음 — PR 생략"
             gh issue comment "$NUM" --repo "${{ github.repository }}" --body "⚠️ 자동 구현이 코드 변경을 만들지 못했습니다(작업 트리 비어있음). 이슈 스펙을 더 구체화하거나 수동 확인이 필요합니다." || true
-            exit 0
+            exit 1
           fi
           TITLE=$(head -1 /tmp/impl-title.txt 2>/dev/null | xargs)
           [ -z "$TITLE" ] && TITLE="$ITITLE"

--- a/apps/web/__tests__/slack-natural-router.test.ts
+++ b/apps/web/__tests__/slack-natural-router.test.ts
@@ -41,6 +41,7 @@ describe("routeNaturalLanguage", () => {
 
   it("특정 이슈 개발과 일반 개발을 구분", () => {
     expect(routeNaturalLanguage("#457 개발해").actions[0]).toEqual({ name: "implement_task", payload: { issue: 457 } });
+    expect(routeNaturalLanguage("오늘자 이슈 작업 진행해줘").actions[0]).toEqual({ name: "implement", payload: { target: "latest_issue" } });
     expect(routeNaturalLanguage("다음 작업 개발 진행해").actions[0]).toEqual({ name: "implement", payload: {} });
   });
 

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -20,6 +20,7 @@ import {
   appendFeedbackLog,
   getRecentFeedbackLog,
   getTodayAutoPRs,
+  getLatestActionableIssue,
 } from "@/lib/slack/github";
 import { classifyIntent, truncate } from "@/lib/slack/intent";
 import { routeNaturalLanguage } from "@/lib/slack/natural-router";
@@ -480,6 +481,14 @@ async function executeAction(
         return "🧪 *integrity-checker 접수* — 정합성 검수 작업 이슈를 생성합니다. 투자조언·근거·강세/약세 균형을 우선 확인합니다.";
       }
       case "implement": {
+        if (action.payload.target === "latest_issue") {
+          const issue = await getLatestActionableIssue();
+          if (!issue) {
+            return "⚠️ 구현할 최신 작업 이슈를 찾지 못했습니다. `#이슈번호 개발해`처럼 번호를 지정해 주세요.";
+          }
+          await triggerWorkflow("implement-task.yml", { issue: String(issue.number) });
+          return `🚀 *#${issue.number} 구현 시작* — 최신 작업 이슈로 판단했습니다: ${issue.title}\n${issue.html_url}\nClaude Code가 구현 후 PR을 올립니다. CI 통과 시 자동 머지 게이트까지 이어집니다.`;
+        }
         const raw = action.payload.date;
         // 유효한 YYYY-MM-DD 만 사용, 아니면(placeholder 포함) 오늘 KST
         const date = typeof raw === "string" && /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : kstDate();

--- a/apps/web/lib/slack/commands.ts
+++ b/apps/web/lib/slack/commands.ts
@@ -6,6 +6,7 @@ import {
   mergePR,
   getWorkflowRuns,
   getFileContent,
+  getLatestActionableIssue,
 } from "./github";
 
 interface CommandResult {
@@ -84,11 +85,22 @@ export async function dispatchCommand(
 
 async function handleImplement(args: string): Promise<CommandResult> {
   if (!args) {
-    return { text: "사용법: `/fomo implement {YYYY-MM-DD}`\n예: `/fomo implement 2026-05-25`" };
+    const issue = await getLatestActionableIssue();
+    if (!issue) {
+      return { text: "사용법: `/fomo implement {YYYY-MM-DD}` 또는 `/fomo implement #{이슈번호}`\n예: `/fomo implement 2026-05-25`, `/fomo implement #607`" };
+    }
+    await triggerWorkflow("implement-task.yml", { issue: String(issue.number) });
+    return { text: `최신 작업 이슈 #${issue.number} 구현 워크플로우 트리거됨: ${issue.title}` };
+  }
+
+  const issueMatch = args.match(/^#?(\d+)$/);
+  if (issueMatch?.[1]) {
+    await triggerWorkflow("implement-task.yml", { issue: issueMatch[1] });
+    return { text: `이슈 #${issueMatch[1]} 구현 워크플로우 트리거됨` };
   }
 
   if (!/^\d{4}-\d{2}-\d{2}$/.test(args)) {
-    return { text: "날짜 형식이 올바르지 않습니다. `YYYY-MM-DD` 형식으로 입력하세요.\n예: `/fomo implement 2026-05-25`" };
+    return { text: "입력 형식이 올바르지 않습니다. `YYYY-MM-DD` 또는 `#이슈번호` 형식으로 입력하세요.\n예: `/fomo implement 2026-05-25`, `/fomo implement #607`" };
   }
 
   const inputs: Record<string, string> = { brief_date: args };

--- a/apps/web/lib/slack/github.ts
+++ b/apps/web/lib/slack/github.ts
@@ -380,3 +380,44 @@ export async function getRecentIssues(label: string, since: string, limit = 20) 
     )
   );
 }
+
+const ACTIONABLE_AGENT_LABELS = [
+  "task",
+  "pipeline-monitor",
+  "integrity-check",
+  "source-discovery",
+  "ssot-sync",
+];
+
+export async function getLatestActionableIssue(): Promise<{
+  number: number;
+  title: string;
+  html_url: string;
+  labels: string[];
+} | null> {
+  const issues = (await githubApi(
+    `/repos/${REPO}/issues?state=open&per_page=50&sort=created&direction=desc`
+  )) as Array<{
+    number: number;
+    title: string;
+    html_url?: string;
+    pull_request?: unknown;
+    labels?: ({ name: string } | string)[];
+  }>;
+
+  for (const issue of issues) {
+    if (issue.pull_request) continue;
+    const labels = (issue.labels ?? []).map((label) =>
+      typeof label === "string" ? label : label.name
+    );
+    if (labels.some((label) => ACTIONABLE_AGENT_LABELS.includes(label))) {
+      return {
+        number: issue.number,
+        title: issue.title,
+        html_url: issue.html_url ?? "",
+        labels,
+      };
+    }
+  }
+  return null;
+}

--- a/apps/web/lib/slack/natural-router.ts
+++ b/apps/web/lib/slack/natural-router.ts
@@ -155,6 +155,13 @@ export function routeNaturalLanguage(input: string): NaturalRoute {
         "implement_task",
       );
     }
+    if (/(오늘자|오늘|최근|방금|새로\s*뜬|방금\s*뜬).*(이슈|issue)|(이슈|issue).*(작업|처리|진행)/i.test(text)) {
+      return route(
+        [{ name: "implement", payload: { target: "latest_issue" } }],
+        "🚀 최신 작업 이슈 구현 요청으로 이해했어요. 최근 열린 작업 이슈를 찾아 구현 워크플로를 실행할게요.",
+        "implement",
+      );
+    }
     return route(
       [{ name: "implement", payload: {} }],
       "🚀 개발 실행 요청으로 이해했어요. 오늘 기준 auto-implement를 실행할게요.",


### PR DESCRIPTION
## Summary
- fail auto-implement/auto-merge when no target issue, no PR, or no changes are produced instead of reporting success
- route Slack requests like "오늘자 이슈 작업 진행" to the latest actionable issue
- mark agent-ops issues as task-capable and let implement-task/CI/auto-merge handle task and agent issue branches

## Verification
- ruby YAML parse for .github/workflows/*.yml
- npm run test -- apps/web/__tests__/slack-natural-router.test.ts apps/web/__tests__/slack-actions.test.ts
- npm run typecheck:web
- npm run build:web