### PR TITLE
Dedupe stock card reason signals

### DIFF
--- a/apps/fomo-web/__tests__/cardCopyDedupe.test.ts
+++ b/apps/fomo-web/__tests__/cardCopyDedupe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { dedupeCardCopy } from "../lib/cardCopyDedupe";
+
+describe("dedupeCardCopy", () => {
+  it("lets the headline own a repeated supply reason", () => {
+    const copy = dedupeCardCopy({
+      headline: "기관이 4일째 사는 중이에요.",
+      why: "가격은 빠졌지만 기관 수급이 이어져서 확인 대상으로 보여줘요.",
+      feedBull: { text: "기관이 4일째 사는 중이에요.", source: "수급" },
+      feedBear: { text: "오늘 가격은 6,800 (-10.66%) 하락으로 움직였어요.", source: "가격" },
+    });
+
+    expect(copy.why).toBeUndefined();
+    expect(copy.feedBull).toBeUndefined();
+    expect(copy.feedBear).toEqual({
+      text: "오늘 가격은 6,800 (-10.66%) 하락으로 움직였어요.",
+      source: "가격",
+    });
+  });
+
+  it("keeps a grounded source reason even when the headline is also material", () => {
+    const copy = dedupeCardCopy({
+      headline: "가격은 빠졌는데, 뉴스·커뮤니티 언급은 늘었어요.",
+      why: "‘바이오’ 흐름에서 같이 잡힌 원문 근거가 있어요: 신약개발 해법은 AI·오픈이노베이션",
+      feedBull: { text: "오늘 이 종목을 직접 언급한 뉴스가 있어요.", source: "뉴스" },
+      preserveGroundedReason: true,
+    });
+
+    expect(copy.why).toBe("‘바이오’ 흐름에서 같이 잡힌 원문 근거가 있어요: 신약개발 해법은 AI·오픈이노베이션");
+    expect(copy.feedBull).toBeUndefined();
+  });
+});

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -10,6 +10,7 @@ import { recordStockInterest } from "@/lib/stockInterest";
 import { upsertWatch } from "@/lib/watchlist";
 import type { DeckStock } from "@/lib/discoveryDeck";
 import { whyShown } from "@/lib/whyShown";
+import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon } from "@/components/icons";
 
