### PR TITLE
feat(fomo): add stock research report sources

### DIFF
--- a/apps/web/__tests__/lib/fomo-news-sources.test.ts
+++ b/apps/web/__tests__/lib/fomo-news-sources.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNaverCompanyResearchHtml } from "../../lib/fomo-news-sources";
+
+const html = `
+<table>
+  <tr>
+    <td>
+      <a href="/item/main.naver?code=005930" title="삼성전자" class="stock_item">삼성전자</a>
+    </td>
+    <td>
+      <a href="company_read.naver?nid=93658&page=1">중기 주가 상승세 유지 예상</a>
+    </td>
+    <td>하나증권</td>
+    <td class="file"><a href="https://stock.pstatic.net/stock-research/company/93658.pdf">PDF</a></td>
+    <td class="date">26.06.23</td>
+  </tr>
+  <tr>
+    <td>
+      <a href="/item/main.naver?code=000660" title="SK하이닉스" class="stock_item">SK하이닉스</a>
+    </td>
+    <td>
+      <a href="company_read.naver?nid=93659&page=1">HBM 수요 점검</a>
+    </td>
+    <td>신한투자증권</td>
+    <td class="file"></td>
+    <td class="date">26.06.22</td>
+  </tr>
+</table>
+`;
+
+describe("parseNaverCompanyResearchHtml", () => {
+  it("종목코드로 좁힌 증권사 리서치 리포트를 원문 근거 기사로 정규화한다", () => {
+    const out = parseNaverCompanyResearchHtml(html, {
+      code: "005930",
+      stock: "삼성전자",
+      nowIso: "2026-06-23T00:00:00.000Z",
+      limit: 6,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      title: "중기 주가 상승세 유지 예상",
+      url: "https://stock.pstatic.net/stock-research/company/93658.pdf",
+      source: "하나증권 리서치",
+      category: "리서치",
+      summary: "삼성전자 종목 리포트 · 하나증권 · 26.06.23",
+      tier: "news-mid",
+      lang: "ko",
+    });
+    expect(out[0]!.publishedAt).toBe("2026-06-23T00:00:00.000Z");
+  });
+
+  it("일치하지 않는 종목 리포트는 섞지 않는다", () => {
+    const out = parseNaverCompanyResearchHtml(html, {
+      code: "005930",
+      stock: "삼성전기",
+      nowIso: "2026-06-23T00:00:00.000Z",
+    });
+
+    expect(out).toEqual([]);
+  });
+});

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, emptyThemeInsight, stockDef, supplyDemandFact, type CondensedInsight } from "@fomo/core";
-import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { withCors, kstDate, kstSlot, cacheVersion } from "../../../../lib/fomo";
 import { understandStock } from "../../../../lib/theme-understanding";
 import { readLatestSupplyDemand } from "../../../../lib/supply-demand-store";
 
