### PR TITLE
feat(fomo-web): add today discovery stock deck

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -11,6 +11,7 @@ import {
 } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { SectorStockDeck } from "@/components/SectorStockDeck";
+import { TodayDiscoveryDeck } from "@/components/TodayDiscoveryDeck";
 import { KEYWORDS_UPDATED_EVENT, fetchKeywords, fetchThemeInsight, recordTaste, type KeywordsResponse } from "@/lib/fomoApi";
 import { keywordInterestScore, recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
@@ -181,13 +182,13 @@ function SectorChips({
 }
 
 export function KeywordCardFeed({ loggedIn, onRequireLogin }: FeedGate = {}) {
-  // 섹터 네비: null = "오늘"(기존 쏠림 피드, 무변경). 섹터 선택 시 그 섹터 종목 무한 스와이프.
+  // 섹터 네비: null = "오늘의 발견"(전체 종목 풀). 섹터 선택 시 그 섹터 종목 무한 스와이프.
   const [activeSector, setActiveSector] = useState<StockSector | null>(null);
   return (
     <div className="w-full">
       <SectorChips active={activeSector} onSelect={setActiveSector} />
       {activeSector === null ? (
-        <TodayFeed loggedIn={loggedIn} onRequireLogin={onRequireLogin} />
+        <TodayDiscoveryDeck loggedIn={loggedIn} onRequireLogin={onRequireLogin} />
       ) : (
         <SectorStockDeck
           key={activeSector}

--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -34,10 +34,10 @@ const NEON = "#D8FF3A";
 const EMPTY_FOMO = computeFomoScore({});
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
-type DeckStock = SectorStock & { reason?: string };
+export type DeckStock = SectorStock & { reason?: string };
 
 /** 종목별 앞면 데이터(stock-front 응답 캐시). 포모 점수(척추)·스파크라인·가격. */
-type FrontEntry = {
+export type FrontEntry = {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
   taFact?: TaFact;
@@ -85,7 +85,7 @@ function stockPersonalizationRank(stock: string, nowMs = Date.now()): number {
   return stockInterestScore(stock, nowMs) + watchBoost;
 }
 
-function rankInstantStocks(stocks: readonly DeckStock[], nowMs = Date.now()): DeckStock[] {
+export function rankInstantStocks(stocks: readonly DeckStock[], nowMs = Date.now()): DeckStock[] {
   return stocks
     .map((stock, index) => ({ stock, index, rank: stockPersonalizationRank(stock.canonical, nowMs) }))
     .sort(
@@ -358,7 +358,7 @@ export function SectorStockDeck({ sector, loggedIn, onRequireLogin }: SectorDeck
       </div>
     );
   return (
-    <SectorDeckInner
+    <StockDiscoveryDeckInner
       stocks={state.stocks}
       initialFronts={state.fronts}
       loggedIn={loggedIn}
@@ -367,7 +367,7 @@ export function SectorStockDeck({ sector, loggedIn, onRequireLogin }: SectorDeck
   );
 }
 
-function SectorDeckInner({
+export function StockDiscoveryDeckInner({
   stocks,
   initialFronts,
   loggedIn,

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SECTORS, type KeywordCard, type SectorStock, type StockSector } from "@fomo/core";
+import {
+  type DeckStock,
+  rankInstantStocks,
+  StockDiscoveryDeckInner,
+} from "@/components/SectorStockDeck";
+import { fetchSectorStocks, getCachedKeywords, warmKeywords } from "@/lib/fomoApi";
+import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
+
+const MAX_DISCOVERY_STOCKS = 60;
+const MIN_DISCOVERY_STOCKS = 30;
+const DISCOVERY_SECTORS: readonly StockSector[] = SECTORS.filter((sector) => sector !== "코인").slice(0, 6);
+const DISCOVERY_SECTOR_SET = new Set<string>(DISCOVERY_SECTORS);
+
+interface TodayDiscoveryDeckProps {
+  loggedIn?: boolean | undefined;
+  onRequireLogin?: (() => void) | undefined;
+}
+
+interface SectorPool {
+  sector: StockSector;
+  stocks: SectorStock[];
+}
+
+function toSector(value: string): StockSector | null {
+  return DISCOVERY_SECTOR_SET.has(value) ? (value as StockSector) : null;
+}
+
+function mergeTodayDiscoveryStocks(pools: readonly SectorPool[], cards: readonly KeywordCard[]): DeckStock[] {
+  const byCanonical = new Map<string, DeckStock>();
+
+  // 1) 캐시에 있는 발굴주를 먼저 넣는다. reason 이 있는 종목은 오늘 발견 풀의 핵심 신호다.
+  for (const card of cards) {
+    const sector = toSector(card.keyword);
+    const surprise = card.surpriseStock;
+    if (!sector || !surprise?.reason) continue;
+    byCanonical.set(surprise.canonical, {
+      canonical: surprise.canonical,
+      market: surprise.market,
+      country: surprise.country,
+      marquee: false,
+      sector,
+      reason: surprise.reason,
+    });
+  }
+
+  // 2) 여러 섹터 baseline pool 을 합친다. 이미 발굴주가 있으면 naverCode/marquee 메타만 보강한다.
+  for (const pool of pools) {
+    for (const stock of pool.stocks) {
+      const current = byCanonical.get(stock.canonical);
+      if (current) {
+        byCanonical.set(stock.canonical, {
+          ...stock,
+          ...(current.reason ? { reason: current.reason } : {}),
+        });
+        continue;
+      }
+      byCanonical.set(stock.canonical, stock);
+    }
+  }
+
+  const ranked = rankInstantStocks([...byCanonical.values()]);
+  return ranked.slice(0, MAX_DISCOVERY_STOCKS);
+}
+
+function DiscoveryEmpty() {
+  return (
+    <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout">
+      오늘 발견 풀을 불러오지 못했어요.
+      <br />
+      잠깐 뒤 다시 들어와 주세요.
+    </div>
+  );
+}
+
+export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryDeckProps) {
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "error" }
+    | { kind: "ready"; stocks: DeckStock[] }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    setState({ kind: "loading" });
+    (async () => {
+      try {
+        const cachedKeywords = getCachedKeywords();
+        if (!cachedKeywords) {
+          warmKeywords().catch((err) => console.warn("[TodayDiscoveryDeck] keywords warm failed", err));
+        }
+
+        const settled = await Promise.allSettled(
+          DISCOVERY_SECTORS.map(async (sector) => ({
+            sector,
+            stocks: (await fetchSectorStocks(sector, true)).stocks ?? [],
+          }))
+        );
+        if (!alive) return;
+
+        const pools: SectorPool[] = [];
+        for (const result of settled) {
+          if (result.status === "fulfilled" && result.value.stocks.length > 0) {
+            pools.push(result.value);
+          }
+        }
+        const stocks = mergeTodayDiscoveryStocks(pools, cachedKeywords?.cards ?? []);
+        if (stocks.length === 0) {
+          setState({ kind: "error" });
+          return;
+        }
+        setState({ kind: "ready", stocks });
+      } catch (err) {
+        console.warn("[TodayDiscoveryDeck] fetch failed", err);
+        if (alive) setState({ kind: "error" });
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (state.kind === "loading") {
+    return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
+  }
+  if (state.kind === "error") return <DiscoveryEmpty />;
+
+  return (
+    <StockDiscoveryDeckInner
+      stocks={state.stocks.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.stocks.length))}
+      loggedIn={loggedIn}
+      onRequireLogin={onRequireLogin}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add TodayDiscoveryDeck for the default Today tab so first entry shows stock discovery cards instead of keyword cards
- Build the MVP discovery pool from the top 6 real @fomo/core SECTORS, excluding coin for baseline stock-front coverage
- Mix cached surpriseStock reasons first, merge/dedupe sector baseline pools, rank with existing stock interest/watchlist signals, and cap at 60 cards
- Reuse the existing SectorStockDeck swipe engine so only current + next card hydrate stock-front lite

## Verification
- npm run typecheck:fomo-web
- npm run build:fomo-web
- npm run lint
- npm run typecheck
- npm run build:web
- npm run test
- Smoke: top 6 baseline sectors produce 67 local candidates before cap, so TodayDiscoveryDeck lands in the 30-60 target range