### PR TITLE
[codex] add discovery drawer and metrics

### DIFF
--- a/apps/fomo-web/__tests__/discoveryMetrics.test.ts
+++ b/apps/fomo-web/__tests__/discoveryMetrics.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { applyDiscoveryMetricEvent, type DiscoveryMetricState } from "../lib/discoveryMetrics";
+
+function state(): DiscoveryMetricState {
+  return {
+    sessionId: "test-session",
+    sessionStartedAt: 1_000,
+    swipes: 0,
+    rightSwipes: 0,
+    leftSwipes: 0,
+    depthOpens: 0,
+    interestButtonClicks: 0,
+    hydrateCompletions: 0,
+    swipesBeforeHydrate: 0,
+    reachedTenSwipes: false,
+  };
+}
+
+describe("discovery metrics", () => {
+  it("records first card and first swipe timing once", () => {
+    let next = applyDiscoveryMetricEvent(state(), "first_card_display", { nowMs: 1_120 });
+    next = applyDiscoveryMetricEvent(next, "first_card_display", { nowMs: 1_400 });
+    next = applyDiscoveryMetricEvent(next, "swipe", { direction: "right", nowMs: 1_500, hydrated: true });
+    next = applyDiscoveryMetricEvent(next, "swipe", { direction: "left", nowMs: 2_000, hydrated: true });
+
+    expect(next.firstCardMs).toBe(120);
+    expect(next.firstSwipeMs).toBe(500);
+    expect(next.swipes).toBe(2);
+    expect(next.rightSwipes).toBe(1);
+    expect(next.leftSwipes).toBe(1);
+  });
+
+  it("counts depth, interest button, hydration, and pre-hydrate swipes", () => {
+    let next = applyDiscoveryMetricEvent(state(), "card_hydrate");
+    next = applyDiscoveryMetricEvent(next, "swipe", { direction: "left", elapsedMs: 30, hydrated: false });
+    next = applyDiscoveryMetricEvent(next, "interest_button");
+    next = applyDiscoveryMetricEvent(next, "depth_open");
+
+    expect(next.hydrateCompletions).toBe(1);
+    expect(next.swipesBeforeHydrate).toBe(1);
+    expect(next.interestButtonClicks).toBe(1);
+    expect(next.depthOpens).toBe(1);
+  });
+
+  it("marks sessions that reach ten swipes", () => {
+    let next = state();
+    for (let i = 0; i < 10; i += 1) {
+      next = applyDiscoveryMetricEvent(next, "swipe", { direction: "right", elapsedMs: i, hydrated: true });
+    }
+
+    expect(next.swipes).toBe(10);
+    expect(next.reachedTenSwipes).toBe(true);
+  });
+});

--- a/apps/fomo-web/__tests__/watchlist.test.ts
+++ b/apps/fomo-web/__tests__/watchlist.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getWatchlist, toggleWatch, upsertWatch } from "../lib/watchlist";
+
+const storage = new Map<string, string>();
+
+function installLocalStorage() {
+  storage.clear();
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  storage.clear();
+});
+
+describe("watchlist discovery metadata", () => {
+  it("keeps old watchlist rows readable while dropping malformed values", () => {
+    installLocalStorage();
+    storage.set(
+      "fomo_watchlist",
+      JSON.stringify([
+        { stock: "삼성SDI", ts: 100 },
+        { stock: "대주전자재료", ts: 200, sector: "2차전지", reason: "같은 흐름에서 같이 움직인 종목이에요." },
+        { stock: 123, ts: 300 },
+      ])
+    );
+
+    expect(getWatchlist()).toEqual([
+      { stock: "대주전자재료", ts: 200, sector: "2차전지", reason: "같은 흐름에서 같이 움직인 종목이에요." },
+      { stock: "삼성SDI", ts: 100 },
+    ]);
+  });
+
+  it("upserts discovery metadata by stock", () => {
+    installLocalStorage();
+
+    upsertWatch("대주전자재료", 100, { sector: "2차전지", reason: "첫 이유" });
+    upsertWatch("대주전자재료", 200, { sector: "2차전지", reason: "갱신된 이유" });
+
+    expect(getWatchlist()).toEqual([
+      { stock: "대주전자재료", ts: 200, sector: "2차전지", reason: "갱신된 이유" },
+    ]);
+  });
+
+  it("toggleWatch stores metadata on add and removes the item on the next toggle", () => {
+    installLocalStorage();
+
+    expect(toggleWatch("한미반도체", 100, { sector: "반도체", reason: "보여주는 이유" })).toBe(true);
+    expect(getWatchlist()[0]).toMatchObject({ stock: "한미반도체", sector: "반도체", reason: "보여주는 이유" });
+
+    expect(toggleWatch("한미반도체", 200)).toBe(false);
+    expect(getWatchlist()).toEqual([]);
+  });
+});

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -767,7 +767,10 @@ export function StockInsightView({
   }, [stock]);
 
   const toggleWatched = () => {
-    const now = toggleWatch(stock, Date.now());
+    const now = toggleWatch(stock, Date.now(), {
+      ...(context?.fromTheme ? { sector: context.fromTheme } : {}),
+      ...(context?.reason ? { reason: context.reason } : {}),
+    });
     setWatchedState(now);
     recordTaste("stock", stock, now ? "more" : "less"); // 서버 취향 신호(트랙 B 재사용)
   };

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import { MOCK_KEYWORD_CARDS, scoreToColor, type KeywordCard } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
+import { MyDiscoveryPreview } from "@/components/MyDiscoveryPreview";
 import { getHistory } from "@/lib/keywordHistory";
