### PR TITLE
[codex] Harden daily product monitor automation

### DIFF
--- a/.github/workflows/daily-product-monitor.yml
+++ b/.github/workflows/daily-product-monitor.yml
@@ -13,6 +13,10 @@ on:
         description: "critical 발견 시 implement-task 자동 실행 여부"
         required: false
         default: "true"
+      lookback_hours:
+        description: "검사 기간(시간). 기본 24"
+        required: false
+        default: "24"
 
 permissions:
   actions: write
@@ -32,12 +36,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '24' }}
         run: |
           set -euo pipefail
 
           TODAY=$(TZ=Asia/Seoul date '+%Y-%m-%d')
-          SINCE=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
+          if ! [[ "${LOOKBACK_HOURS:-24}" =~ ^[0-9]+$ ]]; then LOOKBACK_HOURS=24; fi
+          if [ "$LOOKBACK_HOURS" -lt 1 ] || [ "$LOOKBACK_HOURS" -gt 168 ]; then LOOKBACK_HOURS=24; fi
+          SINCE=$(date -u -d "${LOOKBACK_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ')
           echo "today=$TODAY" >> "$GITHUB_OUTPUT"
+          echo "lookback_hours=$LOOKBACK_HOURS" >> "$GITHUB_OUTPUT"
 
           gh label create "daily-product-monitor" --repo "$REPO" --force --color "0052cc" --description "Daily bottom-up product health monitor" >/dev/null 2>&1 || true
           gh label create "pipeline-monitor" --repo "$REPO" --force --color "1d76db" --description "Agent pipeline monitoring request" >/dev/null 2>&1 || true
@@ -65,24 +73,65 @@ jobs:
             ]
           ' /tmp/runs.json > /tmp/critical-runs.json
 
-          CRITICAL_COUNT=$(jq 'length' /tmp/critical-runs.json)
+          jq --arg since "$SINCE" '
+            [
+              .[]
+              | select(.workflowName == "FOMO Index Pipeline" or .workflowName == "Keyword Cards Pipeline" or .workflowName == "Supply Demand Pipeline")
+              | select(.status == "completed")
+              | select(.conclusion == "success")
+            ]
+            | group_by(.workflowName)
+            | map(max_by(.createdAt))
+            | sort_by(.workflowName)
+          ' /tmp/runs.json > /tmp/latest-product-success.json
+
+          STALE_NOTES=()
+          for workflow in "FOMO Index Pipeline" "Keyword Cards Pipeline" "Supply Demand Pipeline"; do
+            LAST=$(jq -r --arg w "$workflow" '.[] | select(.workflowName == $w) | .createdAt' /tmp/latest-product-success.json | head -1)
+            if [ -z "$LAST" ]; then
+              STALE_NOTES+=("$workflow: 최근 성공 실행 없음")
+              continue
+            fi
+            if [[ "$LAST" < "$SINCE" ]]; then
+              STALE_NOTES+=("$workflow: 최근 성공 $LAST (기준 $SINCE 이전)")
+            fi
+          done
+          printf '%s\n' "${STALE_NOTES[@]}" | sed '/^$/d' > /tmp/stale-product.txt
+
+          CRITICAL_RUN_COUNT=$(jq 'length' /tmp/critical-runs.json)
+          STALE_COUNT=$(wc -l < /tmp/stale-product.txt | tr -d ' ')
+          CRITICAL_COUNT=$((CRITICAL_RUN_COUNT + STALE_COUNT))
           echo "critical_count=$CRITICAL_COUNT" >> "$GITHUB_OUTPUT"
+          echo "critical_run_count=$CRITICAL_RUN_COUNT" >> "$GITHUB_OUTPUT"
+          echo "stale_count=$STALE_COUNT" >> "$GITHUB_OUTPUT"
 
           {
             echo "# Daily Product Monitor — $TODAY"
             echo
-            echo "기간: 최근 24시간 ($SINCE 이후)"
+            echo "기간: 최근 ${LOOKBACK_HOURS}시간 ($SINCE 이후)"
             echo
             if [ "$CRITICAL_COUNT" = "0" ]; then
               echo "상태: 정상"
               echo
-              echo "크리티컬한 CI/제품 파이프라인 실패를 발견하지 못했습니다. 오늘은 개발 작업을 만들지 않습니다."
+              echo "크리티컬한 CI/제품 파이프라인 실패나 stale 신호를 발견하지 못했습니다. 오늘은 개발 작업을 만들지 않습니다."
+              echo
+              echo "## 최근 제품 파이프라인 성공"
+              jq -r '.[] | "- \(.workflowName): \(.createdAt) / \(.url)"' /tmp/latest-product-success.json
             else
               echo "상태: 위험"
               echo
-              echo "아래 critical run을 확인하고, 제품/운영 안정성을 회복하는 최소 수정 PR을 만드세요."
+              echo "아래 critical 신호를 확인하고, 제품/운영 안정성을 회복하는 최소 수정 PR을 만드세요."
               echo
-              jq -r '.[] | "- \(.workflowName): \(.displayTitle) / \(.conclusion) / \(.url)"' /tmp/critical-runs.json
+              if [ "$CRITICAL_RUN_COUNT" != "0" ]; then
+                echo "## 실패/타임아웃 run"
+                jq -r '.[] | "- \(.workflowName): \(.displayTitle) / \(.conclusion) / \(.url)"' /tmp/critical-runs.json
+                echo
+              fi
+              if [ "$STALE_COUNT" != "0" ]; then
+                echo "## stale 제품 파이프라인"
+                sed 's/^/- /' /tmp/stale-product.txt
+                echo
+              fi
               echo
               echo "## 작업 원칙"
               echo "- 새 제품 방향/기능 제안 금지"
@@ -91,6 +140,13 @@ jobs:
               echo "- 비용/외부 서비스/prod DDL 필요 시 구현하지 말고 이슈에 사유 기록"
             fi
           } > /tmp/monitor-body.md
