### PR TITLE
[codex] improve discovery deck mix

### DIFF
--- a/apps/fomo-web/__tests__/discoveryDeck.test.ts
+++ b/apps/fomo-web/__tests__/discoveryDeck.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { KeywordCard, SectorStock, StockSector } from "@fomo/core";
+import { buildTodayDiscoveryStocks, MAX_DISCOVERY_STOCKS } from "../lib/discoveryDeck";
+
+const storage = new Map<string, string>();
+
+function installLocalStorage() {
+  storage.clear();
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  storage.clear();
+});
+
+function stock(i: number, sector: StockSector = "AI", marquee = false): SectorStock {
+  return {
+    canonical: `테스트${i}`,
+    market: "KOSDAQ",
+    country: "KR",
+    naverCode: `${100000 + i}`,
+    marquee,
+    sector,
+  };
+}
+
+function pools(count: number) {
+  return [{ sector: "AI" as StockSector, stocks: Array.from({ length: count }, (_, i) => stock(i, "AI", i < 8)) }];
+}
+
+describe("buildTodayDiscoveryStocks", () => {
+  it("dedupes canonical stocks and caps the discovery deck", () => {
+    const cards = [
+      {
+        keyword: "AI",
+        surpriseStock: {
+          canonical: "테스트3",
+          market: "KOSDAQ",
+          country: "KR",
+          mentions: 2,
+          surprise: 0.8,
+          reason: "원문 근거",
+        },
+      } as KeywordCard,
+    ];
+
+    const result = buildTodayDiscoveryStocks(pools(70), cards, ["AI"]);
+
+    expect(result).toHaveLength(MAX_DISCOVERY_STOCKS);
+    expect(new Set(result.map((s) => s.canonical)).size).toBe(result.length);
+    expect(result.find((s) => s.canonical === "테스트3")?.reason).toBe("원문 근거");
+  });
+
+  it("pushes recently seen and lessed stocks out of the first 20 when there is enough pool", () => {
+    installLocalStorage();
+    const now = Date.now();
+    storage.set(
+      "fomo_stock_interest",
+      JSON.stringify([
+        { stock: "테스트0", signal: "seen", ts: now },
+        { stock: "테스트1", signal: "less", ts: now },
+      ])
+    );
+
+    const result = buildTodayDiscoveryStocks(pools(45), [], ["AI"]);
+    const first20 = result.slice(0, 20).map((s) => s.canonical);
+
+    expect(first20).not.toContain("테스트0");
+    expect(first20).not.toContain("테스트1");
+  });
+});

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -273,6 +273,7 @@ export function StockSwipeDeck({
   const dragging = useRef(false);
   const startX = useRef(0);
   const moved = useRef(false);
+  const lastSeenStock = useRef<string | null>(null);
 
   // 앞면 FOMO 신호 — ④ 정렬 때 풀 전체를 이미 받아 seed(initialFronts). 빠진 종목만 도달 시 lazy 보강.
   const [front, setFront] = useState<Record<string, FrontEntry>>(initialFronts ?? {});
@@ -437,6 +438,13 @@ export function StockSwipeDeck({
     ensureFront(at(idx));
     ensureFront(at(idx + 1));
   }, [idx, ensureFront]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const stock = at(idx).canonical;
+    if (lastSeenStock.current === stock) return;
+    lastSeenStock.current = stock;
+    recordStockInterest(stock, "seen", Date.now());
+  }, [idx, stocks]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const top = at(idx);
   const topTransform = exiting

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -1,9 +1,17 @@
-import type { KeywordCard, SectorStock, StockSector } from "@fomo/core";
-import { getWatchlist } from "@/lib/watchlist";
-import { stockInterestScore } from "@/lib/stockInterest";
+import { stocksBySector, type KeywordCard, type SectorStock, type StockSector } from "@fomo/core";
+import { getWatchlist } from "./watchlist";
+import { recentSeenStocks, stockInteractionSummary, stockInterestScore } from "./stockInterest";
 
 export const MAX_DISCOVERY_STOCKS = 60;
 export const MIN_DISCOVERY_STOCKS = 30;
+export const RECENT_SEEN_LIMIT = 20;
+
+export const DISCOVERY_MIX = {
+  marquee: 0.4,
+  discovered: 0.3,
+  tasteSimilar: 0.2,
+  quietLead: 0.1,
+} as const;
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
 export type DeckStock = SectorStock & { reason?: string; whyShown?: string };
@@ -99,5 +107,87 @@ export function buildTodayDiscoveryStocks(
     }
   }
 
-  return rankInstantStocks([...byCanonical.values()]).slice(0, MAX_DISCOVERY_STOCKS);
+  const all = rankTodayDiscoveryStocks([...byCanonical.values()]);
+  if (all.length <= MIN_DISCOVERY_STOCKS) return all;
+
+  const picked = new Map<string, DeckStock>();
+  const add = (stock: DeckStock) => {
+    if (!picked.has(stock.canonical)) picked.set(stock.canonical, stock);
+  };
+  const take = (group: readonly DeckStock[], count: number) => {
+    for (const stock of group) {
+      if (picked.size >= MAX_DISCOVERY_STOCKS || count <= 0) break;
+      if (picked.has(stock.canonical)) continue;
+      add(stock);
+      count -= 1;
+    }
+  };
+
+  const target = Math.min(MAX_DISCOVERY_STOCKS, all.length);
+  const discoveredTarget = Math.round(target * DISCOVERY_MIX.discovered);
+  const tasteTarget = Math.round(target * DISCOVERY_MIX.tasteSimilar);
+  const marqueeTarget = Math.round(target * DISCOVERY_MIX.marquee);
+  const quietLeadTarget = Math.round(target * DISCOVERY_MIX.quietLead);
+
+  const early = all.filter((s) => !isSuppressedForEarlyDiscovery(s));
+  const late = all.filter((s) => isSuppressedForEarlyDiscovery(s));
+  const discovered = early.filter((s) => !!s.reason);
+  const tasteSimilar = early.filter((s) => !s.reason && isTasteSimilarStock(s));
+  const marquee = early.filter((s) => !s.reason && s.marquee);
+  const quietLead: DeckStock[] = []; // 수급/💎 후보 데이터가 빌더 입력에 없으면 만들지 않는다.
+  const rest = early.filter((s) => !s.reason && !s.marquee && !isTasteSimilarStock(s));
+
+  take(discovered, discoveredTarget);
+  take(tasteSimilar, tasteTarget);
+  take(marquee, marqueeTarget);
+  take(quietLead, quietLeadTarget);
+  take(rest, target - picked.size);
+  take(early, target - picked.size);
+  take(late, target - picked.size);
+
+  return [...picked.values()].slice(0, MAX_DISCOVERY_STOCKS);
+}
+
+function isSuppressedForEarlyDiscovery(stock: DeckStock, nowMs = Date.now()): boolean {
+  if (recentSeenStocks(RECENT_SEEN_LIMIT).includes(stock.canonical)) return true;
+  const summary = stockInteractionSummary(stock.canonical);
+  const dayMs = 86_400_000;
+  const isFreshInteraction = typeof summary.lastTs === "number" && nowMs - summary.lastTs < dayMs;
+  return isFreshInteraction && (summary.lastSignal === "less" || summary.lastSignal === "more" || summary.lastSignal === "view_depth");
+}
+
+function rankTodayDiscoveryStocks(stocks: readonly DeckStock[], nowMs = Date.now()): DeckStock[] {
+  const recent = recentSeenStocks(RECENT_SEEN_LIMIT);
+  const recentRank = new Map(recent.map((stock, index) => [stock, RECENT_SEEN_LIMIT - index]));
+  return stocks
+    .map((stock, index) => ({ stock, index, rank: todayDiscoveryRank(stock, recentRank, nowMs) }))
+    .sort((a, b) => b.rank - a.rank || a.index - b.index)
+    .map((row) => row.stock);
+}
+
+function todayDiscoveryRank(stock: DeckStock, recentRank: ReadonlyMap<string, number>, nowMs: number): number {
+  const summary = stockInteractionSummary(stock.canonical);
+  const dayMs = 86_400_000;
+  const isFreshInteraction = typeof summary.lastTs === "number" && nowMs - summary.lastTs < dayMs;
+  const interest = stockInterestScore(stock.canonical, nowMs);
+  const recentPenalty = recentRank.get(stock.canonical) ?? 0;
+  const lessPenalty = isFreshInteraction && summary.lastSignal === "less" ? 220 : summary.lessCount > summary.moreCount + summary.depthCount ? 80 : 0;
+  const positiveRevisitPenalty =
+    isFreshInteraction && (summary.lastSignal === "more" || summary.lastSignal === "view_depth") ? 70 : 0;
+  return (
+    (stock.reason ? 90 : 0) +
+    (stock.marquee ? 35 : 0) +
+    (isTasteSimilarStock(stock) ? 40 : 0) +
+    interest * 0.25 -
+    recentPenalty * 10 -
+    lessPenalty -
+    positiveRevisitPenalty
+  );
+}
+
+function isTasteSimilarStock(stock: DeckStock): boolean {
+  const watch = getWatchlist();
+  if (watch.length === 0) return false;
+  const peers = new Set(stocksBySector(stock.sector).map((s) => s.canonical));
+  return watch.some((w) => w.stock !== stock.canonical && peers.has(w.stock));
 }

