### PR TITLE
Fix stock insight timeout and lift source-backed headlines

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -143,6 +143,12 @@ function compactEvidenceLine(text: string | undefined): string | undefined {
   return clean.length > 58 ? `${clean.slice(0, 57)}…` : clean;
 }
 
+function compactReasonHeadlineSeed(text: string | undefined): string | undefined {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  if (!clean) return undefined;
+  return clean.length > 38 ? `${clean.slice(0, 37)}…` : clean;
+}
+
 function FeedSignalStrip({
   bull,
   bear,
@@ -418,7 +424,7 @@ export function StockSwipeDeck({
 
   // 카드 표현 — 포모 점수(척추, 단일 출처) → fomoCardView.
   // 긴 원문 재료는 why/depth 로 보내고, 앞면은 잘리지 않는 핵심 독해만 남긴다.
-  const cardFor = (stock: DeckStock): { view: FomoCardView; subLine?: string } => {
+  const cardFor = (stock: DeckStock): { view: FomoCardView; subLine?: string; usedReasonHeadline?: boolean } => {
     const e = front[stock.canonical];
     if (!e) {
       const view: FomoCardView = {
@@ -432,15 +438,25 @@ export function StockSwipeDeck({
       return { view, subLine: "가격·거래량 신호를 불러오고 있어요." };
     }
     const fomo = e?.fomo ?? EMPTY_FOMO;
+    const reasonHeadlineSeed = compactReasonHeadlineSeed(stock.reason);
+    const signalsForHook: CardFrontSignals = {
+      ...(e?.signals ?? {}),
+      ...(!e?.signals.newsEventLabel && reasonHeadlineSeed ? { newsEventLabel: reasonHeadlineSeed } : {}),
+    };
     const hook = selectFomoHook({
       fomo,
-      ...(e?.signals ? { signals: e.signals } : {}),
+      signals: signalsForHook,
       ...(e?.taFact ? { taFact: e.taFact } : {}),
     });
     const baseView = fomoCardView(fomo, { sector: stock.sector, ...(stock.reason ? { reason: stock.reason } : {}) });
     const view = { ...baseView, headline: hook.headline };
-    const evidenceLine = compactEvidenceLine(stock.reason);
-    return { view, ...(evidenceLine || hook.subLine ? { subLine: evidenceLine ?? hook.subLine } : {}) };
+    const usedReasonHeadline = !!reasonHeadlineSeed && !e?.signals.newsEventLabel && hook.kind === "news_event";
+    const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);
+    return {
+      view,
+      ...(evidenceLine || hook.subLine ? { subLine: evidenceLine ?? hook.subLine } : {}),
+      ...(usedReasonHeadline ? { usedReasonHeadline } : {}),
+    };
   };
   const rankLabelFor = (stock: DeckStock): string | undefined => {
     const r = front[stock.canonical]?.signals.marketCapRank;
@@ -462,13 +478,13 @@ export function StockSwipeDeck({
     if (!e) {
       return <StockCardLoadingFace stock={stock} themeLabel={stock.sector} progress={progress} />;
     }
-    const { view, subLine } = cardFor(stock);
+    const { view, subLine, usedReasonHeadline } = cardFor(stock);
     const deduped = dedupeCardCopy({
       headline: view.headline,
       why: whyFor(stock),
       feedBull: e?.feedBull,
       feedBear: e?.feedBear,
-      preserveGroundedReason: !!stock.reason,
+      preserveGroundedReason: !!stock.reason && !usedReasonHeadline,
     });
     return (
       <StockCardFace

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -21,7 +21,7 @@ export function OPTIONS() {
 
 // theme-insight 와 동일 정책 — (KST날짜, 종목) 키로 cold 를 하루 1회로. revalidate 6h(SWR — 대기 없이 갱신).
 const REVALIDATE_S = 21_600; // 6h
-const USER_WAIT_MS = 8_500;
+const USER_WAIT_MS = 6_000;
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(stock: string): Promise<CondensedInsight> {

--- a/packages/fomo-core/__tests__/card-front-hook.test.ts
+++ b/packages/fomo-core/__tests__/card-front-hook.test.ts
@@ -295,6 +295,40 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
     expect(hook.subLine).toBe("최근 거래가 평소 2.5배로 늘었어요.");
   });
 
+  it("뉴스 이벤트는 하락 긴장형보다 먼저 헤드라인을 차지한다", () => {
+    const fomo = computeFomoScore({ mentionScore: 100, volumeRatio: 2.4, changePct: -8.3 });
+    const hook = selectFomoHook({
+      fomo,
+      signals: {
+        newsEventLabel: "신약개발 해법은 AI·오픈이노베이션",
+        mentionScore: 100,
+        mentionCount: 4,
+        volumeRatio: 2.4,
+        changePct: -8.3,
+      },
+    });
+
+    expect(hook.kind).toBe("news_event");
+    expect(hook.headline).toBe("신약개발 해법은 AI·오픈이노베이션 소식이 나왔어요.");
+    expect(hook.subLine).toBe("가격은 빠졌는데, 뉴스·커뮤니티 언급은 늘었어요.");
+  });
+
+  it("긴 뉴스 원문 제목은 카드 헤드라인에서 짧게 정리한다", () => {
+    const fomo = computeFomoScore({ mentionScore: 80 });
+    const hook = selectFomoHook({
+      fomo,
+      signals: {
+        newsEventLabel: "SK바이오팜 신약개발 해법은 AI·오픈이노베이션과 글로벌 공동연구 확대",
+        mentionScore: 80,
+        mentionCount: 3,
+      },
+    });
+
+    expect(hook.kind).toBe("news_event");
+    expect(hook.headline).toBe("SK바이오팜 신약개발 해법은 AI·오픈이노베이션과 글로벌 공동연구 … 소식이 나왔어요.");
+    expect(hook.headline.length).toBeLessThanOrEqual(50);
+  });
+
   it("헤드라인·보조문장은 안전하고 결정적이다", () => {
     const fomo = computeFomoScore({ foreignNetStreak: 4, volumeRatio: 2.4, changePct: 0.4 });
     const fact: TaFact = {

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -360,6 +360,16 @@ function ratioText(ratio: number): string {
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
 }
 
+function compactNewsLabel(label: string): string {
+  const clean = label
+    .replace(/\s+/g, " ")
+    .replace(/[.!?。]+$/, "")
+    .replace(/\s+소식$/, "")
+    .trim();
+  if (clean.length <= 38) return clean;
+  return `${clean.slice(0, 37)}…`;
+}
+
 const TA_EVERYDAY: Record<TaFactKind, string> = {
   accumulation_divergence: "거래는 느는데 가격은 잠잠해요.",
   bollinger_squeeze: "며칠째 가격이 좁은 폭에서만 움직이고 있어요.",
@@ -446,12 +456,12 @@ function newsEventCandidate(signals: CardFrontSignals): HookCandidate | null {
     signals.newsEventLabel?.trim() ??
     (signals.catalysts ?? []).find((c) => c.kind === "news" && c.label.trim())?.label.trim();
   if (!label || label === "재료") return null;
-  const event = label.replace(/[.!?。]+$/, "").replace(/\s+소식$/, "");
+  const event = compactNewsLabel(label);
   const headline = `${event} 소식이 나왔어요.`;
   return {
     kind: "news_event",
     tier: "material",
-    score: 0.94,
+    score: 1.18,
     headline,
   };
 }


### PR DESCRIPTION
## Summary
- Return stock-insight cold fallback within 6s so quality/report clients do not hit the 8s timeout before the honest fallback payload
- Let grounded stock.reason become a news_event headline candidate on the swipe card when backend newsEventLabel is absent
- Raise concrete news/source-backed material above axis-tension headlines and compact long news labels for card fit

## Verification
- npm test -- packages/fomo-core/__tests__/card-front-hook.test.ts apps/fomo-web/__tests__/cardCopyDedupe.test.ts
- npm run typecheck:fomo-web
- npm run typecheck:fomo-core
- npm run build:web
- npm run build:fomo-web
- npm run lint
- git diff --check

## Notes
Before this change, production stock-insight could return a valid fallback after ~11.5s, but the quality report aborts at 8s. The endpoint now gives the honest fallback earlier while the cache warm continues.
