### PR TITLE
[codex] serve keyword snapshots before live compute

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -80,6 +80,8 @@ export interface KeywordsResponse {
   cards: KeywordCard[];
   confidence: KeywordConfidence;
   live: boolean;
+  stale?: boolean;
+  snapshotDate?: string | null;
 }
 let keywordsCache: KeywordsResponse | null = null;
 let keywordsInflight: Promise<KeywordsResponse> | null = null;

--- a/apps/web/__tests__/api/fomo/keywords.test.ts
+++ b/apps/web/__tests__/api/fomo/keywords.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: () => unknown) => fn,
+}));
+
+vi.mock("../../../lib/fomo", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/fomo")>();
+  return {
+    ...actual,
+    kstDate: () => "2026-06-23",
+    cacheVersion: () => "test",
+  };
+});
+
+vi.mock("../../../lib/keyword-snapshot", () => ({
+  readKeywordSnapshot: vi.fn(),
+  readLatestKeywordSnapshot: vi.fn(),
+}));
+
+vi.mock("../../../lib/keyword-pipeline", () => ({
+  computeKeywordCards: vi.fn(),
+}));
+
+import { MOCK_KEYWORD_CARDS } from "@fomo/core";
+import { GET } from "@/app/api/fomo/keywords/route";
+import { computeKeywordCards } from "../../../lib/keyword-pipeline";
+import {
+  readKeywordSnapshot,
+  readLatestKeywordSnapshot,
+} from "../../../lib/keyword-snapshot";
+
+const mockToday = vi.mocked(readKeywordSnapshot);
+const mockLatest = vi.mocked(readLatestKeywordSnapshot);
+const mockCompute = vi.mocked(computeKeywordCards);
+
+const cards = MOCK_KEYWORD_CARDS.slice(0, 2);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("/api/fomo/keywords Phase 3 snapshot-first policy", () => {
+  it("returns today's snapshot without live compute", async () => {
+    mockToday.mockResolvedValueOnce({ date: "2026-06-23", cards, confidence: "low" });
+
+    const res = await GET(new Request("https://example.com/api/fomo/keywords"));
+    const body = await res.json();
+
+    expect(body.live).toBe(false);
+    expect(body.stale).toBe(false);
+    expect(body.snapshotDate).toBe("2026-06-23");
+    expect(body.cards).toHaveLength(2);
+    expect(mockLatest).not.toHaveBeenCalled();
+    expect(mockCompute).not.toHaveBeenCalled();
+  });
+
+  it("returns latest snapshot as stale when today's snapshot is missing", async () => {
+    mockToday.mockResolvedValueOnce(null);
+    mockLatest.mockResolvedValueOnce({ date: "2026-06-22", cards, confidence: "medium" });
+
+    const res = await GET(new Request("https://example.com/api/fomo/keywords"));
+    const body = await res.json();
+
+    expect(body.date).toBe("2026-06-23");
+    expect(body.live).toBe(false);
+    expect(body.stale).toBe(true);
+    expect(body.snapshotDate).toBe("2026-06-22");
+    expect(body.confidence).toBe("medium");
+    expect(mockCompute).not.toHaveBeenCalled();
+  });
+
+  it("returns fallback cards without live compute when no snapshot exists", async () => {
+    mockToday.mockResolvedValueOnce(null);
+    mockLatest.mockResolvedValueOnce(null);
+
+    const res = await GET(new Request("https://example.com/api/fomo/keywords"));
+    const body = await res.json();
+
+    expect(body.live).toBe(false);
+    expect(body.stale).toBe(true);
+    expect(body.snapshotDate).toBeNull();
+    expect(body.confidence).toBe("fallback");
+    expect(body.cards.length).toBeGreaterThan(0);
+    expect(mockCompute).not.toHaveBeenCalled();
+  });
+
+  it("runs live compute only when live=1 is explicit", async () => {
+    mockCompute.mockResolvedValueOnce({ cards, confidence: "low" });
+
+    const res = await GET(new Request("https://example.com/api/fomo/keywords?live=1"));
+    const body = await res.json();
+
+    expect(body.live).toBe(true);
+    expect(body.stale).toBe(false);
+    expect(body.snapshotDate).toBeNull();
+    expect(body.cards).toHaveLength(2);
+    expect(mockToday).not.toHaveBeenCalled();
+    expect(mockLatest).not.toHaveBeenCalled();
+    expect(mockCompute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -3,15 +3,16 @@ import { unstable_cache } from "next/cache";
 import type { KeywordCard, KeywordConfidence } from "@fomo/core";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { computeKeywordCards } from "../../../../lib/keyword-pipeline";
-import { readKeywordSnapshot } from "../../../../lib/keyword-snapshot";
+import { readKeywordSnapshot, readLatestKeywordSnapshot } from "../../../../lib/keyword-snapshot";
 
 /**
  * 키워드 카드 API — "오늘 사람들 시선이 가장 쏠린 키워드" 실데이터 산출. KEYWORD_ENGINE_SPEC §4.6.
  *
- * 응답 경로(§4.6 — 절대 빈값 없음):
- *   1) 오늘 KeywordCardSnapshot 있으면 그대로 반환(live:false) — Phase 4 cron 이 미리 채운 것.
- *   2) 없으면(스냅샷 전/테이블 미생성) 라이브 산출(live:true). 산출·검증·코멘트는 computeKeywordCards 공유.
- *   3) 라이브도 실패하면 mock 명시적 폴백(confidence:"fallback").
+ * 응답 경로(Performance Spine Phase 3 — 유저 요청에서 무거운 엔진 금지):
+ *   1) 오늘 KeywordCardSnapshot 있으면 그대로 반환(live:false, stale:false)
+ *   2) 오늘 스냅샷이 없으면 가장 최근 스냅샷 반환(live:false, stale:true)
+ *   3) 최근 스냅샷도 없으면 mock 명시적 폴백(confidence:"fallback", live:false)
+ *   4) 라이브 산출은 /api/fomo/keywords?live=1 로 명시했을 때만 허용(개발/운영 확인용).
  *
  * 응답 정직성(§5): confidence 를 반드시 동봉. 30일 기준선이 아직 없어 라이브는 'low'(가짜 high 금지).
  *
@@ -31,6 +32,8 @@ interface KeywordsPayload {
   cards: readonly KeywordCard[];
   confidence: KeywordConfidence;
   live: boolean;
+  stale: boolean;
+  snapshotDate: string | null;
 }
 
 // ── 영속 캐시(Vercel Data Cache) + in-flight dedup ──────────────────────────
@@ -51,21 +54,63 @@ async function computeLive(date: string): Promise<KeywordsPayload> {
       { revalidate: 1800 }
     );
     const { cards, confidence } = await load();
-    return { date, cards, confidence, live: true };
+    return { date, cards, confidence, live: true, stale: false, snapshotDate: null };
   } catch (err) {
     console.warn("[fomo/keywords] live compute failed — mock fallback", err);
     const { MOCK_KEYWORD_CARDS } = await import("@fomo/core");
-    return { date, cards: MOCK_KEYWORD_CARDS, confidence: "fallback", live: false };
+    return {
+      date,
+      cards: MOCK_KEYWORD_CARDS,
+      confidence: "fallback",
+      live: false,
+      stale: true,
+      snapshotDate: null,
+    };
   }
 }
 
-/** 스냅샷-우선 → 라이브(Data Cache, dedup). */
-async function getPayload(date: string): Promise<KeywordsPayload> {
+/** 스냅샷-우선 → 최근 스냅샷 → lightweight fallback. 라이브는 일반 앱 요청에서 돌리지 않는다. */
+async function getSnapshotPayload(date: string): Promise<KeywordsPayload> {
   // 1) 오늘 스냅샷(테이블 없으면 null) — cron 이 채운 안정 데이터를 외부 호출 없이 즉시 반환.
   const snap = await readKeywordSnapshot(date);
-  if (snap) return { date, cards: snap.cards, confidence: snap.confidence, live: false };
+  if (snap) {
+    return {
+      date,
+      cards: snap.cards,
+      confidence: snap.confidence,
+      live: false,
+      stale: false,
+      snapshotDate: snap.date,
+    };
+  }
 
-  // 2) 라이브 산출 — Data Cache 가 영속 캐시, inflight 가 인스턴스 내 동시 dedup.
+  // 2) 오늘 스냅샷이 아직 없으면 최근 스냅샷을 즉시 반환한다. 사용자 요청에서 LLM/뉴스 수집을 돌리지 않기 위함.
+  const latest = await readLatestKeywordSnapshot(date);
+  if (latest) {
+    return {
+      date,
+      cards: latest.cards,
+      confidence: latest.confidence,
+      live: false,
+      stale: latest.date !== date,
+      snapshotDate: latest.date,
+    };
+  }
+
+  // 3) 최근 스냅샷도 없으면 lightweight fallback. 빈 배열/무한 로딩 금지, confidence 는 fallback.
+  const { MOCK_KEYWORD_CARDS } = await import("@fomo/core");
+  return {
+    date,
+    cards: MOCK_KEYWORD_CARDS,
+    confidence: "fallback",
+    live: false,
+    stale: true,
+    snapshotDate: null,
+  };
+}
+
+/** 명시적 live=1 확인용 경로 — Data Cache 가 영속 캐시, inflight 가 인스턴스 내 동시 dedup. */
+async function getLivePayload(date: string): Promise<KeywordsPayload> {
   if (inflight) return inflight;
   inflight = computeLive(date).finally(() => {
     inflight = null;
@@ -73,9 +118,10 @@ async function getPayload(date: string): Promise<KeywordsPayload> {
   return inflight;
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   const date = kstDate();
-  const payload = await getPayload(date);
+  const live = new URL(request.url).searchParams.get("live") === "1";
+  const payload = live ? await getLivePayload(date) : await getSnapshotPayload(date);
   return withCors(
     NextResponse.json(payload, {
       // 엣지 캐시 — 외부 소스 레이트리밋 보호(피드/배너와 동일 정책).

--- a/apps/web/lib/keyword-pipeline.ts
+++ b/apps/web/lib/keyword-pipeline.ts
@@ -14,7 +14,7 @@ import {
 } from "@fomo/core";
 import { fetchAllNews } from "./fomo-news-sources";
 import { addKeywordCardComments } from "./fomo-keyword-comment";
-import { readLatestSupplyDemand } from "./supply-demand-store";
+import { readLatestSupplyDemandByTickers } from "./supply-demand-store";
 
 /**
  * 키워드별 수급 보조 신호(0~1, 장마감 확정 방향). SUPPLY DEMAND SCORE HANDOFF §3.
@@ -25,20 +25,22 @@ async function buildSupplyByKeyword(
   extracted: readonly { keyword: string; articles: KeywordSourceItem[] }[]
 ): Promise<Record<string, number>> {
   const out: Record<string, number> = {};
-  await Promise.all(
-    extracted.map(async (kw) => {
-      const codes = extractStocks(kw.articles, { minMentions: 1 })
-        .map((s) => s.naverCode)
-        .filter((c): c is string => !!c);
-      if (codes.length === 0) return;
-      const flows = (await Promise.all(codes.map((c) => readLatestSupplyDemand(c)))).filter(
-        (f): f is NonNullable<typeof f> => f != null
-      );
-      if (flows.length === 0) return; // 데이터 없으면 생략(가짜 금지)
-      const net = flows.reduce((s, f) => s + f.foreignNet + f.institutionNet, 0);
-      out[kw.keyword] = net > 0 ? 0.65 : net < 0 ? 0.35 : 0.5;
-    })
+  const codesByKeyword = extracted.map((kw) => ({
+    keyword: kw.keyword,
+    codes: extractStocks(kw.articles, { minMentions: 1 })
+      .map((s) => s.naverCode)
+      .filter((c): c is string => !!c),
+  }));
+  const flowsByTicker = await readLatestSupplyDemandByTickers(
+    codesByKeyword.flatMap((kw) => kw.codes)
   );
+
+  for (const kw of codesByKeyword) {
+    const flows = kw.codes.map((code) => flowsByTicker[code]).filter((f) => f != null);
+    if (flows.length === 0) continue; // 데이터 없으면 생략(가짜 금지)
+    const net = flows.reduce((s, f) => s + f.foreignNet + f.institutionNet, 0);
+    out[kw.keyword] = net > 0 ? 0.65 : net < 0 ? 0.35 : 0.5;
+  }
   return out;
 }
 

--- a/apps/web/lib/keyword-snapshot.ts
+++ b/apps/web/lib/keyword-snapshot.ts
@@ -11,6 +11,7 @@ import { prisma } from "./prisma";
  */
 
 export interface KeywordSnapshot {
+  date: string;
   cards: readonly KeywordCard[];
   confidence: KeywordConfidence;
 }
@@ -21,6 +22,7 @@ export async function readKeywordSnapshot(date: string): Promise<KeywordSnapshot
     const row = await prisma.keywordCardSnapshot.findUnique({ where: { date } });
     if (!row) return null;
     return {
+      date: row.date,
       cards: row.cards as unknown as KeywordCard[],
       confidence: row.confidence as KeywordConfidence,
     };
@@ -31,10 +33,29 @@ export async function readKeywordSnapshot(date: string): Promise<KeywordSnapshot
   }
 }
 
+/** 가장 최근(KST date 이하) 스냅샷. 오늘 스냅샷이 없어도 유저 요청에서 라이브 산출로 빠지지 않게 한다. */
+export async function readLatestKeywordSnapshot(date: string): Promise<KeywordSnapshot | null> {
+  try {
+    const row = await prisma.keywordCardSnapshot.findFirst({
+      where: { date: { lte: date } },
+      orderBy: { date: "desc" },
+    });
+    if (!row) return null;
+    return {
+      date: row.date,
+      cards: row.cards as unknown as KeywordCard[],
+      confidence: row.confidence as KeywordConfidence,
+    };
+  } catch (err) {
+    console.warn("[keyword-snapshot] latest read skipped (table missing?)", (err as Error)?.message);
+    return null;
+  }
+}
+
 /** 스냅샷 upsert(날짜 unique). cron 전용. 실패 시 throw — 스크립트가 비정상 종료로 가시화. */
 export async function writeKeywordSnapshot(
   date: string,
-  snapshot: KeywordSnapshot
+  snapshot: Omit<KeywordSnapshot, "date">
 ): Promise<void> {
   await prisma.keywordCardSnapshot.upsert({
     where: { date },

--- a/apps/web/lib/supply-demand-store.ts
+++ b/apps/web/lib/supply-demand-store.ts
@@ -62,6 +62,36 @@ export async function readLatestSupplyDemand(ticker: string): Promise<InvestorFl
   }
 }
 
+/** 여러 종목의 최신 수급을 한 번에 조회. 키워드 파이프라인에서 DB 세션 폭주를 막기 위한 배치 경로. */
+export async function readLatestSupplyDemandByTickers(
+  tickers: readonly string[]
+): Promise<Record<string, InvestorFlow>> {
+  const unique = Array.from(new Set(tickers.filter(Boolean)));
+  if (unique.length === 0) return {};
+
+  try {
+    const rows = await prisma.supplyDemandDaily.findMany({
+      where: { ticker: { in: unique } },
+      orderBy: [{ ticker: "asc" }, { date: "desc" }],
+    });
+
+    const out: Record<string, InvestorFlow> = {};
+    for (const row of rows) {
+      if (out[row.ticker]) continue;
+      out[row.ticker] = {
+        date: row.date,
+        foreignNet: row.foreignNet,
+        institutionNet: row.institutionNet,
+        ...(row.individualNet != null ? { individualNet: row.individualNet } : {}),
+      };
+    }
+    return out;
+  } catch (err) {
+    console.warn("[supply-demand-store] batch read skipped (table missing?)", (err as Error)?.message);
+    return {};
+  }
+}
+
 /** 한 종목의 최근 N거래일 수급(최신순). 연속 순매수/순매도(streak) 계산용. 테이블 미생성이면 빈 배열. */
 export async function readSupplyDemandHistory(
   ticker: string,


### PR DESCRIPTION
## What

- Change `/api/fomo/keywords` to serve today's snapshot first, then the most recent snapshot, then a lightweight fallback.
- Keep live keyword computation available only through explicit `?live=1` for dev/ops verification.
- Add response metadata: `stale` and `snapshotDate`.
- Batch keyword-pipeline supply-demand reads into one query to avoid DB session spikes during snapshot generation.
- Add API regression tests proving normal app calls do not invoke live compute.

## Why

Phase 3 of the performance spine says user entry must not run the heavy keyword engine. The app should show cron snapshots immediately and let the operational pipeline do live generation.

Recent pipeline health also showed one scheduled failure from DB session exhaustion after cards were computed. The batch supply-demand read keeps the pipeline lighter without changing the scoring contract or adding new infra.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build:web`
- `npm run build:fomo-web`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/fomo npx prisma validate`

## Pipeline Health

- `DATABASE_URL` GitHub secret exists.
- Keyword Cards Pipeline latest successful run completed snapshot generation and Slack health reporting.
- Latest failed scheduled run computed 9 cards with `confidence=low`, then failed on DB session pool exhaustion during snapshot upsert. This PR reduces the upstream parallel DB reads and makes the user-facing API resilient by falling back to the most recent snapshot without live compute.
