### PR TITLE
feat(fomo): enrich stock depth news evidence

### DIFF
--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -1,7 +1,9 @@
 import {
   parseNaverNews,
+  parseNaverStockNews,
   parseRssFeed,
   parseYahooRss,
+  type NaverStockNewsRawGroup,
   type NaverNewsRaw,
   type NewsSource,
   type RawArticle,
@@ -88,6 +90,7 @@ const KR_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] 
 // ───────────────────────── 네이버 금융 뉴스 (JSON) ─────────────────────────
 // 해외 증시 실시간 뉴스(이미 한국어). api.stock.naver.com/news/worldNews.
 const NAVER_NEWS_URL = "https://api.stock.naver.com/news/worldNews?pageSize=20&page=1";
+const NAVER_STOCK_NEWS_URL = "https://api.stock.naver.com/news/stock";
 
 export const naverNewsSource: NewsSource = {
   id: "naver",
@@ -110,6 +113,24 @@ export const naverNewsSource: NewsSource = {
     }
   },
 };
+
+/** 네이버 종목별 뉴스 — stock-insight 원문 근거 보강용. 코드 1개만 좁게 조회한다. */
+export async function fetchNaverStockNews(code: string, pageSize = 10): Promise<RawArticle[]> {
+  if (!/^\d{6}$/.test(code)) return [];
+  try {
+    const res = await fetch(`${NAVER_STOCK_NEWS_URL}/${code}?pageSize=${pageSize}&page=1`, {
+      headers: { accept: "application/json", "user-agent": BROWSER_UA },
+      signal: AbortSignal.timeout(8_000),
+      next: { revalidate: 600 },
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as NaverStockNewsRawGroup[];
+    return withTier(parseNaverStockNews(Array.isArray(json) ? json : [], new Date().toISOString()), "news-mid");
+  } catch (err) {
+    console.warn(`[fomo/news] naver stock ${code} error`, err);
+    return [];
+  }
+}
 
 /** 한국 RSS 피드 1개 → 한국어 RawArticle[]. 실패 시 빈 배열. */
 function makeKoreanRssSource({ id, url, source, tier }: (typeof KR_FEEDS)[number]): NewsSource {

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -18,7 +18,7 @@ import {
   type WordingVerdict,
   type OfficialFact,
 } from "@fomo/core";
-import { fetchAllNews } from "./fomo-news-sources";
+import { fetchAllNews, fetchNaverStockNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
 
@@ -225,7 +225,8 @@ export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
   const isForeign = def ? def.country !== "KR" : false;
   const matches = (s: string) => stockMatchesText(stock, s);
 
-  const [newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
+  const [stockNewsRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
+    code ? fetchNaverStockNews(code, MAX_NEWS) : Promise.resolve([]),
     fetchAllNews(),
     fetchDcStockTitles(),
     code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
@@ -240,22 +241,37 @@ export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
   const docs: SourceDoc[] = [];
   let n = 0;
   const nextId = () => `S${++n}`;
+  const seenNews = new Set<string>();
+  const pushNews = (a: Awaited<ReturnType<typeof fetchAllNews>>[number]) => {
+    const key = a.url || a.title;
+    if (!key || seenNews.has(key)) return;
+    seenNews.add(key);
+    docs.push({
+      id: nextId(),
+      kind: "news",
+      title: a.title,
+      ...(a.summary ? { body: a.summary } : {}),
+      ...(a.source ? { source: a.source } : {}),
+      ...(a.url ? { url: a.url } : {}),
+      ...(a.publishedAt ? { publishedAt: a.publishedAt } : {}),
+      tier: a.tier ?? "news-mid",
+    });
+  };
+
+  // 네이버 종목별 뉴스 — 전체 금융 RSS보다 종목 커버리지가 높아 stock-insight grounded 근거의 1순위 연료다.
+  if (stockNewsRes.status === "fulfilled") {
+    const hit = stockNewsRes.value
+      .filter((a) => matches(`${a.title} ${a.summary ?? ""}`))
+      .slice(0, MAX_NEWS);
+    for (const a of hit) pushNews(a);
+  } else {
+    console.warn("[stock-understanding] naver stock news error", stockNewsRes.reason);
+  }
 
   // 뉴스 — 종목명(별칭 포함)이 제목/요약에 등장하는 기사만.
   if (newsRes.status === "fulfilled") {
     const hit = newsRes.value.filter((a) => matches(`${a.title} ${a.summary ?? ""}`)).slice(0, MAX_NEWS);
-    for (const a of hit) {
-      docs.push({
-        id: nextId(),
-        kind: "news",
-        title: a.title,
-        ...(a.summary ? { body: a.summary } : {}),
-        ...(a.source ? { source: a.source } : {}),
-        ...(a.url ? { url: a.url } : {}),
-        ...(a.publishedAt ? { publishedAt: a.publishedAt } : {}),
-        tier: a.tier ?? "news-mid",
-      });
-    }
+    for (const a of hit) pushNews(a);
   } else {
     console.warn("[stock-understanding] news error", newsRes.reason);
   }

--- a/packages/fomo-core/__tests__/news-feed.test.ts
+++ b/packages/fomo-core/__tests__/news-feed.test.ts
@@ -5,6 +5,7 @@ import {
   localizeArticle,
   parseKoTranslations,
   parseNaverNews,
+  parseNaverStockNews,
   parseRssFeed,
   parseYahooRss,
   scoreArticleFomo,
@@ -135,6 +136,45 @@ describe("parseNaverNews", () => {
     expect(out[0]!.url).toBe("https://n.news.naver.com/mnews/article/fnGuide/123");
     expect(out[0]!.summary).toBe("반도체 강세");
     expect(out[0]!.publishedAt).toBe("2026-06-12T04:07:57.000Z");
+  });
+});
+
+describe("parseNaverStockNews", () => {
+  it("네이버 종목별 뉴스 그룹 → 한국어 기사 (중복 URL 제거)", () => {
+    const groups = [
+      {
+        total: 2,
+        items: [
+          {
+            officeId: "018",
+            articleId: "0006312961",
+            officeName: "이데일리",
+            datetime: "202606231203",
+            title: "짧은 제목",
+            titleFull: "'삼전닉스'가 끌어올린 R&amp;D 기업 실적",
+            body: "반도체 호황이 삼성전자와 SK하이닉스를 중심으로 기업 실적을 끌어올렸다.",
+            mobileNewsUrl: "https://n.news.naver.com/mnews/article/018/0006312961",
+          },
+          {
+            officeId: "018",
+            articleId: "0006312961",
+            officeName: "이데일리",
+            datetime: "202606231203",
+            titleFull: "중복 기사",
+            mobileNewsUrl: "https://n.news.naver.com/mnews/article/018/0006312961",
+          },
+        ],
+      },
+    ];
+
+    const out = parseNaverStockNews(groups, "2026-06-23T03:00:00Z");
+    expect(out).toHaveLength(1);
+    expect(out[0]!.title).toBe("'삼전닉스'가 끌어올린 R&D 기업 실적");
+    expect(out[0]!.source).toBe("이데일리");
+    expect(out[0]!.url).toBe("https://n.news.naver.com/mnews/article/018/0006312961");
+    expect(out[0]!.publishedAt).toBe("2026-06-23T03:03:00.000Z");
+    expect(out[0]!.summary).toContain("반도체 호황");
+    expect(out[0]!.lang).toBe("ko");
   });
 });
 

--- a/packages/fomo-core/src/news-feed/parse.ts
+++ b/packages/fomo-core/src/news-feed/parse.ts
@@ -36,6 +36,17 @@ function slugId(url: string): string {
   return `news-${url.replace(/^https?:\/\//, "").replace(/[^a-z0-9]+/gi, "-").slice(0, 60)}`;
 }
 
+function decodeHtmlText(s: string): string {
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#(\d+);/g, (_, n: string) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n: string) => String.fromCodePoint(Number.parseInt(n, 16)));
+}
+
 /**
  * 범용 RSS 2.0 파서 — 한국 금융 뉴스(한경/매경/연합 등) 정규화용.
  * 표준 <item>(title/link/description/pubDate)만 본다. category 영문 추론 없음(한국어 소스).
@@ -103,6 +114,22 @@ export interface NaverNewsRaw {
   dt?: string;
 }
 
+/** 네이버 종목별 뉴스 JSON 1그룹. (api.stock.naver.com/news/stock/{code}) */
+export interface NaverStockNewsRawGroup {
+  total?: number;
+  items?: Array<{
+    officeId?: string;
+    articleId?: string;
+    officeName?: string;
+    /** "YYYYMMDDHHmm" (KST). */
+    datetime?: string;
+    title?: string;
+    titleFull?: string;
+    body?: string;
+    mobileNewsUrl?: string;
+  }>;
+}
+
 /** "YYYYMMDDHHmmss"(KST) → ISO. 실패 시 빈 문자열. */
 function naverDtToIso(dt: string | undefined): string {
   if (!dt || !/^\d{14}$/.test(dt)) return "";
@@ -113,6 +140,11 @@ function naverDtToIso(dt: string | undefined): string {
   return Number.isNaN(t) ? "" : new Date(t).toISOString();
 }
 
+function naverStockDtToIso(dt: string | undefined): string {
+  if (!dt || !/^\d{12}$/.test(dt)) return "";
+  return naverDtToIso(`${dt}00`);
+}
+
 /**
  * 네이버 금융 뉴스 JSON → RawArticle[]. 이미 한국어(국내·해외 모두 한국어 번역 제공).
  * 본문 요약(subcontent)은 길어서 잘라 담는다. URL은 표준 n.news.naver.com 패턴.
@@ -121,12 +153,14 @@ export function parseNaverNews(items: NaverNewsRaw[], nowIso: string): RawArticl
   const out: RawArticle[] = [];
   const seen = new Set<string>();
   for (const it of items ?? []) {
-    const title = (it.tit ?? "").replace(/<[^>]*>/g, "").trim();
+    const title = decodeHtmlText((it.tit ?? "").replace(/<[^>]*>/g, "")).trim();
     if (!title || !it.oid || !it.aid) continue;
     const url = `https://n.news.naver.com/mnews/article/${it.oid}/${it.aid}`;
     if (seen.has(url)) continue;
     seen.add(url);
-    const summary = (it.subcontent ?? "").replace(/<[^>]*>/g, "").replace(/\*\*/g, "").trim().slice(0, 160);
+    const summary = decodeHtmlText((it.subcontent ?? "").replace(/<[^>]*>/g, "").replace(/\*\*/g, ""))
+      .trim()
+      .slice(0, 160);
     out.push({
       id: slugId(url),
       title,
@@ -136,6 +170,38 @@ export function parseNaverNews(items: NaverNewsRaw[], nowIso: string): RawArticl
       lang: "ko",
       ...(summary ? { summary } : {}),
     });
+  }
+  return out;
+}
+
+/** 네이버 종목별 뉴스 JSON → RawArticle[]. 종목 뎁스 원문 근거 보강용. */
+export function parseNaverStockNews(groups: NaverStockNewsRawGroup[], nowIso: string): RawArticle[] {
+  const out: RawArticle[] = [];
+  const seen = new Set<string>();
+  for (const group of groups ?? []) {
+    for (const it of group.items ?? []) {
+      const title = decodeHtmlText((it.titleFull || it.title || "").replace(/<[^>]*>/g, "")).trim();
+      if (!title) continue;
+      const url =
+        it.mobileNewsUrl ||
+        (it.officeId && it.articleId
+          ? `https://n.news.naver.com/mnews/article/${it.officeId}/${it.articleId}`
+          : "");
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      const summary = decodeHtmlText((it.body ?? "").replace(/<[^>]*>/g, "").replace(/\s+/g, " "))
+        .trim()
+        .slice(0, 200);
+      out.push({
+        id: slugId(url),
+        title,
+        url,
+        source: it.officeName?.trim() || "네이버 금융",
+        publishedAt: naverStockDtToIso(it.datetime) || nowIso,
+        lang: "ko",
+        ...(summary ? { summary } : {}),
+      });
+    }
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- Add a parser for Naver per-stock news responses, including date normalization, dedupe, and HTML entity decoding
- Add fetchNaverStockNews(code) and wire it into stock depth document collection
- Filter per-stock news back through stock alias matching so broad Samsung/SK group articles do not pollute stock-specific insight

## Verification
- npm run test -- news-feed
- npm run typecheck
- npm run lint
- npm run build:web
- npm run build:fomo-web
- Smoke: collectStockDocs('삼성SDI') now returns 1 stock-specific news doc + 10 community docs, with HTML entities decoded