### PR TITLE
Tighten stock insight fallback timeout

### DIFF
--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -21,7 +21,7 @@ export function OPTIONS() {
 
 // theme-insight 와 동일 정책 — (KST날짜, 종목) 키로 cold 를 하루 1회로. revalidate 6h(SWR — 대기 없이 갱신).
 const REVALIDATE_S = 21_600; // 6h
-const USER_WAIT_MS = 6_000;
+const USER_WAIT_MS = 4_500;
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(stock: string): Promise<CondensedInsight> {


### PR DESCRIPTION
## Summary
- Lower stock-insight user wait fallback from 6.0s to 4.5s
- Keeps the quality report's 8s timeout clear even after official supply-demand fact lookup is appended

## Verification
- npm run build:web
- npm run typecheck:web
- git diff --check

## Context
Production after #639 returned the honest fallback in ~8.4s for Samsung Electronics. This was better than before but still too close to the quality report timeout. This patch leaves more buffer.