+
+          if [ "$CRITICAL_COUNT" = "0" ]; then
+            SUMMARY="🟢 정상 — 실패 0건, stale 0건. 개발 스킵."
+          else
+            SUMMARY="🚨 위험 — 실패 ${CRITICAL_RUN_COUNT}건, stale ${STALE_COUNT}건."
+          fi
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
 
       - name: Create critical task issue
         id: issue
@@ -126,6 +182,7 @@ jobs:
           echo "created issue #$NUM"
 
       - name: Auto-fix critical issue
+        id: autofix
         if: |
           steps.issue.outputs.number != '' &&
           (github.event_name == 'schedule' || github.event.inputs.auto_fix != 'false')
@@ -135,25 +192,65 @@ jobs:
           NUM: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          gh workflow run implement-task.yml --repo "$REPO" -f issue="$NUM"
+          gh workflow run implement-task.yml --repo "$REPO" \
+            -f issue="$NUM" \
+            -f max_turns="30" \
+            -f timeout_minutes="25" \
+            -f max_changed_files="12" \
+            -f max_added_lines="900" \
+            -f allowed_paths=".github,apps/web,scripts,packages/fomo-core,packages/shared"
           gh issue comment "$NUM" --repo "$REPO" \
-            --body "🤖 Daily Product Monitor가 critical 상태를 감지해 implement-task 자동 수정을 시작했습니다."
+            --body "🤖 Daily Product Monitor가 critical 상태를 감지해 implement-task 자동 수정을 시작했습니다.\\n\\n자동 수정 가드: max_turns=30, timeout=25m, changed_files<=12, added_lines<=900, allowed_paths=.github/apps/web/scripts/packages."
+          echo "started=true" >> "$GITHUB_OUTPUT"
+
+      - name: Record auto-fix dispatch result
+        if: always() && steps.issue.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.issue.outputs.number }}
+          AUTO_FIX_STARTED: ${{ steps.autofix.outputs.started }}
+          AUTO_FIX_OUTCOME: ${{ steps.autofix.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ "${AUTO_FIX_STARTED:-false}" = "true" ]; then
+            BODY="✅ auto-fix dispatch 성공. implement-task 실행 상태는 \`/fomo status\` 또는 Actions에서 확인하세요.\\n\\nMonitor run: ${RUN_URL}"
+          elif [ "${AUTO_FIX_OUTCOME:-skipped}" = "skipped" ]; then
+            BODY="ℹ️ auto-fix는 이번 실행에서 스킵됐습니다(auto_fix=false 또는 조건 불일치).\\n\\nMonitor run: ${RUN_URL}"
+          else
+            BODY="⚠️ auto-fix dispatch 실패. 자동 개발은 시작되지 않았습니다. Actions 로그를 보고 수동으로 이어받아 주세요.\\n\\nMonitor run: ${RUN_URL}"
+          fi
+          gh issue comment "$NUM" --repo "$REPO" --body "$BODY" || true
 
       - name: Report to Slack
         if: always() && vars.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
           CRITICAL_COUNT: ${{ steps.inspect.outputs.critical_count }}
+          CRITICAL_RUN_COUNT: ${{ steps.inspect.outputs.critical_run_count }}
+          STALE_COUNT: ${{ steps.inspect.outputs.stale_count }}
+          SUMMARY: ${{ steps.inspect.outputs.summary }}
           TODAY: ${{ steps.inspect.outputs.today }}
+          LOOKBACK_HOURS: ${{ steps.inspect.outputs.lookback_hours }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          AUTO_FIX_STARTED: ${{ steps.autofix.outputs.started }}
+          AUTO_FIX_OUTCOME: ${{ steps.autofix.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           URL=$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')
           if [ "${CRITICAL_COUNT:-0}" = "0" ]; then
-            TEXT="🟢 *Daily Product Monitor* — ${TODAY}\n크리티컬한 제품/운영 깨짐 없음. 오늘은 개발 스킵.\n${RUN_URL}"
+            TEXT="🟢 *Daily Product Monitor* — ${TODAY}\n${SUMMARY}\n범위: 최근 ${LOOKBACK_HOURS}시간\n다음 액션: 없음 — 오늘은 개발 스킵.\n${RUN_URL}"
           else
-            TEXT="🚨 *Daily Product Monitor* — ${TODAY}\ncritical ${CRITICAL_COUNT}건 감지. 이슈 #${ISSUE_NUMBER} 생성/재사용 후 자동 수정 시도.\n${RUN_URL}"
+            if [ "${AUTO_FIX_STARTED:-false}" = "true" ]; then
+              NEXT="이슈 #${ISSUE_NUMBER} 생성/재사용 → implement-task 자동 수정 시작"
+            elif [ "${AUTO_FIX_OUTCOME:-skipped}" = "skipped" ]; then
+              NEXT="이슈 #${ISSUE_NUMBER} 생성/재사용 → auto-fix 스킵"
+            else
+              NEXT="이슈 #${ISSUE_NUMBER} 생성/재사용 → auto-fix dispatch 실패, 수동 확인 필요"
+            fi
+            TEXT="🚨 *Daily Product Monitor* — ${TODAY}\n${SUMMARY}\n범위: 최근 ${LOOKBACK_HOURS}시간\n분해: 실패 ${CRITICAL_RUN_COUNT:-0}건 · stale ${STALE_COUNT:-0}건\n다음 액션: ${NEXT}\n${RUN_URL}"
           fi
           jq -n --arg text "$TEXT" '{text: $text}' > /tmp/slack.json
           curl -sS -X POST -H 'Content-type: application/json' --data @/tmp/slack.json "$URL" || true

--- a/.github/workflows/implement-task.yml
+++ b/.github/workflows/implement-task.yml
@@ -15,6 +15,26 @@ on:
       effort:
         description: "effort (비우면 vars.CLAUDE_EFFORT → medium)"
         required: false
+      max_turns:
+        description: "Claude Code 최대 턴 수 (기본 40, Daily Monitor는 30 권장)"
+        required: false
+        default: "40"
+      timeout_minutes:
+        description: "Claude Code 구현 단계 timeout 분 (기본 30)"
+        required: false
+        default: "30"
+      max_changed_files:
+        description: "자동 PR 허용 최대 변경 파일 수 (기본 18)"
+        required: false
+        default: "18"
+      max_added_lines:
+        description: "자동 PR 허용 최대 추가 라인 수 (기본 1200)"
+        required: false
+        default: "1200"
+      allowed_paths:
+        description: "쉼표 구분 허용 경로 prefix. 비우면 경로 제한 없음"
+        required: false
+        default: ""
 
 # 충돌 방지(2026-06): 모든 task 구현을 *직렬화*한다(공유 그룹). 동시에 여러 task 를 구현하면
 # 각자 main 에서 분기해 서로 모르는 설계를 만들어 충돌하므로, 한 번에 하나만 실행한다.
@@ -112,23 +132,53 @@ jobs:
         env:
           IN_MODEL: ${{ github.event.inputs.model }}
           IN_EFFORT: ${{ github.event.inputs.effort }}
+          IN_MAX_TURNS: ${{ github.event.inputs.max_turns }}
+          IN_TIMEOUT_MINUTES: ${{ github.event.inputs.timeout_minutes }}
+          IN_MAX_CHANGED_FILES: ${{ github.event.inputs.max_changed_files }}
+          IN_MAX_ADDED_LINES: ${{ github.event.inputs.max_added_lines }}
+          IN_ALLOWED_PATHS: ${{ github.event.inputs.allowed_paths }}
           VAR_MODEL: ${{ vars.CLAUDE_MODEL }}
           VAR_EFFORT: ${{ vars.CLAUDE_EFFORT }}
         run: |
+          set -euo pipefail
+          MAX_TURNS="${IN_MAX_TURNS:-40}"
+          TIMEOUT_MINUTES="${IN_TIMEOUT_MINUTES:-30}"
+          MAX_CHANGED_FILES="${IN_MAX_CHANGED_FILES:-18}"
+          MAX_ADDED_LINES="${IN_MAX_ADDED_LINES:-1200}"
+          [[ "$MAX_TURNS" =~ ^[0-9]+$ ]] || MAX_TURNS=40
+          [[ "$TIMEOUT_MINUTES" =~ ^[0-9]+$ ]] || TIMEOUT_MINUTES=30
+          [[ "$MAX_CHANGED_FILES" =~ ^[0-9]+$ ]] || MAX_CHANGED_FILES=18
+          [[ "$MAX_ADDED_LINES" =~ ^[0-9]+$ ]] || MAX_ADDED_LINES=1200
+          if [ "$MAX_TURNS" -lt 5 ] || [ "$MAX_TURNS" -gt 80 ]; then MAX_TURNS=40; fi
+          if [ "$TIMEOUT_MINUTES" -lt 5 ] || [ "$TIMEOUT_MINUTES" -gt 60 ]; then TIMEOUT_MINUTES=30; fi
+          if [ "$MAX_CHANGED_FILES" -lt 1 ] || [ "$MAX_CHANGED_FILES" -gt 80 ]; then MAX_CHANGED_FILES=18; fi
+          if [ "$MAX_ADDED_LINES" -lt 1 ] || [ "$MAX_ADDED_LINES" -gt 5000 ]; then MAX_ADDED_LINES=1200; fi
           echo "model=${IN_MODEL:-${VAR_MODEL:-claude-opus-4-8}}" >> "$GITHUB_OUTPUT"
           echo "effort=${IN_EFFORT:-${VAR_EFFORT:-medium}}" >> "$GITHUB_OUTPUT"
+          echo "max_turns=$MAX_TURNS" >> "$GITHUB_OUTPUT"
+          echo "timeout_minutes=$TIMEOUT_MINUTES" >> "$GITHUB_OUTPUT"
+          echo "max_changed_files=$MAX_CHANGED_FILES" >> "$GITHUB_OUTPUT"
+          echo "max_added_lines=$MAX_ADDED_LINES" >> "$GITHUB_OUTPUT"
+          echo "allowed_paths=${IN_ALLOWED_PATHS:-}" >> "$GITHUB_OUTPUT"
 
       - name: Implement with Claude Code
         id: implement
         if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0' && steps.gate.outputs.passed == 'true'
+        timeout-minutes: ${{ fromJSON(steps.model.outputs.timeout_minutes) }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--max-turns 80 --model ${{ steps.model.outputs.model }} --effort ${{ steps.model.outputs.effort }} --allowedTools "Read,Edit,Write,Glob,Grep,Bash"'
+          claude_args: '--max-turns ${{ steps.model.outputs.max_turns }} --model ${{ steps.model.outputs.model }} --effort ${{ steps.model.outputs.effort }} --allowedTools "Read,Edit,Write,Glob,Grep,Bash"'
           prompt: |
             당신은 FOMO Club(모노레포)의 시니어 풀스택 개발자입니다.
             아래 **하위 개발 이슈(task)** 의 "작업 내용 / 관련 파일 / 완료 체크리스트" 를 그대로 구현하세요.
             이슈에 적힌 범위만 — 임의로 더하거나 빼지 마세요.
+
+            ## 자동 구현 비용/범위 가드
+            - 이번 실행 한도: max_turns=${{ steps.model.outputs.max_turns }}, timeout=${{ steps.model.outputs.timeout_minutes }}분.
+            - 자동 PR 한도: changed_files<=${{ steps.model.outputs.max_changed_files }}, added_lines<=${{ steps.model.outputs.max_added_lines }}.
+            - allowed_paths가 비어있지 않으면 그 prefix 밖 파일은 변경하지 마세요: ${{ steps.model.outputs.allowed_paths }}
+            - 범위 초과가 필요하면 구현하지 말고 이슈 코멘트/요약에 "수동 확인 필요"라고 남길 근거를 정리하세요.
 
             ## 모노레포 구조 (FOMO Club)
             - apps/fomo-web — Next.js (무가입 웹). components/HomeView·FomoFace·EmotionCalendar 등
@@ -155,6 +205,88 @@ jobs:
             ## 구현할 이슈 #${{ github.event.inputs.issue }}: ${{ steps.task.outputs.title }}
             ${{ steps.task.outputs.body }}
 
+      - name: Scope and budget guard
+        id: scope_guard
+        if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0' && steps.gate.outputs.passed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUM: ${{ github.event.inputs.issue }}
+          ALLOWED_PATHS: ${{ steps.model.outputs.allowed_paths }}
+          MAX_CHANGED_FILES: ${{ steps.model.outputs.max_changed_files }}
+          MAX_ADDED_LINES: ${{ steps.model.outputs.max_added_lines }}
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed_files=0" >> "$GITHUB_OUTPUT"
+            echo "added_lines=0" >> "$GITHUB_OUTPUT"
+            echo "disallowed=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --numstat > /tmp/numstat.txt
+          CHANGED_FILES=$(git diff --name-only | wc -l | tr -d ' ')
+          ADDED_LINES=$(awk '{ if ($1 ~ /^[0-9]+$/) s += $1 } END { print s + 0 }' /tmp/numstat.txt)
+          echo "changed_files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
+          echo "added_lines=$ADDED_LINES" >> "$GITHUB_OUTPUT"
+
+          DISALLOWED=""
+          if [ -n "${ALLOWED_PATHS:-}" ]; then
+            while IFS= read -r file; do
+              [ -z "$file" ] && continue
+              OK=false
+              IFS=',' read -ra PREFIXES <<< "$ALLOWED_PATHS"
+              for prefix in "${PREFIXES[@]}"; do
+                prefix="$(echo "$prefix" | xargs)"
+                [ -z "$prefix" ] && continue
+                if [[ "$file" == "$prefix"* ]]; then OK=true; break; fi
+              done
+              if [ "$OK" != "true" ]; then
+                DISALLOWED="${DISALLOWED}${file}\n"
+              fi
+            done < <(git diff --name-only)
+          fi
+
+          {
+            echo "disallowed<<__EOF__"
+            printf '%b' "$DISALLOWED"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+          FAIL=false
+          REASONS=()
+          if [ "$CHANGED_FILES" -gt "$MAX_CHANGED_FILES" ]; then
+            FAIL=true
+            REASONS+=("changed_files ${CHANGED_FILES} > ${MAX_CHANGED_FILES}")
+          fi
+          if [ "$ADDED_LINES" -gt "$MAX_ADDED_LINES" ]; then
+            FAIL=true
+            REASONS+=("added_lines ${ADDED_LINES} > ${MAX_ADDED_LINES}")
+          fi
+          if [ -n "$DISALLOWED" ]; then
+            FAIL=true
+            REASONS+=("allowed_paths 밖 변경 포함")
+          fi
+
+          if [ "$FAIL" = "true" ]; then
+            {
+              echo "🛑 자동 구현 범위/비용 가드에 걸려 PR 생성을 중단했습니다."
+              echo
+              echo "- changed_files: ${CHANGED_FILES}/${MAX_CHANGED_FILES}"
+              echo "- added_lines: ${ADDED_LINES}/${MAX_ADDED_LINES}"
+              if [ -n "${ALLOWED_PATHS:-}" ]; then echo "- allowed_paths: ${ALLOWED_PATHS}"; fi
+              echo "- reason: ${REASONS[*]}"
+              if [ -n "$DISALLOWED" ]; then
+                echo
+                echo "허용 경로 밖 변경:"
+                printf '%b' "$DISALLOWED" | sed 's/^/- /'
+              fi
+              echo
+              echo "필요하면 이슈 범위를 좁히거나 수동 PR로 이어받아 주세요."
+            } > /tmp/scope-guard.md
+            gh issue comment "$NUM" --repo "${{ github.repository }}" --body-file /tmp/scope-guard.md || true
+            exit 1
+          fi
+
       # ── H1 자가수정: lint/typecheck 검증 → 실패 시 에러 물고 1회 재수정 ──
       - name: Verify build (lint + typecheck)
         id: verify
@@ -170,14 +302,16 @@ jobs:
 
       - name: Self-correct (Claude Code, 1 retry)
         if: steps.verify.outputs.ok == 'false'
+        timeout-minutes: 15
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --effort ${{ steps.model.outputs.effort }} --allowedTools "Read,Edit,Write,Glob,Grep,Bash"'
+          claude_args: '--max-turns 20 --model ${{ steps.model.outputs.model }} --effort ${{ steps.model.outputs.effort }} --allowedTools "Read,Edit,Write,Glob,Grep,Bash"'
           prompt: |
             직전 구현이 lint/typecheck 에서 실패했습니다. 아래 에러를 보고 **고치세요**.
             범위는 그대로(이슈 #${{ github.event.inputs.issue }}). `npm run lint`·`npm run typecheck` 가 통과할 때까지 수정.
             commit/push/PR 생성은 하지 마세요(다음 단계 처리).
+            추가 변경은 최소화하고, allowed_paths가 있으면 계속 지키세요: ${{ steps.model.outputs.allowed_paths }}
 
             ## 실패 로그
             ${{ steps.verify.outputs.log }}
@@ -200,6 +334,13 @@ jobs:
           ITITLE: ${{ steps.task.outputs.title }}
           VERIFY1: ${{ steps.verify.outputs.ok }}
           VERIFY2: ${{ steps.reverify.outputs.ok }}
+          CHANGED_FILES: ${{ steps.scope_guard.outputs.changed_files }}
+          ADDED_LINES: ${{ steps.scope_guard.outputs.added_lines }}
+          MAX_CHANGED_FILES: ${{ steps.model.outputs.max_changed_files }}
+          MAX_ADDED_LINES: ${{ steps.model.outputs.max_added_lines }}
+          MAX_TURNS: ${{ steps.model.outputs.max_turns }}
+          TIMEOUT_MINUTES: ${{ steps.model.outputs.timeout_minutes }}
+          ALLOWED_PATHS: ${{ steps.model.outputs.allowed_paths }}
         run: |
           set -uo pipefail
           if [ -z "$(git status --porcelain)" ]; then
@@ -234,6 +375,8 @@ jobs:
           - 에이전트: Claude Code (구독 인증)
           - 검증: ${VERIFY_NOTE}
           - 작업: ${TITLE}
+          - 자동 구현 가드: max_turns=${MAX_TURNS}, timeout=${TIMEOUT_MINUTES}m, changed_files=${CHANGED_FILES:-?}/${MAX_CHANGED_FILES}, added_lines=${ADDED_LINES:-?}/${MAX_ADDED_LINES}
+          - 허용 경로: ${ALLOWED_PATHS:-"(제한 없음)"}
 
           ${PRISMA_NOTE}
           PREOF

--- a/apps/web/__tests__/slack-actions.test.ts
+++ b/apps/web/__tests__/slack-actions.test.ts
@@ -158,4 +158,8 @@ describe("select_project 액션 (톱다운 프로젝트 선택)", () => {
     expect(KNOWN_ACTIONS.has("monitor")).toBe(true);
     expect(HIGH_IMPACT_ACTIONS.has("monitor")).toBe(true);
   });
+  it("monitor 보고 전용 페이로드 파싱", () => {
+    const r = parseActions('보고만 실행\n[[ACTION:monitor]] {"auto_fix":false}');
+    expect(r.actions).toEqual([{ name: "monitor", payload: { auto_fix: false } }]);
+  });
 });

--- a/apps/web/__tests__/slack-natural-router.test.ts
+++ b/apps/web/__tests__/slack-natural-router.test.ts
@@ -25,7 +25,8 @@ describe("routeNaturalLanguage", () => {
   });
 
   it("데일리 제품 모니터링 요청을 monitor로 라우팅", () => {
-    expect(routeNaturalLanguage("데일리 제품 모니터링 돌려줘").actions[0]).toEqual({ name: "monitor", payload: {} });
+    expect(routeNaturalLanguage("데일리 제품 모니터링 돌려줘").actions[0]).toEqual({ name: "monitor", payload: { auto_fix: true } });
+    expect(routeNaturalLanguage("제품 모니터링 보고만 해줘").actions[0]).toEqual({ name: "monitor", payload: { auto_fix: false } });
   });
 
   it("조회/상태 질문은 실행하지 않음", () => {

--- a/apps/web/app/api/slack/events/route.ts
+++ b/apps/web/app/api/slack/events/route.ts
@@ -325,7 +325,8 @@ ${taskRunList || "(없음)"}
   \`[[ACTION:select_project]] {"id":"P1"}\` — 후보 중 활성 프로젝트 선택 ("P1 시작", "P2 프로젝트 하자"). 선택 시 **기획문서(PRD)** 를 먼저 작성(아직 분해 안 함).
   \`[[ACTION:approve_plan]] {"id":"P2"}\` — 기획문서 검토 후 승인 ("P2 기획 승인", "이 기획으로 개발 진행"). 승인 시 직군(기획/백엔드/프론트·UX/품질)별 하위 이슈로 분해.
   \`[[ACTION:implement_task]] {"issue":457}\` — 특정 프로젝트 하위 task 이슈를 실제 구현 → PR ("#457 개발해", "457 구현해", "이 이슈 개발"). 번호가 명시된 task 개발 지시.
-  \`[[ACTION:monitor]]\` — Daily Product Monitor 실행. critical 없으면 보고만 하고 스킵, 있으면 task 이슈 생성 후 자동 수정 시도.
+  \`[[ACTION:monitor]]\` — Daily Product Monitor 실행. critical 없으면 보고만 하고 스킵, 있으면 task 이슈 생성 후 제한된 자동 수정 시도.
+  \`[[ACTION:monitor]] {"auto_fix":false}\` — Daily Product Monitor 보고 전용 실행. critical이 있어도 자동 수정은 하지 않음.
   \`[[ACTION:implement]] {"target":"latest_issue"}\` — 최신 작업 이슈 구현. CEO Brief/date 기반 auto-implement는 기본 경로에서 제외.
   \`[[ACTION:merge]] {"pr":291}\` — 특정 PR squash 머지 ("이 PR 머지해", 번호 명시)
   \`[[ACTION:merge_all]]\` — 열린 PR 중 **이상 없는 것 전부** 머지 ("PR 전부 머지", "남은 PR 머지", "이상없으면 다 머지"). 번호 불필요 — 초안·CI미통과·충돌은 자동 제외.
@@ -341,6 +342,7 @@ ${taskRunList || "(없음)"}
 **개발/구현 실행 트리거 (자주 쓰임 — 반드시 정확히 인식)**:
 - 다음과 같은 발화는 **제품 모니터링 실행 지시**다 → \`[[ACTION:monitor]]\` 토큰을 출력한다:
   "데일리 모니터링 돌려", "제품 상태 체크해", "오늘 제품 모니터링", "크리티컬 있나 봐줘".
+- "보고만", "수정 없이", "개발 없이", "no-fix"가 붙으면 → \`[[ACTION:monitor]] {"auto_fix":false}\` 토큰을 출력한다.
 - 다음과 같은 발화는 **최신 작업 이슈 구현 지시**다 → \`[[ACTION:implement]] {"target":"latest_issue"}\` 토큰을 출력한다:
   "개발해", "구현해", "작업 진행해" 처럼 번호는 없지만 이미 열린 작업 이슈를 진행하라는 말.
 - CEO Brief/date 기반 구현은 사용하지 않는다.
@@ -468,8 +470,11 @@ async function executeAction(
         return "🧪 *integrity-checker 접수* — 정합성 검수 작업 이슈를 생성합니다. 투자조언·근거·강세/약세 균형을 우선 확인합니다.";
       }
       case "monitor": {
-        await triggerWorkflow("daily-product-monitor.yml", { auto_fix: "true" });
-        return "🩺 *Daily Product Monitor 실행* — critical 없으면 보고만 하고 스킵, 있으면 작업 이슈를 만들고 자동 수정 시도합니다.";
+        const autoFix = action.payload.auto_fix === false ? "false" : "true";
+        await triggerWorkflow("daily-product-monitor.yml", { auto_fix: autoFix });
+        return autoFix === "false"
+          ? "🩺 *Daily Product Monitor 보고 전용 실행* — critical이 있어도 이슈만 만들고 자동 수정은 하지 않습니다."
+          : "🩺 *Daily Product Monitor 실행* — critical 없으면 보고만 하고 스킵, 있으면 작업 이슈를 만들고 제한된 자동 수정까지 시도합니다.";
       }
       case "implement": {
         if (action.payload.target === "latest_issue") {

--- a/apps/web/lib/slack/commands.ts
+++ b/apps/web/lib/slack/commands.ts
@@ -121,26 +121,56 @@ async function handleStatus(): Promise<CommandResult> {
     getWorkflowRuns("implement-task.yml", 3),
   ]);
 
-  const prList = (prs as { number: number; title: string }[])
-    .map((pr) => `  #${pr.number}: ${pr.title}`)
+  const prList = (prs as { number: number; title: string; html_url?: string }[])
+    .map((pr) => `  #${pr.number}: ${pr.title}${pr.html_url ? ` — ${pr.html_url}` : ""}`)
     .join("\n") || "  (없음)";
 
+  const formatRun = (r: {
+    conclusion: string | null;
+    status?: string;
+    created_at: string;
+    html_url?: string;
+    event?: string;
+  }) => {
+    const state = r.status && r.status !== "completed" ? r.status : r.conclusion || "running";
+    const icon =
+      state === "success" ? "🟢" :
+      state === "failure" ? "🔴" :
+      state === "timed_out" ? "⏱️" :
+      state === "cancelled" ? "⚪" :
+      "🟡";
+    return `  ${icon} ${state} — ${r.created_at}${r.event ? ` (${r.event})` : ""}${r.html_url ? ` — ${r.html_url}` : ""}`;
+  };
+
   const monitorList = (
-    (monitorRuns as { workflow_runs: { conclusion: string; created_at: string }[] })
+    (monitorRuns as { workflow_runs: { conclusion: string | null; status?: string; created_at: string; html_url?: string; event?: string }[] })
       .workflow_runs || []
   )
-    .map((r) => `  ${r.conclusion || "running"} — ${r.created_at}`)
+    .map(formatRun)
     .join("\n") || "  (없음)";
 
   const taskList = (
-    (taskRuns as { workflow_runs: { conclusion: string; created_at: string }[] })
+    (taskRuns as { workflow_runs: { conclusion: string | null; status?: string; created_at: string; html_url?: string; event?: string }[] })
       .workflow_runs || []
   )
-    .map((r) => `  ${r.conclusion || "running"} — ${r.created_at}`)
+    .map(formatRun)
     .join("\n") || "  (없음)";
 
   return {
-    text: `*현재 상태*\n\n*오픈 PR:*\n${prList}\n\n*Daily Product Monitor 최근 실행:*\n${monitorList}\n\n*Implement Task 최근 실행:*\n${taskList}`,
+    text: [
+      "*현재 상태*",
+      "",
+      "*오픈 PR:*",
+      prList,
+      "",
+      "*Daily Product Monitor 최근 실행:*",
+      monitorList,
+      "",
+      "*Implement Task 최근 실행:*",
+      taskList,
+      "",
+      "_해석: Monitor가 초록이면 그날은 개발 스킵일 수 있습니다. Implement Task가 빨강이면 자동 PR이 안 만들어졌다는 뜻이므로 이슈 코멘트/Actions 로그를 확인하세요._",
+    ].join("\n"),
   };
 }
 
@@ -170,10 +200,15 @@ async function handlePipeline(args: string): Promise<CommandResult> {
 }
 
 async function handleMonitor(args: string): Promise<CommandResult> {
+  const noFix = /(?:^|\s)(no-fix|nofix|report-only)(?:\s|$)|보고만|수정\s*없이/i.test(args);
   await triggerWorkflow("daily-product-monitor.yml", {
-    auto_fix: args.includes("no-fix") ? "false" : "true",
+    auto_fix: noFix ? "false" : "true",
   });
-  return { text: "🩺 Daily Product Monitor를 수동 실행했습니다. critical 없으면 보고만 하고 스킵, 있으면 이슈 생성 후 자동 수정 시도합니다." };
+  return {
+    text: noFix
+      ? "🩺 Daily Product Monitor를 보고 전용으로 수동 실행했습니다. critical이 있어도 이슈만 만들고 자동 수정은 하지 않습니다."
+      : "🩺 Daily Product Monitor를 수동 실행했습니다. critical 없으면 보고만 하고 스킵, 있으면 이슈 생성 후 제한된 자동 수정 시도까지 진행합니다.",
+  };
 }
 
 async function handleSourceDiscovery(args: string): Promise<CommandResult> {
@@ -214,6 +249,7 @@ async function handleHelp(): Promise<CommandResult> {
     text: [
       "*FOMO Club Agent 커맨드:*",
       "`/fomo monitor` — Daily Product Monitor 수동 실행",
+      "`/fomo monitor no-fix` — 보고 전용 실행(자동 수정 안 함)",
       "`/fomo implement #{이슈번호}` — 지정 작업 이슈 구현",
       "`/fomo council` — 잠김: 자율기획 루프는 실행하지 않음",
       "`/fomo status` — 오픈 PR + 모니터/구현 실행 상태 요약",

--- a/apps/web/lib/slack/natural-router.ts
+++ b/apps/web/lib/slack/natural-router.ts
@@ -124,9 +124,12 @@ export function routeNaturalLanguage(input: string): NaturalRoute {
   }
 
   if (/(데일리|daily|매일|제품).*(모니터|monitor|점검|체크)|모니터링.*(실행|돌려|시작)/i.test(text)) {
+    const autoFix = !/(no-fix|nofix|report-only|보고만|수정\s*없이|자동\s*수정\s*없이|개발\s*없이|스킵만)/i.test(text);
     return route(
-      [{ name: "monitor", payload: {} }],
-      "🩺 Daily Product Monitor 실행 요청으로 이해했어요. critical 없으면 보고만 하고 스킵할게요.",
+      [{ name: "monitor", payload: { auto_fix: autoFix } }],
+      autoFix
+        ? "🩺 Daily Product Monitor 실행 요청으로 이해했어요. critical 없으면 보고만 하고, 있으면 제한된 자동 수정까지 시도할게요."
+        : "🩺 Daily Product Monitor 보고 전용 실행으로 이해했어요. critical이 있어도 자동 수정은 하지 않을게요.",
       "monitor",
     );
   }


### PR DESCRIPTION
## Summary
- expand Daily Product Monitor from workflow failure checks to failure + stale product pipeline detection
- make auto-fix dispatch observable with issue comments and clearer Slack summaries
- add report-only monitor routing for Slack natural language and /fomo monitor no-fix
- add implement-task cost/scope guards: max turns, timeout, changed file count, added lines, allowed path prefixes

## Why
This moves the agent loop toward the desired bottom-up operating model: lightweight daily monitoring, development only when critical issues are found, and bounded automatic implementation when it does run.

## Validation
- YAML parse for all .github/workflows/*.yml
- npm run test -- apps/web/__tests__/slack-natural-router.test.ts apps/web/__tests__/slack-actions.test.ts
- npm run typecheck:web
- npm run build:web
- git diff --check

## Notes
- Product/UI track files were not staged or included. Existing local changes in apps/fomo-web/** and packages/fomo-core/** are left untouched.
- Daily monitor auto-fix now calls implement-task with tighter defaults: max_turns=30, timeout=25m, changed_files<=12, added_lines<=900, allowed_paths=.github/apps/web/scripts/packages.