-import { getWatchlist } from "@/lib/watchlist";
+import { getWatchlist, type WatchItem } from "@/lib/watchlist";
 
 /**
  * 히스토리 탭 — 내가 본 키워드 카드 다시 보기. KEYWORD_CARD_FEED_DEV_SPEC v3.
@@ -23,7 +24,7 @@ export function KeywordHistory() {
   const [history] = useState(() => getHistory());
   const [watchlist] = useState(() => getWatchlist());
   const [selected, setSelected] = useState<KeywordCard | null>(null);
-  const [stockSel, setStockSel] = useState<string | null>(null);
+  const [stockSel, setStockSel] = useState<WatchItem | null>(null);
 
   if (history.length === 0 && watchlist.length === 0) {
     return (
@@ -37,23 +38,7 @@ export function KeywordHistory() {
 
   return (
     <div className="w-full">
-      {watchlist.length > 0 && (
-        <section className="mb-6">
-          <p className="mb-3 px-1 text-xs text-muted">관심 종목 ♥</p>
-          <div className="flex flex-col gap-2.5">
-            {watchlist.map((w) => (
-              <button
-                key={`${w.stock}-${w.ts}`}
-                onClick={() => setStockSel(w.stock)}
-                className="flex w-full items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-3 text-left transition-colors hover:border-muted"
-              >
-                <span className="text-base font-semibold text-whiteout">{w.stock}</span>
-                <span className="text-[11px] text-muted">{relativeTime(w.ts)}</span>
-              </button>
-            ))}
-          </div>
-        </section>
-      )}
+      <MyDiscoveryPreview items={watchlist} onOpen={setStockSel} />
 
       {history.length > 0 && <p className="mb-3 px-1 text-xs text-muted">내가 본 키워드</p>}
       <div className="flex flex-col gap-2.5">
@@ -83,7 +68,16 @@ export function KeywordHistory() {
       </div>
 
       {selected && <KeywordDepthPage card={selected} onClose={() => setSelected(null)} />}
-      {stockSel && <StockInsightView stock={stockSel} onClose={() => setStockSel(null)} />}
+      {stockSel && (
+        <StockInsightView
+          stock={stockSel.stock}
+          context={{
+            ...(stockSel.sector ? { fromTheme: stockSel.sector } : {}),
+            ...(stockSel.reason ? { reason: stockSel.reason } : {}),
+          }}
+          onClose={() => setStockSel(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/fomo-web/components/MyDiscoveryPreview.tsx
+++ b/apps/fomo-web/components/MyDiscoveryPreview.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { WatchItem } from "@/lib/watchlist";
+
+function relativeTime(ts: number): string {
+  const mins = Math.floor((Date.now() - ts) / 60_000);
+  if (mins < 1) return "방금";
+  if (mins < 60) return `${mins}분 전`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  return `${Math.floor(hours / 24)}일 전`;
+}
+
+export function MyDiscoveryPreview({
+  items,
+  onOpen,
+}: {
+  items: readonly WatchItem[];
+  onOpen: (item: WatchItem) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-center justify-between px-1">
+        <p className="text-xs text-muted">내 발굴함</p>
+        <span className="font-pixel text-[10px] text-muted">{items.length}</span>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        {items.slice(0, 8).map((item) => (
+          <button
+            key={`${item.stock}-${item.ts}`}
+            onClick={() => onOpen(item)}
+            className="w-full rounded-xl border border-hairline bg-surface px-4 py-3 text-left transition-colors hover:border-muted"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="min-w-0 truncate text-base font-semibold text-whiteout">{item.stock}</span>
+              <span className="shrink-0 text-[11px] text-muted">{relativeTime(item.ts)}</span>
+            </div>
+            {(item.sector || item.reason) && (
+              <div className="mt-1.5 flex flex-col gap-1">
+                {item.sector && <span className="text-[11px] text-muted"># {item.sector}</span>}
+                {item.reason && <span className="line-clamp-2 text-xs leading-5 text-muted">{item.reason}</span>}
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -6,8 +6,10 @@ import type { CardFrontSignals, FomoScoreResult, FomoCardView, TaFact } from "@f
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import { recordStockInterest } from "@/lib/stockInterest";
+import { upsertWatch } from "@/lib/watchlist";
 import type { DeckStock } from "@/lib/discoveryDeck";
 import { whyShown } from "@/lib/whyShown";
+import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon } from "@/components/icons";
 
 /**
@@ -262,6 +264,7 @@ interface StockSwipeDeckProps {
 export function StockSwipeDeck({
   stocks,
   initialFronts,
+  contextLabel,
   loggedIn,
   onRequireLogin,
 }: StockSwipeDeckProps) {
@@ -274,6 +277,8 @@ export function StockSwipeDeck({
   const startX = useRef(0);
   const moved = useRef(false);
   const lastSeenStock = useRef<string | null>(null);
+  const firstCardRecorded = useRef(false);
+  const hydratedRecorded = useRef<Set<string>>(new Set());
 
   // 앞면 FOMO 신호 — ④ 정렬 때 풀 전체를 이미 받아 seed(initialFronts). 빠진 종목만 도달 시 lazy 보강.
   const [front, setFront] = useState<Record<string, FrontEntry>>(initialFronts ?? {});
@@ -352,6 +357,9 @@ export function StockSwipeDeck({
       signals: e?.signals,
     });
   };
+  const saveDiscovery = (stock: DeckStock) => {
+    upsertWatch(stock.canonical, Date.now(), { sector: stock.sector, reason: whyFor(stock) });
+  };
   const renderFace = (stock: DeckStock, progress?: string) => {
     const { view, catalysts, subLine } = cardFor(stock);
     const e = front[stock.canonical];
@@ -390,19 +398,26 @@ export function StockSwipeDeck({
 
   const advance = useCallback(
     (dir: "left" | "right") => {
-      const stock = at(idx).canonical;
-      recordStockInterest(stock, dir === "right" ? "more" : "less", Date.now());
-      recordTaste("stock", stock, dir === "right" ? "more" : "less"); // 트랙 B 적재
+      const stock = at(idx);
+      if (dir === "right") saveDiscovery(stock);
+      recordDiscoveryEvent("swipe", { direction: dir, hydrated: !!front[stock.canonical] });
+      recordStockInterest(stock.canonical, dir === "right" ? "more" : "less", Date.now());
+      recordTaste("stock", stock.canonical, dir === "right" ? "more" : "less"); // 트랙 B 적재
       flingNext(dir);
     },
-    [idx, stocks, flingNext]
+    [idx, stocks, flingNext, front]
   );
 
-  const openDepth = (stock: DeckStock) => {
+  const openDepth = (stock: DeckStock, source: "card" | "interest_button" = "card") => {
     if (!loggedIn && onRequireLogin) {
       onRequireLogin();
       return;
     }
+    if (source === "interest_button") {
+      saveDiscovery(stock);
+      recordDiscoveryEvent("interest_button");
+    }
+    recordDiscoveryEvent("depth_open");
     recordStockInterest(stock.canonical, "view_depth", Date.now());
     recordTaste("stock", stock.canonical, "view_depth"); // 강한 관심
     setSelected(stock);
@@ -440,11 +455,26 @@ export function StockSwipeDeck({
   }, [idx, ensureFront]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    recordDiscoveryEvent("deck_mount");
+  }, [contextLabel]);
+
+  useEffect(() => {
     const stock = at(idx).canonical;
+    if (!firstCardRecorded.current) {
+      firstCardRecorded.current = true;
+      recordDiscoveryEvent("first_card_display");
+    }
     if (lastSeenStock.current === stock) return;
     lastSeenStock.current = stock;
     recordStockInterest(stock, "seen", Date.now());
   }, [idx, stocks]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const stock = at(idx).canonical;
+    if (!front[stock] || hydratedRecorded.current.has(stock)) return;
+    hydratedRecorded.current.add(stock);
+    recordDiscoveryEvent("card_hydrate");
+  }, [idx, front, stocks]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const top = at(idx);
   const topTransform = exiting
@@ -462,7 +492,7 @@ export function StockSwipeDeck({
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onClick={() => {
-            if (!moved.current && !exiting) openDepth(top);
+            if (!moved.current && !exiting) openDepth(top, "card");
           }}
           className="glass-card absolute inset-0 z-10 cursor-pointer overflow-hidden rounded-2xl px-6 py-7"
           style={{ transform: topTransform, transition: topTransition }}
@@ -493,7 +523,7 @@ export function StockSwipeDeck({
           ✕
         </button>
         <button
-          onClick={() => openDepth(top)}
+          onClick={() => openDepth(top, "interest_button")}
           disabled={!!exiting}
           aria-label="관심 — 자세히 보기"
           className="flex h-14 flex-1 items-center justify-center rounded-full text-sm font-bold text-canvas transition-opacity disabled:opacity-40"

--- a/apps/fomo-web/lib/discoveryMetrics.ts
+++ b/apps/fomo-web/lib/discoveryMetrics.ts
@@ -1,0 +1,107 @@
+const KEY = "fomo_discovery_metrics";
+
+export type DiscoveryMetricEvent =
+  | "deck_mount"
+  | "first_card_display"
+  | "card_hydrate"
+  | "swipe"
+  | "depth_open"
+  | "interest_button";
+
+export interface DiscoveryMetricState {
+  sessionId: string;
+  sessionStartedAt: number;
+  firstCardMs?: number;
+  firstSwipeMs?: number;
+  swipes: number;
+  rightSwipes: number;
+  leftSwipes: number;
+  depthOpens: number;
+  interestButtonClicks: number;
+  hydrateCompletions: number;
+  swipesBeforeHydrate: number;
+  reachedTenSwipes: boolean;
+}
+
+export interface DiscoveryMetricPayload {
+  nowMs?: number;
+  elapsedMs?: number;
+  direction?: "left" | "right";
+  hydrated?: boolean;
+}
+
+const now = () => (typeof performance !== "undefined" ? performance.now() : Date.now());
+
+function createState(nowMs = now()): DiscoveryMetricState {
+  return {
+    sessionId: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    sessionStartedAt: nowMs,
+    swipes: 0,
+    rightSwipes: 0,
+    leftSwipes: 0,
+    depthOpens: 0,
+    interestButtonClicks: 0,
+    hydrateCompletions: 0,
+    swipesBeforeHydrate: 0,
+    reachedTenSwipes: false,
+  };
+}
+
+function readState(): DiscoveryMetricState {
+  if (typeof window === "undefined") return createState();
+  try {
+    const raw = window.sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as DiscoveryMetricState) : createState();
+  } catch {
+    return createState();
+  }
+}
+
+function writeState(state: DiscoveryMetricState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(KEY, JSON.stringify(state));
+  } catch {
+    /* 계측 실패는 제품 흐름을 막지 않는다 */
+  }
+}
+
+export function applyDiscoveryMetricEvent(
+  state: DiscoveryMetricState,
+  event: DiscoveryMetricEvent,
+  payload: DiscoveryMetricPayload = {}
+): DiscoveryMetricState {
+  const next = { ...state };
+  const elapsed = payload.elapsedMs ?? Math.max(0, (payload.nowMs ?? now()) - state.sessionStartedAt);
+  if (event === "first_card_display" && next.firstCardMs === undefined) next.firstCardMs = elapsed;
+  if (event === "card_hydrate") next.hydrateCompletions += 1;
+  if (event === "depth_open") next.depthOpens += 1;
+  if (event === "interest_button") next.interestButtonClicks += 1;
+  if (event === "swipe") {
+    next.swipes += 1;
+    if (next.firstSwipeMs === undefined) next.firstSwipeMs = elapsed;
+    if (payload.direction === "right") next.rightSwipes += 1;
+    if (payload.direction === "left") next.leftSwipes += 1;
+    if (payload.hydrated === false) next.swipesBeforeHydrate += 1;
+    if (next.swipes >= 10) next.reachedTenSwipes = true;
+  }
+  return next;
+}
+
+export function recordDiscoveryEvent(event: DiscoveryMetricEvent, payload: DiscoveryMetricPayload = {}): void {
+  const state = applyDiscoveryMetricEvent(readState(), event, payload);
+  writeState(state);
+  if (process.env.NODE_ENV !== "production") {
+    console.debug("[discovery-metric]", event, payload, state);
+  }
+}
+
+export function readDiscoveryMetrics(): DiscoveryMetricState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as DiscoveryMetricState) : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/fomo-web/lib/watchlist.ts
+++ b/apps/fomo-web/lib/watchlist.ts
@@ -11,13 +11,30 @@ const CAP = 200;
 export interface WatchItem {
   stock: string;
   ts: number;
+  sector?: string;
+  reason?: string;
 }
 
 function read(): WatchItem[] {
   if (typeof window === "undefined") return [];
   try {
     const raw = window.localStorage.getItem(KEY);
-    return raw ? (JSON.parse(raw) as WatchItem[]) : [];
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item): WatchItem | null => {
+        if (!item || typeof item !== "object") return null;
+        const row = item as Record<string, unknown>;
+        if (typeof row.stock !== "string" || typeof row.ts !== "number") return null;
+        return {
+          stock: row.stock,
+          ts: row.ts,
+          ...(typeof row.sector === "string" ? { sector: row.sector } : {}),
+          ...(typeof row.reason === "string" ? { reason: row.reason } : {}),
+        };
+      })
+      .filter((item): item is WatchItem => item !== null);
   } catch {
     return [];
   }
