### PR TITLE
[codex] cache fomo web api calls

### DIFF
--- a/apps/fomo-web/__tests__/apiCache.test.ts
+++ b/apps/fomo-web/__tests__/apiCache.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cachedGet, clearApiCache, readCached } from "../lib/apiCache";
+
+beforeEach(() => {
+  vi.useRealTimers();
+  clearApiCache();
+});
+
+describe("apiCache", () => {
+  it("dedupes concurrent requests with the same key", async () => {
+    const fetcher = vi.fn(async () => ({ ok: true }));
+
+    const [a, b] = await Promise.all([
+      cachedGet("same", fetcher, 1_000),
+      cachedGet("same", fetcher, 1_000),
+    ]);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(a).toEqual({ ok: true });
+    expect(b).toEqual({ ok: true });
+  });
+
+  it("serves cached values within ttl", async () => {
+    const fetcher = vi
+      .fn<() => Promise<{ value: number }>>()
+      .mockResolvedValueOnce({ value: 1 })
+      .mockResolvedValueOnce({ value: 2 });
+
+    const first = await cachedGet("ttl", fetcher, 1_000);
+    const second = await cachedGet("ttl", fetcher, 1_000);
+
+    expect(first.value).toBe(1);
+    expect(second.value).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(readCached<{ value: number }>("ttl")?.value).toBe(1);
+  });
+
+  it("refetches after ttl expires", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi
+      .fn<() => Promise<{ value: number }>>()
+      .mockResolvedValueOnce({ value: 1 })
+      .mockResolvedValueOnce({ value: 2 });
+
+    await expect(cachedGet("expire", fetcher, 1_000)).resolves.toEqual({ value: 1 });
+    vi.advanceTimersByTime(1_001);
+    await expect(cachedGet("expire", fetcher, 1_000)).resolves.toEqual({ value: 2 });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the previous value when refresh fails", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi
+      .fn<() => Promise<{ value: number }>>()
+      .mockResolvedValueOnce({ value: 1 })
+      .mockRejectedValueOnce(new Error("network"));
+
+    await expect(cachedGet("stale", fetcher, 1_000)).resolves.toEqual({ value: 1 });
+    vi.advanceTimersByTime(1_001);
+    await expect(cachedGet("stale", fetcher, 1_000)).resolves.toEqual({ value: 1 });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/fomo-web/lib/apiCache.ts
+++ b/apps/fomo-web/lib/apiCache.ts
@@ -1,0 +1,54 @@
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+const memoryCache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+export function readCached<T>(key: string): T | null {
+  const entry = memoryCache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= nowMs()) return null;
+  return entry.value as T;
+}
+
+export function setCached<T>(key: string, value: T, ttlMs: number): T {
+  memoryCache.set(key, { value, expiresAt: nowMs() + Math.max(0, ttlMs) });
+  return value;
+}
+
+export async function cachedGet<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttlMs: number
+): Promise<T> {
+  const cached = readCached<T>(key);
+  if (cached) return cached;
+
+  const pending = inflight.get(key);
+  if (pending) return pending as Promise<T>;
+
+  const previous = memoryCache.get(key)?.value as T | undefined;
+  const promise = fetcher()
+    .then((value) => setCached(key, value, ttlMs))
+    .catch((err) => {
+      if (previous !== undefined) return previous;
+      throw err;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+export function clearApiCache(): void {
+  memoryCache.clear();
+  inflight.clear();
+}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -10,12 +10,28 @@ import type {
   ScoredArticle,
 } from "@fomo/core";
 import { getSessionId } from "@/lib/session";
+import { cachedGet, readCached } from "./apiCache";
 
 export type { BannerItem } from "@fomo/core";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_FOMO_API_BASE?.replace(/\/$/, "") ||
   "https://fomo-club-backend.vercel.app";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const CACHE_TTL = {
+  keywords: 10 * MINUTE,
+  sectorStocks: HOUR,
+  stockFront: 10 * MINUTE,
+  stockBasics: 6 * HOUR,
+  themeInsight: 6 * HOUR,
+  stockInsight: 6 * HOUR,
+} as const;
+
+function kstDateKey(now = new Date()): string {
+  return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
+}
 
 export interface FomoIndexResponse {
   date: string;
@@ -83,44 +99,53 @@ export interface KeywordsResponse {
   stale?: boolean;
   snapshotDate?: string | null;
 }
-let keywordsCache: KeywordsResponse | null = null;
-let keywordsInflight: Promise<KeywordsResponse> | null = null;
+const keywordsKey = () => `keywords:${kstDateKey()}`;
 
-export const getCachedKeywords = () => keywordsCache;
+export const getCachedKeywords = () => readCached<KeywordsResponse>(keywordsKey());
 
 export const fetchKeywords = async () => {
-  const res = await get<KeywordsResponse>("/api/fomo/keywords");
-  keywordsCache = res;
-  return res;
+  return cachedGet(
+    keywordsKey(),
+    () => get<KeywordsResponse>("/api/fomo/keywords"),
+    CACHE_TTL.keywords
+  );
 };
 
-export const warmKeywords = () => {
-  if (!keywordsInflight) {
-    keywordsInflight = fetchKeywords().finally(() => {
-      keywordsInflight = null;
-    });
-  }
-  return keywordsInflight;
-};
+export const warmKeywords = () => fetchKeywords();
 
 /** 테마 이해·응축(데이터 엔진 Track A+B) — 뎁스 페이지가 카드 탭 시 lazy 로 부른다. */
 export type { CondensedInsight } from "@fomo/core";
 export const fetchThemeInsight = (theme: string) =>
-  get<import("@fomo/core").CondensedInsight>(
-    `/api/fomo/theme-insight?theme=${encodeURIComponent(theme)}`
+  cachedGet(
+    `theme-insight:${theme}`,
+    () =>
+      get<import("@fomo/core").CondensedInsight>(
+        `/api/fomo/theme-insight?theme=${encodeURIComponent(theme)}`
+      ),
+    CACHE_TTL.themeInsight
   );
 
 /** 개별 종목 이해·응축(작업3) — 종목 라벨 탭 시 lazy 로 부른다(테마 뎁스와 동일 구조). */
 export const fetchStockInsight = (stock: string) =>
-  get<import("@fomo/core").CondensedInsight>(
-    `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`
+  cachedGet(
+    `stock-insight:${stock}`,
+    () =>
+      get<import("@fomo/core").CondensedInsight>(
+        `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`
+      ),
+    CACHE_TTL.stockInsight
   );
 
 /** 종목 기본 정보(바닥 — 주가·개요·시총·지표·재무). 항상 깔린다(원문 무관). */
 export type { StockBasics } from "@fomo/core";
 export const fetchStockBasics = (stock: string) =>
-  get<import("@fomo/core").StockBasics>(
-    `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}`
+  cachedGet(
+    `stock-basics:${stock}`,
+    () =>
+      get<import("@fomo/core").StockBasics>(
+        `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}`
+      ),
+    CACHE_TTL.stockBasics
   );
 
 /** 카드 앞면 FOMO 신호(rev2 후속) — baseline·라이브 수급 streak·시총순위·3개월 스파크라인. 도달 종목 lazy. */
@@ -137,7 +162,11 @@ export interface StockFrontResponse {
   changeDir?: "up" | "down" | "flat";
 }
 export const fetchStockFront = (stock: string) =>
-  get<StockFrontResponse>(`/api/fomo/stock-front?stock=${encodeURIComponent(stock)}`);
+  cachedGet(
+    `stock-front:${stock}`,
+    () => get<StockFrontResponse>(`/api/fomo/stock-front?stock=${encodeURIComponent(stock)}`),
+    CACHE_TTL.stockFront
+  );
 
 /** 섹터 → 종목 풀(섹터구조 ②). 콜드스타트 노출 순. baseline=true 면 baseline 보장(국내) 종목만. */
 export type { StockSector, SectorStock } from "@fomo/core";
@@ -146,8 +175,13 @@ export interface SectorStocksResponse {
   stocks: import("@fomo/core").SectorStock[];
 }
 export const fetchSectorStocks = (sector: string, baselineOnly = false) =>
-  get<SectorStocksResponse>(
-    `/api/fomo/sector-stocks?sector=${encodeURIComponent(sector)}${baselineOnly ? "&baseline=1" : ""}`
+  cachedGet(
+    `sector-stocks:${sector}:${baselineOnly ? "baseline" : "all"}`,
+    () =>
+      get<SectorStocksResponse>(
+        `/api/fomo/sector-stocks?sector=${encodeURIComponent(sector)}${baselineOnly ? "&baseline=1" : ""}`
+      ),
+    CACHE_TTL.sectorStocks
   );
 
 export const fetchCalendar = (sessionId: string, month?: string) =>


### PR DESCRIPTION
## What

- Add a small client-side API cache for `apps/fomo-web`.
- Deduplicate concurrent requests by cache key.
- Apply TTLs from Phase 4:
  - keywords: 10 minutes, KST date key
  - sector stocks: 1 hour
  - stock front: 10 minutes
  - stock basics: 6 hours
  - theme/stock insight: 6 hours
- Keep existing fetch behavior as the network path and fall back to the previous cached value if a refresh fails.
- Add unit tests for dedupe, TTL cache hits, expiration, and stale fallback.

## Why

Phase 4 targets repeated client calls during tab switches and depth navigation. Backend caches already help, but the fomo web client was still issuing duplicate `no-store` requests inside one browser session. This keeps the UI responsive and lowers backend pressure without changing API contracts.

## Notes

The localStorage stale-first keywords path is intentionally left for a later pass. This PR keeps scope to in-memory session cache and inflight dedupe, matching the low-risk Phase 4 path.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build:web`
- `npm run build:fomo-web`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/fomo npx prisma validate`
