### PR TITLE
Restore feed stock signals

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -5,6 +5,7 @@ import { fomoCardView, computeFomoScore, selectFomoHook, sparklinePath } from "@
 import type { CardFrontSignals, FomoScoreResult, FomoCardView, TaFact } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
+import type { FeedSignalPoint } from "@/lib/fomoApi";
 import { recordStockInterest } from "@/lib/stockInterest";
 import { upsertWatch } from "@/lib/watchlist";
 import type { DeckStock } from "@/lib/discoveryDeck";
@@ -35,6 +36,8 @@ export type FrontEntry = {
   priceText?: string;
   changeText?: string;
   changeDir?: "up" | "down" | "flat";
+  feedBull?: FeedSignalPoint;
+  feedBear?: FeedSignalPoint;
 };
 
 function prefersReducedMotion(): boolean {
@@ -87,7 +90,7 @@ function Sparkline({ series }: { series: number[] }) {
   const paths = sparklinePath(pts, W, H);
   if (!paths) return null;
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="mt-3 h-9 w-full shrink-0" aria-hidden>
+    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="mt-2 h-8 w-full shrink-0" aria-hidden>
       <path d={paths.line} fill="none" stroke="rgba(250,250,250,0.52)" strokeWidth={1.8} strokeLinejoin="round" strokeLinecap="round" />
     </svg>
   );
@@ -96,7 +99,7 @@ function Sparkline({ series }: { series: number[] }) {
 function ChartSlot({ series, supported }: { series?: number[] | undefined; supported: boolean }) {
   if (series && series.length >= 2) return <Sparkline series={series} />;
   return (
-    <div className="mt-3 flex h-9 w-full shrink-0 items-center justify-center rounded-lg border border-hairline bg-white/[0.03]">
+    <div className="mt-2 flex h-8 w-full shrink-0 items-center justify-center rounded-lg border border-hairline bg-white/[0.03]">
       <span className="font-pixel text-[10px] text-muted">
         {supported ? "차트 불러오는 중" : "차트 데이터 없음"}
       </span>
@@ -139,6 +142,35 @@ function compactEvidenceLine(text: string | undefined): string | undefined {
   return clean.length > 58 ? `${clean.slice(0, 57)}…` : clean;
 }
 
+function FeedSignalStrip({
+  bull,
+  bear,
+}: {
+  bull?: FeedSignalPoint | undefined;
+  bear?: FeedSignalPoint | undefined;
+}) {
+  if (!bull && !bear) return null;
+  const rows = [
+    bull ? { label: "강세", tone: "#FF4D4D", point: bull } : undefined,
+    bear ? { label: "약세", tone: "#3B82F6", point: bear } : undefined,
+  ].filter((row): row is { label: string; tone: string; point: FeedSignalPoint } => !!row);
+  return (
+    <div className="mt-2 grid shrink-0 gap-1 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
+      {rows.map((row) => (
+        <div key={row.label} className="flex min-w-0 items-center gap-2 text-xs leading-4">
+          <span className="shrink-0 font-pixel" style={{ color: row.tone }}>
+            {row.label}
+          </span>
+          <span className="min-w-0 flex-1 text-muted" style={clampStyle(1)}>
+            {row.point.text}
+          </span>
+          <span className="shrink-0 text-[10px] text-muted/80">{row.point.source}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /**
  * 종목 카드 앞면 — 포모 점수(척추 ②, 단일 출처)로 점수·라벨·헤드라인·톤. 휴리스틱 대체.
  * 정체성 / 현재가 / 포모점수+라벨 / 테마태그 / 헤드라인 / 스파크라인 / 재료. 점수=주목도(품질 아님), 예측 0.
@@ -154,6 +186,8 @@ function StockCardFace({
   sparkline,
   chartSupported,
   subLine,
+  feedBull,
+  feedBear,
   why,
   progress,
 }: {
@@ -167,6 +201,8 @@ function StockCardFace({
   sparkline?: number[] | undefined;
   chartSupported: boolean;
   subLine?: string | undefined;
+  feedBull?: FeedSignalPoint | undefined;
+  feedBear?: FeedSignalPoint | undefined;
   why: string;
   progress?: string | undefined;
 }) {
@@ -232,16 +268,18 @@ function StockCardFace({
         {view.headline}
       </p>
 
-      <div className="mt-2.5 shrink-0 rounded-lg border border-hairline bg-white/[0.035] px-3 py-2">
-        <span className="block text-[10px] text-muted">보여주는 이유</span>
-        <span className="mt-1 text-sm leading-6 text-whiteout" style={clampStyle(2)}>
+      <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
+        <span className="shrink-0 text-[10px] leading-5 text-muted">이유</span>
+        <span className="min-w-0 flex-1 text-sm leading-5 text-whiteout" style={clampStyle(1)}>
           {why}
         </span>
       </div>
 
-      {subLine && (
-        <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-2">
-          <span className="text-sm leading-6 text-muted" style={clampStyle(1)}>
+      <FeedSignalStrip bull={feedBull} bear={feedBear} />
+
+      {subLine && !feedBull && !feedBear && (
+        <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
+          <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
             {subLine}
           </span>
         </div>
@@ -250,7 +288,7 @@ function StockCardFace({
       {/* 미니 스파크라인(최근 흐름) — lite 응답도 짧은 라인차트를 싣는다. */}
       <ChartSlot series={sparkline} supported={chartSupported} />
 
-      <div className="mt-auto flex shrink-0 items-center justify-between pt-4">
+      <div className="mt-auto flex shrink-0 items-center justify-between pt-2">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
         {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
       </div>
@@ -364,6 +402,8 @@ export function StockSwipeDeck({
               ...(d.priceText ? { priceText: d.priceText } : {}),
               ...(d.changeText ? { changeText: d.changeText } : {}),
               ...(d.changeDir ? { changeDir: d.changeDir } : {}),
+              ...(d.feedBull ? { feedBull: d.feedBull } : {}),
+              ...(d.feedBear ? { feedBear: d.feedBear } : {}),
             },
           }))
         )
@@ -432,6 +472,8 @@ export function StockSwipeDeck({
         sparkline={e?.sparkline}
         chartSupported={!!stock.naverCode}
         subLine={subLine}
+        feedBull={e?.feedBull}
+        feedBear={e?.feedBear}
         why={whyFor(stock)}
         progress={progress}
       />

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -206,6 +206,13 @@ export interface StockFrontResponse {
   priceText?: string;
   changeText?: string;
   changeDir?: "up" | "down" | "flat";
+  feedBull?: FeedSignalPoint;
+  feedBear?: FeedSignalPoint;
+}
+
+export interface FeedSignalPoint {
+  text: string;
+  source: "뉴스" | "수급" | "테마" | "가격" | "주목" | "위치" | "거래";
 }
 export const fetchStockFront = (stock: string, opts: { lite?: boolean } = {}) =>
   cachedGet(

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -56,6 +56,23 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
     const actor = foreign >= 3 && institution >= 3 ? "외국인·기관" : foreign >= 3 ? "외국인" : "기관";
     return `가격은 빠졌지만 ${actor} 수급이 이어져서 확인 대상으로 보여줘요.`;
   }
+  if (
+    typeof signals?.themeAverageChangePct === "number" &&
+    typeof signals?.themeRelativeChangePct === "number" &&
+    typeof signals?.changePct === "number" &&
+    signals.themeAverageChangePct >= 2 &&
+    signals.themeRelativeChangePct <= -3
+  ) {
+    return `같은 ${signals.themeLabel ?? stock.sector} 흐름은 평균적으로 움직였는데, 이 종목은 아직 덜 움직여서 보여줘요.`;
+  }
+  if (
+    typeof signals?.themeRelativeRank === "number" &&
+    signals.themeRelativeRank === 1 &&
+    typeof signals.changePct === "number" &&
+    signals.changePct > 0
+  ) {
+    return `${signals.themeLabel ?? stock.sector} 흐름 안에서 오늘 가장 앞에서 움직여서 보여줘요.`;
+  }
   if (isDown && (mentionStrong || volumeStrong)) {
     return "강세 카드가 아니라, 하락 중에도 거래·언급이 몰린 이유를 확인하는 카드예요.";
   }

--- a/apps/web/__tests__/lib/stock-front-lite.test.ts
+++ b/apps/web/__tests__/lib/stock-front-lite.test.ts
@@ -27,6 +27,15 @@ describe("assembleStockFront lite", () => {
         if (url.includes("siseJson.naver")) {
           return new Response(dailyText, { status: 200 });
         }
+        if (url.includes("/basic")) {
+          return Response.json({
+            stockName: "삼성전자",
+            stockExchangeName: "코스피",
+            closePrice: "70,000",
+            compareToPreviousClosePrice: "-1,000",
+            fluctuationsRatio: "-1.41",
+          });
+        }
         return new Response("{}", { status: 500 });
       })
     );
@@ -44,5 +53,34 @@ describe("assembleStockFront lite", () => {
     expect(front.taFact).toBeUndefined();
     expect(front.fomo.inputs.volume).toBeDefined();
     expect(front.fomo.inputs.price).toBeDefined();
+  });
+
+  it("카드 경량 경로에서도 캐시된 coverage와 강세·약세 1줄을 반환한다", async () => {
+    const front = await assembleStockFront(
+      "삼성전자",
+      undefined,
+      {
+        attention: {
+          mentionCount: 5,
+          mentionScore: 85,
+          newsEventLabel: "HBM 공급 확대",
+          newsEventSource: "테스트뉴스",
+        },
+        themeRelative: {
+          themeLabel: "반도체",
+          themeRelativeRank: 6,
+          themePeerCount: 6,
+          themeAverageChangePct: 3.2,
+          themeRelativeChangePct: -4.6,
+        },
+      },
+      { lite: true }
+    );
+
+    expect(front.signals.mentionScore).toBe(85);
+    expect(front.signals.newsEventLabel).toBe("HBM 공급 확대");
+    expect(front.signals.themeRelativeRank).toBe(6);
+    expect(front.feedBull).toEqual({ text: "오늘 이 종목을 직접 언급한 뉴스가 있어요.", source: "뉴스" });
+    expect(front.feedBear).toEqual({ text: "반도체 평균보다 덜 움직였어요.", source: "테마" });
   });
 });

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -60,7 +60,7 @@ async function getFront(stock: string, lite = false): Promise<StockFrontData> {
       const [rankMap, attentionMap, themeRelativeMap] = await Promise.all([
         lite ? Promise.resolve({}) : getRankMap().catch(() => ({})),
         getAttentionMap().catch((): Record<string, StockAttentionSignal> => ({})),
-        !lite && sector
+        sector
           ? getThemeRelativeMap(sector).catch((): Record<string, ThemeRelativeSignal> => ({}))
           : Promise.resolve({} as Record<string, ThemeRelativeSignal>),
       ]);

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -144,11 +144,93 @@ export interface StockFrontData {
   changeText?: string;
   /** 등락 방향(색). */
   changeDir?: "up" | "down" | "flat";
+  /** 피드 카드용 강세 쪽 균형 사실 1줄. 원문/숫자가 있을 때만 채운다. */
+  feedBull?: FeedSignalPoint;
+  /** 피드 카드용 약세·주의 쪽 균형 사실 1줄. 원문/숫자가 있을 때만 채운다. */
+  feedBear?: FeedSignalPoint;
 }
 
 export interface StockFrontOptions {
   /** 카드 앞면용 경량 경로. 시총순위·TA·상세 지표를 빼고 가격/수급/언급/짧은 차트만 쓴다. */
   lite?: boolean;
+}
+
+export interface FeedSignalPoint {
+  text: string;
+  source: "뉴스" | "수급" | "테마" | "가격" | "주목" | "위치" | "거래";
+}
+
+function pushUnique(out: FeedSignalPoint[], point: FeedSignalPoint): void {
+  if (out.some((p) => p.text.replace(/\s+/g, "") === point.text.replace(/\s+/g, ""))) return;
+  out.push(point);
+}
+
+function buildFeedPoints(
+  signals: CardFrontSignals,
+  changeDir: "up" | "down" | "flat" | undefined,
+  changeText: string | undefined
+): { bull?: FeedSignalPoint; bear?: FeedSignalPoint } {
+  const bull: FeedSignalPoint[] = [];
+  const bear: FeedSignalPoint[] = [];
+  const { foreignNetStreak, institutionNetStreak } = signals;
+
+  if (signals.newsEventLabel) {
+    pushUnique(bull, { text: `오늘 이 종목을 직접 언급한 뉴스가 있어요.`, source: "뉴스" });
+  }
+  if (typeof foreignNetStreak === "number" && foreignNetStreak >= 3) {
+    pushUnique(bull, { text: `외국인이 ${foreignNetStreak}일째 사는 중이에요.`, source: "수급" });
+  }
+  if (typeof institutionNetStreak === "number" && institutionNetStreak >= 3) {
+    pushUnique(bull, { text: `기관이 ${institutionNetStreak}일째 사는 중이에요.`, source: "수급" });
+  }
+  if (typeof signals.themeRelativeRank === "number" && signals.themeRelativeRank === 1 && typeof signals.changePct === "number" && signals.changePct > 0) {
+    pushUnique(bull, {
+      text: `${signals.themeLabel ?? "같은 테마"} 안에서 오늘 가장 많이 오른 쪽이에요.`,
+      source: "테마",
+    });
+  }
+  if (typeof signals.mentionScore === "number" && signals.mentionScore >= 60) {
+    pushUnique(bull, { text: "뉴스·커뮤니티 언급이 늘어난 상태예요.", source: "주목" });
+  }
+  if (signals.near52WeekHigh) {
+    pushUnique(bull, { text: "최근 1년 중 높은 가격대에 가까워요.", source: "위치" });
+  }
+  if (changeDir === "up" && changeText) {
+    pushUnique(bull, { text: `오늘 가격은 ${changeText} 상승으로 움직였어요.`, source: "가격" });
+  }
+
+  if (typeof foreignNetStreak === "number" && foreignNetStreak <= -3) {
+    pushUnique(bear, { text: `외국인이 ${Math.abs(foreignNetStreak)}일째 파는 중이에요.`, source: "수급" });
+  }
+  if (typeof institutionNetStreak === "number" && institutionNetStreak <= -3) {
+    pushUnique(bear, { text: `기관이 ${Math.abs(institutionNetStreak)}일째 파는 중이에요.`, source: "수급" });
+  }
+  if (
+    typeof signals.themeAverageChangePct === "number" &&
+    typeof signals.themeRelativeChangePct === "number" &&
+    typeof signals.changePct === "number" &&
+    signals.themeAverageChangePct >= 2 &&
+    signals.themeRelativeChangePct <= -3
+  ) {
+    pushUnique(bear, {
+      text: `${signals.themeLabel ?? "같은 테마"} 평균보다 덜 움직였어요.`,
+      source: "테마",
+    });
+  }
+  if (typeof signals.volumeRatio === "number" && signals.volumeRatio >= 1.8 && changeDir === "down") {
+    pushUnique(bear, { text: "빠지는 중인데 거래량은 늘었어요.", source: "거래" });
+  }
+  if (signals.near52WeekLow) {
+    pushUnique(bear, { text: "최근 1년 낮은 가격대에 가까워요.", source: "위치" });
+  }
+  if (changeDir === "down" && changeText) {
+    pushUnique(bear, { text: `오늘 가격은 ${changeText} 하락으로 움직였어요.`, source: "가격" });
+  }
+
+  return {
+    ...(bull[0] ? { bull: bull[0] } : {}),
+    ...(bear[0] ? { bear: bear[0] } : {}),
+  };
 }
 
 /**
@@ -213,6 +295,7 @@ export async function assembleStockFront(
     ...(typeof signals.institutionNetStreak === "number" ? { institutionNetStreak: signals.institutionNetStreak } : {}),
   });
   const taFact = ta ? selectTaFact(fomo, ta) : undefined;
+  const feedPoints = buildFeedPoints(signals, basics?.changeDir, basics?.changeText);
 
   return {
     signals,
@@ -222,5 +305,7 @@ export async function assembleStockFront(
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),
     ...(basics?.changeDir ? { changeDir: basics.changeDir } : {}),
+    ...(feedPoints.bull ? { feedBull: feedPoints.bull } : {}),
+    ...(feedPoints.bear ? { feedBear: feedPoints.bear } : {}),
   };
 }

--- a/packages/fomo-core/__tests__/card-front-hook.test.ts
+++ b/packages/fomo-core/__tests__/card-front-hook.test.ts
@@ -171,7 +171,7 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
     expect(hook.headline).toBe("가격은 빠졌는데, 거래량은 오히려 늘었어요.");
   });
 
-  it("모양형만 있으면 헤드라인을 차지하지 않고 보조문장으로 내려간다", () => {
+  it("거래량·52주 위치는 피드에서 확인할 재료로 헤드라인 자격을 가진다", () => {
     const volumeFomo = computeFomoScore({ volumeRatio: 2.2, changePct: 1 });
     const positionFomo = computeFomoScore({ changePct: 1, trendStrength: 0.42 });
     expect(volumeFomo.label).toBe("warming");
@@ -179,12 +179,24 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
 
     const a = selectFomoHook({ fomo: volumeFomo, signals: { volumeRatio: 2.2, changePct: 1 } });
     const b = selectFomoHook({ fomo: positionFomo, signals: { near52WeekHigh: true, changePct: 1 } });
-    expect(a.kind).toBe("fallback");
-    expect(a.headline).toBe("아직 조용한 자리예요.");
-    expect(a.subLine).toBe("최근 거래가 평소 2.2배로 늘었어요.");
-    expect(b.kind).toBe("fallback");
-    expect(b.headline).toBe("아직 조용한 자리예요.");
-    expect(b.subLine).toBe("최근 1년 중 가장 높은 가격대까지 왔어요.");
+    expect(a.kind).toBe("volume_event");
+    expect(a.headline).toBe("최근 거래가 평소 2.2배로 늘었어요.");
+    expect(b.kind).toBe("position");
+    expect(b.headline).toBe("최근 1년 중 가장 높은 가격대까지 왔어요.");
+  });
+
+  it("순수 TA 모양형만 있으면 헤드라인을 차지하지 않고 보조문장으로 내려간다", () => {
+    const fomo = computeFomoScore({ changePct: 1, trendStrength: 0.42 });
+    const fact: TaFact = {
+      kind: "ma_bullish",
+      role: "event",
+      confidence: "high",
+      text: "20·60·120일선이 위쪽으로 정렬된 상태예요.",
+    };
+    const hook = selectFomoHook({ fomo, taFact: fact });
+    expect(hook.kind).toBe("fallback");
+    expect(hook.headline).toBe("아직 조용한 자리예요.");
+    expect(hook.subLine).toBe("최근 3개월 흐름이 위쪽으로 이어지고 있어요.");
   });
 
   it("데이터가 빈약하면 상태 헤드라인으로 폴백하고 디테일을 지어내지 않는다", () => {

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -405,7 +405,7 @@ function axisTensionCandidate(fomo: FomoScoreResult, signals: CardFrontSignals):
         : "가격은 빠졌는데, 거래량은 오히려 늘었어요.";
     return {
       kind: "axis_tension",
-      tier: "tension",
+      tier: "material",
       score: 0.92 + strength * 0.18,
       headline,
     };
@@ -415,7 +415,7 @@ function axisTensionCandidate(fomo: FomoScoreResult, signals: CardFrontSignals):
     const gap = Math.min(1, Math.max(0, pct / 12) + Math.max(0, 60 - fomo.attentionAxis) / 120);
     return {
       kind: "axis_tension",
-      tier: "tension",
+      tier: "material",
       score: 0.9 + gap * 0.2,
       headline: `가격은 ${pctText(pct)} 올랐는데, 거래량·뉴스는 아직 안 따라왔어요.`,
     };
@@ -474,7 +474,7 @@ function volumeCandidate(signals: CardFrontSignals): HookCandidate | null {
   if (typeof vr !== "number" || vr < FRONT_VOLUME_RATIO_MIN) return null;
   return {
     kind: "volume_event",
-    tier: "shape",
+    tier: "material",
     score: Math.min(1, 0.42 + vr / 5),
     headline: `최근 거래가 평소 ${ratioText(vr)}배로 늘었어요.`,
   };
@@ -530,7 +530,7 @@ function positionCandidate(signals: CardFrontSignals): HookCandidate | null {
   if (signals.near52WeekLow) {
     return {
       kind: "position",
-      tier: "shape",
+      tier: "material",
       score: 0.56,
       headline: "최근 1년 낮은 구간에 가까워요.",
     };
@@ -538,7 +538,7 @@ function positionCandidate(signals: CardFrontSignals): HookCandidate | null {
   if (!signals.near52WeekHigh) return null;
   return {
     kind: "position",
-    tier: "shape",
+    tier: "material",
     score: 0.58,
     headline: "최근 1년 중 가장 높은 가격대까지 왔어요.",
   };
@@ -548,7 +548,7 @@ function accumulationCandidate(fomo: FomoScoreResult, taFact?: TaFact): HookCand
   if (fomo.inputs.accumulationDivergence !== true && taFact?.kind !== "accumulation_divergence") return null;
   return {
     kind: "accumulation",
-    tier: "shape",
+    tier: "material",
     score: 0.7,
     headline: "거래는 느는데 가격은 잠잠해요.",
   };

--- a/scripts/fomo-quality-report.ts
+++ b/scripts/fomo-quality-report.ts
@@ -61,6 +61,8 @@ interface StockFrontLike {
   sparkline?: unknown[];
   priceText?: string;
   changeText?: string;
+  feedBull?: unknown;
+  feedBear?: unknown;
 }
 
 interface InsightLike {
@@ -163,6 +165,10 @@ function duplicateCount(values: readonly string[]): number {
   return [...counts.values()].reduce((sum, count) => sum + Math.max(0, count - 1), 0);
 }
 
+function rate(count: number, total: number): number {
+  return total > 0 ? count / total : 0;
+}
+
 async function main() {
   const date = kstDate();
   const samples: LatencySample[] = [];
@@ -231,6 +237,14 @@ async function main() {
   const liteTierDist = distribution(liteHooks.map((hook) => hookTier(hook.kind)));
   const liteKindDist = distribution(liteHooks.map((hook) => hook.kind));
   const fullTierDist = distribution(fullHooks.map((hook) => hookTier(hook.kind)));
+  const liteOk = liteResults.map((row) => row.res.data).filter((data): data is StockFrontLike => !!data);
+  const liteCoverage = {
+    sample: liteOk.length,
+    mention: rate(liteOk.filter((row) => typeof row.signals?.mentionScore === "number").length, liteOk.length),
+    themeRelative: rate(liteOk.filter((row) => typeof row.signals?.themeRelativeRank === "number").length, liteOk.length),
+    feedBull: rate(liteOk.filter((row) => !!row.feedBull).length, liteOk.length),
+    feedBear: rate(liteOk.filter((row) => !!row.feedBear).length, liteOk.length),
+  };
 
   const json = {
     date,
@@ -245,6 +259,7 @@ async function main() {
       liteKind: liteKindDist,
       fullTier: fullTierDist,
     },
+    liteCoverage,
     findings,
     rawErrors: rawResults
       .filter((row) => !row.ok)
@@ -268,6 +283,9 @@ async function main() {
         ["Sample stocks", stocks.join(", ") || "none"],
         ["Lite material hooks", formatPercent(liteTierDist.find((row) => row.key === "material")?.rate ?? 0)],
         ["Lite fallback hooks", formatPercent(liteTierDist.find((row) => row.key === "fallback")?.rate ?? 0)],
+        ["Lite mention coverage", formatPercent(liteCoverage.mention)],
+        ["Lite theme-relative coverage", formatPercent(liteCoverage.themeRelative)],
+        ["Lite feed bull/bear", `${formatPercent(liteCoverage.feedBull)} / ${formatPercent(liteCoverage.feedBear)}`],
         [
           "Depth insufficient",
           stockInput.insightCount > 0 ? `${stockInput.insufficientInsightCount}/${stockInput.insightCount}` : "N/A",

--- a/scripts/warm-insights.ts
+++ b/scripts/warm-insights.ts
@@ -5,6 +5,7 @@
  *   즉시지만, 그날·그 슬롯의 *첫* 사용자는 cold 를 맞는다.
  * 해결: cron 이 슬롯 시작마다 그날 테마+등장 종목의 endpoint 를 HTTP 로 미리 호출 → Data Cache 를
  *   현재 슬롯 키로 채운다. 사용자는 항상 warm(즉시). 테이블 신설 없음(기존 Data Cache 재사용).
+ *   스와이프 피드용 stock-front lite 도 함께 데워 attention/theme-relative 캐시를 피드까지 전달한다.
  *
  * Data Cache 는 Vercel 런타임 안에서만 채워지므로, 로컬 함수 호출이 아니라 *배포 endpoint HTTP 호출*이어야 한다.
  * (종목 목록만 collectThemeStocks 로 추출 — 이건 LLM 없는 룰 기반 수집이라 가볍다.)
@@ -51,9 +52,14 @@ async function main() {
     }
   }
 
-  // 3) 그날 등장 종목 뎁스 워밍(가장 느렸던 경로 — cold 33초의 주범).
+  // 3) 피드 카드용 stock-front lite 워밍 — 신호 캐시(attention/theme-relative)를 먼저 채운다.
   const stockList = [...stocks];
   console.log(`[warm-insights] 종목 ${stockList.length}개: ${stockList.join(", ")}`);
+  for (const stock of stockList) {
+    await warm(`/api/fomo/stock-front?stock=${encodeURIComponent(stock)}&lite=1`);
+  }
+
+  // 4) 그날 등장 종목 뎁스 워밍(가장 느렸던 경로 — cold 33초의 주범).
   for (const stock of stockList) {
     await warm(`/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}&blocking=1`);
   }


### PR DESCRIPTION
## Summary
- Restore lite stock-front feed signal coverage by reading cached theme-relative data in lite mode
- Add feedBull/feedBear one-line balanced facts to stock-front and render them on the swipe card
- Reclassify non-price material signals so long-tail cards do not collapse into quiet fallback when real signals exist
- Extend warm-insights and quality report to include lite stock-front coverage metrics

## Local verification
- npm test -- apps/web/__tests__/lib/stock-front-lite.test.ts packages/fomo-core/__tests__/card-front-hook.test.ts apps/fomo-web/__tests__/whyShown.test.ts
- npm run lint
- npm run build:fomo-web
- npm run build:web
- git diff --check

## Before quality baseline
- Lite material hooks: 13%
- Lite fallback hooks: 75%
- Lite mention coverage: 38%
- Lite theme-relative coverage: 0%
- Lite feed bull/bear: 0% / 0%
