### PR TITLE
[codex] add fomo quality reporting

### DIFF
--- a/.github/workflows/daily-product-monitor.yml
+++ b/.github/workflows/daily-product-monitor.yml
@@ -31,6 +31,15 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci
+
       - name: Inspect product health
         id: inspect
         env:
@@ -148,9 +157,77 @@ jobs:
           fi
           echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
 
+      - name: Inspect FOMO quality
+        id: quality
+        env:
+          FOMO_API_BASE: "https://fomo-club-backend.vercel.app"
+          FOMO_WEB_URL: "https://fomo-web-mlender-ais-projects.vercel.app"
+          FOMO_QUALITY_STOCK_LIMIT: "8"
+          FOMO_QUALITY_DEPTH_LIMIT: "3"
+          FOMO_QUALITY_TIMEOUT_MS: "8000"
+          FOMO_QUALITY_JSON_OUT: "/tmp/fomo-quality-report.json"
+          FOMO_QUALITY_MD_OUT: "/tmp/fomo-quality-report.md"
+        run: |
+          set -euo pipefail
+          set +e
+          npm run quality:fomo > /tmp/product-quality.stdout 2> /tmp/product-quality.stderr
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" != "0" ] || [ ! -f /tmp/fomo-quality-report.json ]; then
+            {
+              echo "# FOMO Quality Report"
+              echo
+              echo "상태: critical"
+              echo
+              echo "품질 리포트 스크립트가 실패했습니다."
+              echo
+              echo "## stderr"
+              sed 's/^/    /' /tmp/product-quality.stderr || true
+            } > /tmp/fomo-quality-report.md
+            echo "critical_count=1" >> "$GITHUB_OUTPUT"
+            echo "warn_count=0" >> "$GITHUB_OUTPUT"
+            echo "summary=quality report failed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          node - <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require("fs");
+          const report = JSON.parse(fs.readFileSync("/tmp/fomo-quality-report.json", "utf8"));
+          const critical = report.findings.filter((f) => f.severity === "critical").length;
+          const warn = report.findings.filter((f) => f.severity === "warn").length;
+          const lite = report.latency.find((row) => row.endpoint === "stock_front_lite");
+          const fallback = report.hookDistribution.liteTier.find((row) => row.key === "fallback");
+          const material = report.hookDistribution.liteTier.find((row) => row.key === "material");
+          const pct = (row) => row ? `${Math.round(row.rate * 100)}%` : "0%";
+          const summary = `critical ${critical}, warn ${warn}, lite p95 ${lite?.p95Ms ?? "N/A"}ms, material ${pct(material)}, fallback ${pct(fallback)}`;
+          console.log(`critical_count=${critical}`);
+          console.log(`warn_count=${warn}`);
+          console.log(`summary=${summary}`);
+          NODE
+
+      - name: Combine monitor report
+        id: combine
+        env:
+          INSPECT_CRITICAL: ${{ steps.inspect.outputs.critical_count }}
+          QUALITY_CRITICAL: ${{ steps.quality.outputs.critical_count }}
+        run: |
+          set -euo pipefail
+          TOTAL=$(( ${INSPECT_CRITICAL:-0} + ${QUALITY_CRITICAL:-0} ))
+          echo "critical_count=$TOTAL" >> "$GITHUB_OUTPUT"
+          cp /tmp/monitor-body.md /tmp/monitor-combined-body.md
+          if [ -f /tmp/fomo-quality-report.md ]; then
+            {
+              echo
+              echo "---"
+              echo
+              cat /tmp/fomo-quality-report.md
+            } >> /tmp/monitor-combined-body.md
+          fi
+
       - name: Create critical task issue
         id: issue
-        if: steps.inspect.outputs.critical_count != '0'
+        if: steps.combine.outputs.critical_count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -174,7 +251,7 @@ jobs:
 
           URL=$(gh issue create --repo "$REPO" \
             --title "🚨 [daily-product-monitor] critical $TODAY" \
-            --body-file /tmp/monitor-body.md \
+            --body-file /tmp/monitor-combined-body.md \
             --label "daily-product-monitor,pipeline-monitor,data-quality,task")
           NUM="${URL##*/}"
           echo "number=$NUM" >> "$GITHUB_OUTPUT"
