### PR TITLE
[codex] add stock front lite and stale keywords

### DIFF
--- a/apps/fomo-web/__tests__/apiCache.test.ts
+++ b/apps/fomo-web/__tests__/apiCache.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cachedGet, clearApiCache, readCached } from "../lib/apiCache";
+import { cachedGet, clearApiCache, readCached, refreshCached } from "../lib/apiCache";
 
 beforeEach(() => {
   vi.useRealTimers();
@@ -60,6 +60,24 @@ describe("apiCache", () => {
     vi.advanceTimersByTime(1_001);
     await expect(cachedGet("stale", fetcher, 1_000)).resolves.toEqual({ value: 1 });
 
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshCached ignores fresh cache but shares inflight refreshes", async () => {
+    const fetcher = vi
+      .fn<() => Promise<{ value: number }>>()
+      .mockResolvedValueOnce({ value: 1 })
+      .mockResolvedValueOnce({ value: 2 });
+
+    await cachedGet("refresh", fetcher, 10_000);
+    const [a, b] = await Promise.all([
+      refreshCached("refresh", fetcher, 10_000),
+      refreshCached("refresh", fetcher, 10_000),
+    ]);
+
+    expect(a.value).toBe(2);
+    expect(b.value).toBe(2);
+    expect(readCached<{ value: number }>("refresh")?.value).toBe(2);
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -11,7 +11,7 @@ import {
 } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { SectorStockDeck } from "@/components/SectorStockDeck";
-import { fetchKeywords, fetchThemeInsight, recordTaste } from "@/lib/fomoApi";
+import { KEYWORDS_UPDATED_EVENT, fetchKeywords, fetchThemeInsight, recordTaste, type KeywordsResponse } from "@/lib/fomoApi";
 import { keywordInterestScore, recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
@@ -210,6 +210,12 @@ function TodayFeed({ loggedIn, onRequireLogin }: FeedGate) {
 
   useEffect(() => {
     let alive = true;
+    const onKeywordsUpdated = (event: Event) => {
+      const res = (event as CustomEvent<KeywordsResponse>).detail;
+      if (!alive || !res?.cards?.length) return;
+      setState({ kind: "ready", cards: res.cards, confidence: res.confidence });
+    };
+    window.addEventListener(KEYWORDS_UPDATED_EVENT, onKeywordsUpdated);
     fetchKeywords()
       .then((res) => {
         if (!alive) return;
@@ -222,6 +228,7 @@ function TodayFeed({ loggedIn, onRequireLogin }: FeedGate) {
       });
     return () => {
       alive = false;
+      window.removeEventListener(KEYWORDS_UPDATED_EVENT, onKeywordsUpdated);
     };
   }, []);
 

--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -380,7 +380,7 @@ function SectorDeckInner({
       const key = stock.canonical;
       if (!stock.naverCode || front[key] || inflight.current.has(key)) return;
       inflight.current.add(key);
-      fetchStockFront(key)
+      fetchStockFront(key, { lite: true })
         .then((d) =>
           setFront((prev) => ({
             ...prev,

--- a/apps/fomo-web/lib/apiCache.ts
+++ b/apps/fomo-web/lib/apiCache.ts
@@ -48,6 +48,29 @@ export async function cachedGet<T>(
   return promise;
 }
 
+export async function refreshCached<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttlMs: number
+): Promise<T> {
+  const pending = inflight.get(key);
+  if (pending) return pending as Promise<T>;
+
+  const previous = memoryCache.get(key)?.value as T | undefined;
+  const promise = fetcher()
+    .then((value) => setCached(key, value, ttlMs))
+    .catch((err) => {
+      if (previous !== undefined) return previous;
+      throw err;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, promise);
+  return promise;
+}
+
 export function clearApiCache(): void {
   memoryCache.clear();
   inflight.clear();

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -10,7 +10,7 @@ import type {
   ScoredArticle,
 } from "@fomo/core";
 import { getSessionId } from "@/lib/session";
-import { cachedGet, readCached } from "./apiCache";
+import { cachedGet, readCached, refreshCached, setCached } from "./apiCache";
 
 export type { BannerItem } from "@fomo/core";
 
@@ -28,6 +28,7 @@ const CACHE_TTL = {
   themeInsight: 6 * HOUR,
   stockInsight: 6 * HOUR,
 } as const;
+export const KEYWORDS_UPDATED_EVENT = "fomo:keywords-updated";
 
 function kstDateKey(now = new Date()): string {
   return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
@@ -100,15 +101,60 @@ export interface KeywordsResponse {
   snapshotDate?: string | null;
 }
 const keywordsKey = () => `keywords:${kstDateKey()}`;
+const keywordsStorageKey = () => `fomo:keywords:${kstDateKey()}`;
 
 export const getCachedKeywords = () => readCached<KeywordsResponse>(keywordsKey());
 
+function readStoredKeywords(): KeywordsResponse | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(keywordsStorageKey());
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<KeywordsResponse>;
+    if (!parsed || !Array.isArray(parsed.cards) || typeof parsed.date !== "string") return null;
+    return parsed as KeywordsResponse;
+  } catch (err) {
+    console.warn("[fetchKeywords] localStorage read failed", err);
+    return null;
+  }
+}
+
+function writeStoredKeywords(value: KeywordsResponse): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(keywordsStorageKey(), JSON.stringify(value));
+  } catch (err) {
+    console.warn("[fetchKeywords] localStorage write failed", err);
+  }
+}
+
+function emitKeywordsUpdated(value: KeywordsResponse): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<KeywordsResponse>(KEYWORDS_UPDATED_EVENT, { detail: value }));
+}
+
+const fetchKeywordsNetwork = () => get<KeywordsResponse>("/api/fomo/keywords");
+
 export const fetchKeywords = async () => {
-  return cachedGet(
-    keywordsKey(),
-    () => get<KeywordsResponse>("/api/fomo/keywords"),
-    CACHE_TTL.keywords
-  );
+  const key = keywordsKey();
+  const cached = readCached<KeywordsResponse>(key);
+  if (cached) return cached;
+
+  const stored = readStoredKeywords();
+  if (stored) {
+    setCached(key, stored, CACHE_TTL.keywords);
+    void refreshCached(key, fetchKeywordsNetwork, CACHE_TTL.keywords)
+      .then((fresh) => {
+        writeStoredKeywords(fresh);
+        emitKeywordsUpdated(fresh);
+      })
+      .catch((err) => console.warn("[fetchKeywords] revalidate failed", err));
+    return stored;
+  }
+
+  const res = await cachedGet(key, fetchKeywordsNetwork, CACHE_TTL.keywords);
+  writeStoredKeywords(res);
+  return res;
 };
 
 export const warmKeywords = () => fetchKeywords();
@@ -161,10 +207,13 @@ export interface StockFrontResponse {
   changeText?: string;
   changeDir?: "up" | "down" | "flat";
 }
-export const fetchStockFront = (stock: string) =>
+export const fetchStockFront = (stock: string, opts: { lite?: boolean } = {}) =>
   cachedGet(
-    `stock-front:${stock}`,
-    () => get<StockFrontResponse>(`/api/fomo/stock-front?stock=${encodeURIComponent(stock)}`),
+    `stock-front:${opts.lite ? "lite" : "full"}:${stock}`,
+    () =>
+      get<StockFrontResponse>(
+        `/api/fomo/stock-front?stock=${encodeURIComponent(stock)}${opts.lite ? "&lite=1" : ""}`
+      ),
     CACHE_TTL.stockFront
   );
 

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -50,7 +50,7 @@ async function getThemeRelativeMap(sector: StockSector): Promise<Record<string, 
   return load();
 }
 
-async function getFront(stock: string): Promise<StockFrontData> {
+async function getFront(stock: string, lite = false): Promise<StockFrontData> {
   const today = kstDate();
   const load = unstable_cache(
     async () => {
@@ -58,30 +58,32 @@ async function getFront(stock: string): Promise<StockFrontData> {
       const canonical = def?.canonical ?? stock;
       const sector = def ? sectorOf(def.canonical) : undefined;
       const [rankMap, attentionMap, themeRelativeMap] = await Promise.all([
-        getRankMap().catch(() => ({})),
-        getAttentionMap().catch((): Record<string, StockAttentionSignal> => ({})),
-        sector
+        lite ? Promise.resolve({}) : getRankMap().catch(() => ({})),
+        lite ? Promise.resolve({} as Record<string, StockAttentionSignal>) : getAttentionMap().catch((): Record<string, StockAttentionSignal> => ({})),
+        !lite && sector
           ? getThemeRelativeMap(sector).catch((): Record<string, ThemeRelativeSignal> => ({}))
           : Promise.resolve({} as Record<string, ThemeRelativeSignal>),
       ]);
       return assembleStockFront(stock, rankMap, {
         ...(attentionMap[canonical] ? { attention: attentionMap[canonical] } : {}),
         ...(themeRelativeMap[canonical] ? { themeRelative: themeRelativeMap[canonical] } : {}),
-      });
+      }, { lite });
     },
-    ["fomo-stock-front", cacheVersion(), today, stock],
+    ["fomo-stock-front", lite ? "lite" : "full", cacheVersion(), today, stock],
     { revalidate: REVALIDATE_S }
   );
   return load();
 }
 
 export async function GET(req: Request) {
-  const stock = new URL(req.url).searchParams.get("stock")?.trim();
+  const url = new URL(req.url);
+  const stock = url.searchParams.get("stock")?.trim();
+  const lite = url.searchParams.get("lite") === "1";
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
   try {
-    const data = await getFront(stock);
+    const data = await getFront(stock, lite);
     return withCors(
       NextResponse.json(data, {
         headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400" },

--- a/apps/web/lib/stock-basics.ts
+++ b/apps/web/lib/stock-basics.ts
@@ -1,4 +1,4 @@
-import { assembleStockBasics, resolveStock, type StockBasics } from "@fomo/core";
+import { assembleStockBasics, parseNaverStockBasic, resolveStock, type StockBasics } from "@fomo/core";
 
 /**
  * 종목 기본 정보(바닥) 수집 — STOCK_SCREEN_REDESIGN §2.
@@ -13,11 +13,11 @@ import { assembleStockBasics, resolveStock, type StockBasics } from "@fomo/core"
 const UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
 
-async function getJson(url: string): Promise<unknown> {
+async function getJson(url: string, timeoutMs = 8000): Promise<unknown> {
   try {
     const res = await fetch(url, {
       headers: { "User-Agent": UA, Accept: "application/json" },
-      signal: AbortSignal.timeout(8000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) {
       console.warn("[stock-basics] non-OK", res.status, url);
@@ -28,6 +28,25 @@ async function getJson(url: string): Promise<unknown> {
     console.warn("[stock-basics] fetch failed", url, (err as Error)?.message);
     return null;
   }
+}
+
+/** 카드 앞면 lite용 — 주가·등락만 짧게 가져온다. 상세 지표/재무/개요는 depth API가 맡는다. */
+export async function fetchStockBasicsLite(stock: string, timeoutMs = 3500): Promise<StockBasics> {
+  const def = resolveStock(stock);
+  const code = def?.naverCode;
+  if (!code) return { name: def?.canonical ?? stock, metrics: [] };
+
+  const base = `https://m.stock.naver.com/api/stock/${encodeURIComponent(code)}`;
+  const basic = await getJson(`${base}/basic`, timeoutMs);
+  const parsed = parseNaverStockBasic(basic);
+  return {
+    name: parsed.name || def?.canonical || stock,
+    ...(parsed.market ? { market: parsed.market } : {}),
+    ...(parsed.priceText ? { priceText: parsed.priceText } : {}),
+    ...(parsed.changeText ? { changeText: parsed.changeText } : {}),
+    ...(parsed.changeDir ? { changeDir: parsed.changeDir } : {}),
+    metrics: [],
+  };
 }
 
 /** 종목명으로 기본 정보. 코드 해석 실패(미등록/미국주) → name 만(빈 화면 대신 최소 보장). */

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -13,7 +13,7 @@ import {
   type DailyOhlcv,
   type TaFact,
 } from "@fomo/core";
-import { fetchStockBasics } from "./stock-basics";
+import { fetchStockBasics, fetchStockBasicsLite } from "./stock-basics";
 import { readSupplyDemandHistory } from "./supply-demand-store";
 import type { StockAttentionSignal, ThemeRelativeSignal } from "./stock-signal-coverage";
 
@@ -146,6 +146,11 @@ export interface StockFrontData {
   changeDir?: "up" | "down" | "flat";
 }
 
+export interface StockFrontOptions {
+  /** 카드 앞면용 경량 경로. 시총순위·TA·스파크라인·상세 지표를 빼고 가격/수급/언급만 쓴다. */
+  lite?: boolean;
+}
+
 /**
  * 한 종목의 카드 앞면 데이터 조립 + 포모 점수 산출(척추 단일 출처).
  * baseline(가격·52주) + 라이브 수급 streak + 거래량 회전·추세 + 시총순위 + 스파크라인 → computeFomoScore.
@@ -154,16 +159,18 @@ export interface StockFrontData {
 export async function assembleStockFront(
   stock: string,
   rankMap?: Record<string, RankEntry>,
-  coverage: { attention?: StockAttentionSignal; themeRelative?: ThemeRelativeSignal } = {}
+  coverage: { attention?: StockAttentionSignal; themeRelative?: ThemeRelativeSignal } = {},
+  options: StockFrontOptions = {}
 ): Promise<StockFrontData> {
   const def = resolveStock(stock);
   const code = def?.naverCode;
   if (!code) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
+  const lite = options.lite === true;
 
   const [basics, history, daily] = await Promise.all([
-    fetchStockBasics(stock).catch(() => null),
+    (lite ? fetchStockBasicsLite(stock) : fetchStockBasics(stock)).catch(() => null),
     readSupplyDemandHistory(code).catch(() => []),
-    fetchStockDaily(code),
+    lite ? Promise.resolve({ candles: [], closes: [], volumes: [] }) : fetchStockDaily(code),
   ]);
 
   const signals: CardFrontSignals = basics ? signalsFromBasics(basics) : {};
@@ -187,31 +194,31 @@ export async function assembleStockFront(
     if (streak.institution !== 0) signals.institutionNetStreak = streak.institution;
   }
 
-  const rank = rankMap?.[code];
+  const rank = lite ? undefined : rankMap?.[code];
   if (rank) signals.marketCapRank = { scope: "market", market: rank.market, rank: rank.rank };
 
   // ── 포모 점수(척추) — 거래량 회전·가격(등락·추세)·수급. 언급량·prevScore 는 후속(없으면 제외). ──
-  const volRatio = volumeTurnover(daily.volumes);
+  const volRatio = lite ? undefined : volumeTurnover(daily.volumes);
   if (typeof volRatio === "number") signals.volumeRatio = volRatio;
-  const ta = computeTechnicalAnalysis(daily.candles);
-  const trend = ta.inputs.trendStrength ?? trendStrength(daily.closes);
+  const ta = lite ? null : computeTechnicalAnalysis(daily.candles);
+  const trend = ta?.inputs.trendStrength ?? (lite ? undefined : trendStrength(daily.closes));
   const fomo = computeFomoScore({
     ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
     ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
     ...(typeof trend === "number" ? { trendStrength: trend } : {}),
     ...(typeof signals.mentionScore === "number" ? { mentionScore: signals.mentionScore } : {}),
-    ...(ta.inputs.accumulationDivergence ? { accumulationDivergence: true } : {}),
-    ...(ta.inputs.bollingerSqueeze ? { bollingerSqueeze: true } : {}),
+    ...(ta?.inputs.accumulationDivergence ? { accumulationDivergence: true } : {}),
+    ...(ta?.inputs.bollingerSqueeze ? { bollingerSqueeze: true } : {}),
     ...(typeof signals.foreignNetStreak === "number" ? { foreignNetStreak: signals.foreignNetStreak } : {}),
     ...(typeof signals.institutionNetStreak === "number" ? { institutionNetStreak: signals.institutionNetStreak } : {}),
   });
-  const taFact = selectTaFact(fomo, ta);
+  const taFact = ta ? selectTaFact(fomo, ta) : undefined;
 
   return {
     signals,
     fomo,
     ...(taFact ? { taFact } : {}),
-    sparkline: daily.closes.slice(-66),
+    sparkline: lite ? [] : daily.closes.slice(-66),
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),
     ...(basics?.changeDir ? { changeDir: basics.changeDir } : {}),


### PR DESCRIPTION
## What
- Add `lite=1` stock-front mode for card deck hydration.
- Use lite stock-front from `SectorStockDeck`; depth keeps the full stock-front payload.
- Lite mode skips market-cap rank, attention map, theme relative map, daily OHLCV, TA fact, sparkline, and detailed metrics. It keeps quick basic price/change plus existing supply streak where available, with honest fallback when data is thin.
- Add `fetchStockBasicsLite` with a shorter timeout against the Naver basic endpoint.
- Add localStorage stale-first keywords: return today's stored snapshot immediately, revalidate in the background, and dispatch an update event so the Today feed refreshes when fresh data arrives.
- Add `refreshCached` for shared background refreshes and stale fallback.

## Validation
- `npm run test -- apps/fomo-web/__tests__/apiCache.test.ts`
- `npm run typecheck:fomo-web`
- `npm run typecheck:web`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build:web`
- `npm run build:fomo-web`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/fomo npx prisma validate`
