### PR TITLE
[codex] Fix monitor-triggered task implementation

### DIFF
--- a/.github/workflows/daily-product-monitor.yml
+++ b/.github/workflows/daily-product-monitor.yml
@@ -61,8 +61,27 @@ jobs:
           gh label create "data-quality" --repo "$REPO" --force --color "c2e0c6" --description "Data quality, confidence, fallback, grounding" >/dev/null 2>&1 || true
           gh label create "task" --repo "$REPO" --force --color "bfd4f2" --description "Implementable task issue" >/dev/null 2>&1 || true
 
-          gh run list --repo "$REPO" --branch main --limit 50 \
+          gh run list --repo "$REPO" --branch main --limit 200 \
             --json databaseId,workflowName,displayTitle,conclusion,status,createdAt,url \
+            > /tmp/runs-global.json
+
+          # 제품 파이프라인은 전체 최근 run 목록에서 밀려 오탐이 날 수 있으므로
+          # workflow별로 직접 조회해 stale 판정의 기준 풀에 합친다.
+          gh run list --repo "$REPO" --workflow fomo-index-pipeline.yml --branch main --limit 30 \
+            --json databaseId,workflowName,displayTitle,conclusion,status,createdAt,url \
+            > /tmp/runs-fomo-index.json
+          gh run list --repo "$REPO" --workflow keyword-cards-pipeline.yml --branch main --limit 30 \
+            --json databaseId,workflowName,displayTitle,conclusion,status,createdAt,url \
+            > /tmp/runs-keyword-cards.json
+          gh run list --repo "$REPO" --workflow supply-demand-pipeline.yml --branch main --limit 30 \
+            --json databaseId,workflowName,displayTitle,conclusion,status,createdAt,url \
+            > /tmp/runs-supply-demand.json
+
+          jq -s 'add | unique_by(.databaseId)' \
+            /tmp/runs-global.json \
+            /tmp/runs-fomo-index.json \
+            /tmp/runs-keyword-cards.json \
+            /tmp/runs-supply-demand.json \
             > /tmp/runs.json
 
           jq --arg since "$SINCE" '

--- a/.github/workflows/implement-task.yml
+++ b/.github/workflows/implement-task.yml
@@ -167,6 +167,8 @@ jobs:
         timeout-minutes: ${{ fromJSON(steps.model.outputs.timeout_minutes) }}
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GH_PAT || github.token }}
+          allowed_bots: "github-actions,github-actions[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--max-turns ${{ steps.model.outputs.max_turns }} --model ${{ steps.model.outputs.model }} --effort ${{ steps.model.outputs.effort }} --allowedTools "Read,Edit,Write,Glob,Grep,Bash"'
           prompt: |
@@ -305,6 +307,8 @@ jobs:
         timeout-minutes: 15
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GH_PAT || github.token }}
+          allowed_bots: "github-actions,github-actions[bot]"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--max-turns 20 --model ${{ steps.model.outputs.model }} --effort ${{ steps.model.outputs.effort }} --allowedTools "Read,Edit,Write,Glob,Grep,Bash"'
           prompt: |
@@ -329,7 +333,7 @@ jobs:
       - name: Create Branch and PR
         if: steps.task.outputs.found == 'true' && steps.task.outputs.dup == '0' && steps.gate.outputs.passed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           NUM: ${{ github.event.inputs.issue }}
           ITITLE: ${{ steps.task.outputs.title }}
           VERIFY1: ${{ steps.verify.outputs.ok }}


### PR DESCRIPTION
## Summary
- allow Claude Code Action to run when implement-task is dispatched by the github-actions bot from Daily Product Monitor
- use GH_PAT, when available, for auto PR branch push/create so workflow-file fixes are not rejected by the default GITHUB_TOKEN workflow permission boundary
- make Daily Product Monitor query product pipeline runs per workflow, avoiding stale false positives when the global recent-run window is filled by other workflows

## Root cause
- #626 failed before implementation because Claude Code Action rejected bot actor: `Workflow initiated by non-human actor: github-actions`.
- #614 did produce a workflow-file fix, but push was rejected because the default GitHub App token cannot create/update `.github/workflows/*.yml` without workflow scope.
- #626's Supply Demand stale signal was a false positive: the pipeline had successful runs, but Daily Product Monitor only looked at the global recent 50 runs and missed workflow-specific history.

## Validation
- parsed all .github/workflows/*.yml with PyYAML
- verified `gh run list --workflow supply-demand-pipeline.yml` returns recent successful runs
- git diff --check

## Follow-up after merge
- run Daily Product Monitor in no-fix mode to confirm #626 no longer reproduces
- then close stale monitor issues (#614/#626) if the monitor is clean