@@ -227,10 +304,13 @@ jobs:
         if: always() && vars.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
-          CRITICAL_COUNT: ${{ steps.inspect.outputs.critical_count }}
+          CRITICAL_COUNT: ${{ steps.combine.outputs.critical_count }}
           CRITICAL_RUN_COUNT: ${{ steps.inspect.outputs.critical_run_count }}
           STALE_COUNT: ${{ steps.inspect.outputs.stale_count }}
           SUMMARY: ${{ steps.inspect.outputs.summary }}
+          QUALITY_SUMMARY: ${{ steps.quality.outputs.summary }}
+          QUALITY_CRITICAL_COUNT: ${{ steps.quality.outputs.critical_count }}
+          QUALITY_WARN_COUNT: ${{ steps.quality.outputs.warn_count }}
           TODAY: ${{ steps.inspect.outputs.today }}
           LOOKBACK_HOURS: ${{ steps.inspect.outputs.lookback_hours }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
@@ -241,7 +321,7 @@ jobs:
           set -euo pipefail
           URL=$(printf '%s' "$SLACK_WEBHOOK_URL" | tr -d '[:space:]')
           if [ "${CRITICAL_COUNT:-0}" = "0" ]; then
-            TEXT="🟢 *Daily Product Monitor* — ${TODAY}\n${SUMMARY}\n범위: 최근 ${LOOKBACK_HOURS}시간\n다음 액션: 없음 — 오늘은 개발 스킵.\n${RUN_URL}"
+            TEXT="🟢 *Daily Product Monitor* — ${TODAY}\n${SUMMARY}\n품질: ${QUALITY_SUMMARY:-N/A}\n범위: 최근 ${LOOKBACK_HOURS}시간\n다음 액션: 없음 — 오늘은 개발 스킵.\n${RUN_URL}"
           else
             if [ "${AUTO_FIX_STARTED:-false}" = "true" ]; then
               NEXT="이슈 #${ISSUE_NUMBER} 생성/재사용 → implement-task 자동 수정 시작"
@@ -250,7 +330,7 @@ jobs:
             else
               NEXT="이슈 #${ISSUE_NUMBER} 생성/재사용 → auto-fix dispatch 실패, 수동 확인 필요"
             fi
-            TEXT="🚨 *Daily Product Monitor* — ${TODAY}\n${SUMMARY}\n범위: 최근 ${LOOKBACK_HOURS}시간\n분해: 실패 ${CRITICAL_RUN_COUNT:-0}건 · stale ${STALE_COUNT:-0}건\n다음 액션: ${NEXT}\n${RUN_URL}"
+            TEXT="🚨 *Daily Product Monitor* — ${TODAY}\n${SUMMARY}\n품질: ${QUALITY_SUMMARY:-N/A}\n범위: 최근 ${LOOKBACK_HOURS}시간\n분해: 실패 ${CRITICAL_RUN_COUNT:-0}건 · stale ${STALE_COUNT:-0}건 · 품질 critical ${QUALITY_CRITICAL_COUNT:-0}건 · 품질 warn ${QUALITY_WARN_COUNT:-0}건\n다음 액션: ${NEXT}\n${RUN_URL}"
           fi
           jq -n --arg text "$TEXT" '{text: $text}' > /tmp/slack.json
           curl -sS -X POST -H 'Content-type: application/json' --data @/tmp/slack.json "$URL" || true

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "warm:insights": "tsx scripts/warm-insights.ts",
     "supply:collect": "tsx scripts/supply-demand-collect.ts",
     "metrics:fomo": "tsx scripts/fomo-product-metrics.ts",
+    "quality:fomo": "tsx scripts/fomo-quality-report.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/scripts/__tests__/fomo-quality-report.test.ts
+++ b/scripts/__tests__/fomo-quality-report.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  distribution,
+  evaluateQuality,
+  hookTier,
+  percentile,
+  summarizeLatencies,
+  type HookSample,
+  type LatencySample,
+} from "../fomo-quality-report-core";
+
+describe("fomo-quality-report-core", () => {
+  it("hook kind를 리포트용 tier로 분류한다", () => {
+    expect(hookTier("news_event")).toBe("material");
+    expect(hookTier("relative")).toBe("material");
+    expect(hookTier("axis_tension")).toBe("tension");
+    expect(hookTier("ta_fact")).toBe("shape");
+    expect(hookTier("fallback")).toBe("fallback");
+  });
+
+  it("latency p50/p95와 에러 수를 endpoint별로 요약한다", () => {
+    const samples: LatencySample[] = [
+      { endpoint: "a", ok: true, ms: 100 },
+      { endpoint: "a", ok: true, ms: 300 },
+      { endpoint: "a", ok: false, ms: 900 },
+      { endpoint: "b", ok: true, ms: 40 },
+    ];
+
+    expect(percentile([100, 200, 300], 0.5)).toBe(200);
+    expect(summarizeLatencies(samples)).toEqual([
+      { endpoint: "a", count: 3, ok: 2, error: 1, p50Ms: 100, p95Ms: 300, maxMs: 300 },
+      { endpoint: "b", count: 1, ok: 1, error: 0, p50Ms: 40, p95Ms: 40, maxMs: 40 },
+    ]);
+  });
+
+  it("분포를 count 내림차순으로 계산한다", () => {
+    expect(distribution(["fallback", "material", "fallback"])).toEqual([
+      { key: "fallback", count: 2, rate: 2 / 3 },
+      { key: "material", count: 1, rate: 1 / 3 },
+    ]);
+  });
+
+  it("fallback/insufficient/latency 위험을 finding으로 올린다", () => {
+    const liteHooks: HookSample[] = [
+      { stock: "A", kind: "fallback", headline: "아직 조용한 자리예요." },
+      { stock: "B", kind: "fallback", headline: "아직 조용한 자리예요." },
+      { stock: "C", kind: "news_event", headline: "계약 공시가 나왔어요." },
+    ];
+
+    const findings = evaluateQuality(
+      {
+        cardCount: 3,
+        confidence: "fallback",
+        stale: true,
+        snapshotDate: "2026-06-22",
+        sourceCount: 2,
+        relatedStockCount: 3,
+        duplicateHeadlineCount: 1,
+      },
+      {
+        liteHooks,
+        fullHooks: [],
+        insightCount: 2,
+        insufficientInsightCount: 1,
+      },
+      [{ endpoint: "stock_front_lite", count: 3, ok: 2, error: 1, p50Ms: 2500, p95Ms: 5000, maxMs: 5000 }]
+    );
+
+    expect(findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        "keywords confidence가 fallback입니다.",
+        "카드 중 원문 source가 없는 항목이 있습니다.",
+        "중복 카드 코멘트 1건이 있습니다.",
+        "카드 lite hook fallback 비율이 67%입니다.",
+        "stock_front_lite 에러 1/3건이 있습니다.",
+        "stock_front_lite p95가 5000ms입니다.",
+      ])
+    );
+  });
+});