@@ -26,13 +26,14 @@ const inflight = new Map<string, Promise<CondensedInsight>>();
 
 async function getInsight(stock: string): Promise<CondensedInsight> {
   const today = kstDate();
-  const key = `${today}:${stock}`;
+  const slot = kstSlot();
+  const key = `${today}:${slot}:${stock}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
     async () => condenseThemeInsight(await understandStock(stock)),
-    ["fomo-stock-insight", cacheVersion(), today, stock],
+    ["fomo-stock-insight", cacheVersion(), today, slot, stock],
     { revalidate: REVALIDATE_S }
   );
 

--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -1,4 +1,5 @@
 import {
+  decodeHtmlEntities,
   parseNaverNews,
   parseNaverStockNews,
   parseRssFeed,
@@ -91,6 +92,7 @@ const KR_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] 
 // 해외 증시 실시간 뉴스(이미 한국어). api.stock.naver.com/news/worldNews.
 const NAVER_NEWS_URL = "https://api.stock.naver.com/news/worldNews?pageSize=20&page=1";
 const NAVER_STOCK_NEWS_URL = "https://api.stock.naver.com/news/stock";
+const NAVER_COMPANY_RESEARCH_URL = "https://finance.naver.com/research/company_list.naver";
 
 export const naverNewsSource: NewsSource = {
   id: "naver",
@@ -128,6 +130,94 @@ export async function fetchNaverStockNews(code: string, pageSize = 10): Promise<
     return withTier(parseNaverStockNews(Array.isArray(json) ? json : [], new Date().toISOString()), "news-mid");
   } catch (err) {
     console.warn(`[fomo/news] naver stock ${code} error`, err);
+    return [];
+  }
+}
+
+function cleanResearchText(text: string): string {
+  return decodeHtmlEntities(text.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ")).trim();
+}
+
+function absoluteNaverFinanceUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) return path;
+  return `https://finance.naver.com${path.startsWith("/") ? path : `/research/${path}`}`;
+}
+
+function researchDateToIso(date: string, nowIso: string): string {
+  const m = date.trim().match(/^(\d{2})\.(\d{2})\.(\d{2})$/);
+  if (!m) return nowIso;
+  const year = 2000 + Number(m[1]);
+  const month = m[2];
+  const day = m[3];
+  const ts = Date.parse(`${year}-${month}-${day}T09:00:00+09:00`);
+  return Number.isNaN(ts) ? nowIso : new Date(ts).toISOString();
+}
+
+function researchId(url: string): string {
+  return `research-${url.replace(/^https?:\/\//, "").replace(/[^a-z0-9]+/gi, "-").slice(0, 64)}`;
+}
+
+export function parseNaverCompanyResearchHtml(
+  html: string,
+  opts: { code: string; stock: string; nowIso: string; limit?: number }
+): RawArticle[] {
+  const out: RawArticle[] = [];
+  const seen = new Set<string>();
+  const rowRe = /<tr>\s*<td[^>]*>\s*<a[^>]+code=([^"&]+)[^>]*title="([^"]*)"[^>]*class="stock_item"[^>]*>[\s\S]*?<\/td>\s*<td>\s*<a\s+href="([^"]+)"[^>]*>([\s\S]*?)<\/a>[\s\S]*?<\/td>\s*<td>([\s\S]*?)<\/td>\s*<td\s+class="file">([\s\S]*?)<\/td>\s*<td[^>]*class="date"[^>]*>([\s\S]*?)<\/td>/g;
+  let match: RegExpExecArray | null;
+  while ((match = rowRe.exec(html)) !== null) {
+    const code = cleanResearchText(match[1] ?? "");
+    const stock = cleanResearchText(match[2] ?? "");
+    if (code !== opts.code || stock !== opts.stock) continue;
+
+    const readUrl = absoluteNaverFinanceUrl(match[3] ?? "");
+    const title = cleanResearchText(match[4] ?? "");
+    const broker = cleanResearchText(match[5] ?? "");
+    const fileBlock = match[6] ?? "";
+    const date = cleanResearchText(match[7] ?? "");
+    const pdfUrl = fileBlock.match(/<a\s+href="([^"]+\.pdf[^"]*)"/i)?.[1];
+    const url = pdfUrl ? absoluteNaverFinanceUrl(pdfUrl) : readUrl;
+    if (!title || !url || seen.has(url)) continue;
+    seen.add(url);
+
+    out.push({
+      id: researchId(url),
+      title,
+      url,
+      source: broker ? `${broker} 리서치` : "네이버 증권 리서치",
+      publishedAt: researchDateToIso(date, opts.nowIso),
+      lang: "ko",
+      category: "리서치",
+      summary: `${stock} 종목 리포트 · ${broker || "증권사"} · ${date || "작성일 미상"}`,
+      tier: "news-mid",
+    });
+    if (opts.limit && out.length >= opts.limit) break;
+  }
+  return out;
+}
+
+/** 네이버 증권 종목분석 리포트 — 국내 종목 stock-insight 원문 근거 보강용. */
+export async function fetchNaverCompanyResearch(code: string, stock: string, limit = 6): Promise<RawArticle[]> {
+  if (!/^\d{6}$/.test(code) || !stock.trim()) return [];
+  try {
+    const url = new URL(NAVER_COMPANY_RESEARCH_URL);
+    url.searchParams.set("searchType", "itemCode");
+    url.searchParams.set("itemCode", code);
+    const res = await fetch(url.toString(), {
+      headers: { accept: "text/html", "user-agent": BROWSER_UA },
+      signal: AbortSignal.timeout(8_000),
+      next: { revalidate: 3_600 },
+    });
+    if (!res.ok) return [];
+    const html = new TextDecoder("euc-kr").decode(await res.arrayBuffer());
+    return parseNaverCompanyResearchHtml(html, {
+      code,
+      stock,
+      nowIso: new Date().toISOString(),
+      limit,
+    });
+  } catch (err) {
+    console.warn(`[fomo/news] naver research ${code} error`, err);
     return [];
   }
 }

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -18,7 +18,7 @@ import {
   type WordingVerdict,
   type OfficialFact,
 } from "@fomo/core";
-import { fetchAllNews, fetchNaverStockNews } from "./fomo-news-sources";
+import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
 
@@ -225,8 +225,9 @@ export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
   const isForeign = def ? def.country !== "KR" : false;
   const matches = (s: string) => stockMatchesText(stock, s);
 
-  const [stockNewsRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
+  const [stockNewsRes, researchRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
     code ? fetchNaverStockNews(code, MAX_NEWS) : Promise.resolve([]),
+    code ? fetchNaverCompanyResearch(code, stock, 6) : Promise.resolve([]),
     fetchAllNews(),
     fetchDcStockTitles(),
     code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
@@ -266,6 +267,13 @@ export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
     for (const a of hit) pushNews(a);
   } else {
     console.warn("[stock-understanding] naver stock news error", stockNewsRes.reason);
+  }
+
+  // 증권사 리서치 리포트 — 종목코드로 좁게 조회한 보고서 제목·증권사·PDF 링크. 무료 공개 HTML만 사용한다.
+  if (researchRes.status === "fulfilled") {
+    for (const a of researchRes.value.slice(0, 6)) pushNews(a);
+  } else {
+    console.warn("[stock-understanding] naver research error", stock, researchRes.reason);
   }
 
   // 뉴스 — 종목명(별칭 포함)이 제목/요약에 등장하는 기사만.


### PR DESCRIPTION
## Summary
- add Naver Finance company research report collection for stock-level insight sources
- include broker report title/source/PDF link as grounded news-tier docs for stock depth
- refresh stock-insight cache by KST slot so intraday source changes surface sooner
- cover the research HTML parser with unit tests

## Verification
- npm test -- apps/web/__tests__/lib/fomo-news-sources.test.ts
- npm run typecheck:web
- npm run lint:web
- git diff --check
- npm run build:web