@@ -41,8 +58,30 @@ export function getWatchlist(): WatchItem[] {
   return [...read()].sort((a, b) => b.ts - a.ts);
 }
 
+/** 관심 등록/갱신 — 기존 localStorage 구조와 호환되게 stock 기준으로 upsert. */
+export function upsertWatch(
+  stock: string,
+  nowMs: number,
+  meta: { sector?: string | undefined; reason?: string | undefined } = {}
+): WatchItem | null {
+  if (typeof window === "undefined" || !stock) return null;
+  const list = read().filter((w) => w.stock !== stock);
+  const item: WatchItem = {
+    stock,
+    ts: nowMs,
+    ...(meta.sector ? { sector: meta.sector } : {}),
+    ...(meta.reason ? { reason: meta.reason } : {}),
+  };
+  write([...list, item]);
+  return item;
+}
+
 /** 관심 토글 — 새 상태(true=관심 등록됨) 반환. */
-export function toggleWatch(stock: string, nowMs: number): boolean {
+export function toggleWatch(
+  stock: string,
+  nowMs: number,
+  meta: { sector?: string | undefined; reason?: string | undefined } = {}
+): boolean {
   if (typeof window === "undefined") return false;
   const list = read();
   const exists = list.some((w) => w.stock === stock);
@@ -50,7 +89,7 @@ export function toggleWatch(stock: string, nowMs: number): boolean {
     write(list.filter((w) => w.stock !== stock));
     return false;
   }
-  write([...list, { stock, ts: nowMs }]);
+  upsertWatch(stock, nowMs, meta);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- add My Discovery preview to the history tab using local watchlist metadata
- save discovery reason and sector when users right-swipe or tap the interest button
- add local discovery metrics for first card, swipes, depth opens, interest clicks, hydration, and 10+ swipe sessions
- Phase 4 interaction/design work is intentionally skipped per request

## Verification
- npm run typecheck:fomo-web
- npm run test
- npm run build:fomo-web
- npm run lint