### PR TITLE
[codex] stabilize stock card rationale

### DIFF
--- a/apps/fomo-web/__tests__/whyShown.test.ts
+++ b/apps/fomo-web/__tests__/whyShown.test.ts
@@ -22,7 +22,27 @@ describe("whyShown", () => {
       signals: { mentionScore: 90, mentionCount: 6 },
     });
 
-    expect(text).toBe("대장주 말고 ‘2차전지’ 흐름에서 같이 움직인 종목이에요.");
+    expect(text).toBe("‘2차전지’ 흐름에서 같이 잡힌 원문 근거가 있어요: 실리콘 음극재 원문 근거");
+    expect(text).not.toMatch(FORBIDDEN);
+  });
+
+  it("explains bearish attention as a check card, not a bullish recommendation", () => {
+    const text = whyShown({
+      stock: { ...baseStock, marquee: true },
+      signals: { changePct: -6.4, mentionScore: 80, mentionCount: 5, volumeRatio: 2.1 },
+    });
+
+    expect(text).toBe("강세 카드가 아니라, 하락 중에도 거래·언급이 몰린 이유를 확인하는 카드예요.");
+    expect(text).not.toMatch(FORBIDDEN);
+  });
+
+  it("keeps falling stocks with positive supply explainable", () => {
+    const text = whyShown({
+      stock: baseStock,
+      signals: { changePct: -3.2, foreignNetStreak: 4 },
+    });
+
+    expect(text).toBe("가격은 빠졌지만 외국인 수급이 이어져서 확인 대상으로 보여줘요.");
     expect(text).not.toMatch(FORBIDDEN);
   });
 
@@ -46,7 +66,7 @@ describe("whyShown", () => {
     const first = whyShown({ stock: baseStock });
     const second = whyShown({ stock: baseStock });
 
-    expect(first).toBe("오늘 발견 풀에서 보여주는 종목이에요.");
+    expect(first).toBe("아직 강한 재료는 적어요. 2차전지 발견 풀에서 흐름 확인용으로 보여줘요.");
     expect(second).toBe(first);
     expect(first).not.toMatch(FORBIDDEN);
   });

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -608,6 +608,20 @@ function buildReadPoints(front: StockFrontResponse | null, insight: CondensedIns
   };
 }
 
