### PR TITLE
[codex] restore card charts and timebox depth insights

### DIFF
--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -154,6 +154,17 @@ function Sparkline({ series }: { series: number[] }) {
   );
 }
 
+function ChartSlot({ series, supported }: { series?: number[] | undefined; supported: boolean }) {
+  if (series && series.length >= 2) return <Sparkline series={series} />;
+  return (
+    <div className="mt-4 flex h-11 w-full items-center justify-center rounded-lg border border-hairline bg-white/[0.03]">
+      <span className="font-pixel text-[10px] text-muted">
+        {supported ? "차트 불러오는 중" : "차트 데이터 없음"}
+      </span>
+    </div>
+  );
+}
+
 /** 포모 강도 미터(DESIGN.md §8 모티프) — 10 도트 세그먼트, 점수만큼 오렌지 fill·나머지 dim. */
 function FomoMeter({ score, color }: { score: number; color: string }) {
   const normalized = Math.max(0, Math.min(100, score));
@@ -188,6 +199,7 @@ function StockCardFace({
   changeDir,
   rankLabel,
   sparkline,
+  chartSupported,
   subLine,
   progress,
 }: {
@@ -200,6 +212,7 @@ function StockCardFace({
   changeDir?: "up" | "down" | "flat" | undefined;
   rankLabel?: string | undefined;
   sparkline?: number[] | undefined;
+  chartSupported: boolean;
   subLine?: string | undefined;
   progress?: string | undefined;
 }) {
@@ -271,8 +284,8 @@ function StockCardFace({
         </p>
       )}
 
-      {/* 미니 스파크라인(최근 3개월) */}
-      {sparkline && sparkline.length >= 2 && <Sparkline series={sparkline} />}
+      {/* 미니 스파크라인(최근 흐름) — lite 응답도 짧은 라인차트를 싣는다. */}
+      <ChartSlot series={sparkline} supported={chartSupported} />
 
       {/* 다가오는 재료(있으면) */}
       {catalysts && catalysts.length > 0 && (
@@ -378,7 +391,14 @@ function SectorDeckInner({
   const ensureFront = useCallback(
     (stock: DeckStock) => {
       const key = stock.canonical;
-      if (!stock.naverCode || front[key] || inflight.current.has(key)) return;
+      if (front[key] || inflight.current.has(key)) return;
+      if (!stock.naverCode) {
+        setFront((prev) => ({
+          ...prev,
+          [key]: { signals: {}, fomo: EMPTY_FOMO, sparkline: [] },
+        }));
+        return;
+      }
       inflight.current.add(key);
       fetchStockFront(key, { lite: true })
         .then((d) =>
@@ -445,6 +465,7 @@ function SectorDeckInner({
         changeDir={e?.changeDir}
         rankLabel={rankLabelFor(stock)}
         sparkline={e?.sparkline}
+        chartSupported={!!stock.naverCode}
         subLine={subLine}
         progress={progress}
       />

--- a/apps/web/__tests__/lib/stock-front-lite.test.ts
+++ b/apps/web/__tests__/lib/stock-front-lite.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/supply-demand-store", () => ({
+  readSupplyDemandHistory: vi.fn().mockResolvedValue([]),
+}));
+
+import { assembleStockFront } from "../../lib/stock-front";
+
+const dailyText = `
+[
+["날짜","시가","고가","저가","종가","거래량"],
+["20260616", 990, 1060, 980, 1000, 9000],
+["20260617", 1000, 1100, 990, 1010, 10000],
+["20260618", 1010, 1120, 1000, 1040, 12000],
+["20260619", 1040, 1150, 1030, 1090, 18000],
+["20260622", 1090, 1160, 1080, 1110, 22000],
+["20260623", 1110, 1200, 1100, 1180, 26000]
+]
+`;
+
+describe("assembleStockFront lite", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("siseJson.naver")) {
+          return new Response(dailyText, { status: 200 });
+        }
+        return new Response("{}", { status: 500 });
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("카드 경량 경로에서도 라인차트용 sparkline을 반환한다", async () => {
+    const front = await assembleStockFront("삼성전자", undefined, {}, { lite: true });
+
+    expect(front.sparkline).toEqual([1000, 1010, 1040, 1090, 1110, 1180]);
+    expect(front.taFact).toBeUndefined();
+    expect(front.fomo.inputs.volume).toBeDefined();
+    expect(front.fomo.inputs.price).toBeDefined();
+  });
+});

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -59,7 +59,7 @@ async function getFront(stock: string, lite = false): Promise<StockFrontData> {
       const sector = def ? sectorOf(def.canonical) : undefined;
       const [rankMap, attentionMap, themeRelativeMap] = await Promise.all([
         lite ? Promise.resolve({}) : getRankMap().catch(() => ({})),
-        lite ? Promise.resolve({} as Record<string, StockAttentionSignal>) : getAttentionMap().catch((): Record<string, StockAttentionSignal> => ({})),
+        getAttentionMap().catch((): Record<string, StockAttentionSignal> => ({})),
         !lite && sector
           ? getThemeRelativeMap(sector).catch((): Record<string, ThemeRelativeSignal> => ({}))
           : Promise.resolve({} as Record<string, ThemeRelativeSignal>),

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
-import { condenseThemeInsight, stockDef, supplyDemandFact, type CondensedInsight } from "@fomo/core";
+import { condenseThemeInsight, emptyThemeInsight, stockDef, supplyDemandFact, type CondensedInsight } from "@fomo/core";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { understandStock } from "../../../../lib/theme-understanding";
 import { readLatestSupplyDemand } from "../../../../lib/supply-demand-store";
@@ -21,6 +21,7 @@ export function OPTIONS() {
 
 // theme-insight 와 동일 정책 — (KST날짜, 종목) 키로 cold 를 하루 1회로. revalidate 6h(SWR — 대기 없이 갱신).
 const REVALIDATE_S = 21_600; // 6h
+const USER_WAIT_MS = 8_500;
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(stock: string): Promise<CondensedInsight> {
@@ -40,12 +41,42 @@ async function getInsight(stock: string): Promise<CondensedInsight> {
   return p;
 }
 
+function timeoutFallback(stock: string): CondensedInsight {
+  return condenseThemeInsight(emptyThemeInsight(stock, "인사이트 캐시 준비 중 — 원문 근거가 아직 충분히 모이지 않았어요."));
+}
+
+async function getInsightForRequest(stock: string, blocking: boolean): Promise<{ payload: CondensedInsight; coldFallback: boolean }> {
+  if (blocking) return { payload: await getInsight(stock), coldFallback: false };
+
+  let timedOut = false;
+  const timeout = new Promise<CondensedInsight>((resolve) => {
+    windowlessSetTimeout(() => {
+      timedOut = true;
+      resolve(timeoutFallback(stock));
+    }, USER_WAIT_MS);
+  });
+  const payload = await Promise.race([
+    getInsight(stock).catch((err) => {
+      console.warn("[stock-insight] getInsight failed", stock, (err as Error)?.message);
+      return timeoutFallback(stock);
+    }),
+    timeout,
+  ]);
+  return { payload, coldFallback: timedOut || payload.confidence === "insufficient" };
+}
+
+function windowlessSetTimeout(fn: () => void, ms: number): void {
+  setTimeout(fn, ms);
+}
+
 export async function GET(req: Request) {
-  const stock = new URL(req.url).searchParams.get("stock")?.trim();
+  const url = new URL(req.url);
+  const stock = url.searchParams.get("stock")?.trim();
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
-  const payload = await getInsight(stock);
+  const blocking = url.searchParams.get("blocking") === "1" || req.headers.get("x-warm") === "1";
+  const { payload, coldFallback } = await getInsightForRequest(stock, blocking);
 
   // 수급(외인·기관 장마감 확정) — 공식 지표 섹션에 객관 사실로 동봉(§4). 데이터 없으면 미표시(정직).
   // 캐시 밖에서 1회 조회(일별이라 가벼움). 테이블 전/미수집이면 null → 기존 응답 그대로.
@@ -57,7 +88,11 @@ export async function GET(req: Request) {
 
   return withCors(
     NextResponse.json(out, {
-      headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=1800" },
+      headers: {
+        "Cache-Control": coldFallback
+          ? "public, s-maxage=30, stale-while-revalidate=120"
+          : "public, s-maxage=900, stale-while-revalidate=1800",
+      },
     })
   );
 }

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -147,7 +147,7 @@ export interface StockFrontData {
 }
 
 export interface StockFrontOptions {
-  /** 카드 앞면용 경량 경로. 시총순위·TA·스파크라인·상세 지표를 빼고 가격/수급/언급만 쓴다. */
+  /** 카드 앞면용 경량 경로. 시총순위·TA·상세 지표를 빼고 가격/수급/언급/짧은 차트만 쓴다. */
   lite?: boolean;
 }
 
@@ -170,7 +170,7 @@ export async function assembleStockFront(
   const [basics, history, daily] = await Promise.all([
     (lite ? fetchStockBasicsLite(stock) : fetchStockBasics(stock)).catch(() => null),
     readSupplyDemandHistory(code).catch(() => []),
-    lite ? Promise.resolve({ candles: [], closes: [], volumes: [] }) : fetchStockDaily(code),
+    fetchStockDaily(code, lite ? 110 : 420),
   ]);
 
   const signals: CardFrontSignals = basics ? signalsFromBasics(basics) : {};
@@ -198,10 +198,10 @@ export async function assembleStockFront(
   if (rank) signals.marketCapRank = { scope: "market", market: rank.market, rank: rank.rank };
 
   // ── 포모 점수(척추) — 거래량 회전·가격(등락·추세)·수급. 언급량·prevScore 는 후속(없으면 제외). ──
-  const volRatio = lite ? undefined : volumeTurnover(daily.volumes);
+  const volRatio = volumeTurnover(daily.volumes);
   if (typeof volRatio === "number") signals.volumeRatio = volRatio;
   const ta = lite ? null : computeTechnicalAnalysis(daily.candles);
-  const trend = ta?.inputs.trendStrength ?? (lite ? undefined : trendStrength(daily.closes));
+  const trend = ta?.inputs.trendStrength ?? trendStrength(daily.closes);
   const fomo = computeFomoScore({
     ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
     ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
@@ -218,7 +218,7 @@ export async function assembleStockFront(
     signals,
     fomo,
     ...(taFact ? { taFact } : {}),
-    sparkline: lite ? [] : daily.closes.slice(-66),
+    sparkline: daily.closes.slice(lite ? -42 : -66),
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),
     ...(basics?.changeDir ? { changeDir: basics.changeDir } : {}),

--- a/scripts/warm-insights.ts
+++ b/scripts/warm-insights.ts
@@ -55,7 +55,7 @@ async function main() {
   const stockList = [...stocks];
   console.log(`[warm-insights] 종목 ${stockList.length}개: ${stockList.join(", ")}`);
   for (const stock of stockList) {
-    await warm(`/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`);
+    await warm(`/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}&blocking=1`);
   }
 
   console.log(`[warm-insights] 완료 — 테마 ${themes.length} + 종목 ${stockList.length} 워밍`);


### PR DESCRIPTION
## What
- Restore card line charts in the `stock-front?lite=1` path.
- Keep lite lightweight by fetching a shorter daily series and still skipping full TA/detail/rank work.
- Add a stable card chart slot:
  - supported Korean stocks show the line when data arrives
  - loading stocks show a small loading state
  - unsupported non-Naver stocks no longer stay stuck in "신호 확인 중"
- Wire stock attention signals back into lite stock-front so material hooks have more fuel.
- Timebox normal `/api/fomo/stock-insight` requests at 8.5s with an honest insufficient fallback.
- Keep warm jobs blocking via `blocking=1` so the cron can still fill the Vercel Data Cache.
- Add a regression test proving lite stock-front returns `sparkline`.

## Root cause
- Phase 5 moved card hydration to `lite=1`, but lite returned `sparkline: []`.
- Some discovered foreign/global stocks also have no `naverCode`, so card hydration was skipped and the card could remain in a loading-looking state.

## Validation
- `npm run test -- apps/web/__tests__/lib/stock-front-lite.test.ts`
- `npm run typecheck`
- `npm run test -- apps/web/__tests__/lib/stock-front-lite.test.ts packages/fomo-core/__tests__/card-front-hook.test.ts scripts/__tests__/fomo-quality-report.test.ts`
- `npm run lint`
- `npm run test`
- `npm run build:web`
- `npm run build:fomo-web`
- `npm run build:api`
