### PR TITLE
[codex] add why shown to stock deck

### DIFF
--- a/apps/fomo-web/__tests__/whyShown.test.ts
+++ b/apps/fomo-web/__tests__/whyShown.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { computeFomoScore } from "@fomo/core";
+import type { DeckStock } from "../lib/discoveryDeck";
+import { whyShown } from "../lib/whyShown";
+
+const baseStock: DeckStock = {
+  canonical: "대주전자재료",
+  market: "KOSDAQ",
+  country: "KR",
+  naverCode: "078600",
+  marquee: false,
+  sector: "2차전지",
+};
+
+const FORBIDDEN = /(매수|매도|사도 되는|타이밍|오를 가능성|추천)/;
+
+describe("whyShown", () => {
+  it("uses grounded discovery reason as the highest-priority display reason", () => {
+    const text = whyShown({
+      stock: { ...baseStock, reason: "실리콘 음극재 원문 근거" },
+      fomoLabel: "incoming",
+      signals: { mentionScore: 90, mentionCount: 6 },
+    });
+
+    expect(text).toBe("대장주 말고 ‘2차전지’ 흐름에서 같이 움직인 종목이에요.");
+    expect(text).not.toMatch(FORBIDDEN);
+  });
+
+  it("explains incoming stocks without sounding like investment advice", () => {
+    const incoming = computeFomoScore({ foreignNetStreak: 4, changePct: 0.3 });
+    const text = whyShown({ stock: baseStock, fomoLabel: incoming.label });
+
+    expect(incoming.label).toBe("incoming");
+    expect(text).toBe("아직 조용한데 수급이 먼저 들어오는 중이에요.");
+    expect(text).not.toMatch(FORBIDDEN);
+  });
+
+  it("uses mention signals only as an attention explanation", () => {
+    const text = whyShown({ stock: baseStock, signals: { mentionScore: 80, mentionCount: 4 } });
+
+    expect(text).toBe("오늘 이 종목을 언급한 뉴스·글이 늘었어요.");
+    expect(text).not.toMatch(FORBIDDEN);
+  });
+
+  it("always returns a deterministic fallback", () => {
+    const first = whyShown({ stock: baseStock });
+    const second = whyShown({ stock: baseStock });
+
+    expect(first).toBe("오늘 발견 풀에서 보여주는 종목이에요.");
+    expect(second).toBe(first);
+    expect(first).not.toMatch(FORBIDDEN);
+  });
+});

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -7,6 +7,7 @@ import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import { recordStockInterest } from "@/lib/stockInterest";
 import type { DeckStock } from "@/lib/discoveryDeck";