+function readGuideLead(front: StockFrontResponse | null, insight: CondensedInsight | null, context?: StockContext): string {
+  const points = buildReadPoints(front, insight);
+  if (front?.changeDir === "down" && points.bull.length === 0 && points.bear.length > 0) {
+    return "강세로 확정해서 보여주는 카드가 아니에요. 하락 중에도 남아 있는 수급·거래·언급 신호를 확인하는 화면이에요.";
+  }
+  if (context?.reason) {
+    return "카드에서 본 이유를 가격·차트·원문 근거로 나눠 확인해요.";
+  }
+  if (front && points.bull.length === 0 && points.bear.length === 0) {
+    return "아직 강한 근거는 적어요. 확인된 가격·차트·수급만 분리해서 봐요.";
+  }
+  return front ? fomoStateSummary(front.fomo) : "";
+}
+
 function PointList({ title, tone, points, empty }: { title: string; tone: string; points: ReadPoint[]; empty: string }) {
   return (
     <div className="rounded-lg border border-hairline bg-surface px-3 py-3">
@@ -634,12 +648,15 @@ function StockReadGuide({
   front,
   insight,
   loading,
+  context,
 }: {
   front: StockFrontResponse | null;
   insight: CondensedInsight | null;
   loading: boolean;
+  context?: StockContext | undefined;
 }) {
   const points = buildReadPoints(front, insight);
+  const lead = readGuideLead(front, insight, context);
   const hasGrounded = !!insight && insight.confidence !== "insufficient" && insight.bull.length + insight.bear.length > 0;
   return (
     <section className="mt-6">
@@ -651,7 +668,7 @@ function StockReadGuide({
           <span className="text-[11px] text-muted">{hasGrounded ? "원문 근거 있음" : "원문 근거 부족"}</span>
         )}
       </div>
-      {front && <p className="mt-2 text-sm leading-6 text-muted">{fomoStateSummary(front.fomo)}</p>}
+      {lead && <p className="mt-2 text-sm leading-6 text-muted">{lead}</p>}
       <div className="mt-3 grid gap-2">
         <PointList
           title="강세 쪽 재료"
@@ -856,7 +873,7 @@ export function StockInsightView({
           <DetailChart front={front} />
 
           {/* 핵심 해석 — 강세/약세 원문이 부족해도 가격·차트·수급으로 읽을 재료를 먼저 보여준다. */}
-          <StockReadGuide front={front} insight={insight} loading={false} />
+          <StockReadGuide front={front} insight={insight} loading={false} context={context} />
 
           {/* 포모 상태 — 카드와 같은 단일 출처지만, 상세의 첫 주인공은 가격/차트가 담당. */}
           <div className="mt-6">

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -214,18 +214,18 @@ function StockCardFace({
       )}
 
       {/* 헤드라인 = 종목별 후킹 사실 1개. 색 강조는 점수/미터/CTA에만 둔다. */}
-      <p className="mt-4 text-xl font-bold leading-8 text-whiteout">
+      <p className="mt-4 line-clamp-3 text-xl font-bold leading-8 text-whiteout">
         {view.isLeading && <GemIcon size={18} className="mr-1 inline-block align-[-2px]" />}
         {view.headline}
       </p>
 
       <div className="mt-3 rounded-lg border border-hairline bg-white/[0.035] px-3 py-2">
         <span className="block text-[10px] text-muted">보여주는 이유</span>
-        <span className="mt-1 block text-sm leading-6 text-whiteout">{why}</span>
+        <span className="mt-1 line-clamp-2 text-sm leading-6 text-whiteout">{why}</span>
       </div>
 
       {subLine && (
-        <p className="mt-2 rounded-lg border border-hairline bg-black/10 px-3 py-2 text-sm leading-6 text-muted">
+        <p className="mt-2 line-clamp-2 rounded-lg border border-hairline bg-black/10 px-3 py-2 text-sm leading-6 text-muted">
           {subLine}
         </p>
       )}
@@ -247,6 +247,55 @@ function StockCardFace({
 
       <div className="mt-auto flex items-center justify-between pt-6">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
+        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+      </div>
+    </div>
+  );
+}
+
+function StockCardLoadingFace({
+  stock,
+  themeLabel,
+  progress,
+}: {
+  stock: DeckStock;
+  themeLabel?: string | undefined;
+  progress?: string | undefined;
+}) {
+  return (
+    <div className="flex h-full flex-col" aria-busy="true" aria-live="polite">
+      <div className="flex items-center gap-2.5">
+        <LogoBadge name={stock.canonical} code={stock.naverCode} />
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-2xl font-bold text-whiteout">{stock.canonical}</span>
+            {stock.marquee && <StarIcon size={14} className="shrink-0 text-text-secondary" />}
+          </div>
+          <span className="font-pixel text-xs text-muted">{MARKET_LABEL[stock.market] ?? stock.market}</span>
+        </div>
+      </div>
+
+      {themeLabel && (
+        <span className="mt-5 inline-flex w-fit items-center rounded-full border border-hairline-soft bg-white/[0.04] px-2.5 py-1 text-xs text-whiteout">
+          # {themeLabel}
+        </span>
+      )}
+
+      <div className="mt-7 rounded-lg border border-hairline bg-white/[0.035] px-3 py-3">
+        <span className="block text-[10px] text-muted">카드 준비 중</span>
+        <span className="mt-1 block text-sm leading-6 text-whiteout">
+          가격·수급·언급 근거를 맞춰 불러오고 있어요.
+        </span>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <div className="h-3 w-5/6 animate-pulse rounded-full bg-white/10" />
+        <div className="h-3 w-2/3 animate-pulse rounded-full bg-white/10" />
+        <div className="h-11 animate-pulse rounded-lg border border-hairline bg-white/[0.03]" />
+      </div>
+
+      <div className="mt-auto flex items-center justify-between pt-6">
+        <span className="font-pixel text-[11px] text-muted">신호 확인 중</span>
         {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
       </div>
     </div>
@@ -361,8 +410,11 @@ export function StockSwipeDeck({
     upsertWatch(stock.canonical, Date.now(), { sector: stock.sector, reason: whyFor(stock) });
   };
   const renderFace = (stock: DeckStock, progress?: string) => {
-    const { view, catalysts, subLine } = cardFor(stock);
     const e = front[stock.canonical];
+    if (!e) {
+      return <StockCardLoadingFace stock={stock} themeLabel={stock.sector} progress={progress} />;
+    }
+    const { view, catalysts, subLine } = cardFor(stock);
     return (
       <StockCardFace
         stock={stock}
@@ -429,6 +481,7 @@ export function StockSwipeDeck({
 
   const onPointerDown = (e: React.PointerEvent) => {
     if (exiting) return;
+    if (!front[at(idx).canonical]) return;
     dragging.current = true;
     moved.current = false;
     startX.current = e.clientX;
@@ -481,10 +534,11 @@ export function StockSwipeDeck({
     ? `translateX(${exiting === "right" ? 140 : -140}%) rotate(${exiting === "right" ? 16 : -16}deg)`
     : `translateX(${dx}px) rotate(${dx * 0.04}deg)`;
   const topTransition = dragging.current ? "none" : `transform ${EXIT_MS}ms cubic-bezier(0.22,1,0.36,1)`;
+  const topReady = !!front[top.canonical];
 
   return (
     <div className="w-full">
-      <div className="relative mx-auto h-[56vh] w-full select-none">
+      <div className="relative mx-auto h-[64vh] min-h-[500px] max-h-[640px] w-full select-none">
         {/* 단일 카드만 렌더 — 글래스모피즘 카드 뒤로 비침 금지(스택 미리보기 제거). */}
         <div
           onPointerDown={onPointerDown}
@@ -492,7 +546,7 @@ export function StockSwipeDeck({
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onClick={() => {
-            if (!moved.current && !exiting) openDepth(top, "card");
+            if (topReady && !moved.current && !exiting) openDepth(top, "card");
           }}
           className="glass-card absolute inset-0 z-10 cursor-pointer overflow-hidden rounded-2xl px-6 py-7"
           style={{ transform: topTransform, transition: topTransition }}
@@ -516,7 +570,7 @@ export function StockSwipeDeck({
       <div className="mt-4 flex items-center justify-center gap-4">
         <button
           onClick={() => advance("left")}
-          disabled={!!exiting}
+          disabled={!!exiting || !topReady}
           aria-label="덜 관심"
           className="flex h-14 w-14 items-center justify-center rounded-full border border-hairline-soft bg-surface-raised text-xl text-muted transition-colors hover:text-whiteout disabled:opacity-40"
         >
@@ -524,7 +578,7 @@ export function StockSwipeDeck({
         </button>
         <button
           onClick={() => openDepth(top, "interest_button")}
-          disabled={!!exiting}
+          disabled={!!exiting || !topReady}
           aria-label="관심 — 자세히 보기"
           className="flex h-14 flex-1 items-center justify-center rounded-full text-sm font-bold text-canvas transition-opacity disabled:opacity-40"
           style={{ backgroundColor: NEON }}

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -24,8 +24,32 @@ function hasWatchedPeer(sector: StockSector, stockName: string): boolean {
 
 export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyShownInput): string {
   if (stock.whyShown) return stock.whyShown;
+  const changePct = signals?.changePct;
+  const isDown = typeof changePct === "number" && changePct < -1;
+  const mentionStrong =
+    (typeof signals?.mentionScore === "number" && signals.mentionScore >= 60) ||
+    (typeof signals?.mentionCount === "number" && signals.mentionCount >= 3);
+  const volumeStrong = typeof signals?.volumeRatio === "number" && signals.volumeRatio >= 1.8;
+  const foreign = signals?.foreignNetStreak ?? 0;
+  const institution = signals?.institutionNetStreak ?? 0;
+  const hasSupplyBuy = foreign >= 3 || institution >= 3;
+  const hasSupplySell = foreign <= -3 || institution <= -3;
+
   if (stock.reason) {
-    return `대장주 말고 ‘${stock.sector}’ 흐름에서 같이 움직인 종목이에요.`;
+    return `‘${stock.sector}’ 흐름에서 같이 잡힌 원문 근거가 있어요: ${stock.reason}`;
+  }
+  if (signals?.newsEventLabel) {
+    return `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${signals.newsEventLabel}`;
+  }
+  if (isDown && hasSupplyBuy) {
+    const actor = foreign >= 3 && institution >= 3 ? "외국인·기관" : foreign >= 3 ? "외국인" : "기관";
+    return `가격은 빠졌지만 ${actor} 수급이 이어져서 확인 대상으로 보여줘요.`;
+  }
+  if (isDown && (mentionStrong || volumeStrong)) {
+    return "강세 카드가 아니라, 하락 중에도 거래·언급이 몰린 이유를 확인하는 카드예요.";
+  }
+  if (hasSupplySell && (mentionStrong || volumeStrong)) {
+    return "약세·주의 신호가 커져서 시장이 어디에 반응하는지 보여줘요.";
   }
   if (hasWatchedPeer(stock.sector, stock.canonical)) {
     return "네가 관심 둔 종목들과 같은 섹터에 있어요.";
@@ -37,10 +61,12 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
     return "아직 조용한데 수급이 먼저 들어오는 중이에요.";
   }
   if (
-    (typeof signals?.mentionScore === "number" && signals.mentionScore >= 60) ||
-    (typeof signals?.mentionCount === "number" && signals.mentionCount >= 3)
+    mentionStrong
   ) {
     return "오늘 이 종목을 언급한 뉴스·글이 늘었어요.";
   }
-  return "오늘 발견 풀에서 보여주는 종목이에요.";
+  if (stock.marquee) {
+    return `강한 재료가 확인된 카드는 아니에요. ${stock.sector} 흐름을 비교할 기준 종목으로 보여줘요.`;
+  }
+  return `아직 강한 재료는 적어요. ${stock.sector} 발견 풀에서 흐름 확인용으로 보여줘요.`;
 }


### PR DESCRIPTION
## Summary
- keep stock cards in a stable loading state until front signals are ready, so headline/reason content does not flip from placeholder copy
- increase stock card height and clamp long headline/reason/sub-line copy to prevent content from being cut behind controls
- strengthen whyShown copy for bearish days: falling stocks with attention/supply now explain that they are check cards, not bullish recommendation cards
- add depth read-guide lead copy so weak/bearish cards explain what to inspect after opening depth

## Verification
- npm run typecheck:fomo-web
- npm run test
- npm run build:fomo-web
- npm run lint
- local Chrome mobile QA screenshot: /tmp/fomo-card-qa-2.png