@@ -203,7 +204,7 @@ function StockCardFace({
   subLine?: string | undefined;
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
-  why: string;
+  why?: string | undefined;
   progress?: string | undefined;
 }) {
   return (
@@ -268,12 +269,14 @@ function StockCardFace({
         {view.headline}
       </p>
 
-      <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
-        <span className="shrink-0 text-[10px] leading-5 text-muted">이유</span>
-        <span className="min-w-0 flex-1 text-sm leading-5 text-whiteout" style={clampStyle(1)}>
-          {why}
-        </span>
-      </div>
+      {why && (
+        <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
+          <span className="shrink-0 text-[10px] leading-5 text-muted">이유</span>
+          <span className="min-w-0 flex-1 text-sm leading-5 text-whiteout" style={clampStyle(1)}>
+            {why}
+          </span>
+        </div>
+      )}
 
       <FeedSignalStrip bull={feedBull} bear={feedBear} />
 
@@ -460,6 +463,13 @@ export function StockSwipeDeck({
       return <StockCardLoadingFace stock={stock} themeLabel={stock.sector} progress={progress} />;
     }
     const { view, subLine } = cardFor(stock);
+    const deduped = dedupeCardCopy({
+      headline: view.headline,
+      why: whyFor(stock),
+      feedBull: e?.feedBull,
+      feedBear: e?.feedBear,
+      preserveGroundedReason: !!stock.reason,
+    });
     return (
       <StockCardFace
         stock={stock}
@@ -472,9 +482,9 @@ export function StockSwipeDeck({
         sparkline={e?.sparkline}
         chartSupported={!!stock.naverCode}
         subLine={subLine}
-        feedBull={e?.feedBull}
-        feedBear={e?.feedBear}
-        why={whyFor(stock)}
+        feedBull={deduped.feedBull}
+        feedBear={deduped.feedBear}
+        why={deduped.why}
         progress={progress}
       />
     );

--- a/apps/fomo-web/lib/cardCopyDedupe.ts
+++ b/apps/fomo-web/lib/cardCopyDedupe.ts
@@ -1,0 +1,89 @@
+import type { FeedSignalPoint } from "./fomoApi";
+
+type CopyCluster =
+  | "foreign-supply"
+  | "institution-supply"
+  | "supply"
+  | "news"
+  | "mention"
+  | "theme"
+  | "price"
+  | "volume"
+  | "position";
+
+interface DedupeInput {
+  headline: string;
+  why: string;
+  feedBull?: FeedSignalPoint | undefined;
+  feedBear?: FeedSignalPoint | undefined;
+  preserveGroundedReason?: boolean | undefined;
+}
+
+interface DedupeOutput {
+  why?: string | undefined;
+  feedBull?: FeedSignalPoint | undefined;
+  feedBear?: FeedSignalPoint | undefined;
+}
+
+function normalizeCopy(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, "").replace(/[‘’'".,:·…]/g, "").trim();
+}
+
+function clustersFor(text: string | undefined): Set<CopyCluster> {
+  const clean = text ?? "";
+  const clusters = new Set<CopyCluster>();
+  if (/외국인/.test(clean)) clusters.add("foreign-supply");
+  if (/기관/.test(clean)) clusters.add("institution-supply");
+  if (/수급|사는 중|파는 중/.test(clean)) clusters.add("supply");
+  if (/뉴스|공시|원문/.test(clean)) clusters.add("news");
+  if (/언급|커뮤니티|글이 늘/.test(clean)) clusters.add("mention");
+  if (/테마|섹터|흐름|평균보다|가장 앞/.test(clean)) clusters.add("theme");
+  if (/가격|상승|하락|빠졌|올랐|덜 움직/.test(clean)) clusters.add("price");
+  if (/거래량|거래/.test(clean)) clusters.add("volume");
+  if (/1년|높은 가격대|낮은 가격대/.test(clean)) clusters.add("position");
+  return clusters;
+}
+
+function hasMaterialOverlap(a: string | undefined, b: string | undefined): boolean {
+  const left = normalizeCopy(a);
+  const right = normalizeCopy(b);
+  if (!left || !right) return false;
+  if (left.includes(right) || right.includes(left)) return true;
+
+  const aClusters = clustersFor(a);
+  const bClusters = clustersFor(b);
+  if (aClusters.has("foreign-supply") && bClusters.has("foreign-supply")) return true;
+  if (aClusters.has("institution-supply") && bClusters.has("institution-supply")) return true;
+  if (aClusters.has("news") && bClusters.has("news")) return true;
+  if (aClusters.has("mention") && bClusters.has("mention")) return true;
+  if (aClusters.has("theme") && bClusters.has("theme")) return true;
+  if (aClusters.has("volume") && bClusters.has("volume")) return true;
+  if (aClusters.has("position") && bClusters.has("position")) return true;
+  return false;
+}
+
+export function dedupeCardCopy({
+  headline,
+  why,
+  feedBull,
+  feedBear,
+  preserveGroundedReason = false,
+}: DedupeInput): DedupeOutput {
+  const whyRestatesHeadline = !preserveGroundedReason && hasMaterialOverlap(headline, why);
+  const visibleWhy = whyRestatesHeadline ? undefined : why;
+
+  const bullText = feedBull?.text;
+  const bearText = feedBear?.text;
+  const shouldHideBull =
+    !!feedBull &&
+    (hasMaterialOverlap(headline, bullText) || (!!visibleWhy && hasMaterialOverlap(visibleWhy, bullText)));
+  const shouldHideBear =
+    !!feedBear &&
+    (hasMaterialOverlap(headline, bearText) || (!!visibleWhy && hasMaterialOverlap(visibleWhy, bearText)));
+
+  return {
+    ...(visibleWhy ? { why: visibleWhy } : {}),
+    ...(!shouldHideBull && feedBull ? { feedBull } : {}),
+    ...(!shouldHideBear && feedBear ? { feedBear } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- Add card copy dedupe so the headline owns the primary reason when reason/feed facts repeat it
- Hide duplicate feed bull/bear rows when they restate the headline or visible reason
- Keep grounded original-source reasons visible, while still hiding duplicated news feed rows

## Verification
- npm test -- apps/fomo-web/__tests__/cardCopyDedupe.test.ts apps/fomo-web/__tests__/whyShown.test.ts
- npm run typecheck:fomo-web
- npm run lint
- npm run build:fomo-web
- git diff --check

## Product note
For cases like "기관이 4일째 사는 중이에요", the card now avoids repeating the same institution-buying fact again in both 이유 and 강세 rows. The bearish/price counterpoint can remain so the card still reads as balanced.