+import { whyShown } from "@/lib/whyShown";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon } from "@/components/icons";
 
 /**
@@ -137,6 +138,7 @@ function StockCardFace({
   sparkline,
   chartSupported,
   subLine,
+  why,
   progress,
 }: {
   stock: DeckStock;
@@ -150,6 +152,7 @@ function StockCardFace({
   sparkline?: number[] | undefined;
   chartSupported: boolean;
   subLine?: string | undefined;
+  why: string;
   progress?: string | undefined;
 }) {
   return (
@@ -213,6 +216,11 @@ function StockCardFace({
         {view.isLeading && <GemIcon size={18} className="mr-1 inline-block align-[-2px]" />}
         {view.headline}
       </p>
+
+      <div className="mt-3 rounded-lg border border-hairline bg-white/[0.035] px-3 py-2">
+        <span className="block text-[10px] text-muted">보여주는 이유</span>
+        <span className="mt-1 block text-sm leading-6 text-whiteout">{why}</span>
+      </div>
 
       {subLine && (
         <p className="mt-2 rounded-lg border border-hairline bg-black/10 px-3 py-2 text-sm leading-6 text-muted">
@@ -335,6 +343,14 @@ export function StockSwipeDeck({
     const r = front[stock.canonical]?.signals.marketCapRank;
     return r ? `시총 ${r.rank}위` : undefined; // 시장명은 1행에 이미 있음(중복 방지)
   };
+  const whyFor = (stock: DeckStock): string => {
+    const e = front[stock.canonical];
+    return whyShown({
+      stock,
+      fomoLabel: e?.fomo.label,
+      signals: e?.signals,
+    });
+  };
   const renderFace = (stock: DeckStock, progress?: string) => {
     const { view, catalysts, subLine } = cardFor(stock);
     const e = front[stock.canonical];
@@ -351,6 +367,7 @@ export function StockSwipeDeck({
         sparkline={e?.sparkline}
         chartSupported={!!stock.naverCode}
         subLine={subLine}
+        why={whyFor(stock)}
         progress={progress}
       />
     );
@@ -481,7 +498,7 @@ export function StockSwipeDeck({
       {selected && (
         <StockInsightView
           stock={selected.canonical}
-          context={{ fromTheme: selected.sector }}
+          context={{ fromTheme: selected.sector, reason: whyFor(selected) }}
           onClose={closeDepth}
         />
       )}

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -6,7 +6,7 @@ export const MAX_DISCOVERY_STOCKS = 60;
 export const MIN_DISCOVERY_STOCKS = 30;
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
-export type DeckStock = SectorStock & { reason?: string };
+export type DeckStock = SectorStock & { reason?: string; whyShown?: string };
 
 export interface SectorPool {
   sector: StockSector;

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -1,0 +1,46 @@
+import type { CardFrontSignals, FomoLabel, StockSector } from "@fomo/core";
+import { stocksBySector } from "@fomo/core";
+import { getWatchlist } from "./watchlist";
+import { stockInterestScore } from "./stockInterest";
+import type { DeckStock } from "./discoveryDeck";
+
+const HIGH_INTEREST_SCORE = 18;
+
+interface WhyShownInput {
+  stock: DeckStock;
+  fomoLabel?: FomoLabel | undefined;
+  signals?: CardFrontSignals | undefined;
+  nowMs?: number | undefined;
+}
+
+function hasWatchedPeer(sector: StockSector, stockName: string): boolean {
+  const watch = getWatchlist();
+  if (watch.length === 0) return false;
+  const sectorStocks = stocksBySector(sector);
+  const names = new Set(sectorStocks.map((s) => s.canonical));
+  names.delete(stockName);
+  return watch.some((w) => names.has(w.stock));
+}
+
+export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyShownInput): string {
+  if (stock.whyShown) return stock.whyShown;
+  if (stock.reason) {
+    return `대장주 말고 ‘${stock.sector}’ 흐름에서 같이 움직인 종목이에요.`;
+  }
+  if (hasWatchedPeer(stock.sector, stock.canonical)) {
+    return "네가 관심 둔 종목들과 같은 섹터에 있어요.";
+  }
+  if (stockInterestScore(stock.canonical, nowMs) >= HIGH_INTEREST_SCORE) {
+    return "네가 자주 멈춘 종목 흐름과 닮았어요.";
+  }
+  if (fomoLabel === "incoming") {
+    return "아직 조용한데 수급이 먼저 들어오는 중이에요.";
+  }
+  if (
+    (typeof signals?.mentionScore === "number" && signals.mentionScore >= 60) ||
+    (typeof signals?.mentionCount === "number" && signals.mentionCount >= 3)
+  ) {
+    return "오늘 이 종목을 언급한 뉴스·글이 늘었어요.";
+  }
+  return "오늘 발견 풀에서 보여주는 종목이에요.";
+}


### PR DESCRIPTION
## What changed
- Add a deterministic whyShown helper for stock discovery cards.
- Show a small "보여주는 이유" line on every stock card.
- Pass the same whyShown sentence into StockInsightView context.reason.
- Add tests for priority, deterministic fallback, and investment-advice guard wording.

## Scope note
Phase 4 interaction/design work is intentionally skipped per request.

## Validation
- npm run typecheck:fomo-web
- npm run build:fomo-web
- npm run lint
- npm run test