--- a/scripts/fomo-quality-report-core.ts
+++ b/scripts/fomo-quality-report-core.ts
@@ -1,0 +1,171 @@
+export type QualityHookKind =
+  | "news_event"
+  | "axis_tension"
+  | "dday"
+  | "supply_streak"
+  | "volume_event"
+  | "mention_event"
+  | "relative"
+  | "position"
+  | "accumulation"
+  | "ta_fact"
+  | "fallback";
+
+export type QualityHookTier = "material" | "tension" | "shape" | "fallback";
+
+export interface LatencySample {
+  endpoint: string;
+  ok: boolean;
+  ms: number;
+}
+
+export interface EndpointLatencySummary {
+  endpoint: string;
+  count: number;
+  ok: number;
+  error: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+  maxMs: number | null;
+}
+
+export interface HookSample {
+  stock: string;
+  kind: QualityHookKind;
+  headline: string;
+}
+
+export interface HookDistributionRow {
+  key: string;
+  count: number;
+  rate: number;
+}
+
+export interface KeywordQualityInput {
+  cardCount: number;
+  confidence?: string;
+  stale?: boolean;
+  snapshotDate?: string | null;
+  sourceCount: number;
+  relatedStockCount: number;
+  duplicateHeadlineCount: number;
+}
+
+export interface StockQualityInput {
+  liteHooks: readonly HookSample[];
+  fullHooks: readonly HookSample[];
+  insightCount: number;
+  insufficientInsightCount: number;
+}
+
+export interface QualityFinding {
+  severity: "ok" | "warn" | "critical";
+  message: string;
+}
+
+export const MATERIAL_HOOKS = new Set<QualityHookKind>([
+  "news_event",
+  "dday",
+  "supply_streak",
+  "mention_event",
+  "relative",
+]);
+
+export const SHAPE_HOOKS = new Set<QualityHookKind>([
+  "volume_event",
+  "position",
+  "accumulation",
+  "ta_fact",
+]);
+
+export function hookTier(kind: QualityHookKind): QualityHookTier {
+  if (MATERIAL_HOOKS.has(kind)) return "material";
+  if (kind === "axis_tension") return "tension";
+  if (SHAPE_HOOKS.has(kind)) return "shape";
+  return "fallback";
+}
+
+export function percentile(values: readonly number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const bounded = Math.max(0, Math.min(1, p));
+  const index = Math.ceil(sorted.length * bounded) - 1;
+  return Math.round(sorted[Math.max(0, index)]!);
+}
+
+export function summarizeLatencies(samples: readonly LatencySample[]): EndpointLatencySummary[] {
+  const endpoints = [...new Set(samples.map((sample) => sample.endpoint))].sort();
+  return endpoints.map((endpoint) => {
+    const rows = samples.filter((sample) => sample.endpoint === endpoint);
+    const okRows = rows.filter((sample) => sample.ok);
+    const latencies = okRows.map((sample) => sample.ms);
+    return {
+      endpoint,
+      count: rows.length,
+      ok: okRows.length,
+      error: rows.length - okRows.length,
+      p50Ms: percentile(latencies, 0.5),
+      p95Ms: percentile(latencies, 0.95),
+      maxMs: latencies.length > 0 ? Math.round(Math.max(...latencies)) : null,
+    };
+  });
+}
+
+export function distribution<T extends string>(values: readonly T[]): HookDistributionRow[] {
+  const total = values.length || 1;
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([key, count]) => ({ key, count, rate: count / total }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+}
+
+export function evaluateQuality(
+  keyword: KeywordQualityInput,
+  stock: StockQualityInput,
+  latency: readonly EndpointLatencySummary[],
+): QualityFinding[] {
+  const findings: QualityFinding[] = [];
+  const add = (severity: QualityFinding["severity"], message: string) => findings.push({ severity, message });
+  const liteTiers = stock.liteHooks.map((hook) => hookTier(hook.kind));
+  const liteFallbackRate = rateOf(liteTiers, "fallback");
+  const liteMaterialRate = rateOf(liteTiers, "material");
+  const insightInsufficientRate =
+    stock.insightCount > 0 ? stock.insufficientInsightCount / stock.insightCount : null;
+
+  if (keyword.cardCount === 0) add("critical", "keywords 카드가 0개입니다.");
+  else add("ok", `keywords 카드 ${keyword.cardCount}개를 받았습니다.`);
+
+  if (keyword.confidence === "fallback") add("critical", "keywords confidence가 fallback입니다.");
+  else if (keyword.stale) add("warn", `keywords snapshot이 stale입니다(${keyword.snapshotDate ?? "unknown"}).`);
+  else add("ok", `keywords confidence=${keyword.confidence ?? "unknown"}입니다.`);
+
+  if (keyword.sourceCount < keyword.cardCount) add("warn", "카드 중 원문 source가 없는 항목이 있습니다.");
+  if (keyword.duplicateHeadlineCount > 0) add("warn", `중복 카드 코멘트 ${keyword.duplicateHeadlineCount}건이 있습니다.`);
+  if (stock.liteHooks.length > 0 && liteFallbackRate >= 0.5) {
+    add("warn", `카드 lite hook fallback 비율이 ${formatPercent(liteFallbackRate)}입니다.`);
+  }
+  if (stock.liteHooks.length > 0 && liteMaterialRate < 0.25) {
+    add("warn", `카드 lite hook 재료형 비율이 ${formatPercent(liteMaterialRate)}로 낮습니다.`);
+  }
+  if (insightInsufficientRate !== null && insightInsufficientRate >= 0.5) {
+    add("warn", `뎁스 insight insufficient 비율이 ${formatPercent(insightInsufficientRate)}입니다.`);
+  }
+
+  for (const row of latency) {
+    if (row.error > 0) add("warn", `${row.endpoint} 에러 ${row.error}/${row.count}건이 있습니다.`);
+    if (row.p95Ms !== null && row.p95Ms > 4500) add("warn", `${row.endpoint} p95가 ${row.p95Ms}ms입니다.`);
+  }
+
+  return findings;
+}
+
+export function formatPercent(value: number | null): string {
+  if (value === null) return "N/A";
+  return `${Math.round(value * 100)}%`;
+}
+
+function rateOf(values: readonly string[], target: string): number {
+  if (values.length === 0) return 0;
+  return values.filter((value) => value === target).length / values.length;
+}

--- a/scripts/fomo-quality-report.ts
+++ b/scripts/fomo-quality-report.ts
@@ -1,0 +1,322 @@
+/**
+ * FOMO 품질 리포트 — 프로덕션 API를 실제로 샘플링해 카드/뎁스 품질과 응답 시간을 숫자로 남긴다.
+ *
+ * 비용 방어:
+ * - keywords 1회
+ * - stock-front lite: 기본 최대 8종목
+ * - stock-front full + stock-insight: 기본 최대 3종목
+ * - LLM이 붙을 수 있는 stock-insight는 daily monitor에서도 작은 샘플만 호출한다.
+ */
+import { selectFomoHook, type FomoHookSignalKind } from "@fomo/core";
+import {
+  distribution,
+  evaluateQuality,
+  formatPercent,
+  hookTier,
+  summarizeLatencies,
+  type HookSample,
+  type LatencySample,
+  type QualityHookKind,
+} from "./fomo-quality-report-core";
+
+const DEFAULT_API_BASE = "https://fomo-club-backend.vercel.app";
+const DEFAULT_WEB_URL = "https://fomo-web-mlender-ais-projects.vercel.app";
+const API_BASE = (process.env.FOMO_API_BASE ?? DEFAULT_API_BASE).replace(/\/$/, "");
+const WEB_URL = (process.env.FOMO_WEB_URL ?? DEFAULT_WEB_URL).replace(/\/$/, "");
+const STOCK_LIMIT = positiveInt(process.env.FOMO_QUALITY_STOCK_LIMIT, 8);
+const DEPTH_LIMIT = positiveInt(process.env.FOMO_QUALITY_DEPTH_LIMIT, 3);
+const TIMEOUT_MS = positiveInt(process.env.FOMO_QUALITY_TIMEOUT_MS, 8000);
+const OUT_JSON = process.env.FOMO_QUALITY_JSON_OUT ?? "fomo-quality-report.json";
+const OUT_MD = process.env.FOMO_QUALITY_MD_OUT ?? "fomo-quality-report.md";
+
+interface KeywordCardLike {
+  keyword?: string;
+  comment?: string;
+  related?: string[];
+  sources?: unknown[];
+  surpriseStock?: { name?: string };
+}
+
+interface KeywordsPayloadLike {
+  date?: string;
+  confidence?: string;
+  stale?: boolean;
+  snapshotDate?: string | null;
+  cards?: KeywordCardLike[];
+}
+
+interface TimedResult<T> {
+  endpoint: string;
+  ok: boolean;
+  ms: number;
+  status: number | null;
+  data?: T;
+  error?: string;
+}
+
+interface StockFrontLike {
+  signals?: Record<string, unknown>;
+  fomo?: Record<string, unknown>;
+  taFact?: unknown;
+  sparkline?: unknown[];
+  priceText?: string;
+  changeText?: string;
+}
+
+interface InsightLike {
+  confidence?: string;
+  whyHot?: string;
+  bull?: unknown[];
+  bear?: unknown[];
+  sources?: unknown[];
+  reason?: string;
+}
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function kstDate(now = new Date()): string {
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+async function timedJson<T>(endpoint: string, url: string): Promise<TimedResult<T>> {
+  const started = performance.now();
+  try {
+    const res = await fetch(url, { cache: "no-store", signal: AbortSignal.timeout(TIMEOUT_MS) });
+    const ms = Math.round(performance.now() - started);
+    if (!res.ok) {
+      return { endpoint, ok: false, ms, status: res.status, error: `HTTP ${res.status}` };
+    }
+    return { endpoint, ok: true, ms, status: res.status, data: (await res.json()) as T };
+  } catch (err) {
+    return { endpoint, ok: false, ms: Math.round(performance.now() - started), status: null, error: (err as Error).message };
+  }
+}
+
+async function timedHead(endpoint: string, url: string): Promise<TimedResult<null>> {
+  const started = performance.now();
+  try {
+    const res = await fetch(url, { method: "HEAD", cache: "no-store", signal: AbortSignal.timeout(TIMEOUT_MS) });
+    const ms = Math.round(performance.now() - started);
+    return { endpoint, ok: res.ok, ms, status: res.status, ...(res.ok ? { data: null } : { error: `HTTP ${res.status}` }) };
+  } catch (err) {
+    return { endpoint, ok: false, ms: Math.round(performance.now() - started), status: null, error: (err as Error).message };
+  }
+}
+
+async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = [];
+  let index = 0;
+  async function worker() {
+    while (index < items.length) {
+      const current = items[index++]!;
+      out.push(await fn(current));
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return out;
+}
+
+function stocksFromKeywords(payload: KeywordsPayloadLike | undefined): string[] {
+  const seen = new Set<string>();
+  for (const card of payload?.cards ?? []) {
+    for (const stock of card.related ?? []) {
+      const cleaned = stock.trim();
+      if (cleaned) seen.add(cleaned);
+    }
+    const surprise = card.surpriseStock?.name?.trim();
+    if (surprise) seen.add(surprise);
+  }
+  if (seen.size === 0) {
+    ["삼성전자", "SK하이닉스", "삼성SDI", "두산로보틱스"].forEach((stock) => seen.add(stock));
+  }
+  return [...seen].slice(0, STOCK_LIMIT);
+}
+
+function hookFromFront(stock: string, data: StockFrontLike | undefined): HookSample | null {
+  if (!data?.fomo) return null;
+  try {
+    const hook = selectFomoHook({
+      fomo: data.fomo as Parameters<typeof selectFomoHook>[0]["fomo"],
+      signals: (data.signals ?? {}) as Parameters<typeof selectFomoHook>[0]["signals"],
+      taFact: data.taFact as Parameters<typeof selectFomoHook>[0]["taFact"],
+    });
+    return { stock, kind: hook.kind as FomoHookSignalKind as QualityHookKind, headline: hook.headline };
+  } catch {
+    return null;
+  }
+}
+
+function markdownTable(headers: readonly string[], rows: readonly (readonly string[])[]): string {
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...rows.map((row) => `| ${row.join(" | ")} |`),
+  ].join("\n");
+}
+
+function duplicateCount(values: readonly string[]): number {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.values()].reduce((sum, count) => sum + Math.max(0, count - 1), 0);
+}
+
+async function main() {
+  const date = kstDate();
+  const samples: LatencySample[] = [];
+  const rawResults: TimedResult<unknown>[] = [];
+
+  const home = await timedHead("web_home", `${WEB_URL}/`);
+  samples.push(home);
+  rawResults.push(home);
+
+  const keywords = await timedJson<KeywordsPayloadLike>("keywords", `${API_BASE}/api/fomo/keywords`);
+  samples.push(keywords);
+  rawResults.push(keywords as TimedResult<unknown>);
+
+  const stocks = stocksFromKeywords(keywords.data);
+  const liteResults = await mapLimit(stocks, 3, (stock) =>
+    timedJson<StockFrontLike>("stock_front_lite", `${API_BASE}/api/fomo/stock-front?stock=${encodeURIComponent(stock)}&lite=1`).then((res) => ({
+      stock,
+      res,
+    }))
+  );
+  const depthStocks = stocks.slice(0, DEPTH_LIMIT);
+  const fullResults = await mapLimit(depthStocks, 2, (stock) =>
+    timedJson<StockFrontLike>("stock_front_full", `${API_BASE}/api/fomo/stock-front?stock=${encodeURIComponent(stock)}`).then((res) => ({
+      stock,
+      res,
+    }))
+  );
+  const insightResults = await mapLimit(depthStocks, 1, (stock) =>
+    timedJson<InsightLike>("stock_insight", `${API_BASE}/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`).then((res) => ({
+      stock,
+      res,
+    }))
+  );
+
+  for (const row of [...liteResults, ...fullResults, ...insightResults]) {
+    samples.push(row.res);
+    rawResults.push(row.res as TimedResult<unknown>);
+  }
+
+  const cards = keywords.data?.cards ?? [];
+  const comments = cards.map((card) => card.comment?.trim()).filter((comment): comment is string => !!comment);
+  const keywordInput = {
+    cardCount: cards.length,
+    confidence: keywords.data?.confidence,
+    stale: keywords.data?.stale,
+    snapshotDate: keywords.data?.snapshotDate,
+    sourceCount: cards.filter((card) => (card.sources ?? []).length > 0).length,
+    relatedStockCount: stocks.length,
+    duplicateHeadlineCount: duplicateCount(comments),
+  };
+  const liteHooks = liteResults
+    .map(({ stock, res }) => hookFromFront(stock, res.data))
+    .filter((hook): hook is HookSample => hook !== null);
+  const fullHooks = fullResults
+    .map(({ stock, res }) => hookFromFront(stock, res.data))
+    .filter((hook): hook is HookSample => hook !== null);
+  const insights = insightResults.map(({ res }) => res.data).filter((data): data is InsightLike => !!data);
+  const stockInput = {
+    liteHooks,
+    fullHooks,
+    insightCount: insights.length,
+    insufficientInsightCount: insights.filter((insight) => insight.confidence === "insufficient").length,
+  };
+  const latency = summarizeLatencies(samples);
+  const findings = evaluateQuality(keywordInput, stockInput, latency);
+  const liteTierDist = distribution(liteHooks.map((hook) => hookTier(hook.kind)));
+  const liteKindDist = distribution(liteHooks.map((hook) => hook.kind));
+  const fullTierDist = distribution(fullHooks.map((hook) => hookTier(hook.kind)));
+
+  const json = {
+    date,
+    apiBase: API_BASE,
+    webUrl: WEB_URL,
+    stockSample: stocks,
+    keyword: keywordInput,
+    stock: stockInput,
+    latency,
+    hookDistribution: {
+      liteTier: liteTierDist,
+      liteKind: liteKindDist,
+      fullTier: fullTierDist,
+    },
+    findings,
+    rawErrors: rawResults
+      .filter((row) => !row.ok)
+      .map((row) => ({ endpoint: row.endpoint, status: row.status, ms: row.ms, error: row.error })),
+  };
+
+  const md = [
+    `# FOMO Quality Report — ${date}`,
+    "",
+    `API: ${API_BASE}`,
+    `Web: ${WEB_URL}`,
+    "",
+    "## Summary",
+    markdownTable(
+      ["Metric", "Value"],
+      [
+        ["Keyword cards", String(keywordInput.cardCount)],
+        ["Keyword confidence", keywordInput.confidence ?? "unknown"],
+        ["Keyword stale", keywordInput.stale ? `yes (${keywordInput.snapshotDate ?? "unknown"})` : "no"],
+        ["Cards with sources", `${keywordInput.sourceCount}/${keywordInput.cardCount}`],
+        ["Sample stocks", stocks.join(", ") || "none"],
+        ["Lite material hooks", formatPercent(liteTierDist.find((row) => row.key === "material")?.rate ?? 0)],
+        ["Lite fallback hooks", formatPercent(liteTierDist.find((row) => row.key === "fallback")?.rate ?? 0)],
+        [
+          "Depth insufficient",
+          stockInput.insightCount > 0 ? `${stockInput.insufficientInsightCount}/${stockInput.insightCount}` : "N/A",
+        ],
+      ]
+    ),
+    "",
+    "## Latency",
+    markdownTable(
+      ["Endpoint", "OK", "Error", "p50", "p95", "max"],
+      latency.map((row) => [
+        row.endpoint,
+        `${row.ok}/${row.count}`,
+        String(row.error),
+        row.p50Ms === null ? "N/A" : `${row.p50Ms}ms`,
+        row.p95Ms === null ? "N/A" : `${row.p95Ms}ms`,
+        row.maxMs === null ? "N/A" : `${row.maxMs}ms`,
+      ])
+    ),
+    "",
+    "## Card Hook Distribution",
+    markdownTable(
+      ["Tier", "Count", "Rate"],
+      liteTierDist.map((row) => [row.key, String(row.count), formatPercent(row.rate)])
+    ),
+    "",
+    markdownTable(
+      ["Kind", "Count", "Rate"],
+      liteKindDist.map((row) => [row.key, String(row.count), formatPercent(row.rate)])
+    ),
+    "",
+    "## Depth Hook Distribution",
+    markdownTable(
+      ["Tier", "Count", "Rate"],
+      fullTierDist.map((row) => [row.key, String(row.count), formatPercent(row.rate)])
+    ),
+    "",
+    "## Findings",
+    ...findings.map((finding) => `- ${finding.severity.toUpperCase()}: ${finding.message}`),
+    "",
+  ].join("\n");
+
+  await import("node:fs/promises").then((fs) =>
+    Promise.all([fs.writeFile(OUT_JSON, `${JSON.stringify(json, null, 2)}\n`), fs.writeFile(OUT_MD, md)])
+  );
+  process.stdout.write(md);
+}
+
+main().catch((err) => {
+  console.error("[fomo-quality-report] failed", err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What
- Add `npm run quality:fomo`, a production-facing quality report for FOMO Club.
- The report samples:
  - `fomo-web` home availability
  - `/api/fomo/keywords`
  - `/api/fomo/stock-front?lite=1`
  - `/api/fomo/stock-front`
  - `/api/fomo/stock-insight`
- It outputs Markdown + JSON with:
  - endpoint p50/p95/max latency
  - keyword card count, confidence, stale state, source coverage
  - card hook tier/kind distribution
  - depth hook distribution
  - insight insufficient/error signals
  - actionable findings
- Wire the report into `daily-product-monitor.yml` so the monitor now includes product quality, not just workflow failure/stale checks.

## Why
- We now have enough feature surface that guessing is too slow.
- This makes the next product work measurable: lite response speed, card fallback rate, material-hook coverage, and depth insight health.

## Current prod sample
- Keyword cards: 9
- Keyword confidence: low
- Card source coverage: 9/9
- `stock_front_lite`: p95 about 2635ms on a 4-stock local sample
- `stock_front_full`: p95 about 4529ms on a 2-stock local sample
- Lite hook fallback: 75%
- `stock_insight`: 2/2 timed out at 10s in the local sample

These are warnings, not release blockers. They give the next worklist: reduce lite fallback, and make stock insight faster/more cacheable.

## Validation
- `npm run test -- scripts/__tests__/fomo-quality-report.test.ts`
- `npm run typecheck`
- `npm run quality:fomo` against production
- `npm run lint`
- `npm run test`
- `npm run build:web`
- `npm run build:fomo-web`
- `npm run build:api`
