### PR TITLE
[codex] Limit Prisma connections in product pipelines

### DIFF
--- a/.github/workflows/fomo-index-pipeline.yml
+++ b/.github/workflows/fomo-index-pipeline.yml
@@ -33,6 +33,7 @@ jobs:
         id: compute
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PRISMA_CONNECTION_LIMIT: "1"
           AI_API_URL: ${{ secrets.AI_API_URL }}
           AI_API_KEY: ${{ secrets.AI_API_KEY }}
           AI_MODEL: ${{ secrets.AI_MODEL }}

--- a/.github/workflows/keyword-cards-pipeline.yml
+++ b/.github/workflows/keyword-cards-pipeline.yml
@@ -37,6 +37,7 @@ jobs:
         id: generate
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PRISMA_CONNECTION_LIMIT: "1"
           AI_API_URL: ${{ secrets.AI_API_URL }}
           AI_API_KEY: ${{ secrets.AI_API_KEY }}
           AI_MODEL: ${{ secrets.AI_MODEL }}

--- a/.github/workflows/supply-demand-pipeline.yml
+++ b/.github/workflows/supply-demand-pipeline.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Collect supply-demand
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PRISMA_CONNECTION_LIMIT: "1"
           # KIS 앱키가 secrets 에 있으면 개인까지 수집(없으면 네이버 폴백).
           KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
           KIS_APP_SECRET: ${{ secrets.KIS_APP_SECRET }}

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -1,5 +1,23 @@
 import { PrismaClient } from "@prisma/client";
 
+function applyConnectionLimit(): void {
+  const limit = process.env.PRISMA_CONNECTION_LIMIT;
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!limit || !databaseUrl) return;
+
+  try {
+    const url = new URL(databaseUrl);
+    if (!url.searchParams.has("connection_limit")) {
+      url.searchParams.set("connection_limit", limit);
+      process.env.DATABASE_URL = url.toString();
+    }
+  } catch (err) {
+    console.warn("[prisma] PRISMA_CONNECTION_LIMIT ignored", err instanceof Error ? err.message : String(err));
+  }
+}
+
+applyConnectionLimit();
+
 // 공유 Prisma 클라이언트(단일 인스턴스). dev HMR에서 커넥션 폭증 방지용 globalThis 캐시.
 declare global {
   // eslint-disable-next-line no-var


### PR DESCRIPTION
## Summary
- support PRISMA_CONNECTION_LIMIT in the shared Prisma client by appending connection_limit to DATABASE_URL
- set PRISMA_CONNECTION_LIMIT=1 for FOMO Index, Keyword Cards, and Supply Demand product data pipelines
- addresses Daily Product Monitor finding #611: EMAXCONNSESSION on scheduled product pipelines

## Verification
- ruby YAML parse for .github/workflows/*.yml
- npm run typecheck:web
- npm run build:web

Closes #611