### PR TITLE
fix(fomo-web): 숫자 가독성 — 픽셀 폰트 → JetBrains Mono

### DIFF
--- a/apps/fomo-web/app/globals.css
+++ b/apps/fomo-web/app/globals.css
@@ -1,7 +1,7 @@
-/* 본문 Pretendard / 숫자 픽셀 Pixelify Sans(라틴 only, 가시성↑) — @import는 Tailwind보다 먼저.
- * 픽셀 폰트는 *숫자(라틴)에만*. 한글은 Pixelify Sans 글리프가 없어 자동으로 Pretendard 폴백 = 한글 픽셀 금지. */
+/* 본문 Pretendard / 모든 숫자 JetBrains Mono(또렷) — @import는 Tailwind보다 먼저.
+ * 숫자는 JetBrains Mono(가독성). 한글은 글리프 없어 Pretendard 폴백. 픽셀 폰트는 가독성 문제로 폐기. */
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
-@import url("https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;700;800&display=swap");
 
 @tailwind base;
 @tailwind components;

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -92,7 +92,7 @@ export function HomeView({
           <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <div className="flex items-baseline gap-2">
-              <span className="font-pixel text-xl leading-none" style={{ color }}>
+              <span className="font-number text-xl font-bold leading-none" style={{ color }}>
                 {index.score}
               </span>
               <span className="font-pixel text-[11px] text-muted">{index.state}</span>

--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -64,7 +64,7 @@ function SectorFace({ card, progress }: { card: KeywordCard; progress?: string }
         <span className="text-2xl font-bold text-whiteout">{card.keyword}</span>
       </div>
       <div className="mt-3 flex items-baseline gap-2">
-        <span className="font-pixel text-5xl leading-none" style={{ color }}>
+        <span className="font-number text-5xl font-bold leading-none" style={{ color }}>
           {card.fomoScore}
         </span>
         <span className="font-pixel text-sm text-muted">포모 점수</span>

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -486,7 +486,7 @@ function FomoHero({ front, rankLabel }: { front: StockFrontResponse | null; rank
         {rankLabel && <span className="font-pixel text-[11px] text-muted">{rankLabel}</span>}
       </div>
       <div className="mt-1.5 flex items-end gap-2">
-        <span className="font-pixel text-4xl leading-none" style={{ color: tone }}>
+        <span className="font-number text-4xl font-bold leading-none" style={{ color: tone }}>
           {view.scoreText ? fomo.fomoScore : "—"}
         </span>
         <span className="pb-1 text-base font-bold" style={{ color: tone }}>

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -242,7 +242,7 @@ function StockCardFace({
         <div className="mt-3.5 flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5">
           <div className="flex items-baseline gap-1.5">
             <span className="text-[10px] uppercase tracking-wide text-text-secondary">포모</span>
-            <span className="font-display text-3xl leading-none" style={{ color: NEON }}>
+            <span className="font-number text-3xl font-bold leading-none" style={{ color: NEON }}>
               {view.scoreText.replace(/[^0-9]/g, "")}
             </span>
           </div>

--- a/apps/fomo-web/tailwind.config.ts
+++ b/apps/fomo-web/tailwind.config.ts
@@ -48,13 +48,14 @@ const config: Config = {
         lg: "16px",
       },
       fontFamily: {
-        // 본문 Pretendard(담담) / 픽셀 악센트 Galmuri(인디게임의 몸) — design/tokens.json
         body: ["Pretendard", "system-ui", "sans-serif"],
-        // 픽셀 폰트 = 숫자(라틴)만. 한글은 글리프 없어 Pretendard 폴백(= 한글 픽셀 금지, 전역 자동 적용).
-        pixel: ["Pixelify Sans", "Pretendard", "system-ui", "sans-serif"],
         sans: ["Pretendard", "system-ui", "sans-serif"],
-        display: ["Pixelify Sans", "Pretendard", "system-ui", "sans-serif"],
-        mono: ["Pixelify Sans", "Pretendard", "monospace"],
+        // 모든 숫자(점수·가격·등락·온도 등) = 또렷한 모노 JetBrains Mono. 픽셀 폰트는 가독성 떨어져 폐기.
+        // 한글은 JetBrains 글리프 없어 Pretendard 폴백(= 한글 모노 안 박힘). pixel/display/mono/number 전부 동일.
+        number: ["JetBrains Mono", "Pretendard", "monospace"],
+        mono: ["JetBrains Mono", "Pretendard", "monospace"],
+        pixel: ["JetBrains Mono", "Pretendard", "monospace"],
+        display: ["JetBrains Mono", "Pretendard", "monospace"],
       },
     },
   },


### PR DESCRIPTION
## 한 줄
픽셀 폰트(Pixelify)로 박힌 숫자가 "44/39" 구분이 안 돼서 — **읽어야 하는 숫자 전부를 또렷한 모노(JetBrains Mono, OFL)로**. **프로덕션 디자인(색·레이아웃·데이터)은 그대로**, 표현(폰트)만.

## 무엇을
- 폰트 스택 `pixel`/`display`/`mono` → **JetBrains Mono** 통일. 한글은 글리프 없어 Pretendard 폴백(한글 모노 안 박힘).
- 포모 점수·시장 온도·뎁스 히어로 점수 span → `font-number`(=JetBrains). 가격·등락%·델타·progress 전부 또렷.
- Pixelify import 제거(미사용).
- **색·UI·데이터·카피 무변경** — 네온은 점수·스코어바·관심 버튼에만(prod 톤다운 유지).

## 검증 (로컬)
온도 45 / 포모 33 / 가격 362,000원 / 등락 23,500 (-6.10%) / progress 1/60 — 전부 또렷. 866 테스트, typecheck 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)