### PR TITLE
fix(fomo-web): hydrate discovered stock cards

### DIFF
--- a/apps/fomo-web/__tests__/discoveryDeck.test.ts
+++ b/apps/fomo-web/__tests__/discoveryDeck.test.ts
@@ -40,8 +40,8 @@ describe("buildTodayDiscoveryStocks", () => {
       {
         keyword: "AI",
         surpriseStock: {
-          canonical: "테스트3",
-          market: "KOSDAQ",
+          canonical: "SK바이오팜",
+          market: "KOSPI",
           country: "KR",
           mentions: 2,
           surprise: 0.8,
@@ -54,7 +54,36 @@ describe("buildTodayDiscoveryStocks", () => {
 
     expect(result).toHaveLength(MAX_DISCOVERY_STOCKS);
     expect(new Set(result.map((s) => s.canonical)).size).toBe(result.length);
-    expect(result.find((s) => s.canonical === "테스트3")?.reason).toBe("원문 근거");
+    const discovered = result.find((s) => s.canonical === "SK바이오팜");
+    expect(discovered?.reason).toBe("원문 근거");
+    expect(discovered?.naverCode).toBe("326030");
+  });
+
+  it("keeps discovered stocks in the keyword sector while enriching market metadata", () => {
+    const result = buildTodayDiscoveryStocks(
+      [],
+      [
+        {
+          keyword: "AI",
+          surpriseStock: {
+            canonical: "SK바이오팜",
+            market: "KOSPI",
+            country: "KR",
+            mentions: 3,
+            surprise: 0.9,
+            reason: "AI 원문 근거",
+          },
+        } as KeywordCard,
+      ],
+      ["AI"]
+    );
+
+    expect(result[0]).toMatchObject({
+      canonical: "SK바이오팜",
+      sector: "AI",
+      naverCode: "326030",
+      reason: "AI 원문 근거",
+    });
   });
 
   it("pushes recently seen and lessed stocks out of the first 20 when there is enough pool", () => {

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { fomoCardView, computeFomoScore, selectFomoHook, sparklinePath } from "@fomo/core";
 import type { CardFrontSignals, FomoScoreResult, FomoCardView, TaFact } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
@@ -124,6 +124,21 @@ function FomoMeter({ score, color }: { score: number; color: string }) {
 /** 봉인색 — 등락 데이터 전용(DESIGN.md §2). 브랜드(오렌지/네온)와 분리. 상승 적·하락 청(KR 관습). */
 const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
 
+function clampStyle(lines: number): CSSProperties {
+  return {
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: lines,
+    overflow: "hidden",
+  };
+}
+
+function compactEvidenceLine(text: string | undefined): string | undefined {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  if (!clean) return undefined;
+  return clean.length > 58 ? `${clean.slice(0, 57)}…` : clean;
+}
+
 /**
  * 종목 카드 앞면 — 포모 점수(척추 ②, 단일 출처)로 점수·라벨·헤드라인·톤. 휴리스틱 대체.
  * 정체성 / 현재가 / 포모점수+라벨 / 테마태그 / 헤드라인 / 스파크라인 / 재료. 점수=주목도(품질 아님), 예측 0.
@@ -212,19 +227,23 @@ function StockCardFace({
       )}
 
       {/* 헤드라인 = 종목별 후킹 사실 1개. 색 강조는 점수/미터/CTA에만 둔다. */}
-      <p className="mt-3 line-clamp-2 shrink-0 text-lg font-bold leading-7 text-whiteout">
+      <p className="mt-3 shrink-0 text-lg font-bold leading-7 text-whiteout" style={clampStyle(2)}>
         {view.isLeading && <GemIcon size={18} className="mr-1 inline-block align-[-2px]" />}
         {view.headline}
       </p>
 
       <div className="mt-2.5 shrink-0 rounded-lg border border-hairline bg-white/[0.035] px-3 py-2">
         <span className="block text-[10px] text-muted">보여주는 이유</span>
-        <span className="mt-1 line-clamp-2 text-sm leading-6 text-whiteout">{why}</span>
+        <span className="mt-1 text-sm leading-6 text-whiteout" style={clampStyle(2)}>
+          {why}
+        </span>
       </div>
 
       {subLine && (
         <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-2">
-          <span className="line-clamp-1 text-sm leading-6 text-muted">{subLine}</span>
+          <span className="text-sm leading-6 text-muted" style={clampStyle(1)}>
+            {subLine}
+          </span>
         </div>
       )}
 
@@ -377,7 +396,8 @@ export function StockSwipeDeck({
     });
     const baseView = fomoCardView(fomo, { sector: stock.sector, ...(stock.reason ? { reason: stock.reason } : {}) });
     const view = { ...baseView, headline: hook.headline };
-    return { view, ...(hook.subLine ? { subLine: hook.subLine } : {}) };
+    const evidenceLine = compactEvidenceLine(stock.reason);
+    return { view, ...(evidenceLine || hook.subLine ? { subLine: evidenceLine ?? hook.subLine } : {}) };
   };
   const rankLabelFor = (stock: DeckStock): string | undefined => {
     const r = front[stock.canonical]?.signals.marketCapRank;
@@ -522,7 +542,7 @@ export function StockSwipeDeck({
 
   return (
     <div className="w-full">
-      <div className="relative mx-auto h-[64vh] min-h-[500px] max-h-[640px] w-full select-none">
+      <div className="relative mx-auto h-[60svh] min-h-[460px] max-h-[580px] w-full select-none sm:min-h-[500px]">
         {/* 단일 카드만 렌더 — 글래스모피즘 카드 뒤로 비침 금지(스택 미리보기 제거). */}
         <div
           onPointerDown={onPointerDown}

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -1,4 +1,4 @@
-import { stocksBySector, type KeywordCard, type SectorStock, type StockSector } from "@fomo/core";
+import { resolveStock, stocksBySector, type KeywordCard, type SectorStock, type StockSector } from "@fomo/core";
 import { getWatchlist } from "./watchlist";
 import { recentSeenStocks, stockInteractionSummary, stockInterestScore } from "./stockInterest";
 
@@ -19,6 +19,24 @@ export type DeckStock = SectorStock & { reason?: string; whyShown?: string };
 export interface SectorPool {
   sector: StockSector;
   stocks: SectorStock[];
+}
+
+function enrichDiscoveredStock(
+  stock: Pick<SectorStock, "canonical" | "market" | "country" | "naverCode"> & Partial<Pick<SectorStock, "marquee">>,
+  sector: StockSector,
+  reason: string
+): DeckStock {
+  const resolved = resolveStock(stock.canonical);
+  const naverCode = resolved?.naverCode ?? stock.naverCode;
+  return {
+    canonical: resolved?.canonical ?? stock.canonical,
+    market: resolved?.market ?? stock.market,
+    country: resolved?.country ?? stock.country,
+    marquee: resolved?.marquee ?? stock.marquee ?? false,
+    sector,
+    reason,
+    ...(naverCode ? { naverCode } : {}),
+  };
 }
 
 /**
@@ -46,7 +64,7 @@ export function buildSectorDiscoveryStocks(
     const s = c.surpriseStock;
     if (!s?.reason || have.has(s.canonical)) continue;
     have.add(s.canonical);
-    out.push({ canonical: s.canonical, market: s.market, country: s.country, marquee: false, sector, reason: s.reason });
+    out.push(enrichDiscoveredStock(s, sector, s.reason));
   }
   return rankInstantStocks(out);
 }
@@ -83,14 +101,8 @@ export function buildTodayDiscoveryStocks(
     if (!sectorSet.has(card.keyword)) continue;
     const surprise = card.surpriseStock;
     if (!surprise?.reason) continue;
-    byCanonical.set(surprise.canonical, {
-      canonical: surprise.canonical,
-      market: surprise.market,
-      country: surprise.country,
-      marquee: false,
-      sector: card.keyword as StockSector,
-      reason: surprise.reason,
-    });
+    const enriched = enrichDiscoveredStock(surprise, card.keyword as StockSector, surprise.reason);
+    byCanonical.set(enriched.canonical, enriched);
   }
 
   for (const pool of pools) {

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -5,6 +5,7 @@ import { stockInterestScore } from "./stockInterest";
 import type { DeckStock } from "./discoveryDeck";
 
 const HIGH_INTEREST_SCORE = 18;
+const MAX_INLINE_REASON = 34;
 
 interface WhyShownInput {
   stock: DeckStock;
@@ -22,6 +23,12 @@ function hasWatchedPeer(sector: StockSector, stockName: string): boolean {
   return watch.some((w) => names.has(w.stock));
 }
 
+function compactInline(text: string | undefined): string {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  if (!clean) return "";
+  return clean.length > MAX_INLINE_REASON ? `${clean.slice(0, MAX_INLINE_REASON - 1)}…` : clean;
+}
+
 export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyShownInput): string {
   if (stock.whyShown) return stock.whyShown;
   const changePct = signals?.changePct;
@@ -36,10 +43,14 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
   const hasSupplySell = foreign <= -3 || institution <= -3;
 
   if (stock.reason) {
-    return `‘${stock.sector}’ 흐름에서 같이 잡힌 원문 근거가 있어요: ${stock.reason}`;
+    const reason = compactInline(stock.reason);
+    return reason
+      ? `‘${stock.sector}’ 흐름에서 같이 잡힌 원문 근거가 있어요: ${reason}`
+      : `‘${stock.sector}’ 흐름에서 같이 잡힌 원문 근거가 있어요.`;
   }
   if (signals?.newsEventLabel) {
-    return `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${signals.newsEventLabel}`;
+    const label = compactInline(signals.newsEventLabel);
+    return label ? `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${label}` : "오늘 이 종목을 직접 언급한 뉴스가 있어요.";
   }
   if (isDown && hasSupplyBuy) {
     const actor = foreign >= 3 && institution >= 3 ? "외국인·기관" : foreign >= 3 ? "외국인" : "기관";


### PR DESCRIPTION
## Summary
- enrich discovered keyword stocks with canonical stock metadata so out-of-sector discoveries keep naverCode and can load price/chart data
- compact/clamp stock card headline, why, and evidence lines to prevent the rationale block from pushing the card layout out of bounds
- add regression coverage for SK바이오팜 discovered from the AI keyword pool keeping naverCode 326030

## Verification
- npm test -- apps/fomo-web/__tests__/discoveryDeck.test.ts
- npm run build:fomo-web
- npm run typecheck:fomo-web
- npm --workspace @fomo/web run lint
- local mobile smoke at 390x844 for Today and AI tabs