--- a/apps/fomo-web/lib/stockInterest.ts
+++ b/apps/fomo-web/lib/stockInterest.ts
@@ -5,7 +5,7 @@
 const KEY = "fomo_stock_interest";
 const CAP = 300;
 
-export type StockInterest = "more" | "less" | "view_depth";
+export type StockInterest = "more" | "less" | "view_depth" | "seen";
 
 interface StockInterestRecord {
   stock: string;
@@ -21,6 +21,16 @@ function read(): StockInterestRecord[] {
   } catch {
     return [];
   }
+}
+
+export interface StockInteractionSummary {
+  stock: string;
+  lastSignal?: StockInterest | undefined;
+  lastTs?: number | undefined;
+  moreCount: number;
+  lessCount: number;
+  depthCount: number;
+  seenCount: number;
 }
 
 export function recordStockInterest(stock: string, signal: StockInterest, nowMs: number): void {
@@ -41,7 +51,36 @@ export function stockInterestScore(stock: string, nowMs = Date.now()): number {
     .reduce((sum, r) => {
       const ageDays = Math.max(0, (nowMs - r.ts) / dayMs);
       const decay = Math.max(0.25, 1 - ageDays / 21);
-      const weight = r.signal === "view_depth" ? 14 : r.signal === "more" ? 10 : -12;
+      const weight = r.signal === "view_depth" ? 14 : r.signal === "more" ? 10 : r.signal === "less" ? -12 : 0;
       return sum + weight * decay;
     }, 0);
+}
+
+export function recentSeenStocks(limit = 20): string[] {
+  const seen: string[] = [];
+  const used = new Set<string>();
+  for (const record of [...read()].reverse()) {
+    if (record.signal !== "seen" && record.signal !== "more" && record.signal !== "less" && record.signal !== "view_depth") {
+      continue;
+    }
+    if (used.has(record.stock)) continue;
+    used.add(record.stock);
+    seen.push(record.stock);
+    if (seen.length >= limit) break;
+  }
+  return seen;
+}
+
+export function stockInteractionSummary(stock: string): StockInteractionSummary {
+  const rows = read().filter((r) => r.stock === stock);
+  const last = rows.at(-1);
+  return {
+    stock,
+    lastSignal: last?.signal,
+    lastTs: last?.ts,
+    moreCount: rows.filter((r) => r.signal === "more").length,
+    lessCount: rows.filter((r) => r.signal === "less").length,
+    depthCount: rows.filter((r) => r.signal === "view_depth").length,
+    seenCount: rows.filter((r) => r.signal === "seen").length,
+  };
 }


### PR DESCRIPTION
## What changed
- Add explicit discovery mix constants for marquee/discovered/tasteSimilar/quietLead.
- Build today's discovery deck with dedupe, 60-card cap, reason-stock priority, and taste-similar slots.
- Record displayed stock cards as local seen signals without affecting preference score.
- Push recently seen, freshly lessed, and freshly opened/interested stocks out of the early deck when enough alternatives exist.
- Add tests for dedupe/cap and early repeat suppression.

## Scope note
Phase 4 design/interaction work remains skipped per request. quietLead remains a seam until reliable lead-signal data is available in the deck builder input.

## Validation
- npm run typecheck:fomo-web
- npm run build:fomo-web
- npm run lint
- npm run test