### PR TITLE
fix(fomo): warm stock insight screen cache

### DIFF
--- a/apps/web/__tests__/api/fomo/stock-insight-cache.test.ts
+++ b/apps/web/__tests__/api/fomo/stock-insight-cache.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { stockInsightCacheControl } from "@/lib/stock-insight-cache";
+
+describe("stock-insight cache policy", () => {
+  it("준비 중 폴백 응답은 CDN에 저장하지 않는다", () => {
+    expect(stockInsightCacheControl(true)).toBe("no-store, max-age=0");
+  });
+
+  it("성공 응답만 화면 경로 캐시에 남긴다", () => {
+    expect(stockInsightCacheControl(false)).toBe("public, s-maxage=900, stale-while-revalidate=1800");
+  });
+});

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { condenseThemeInsight, emptyThemeInsight, stockDef, supplyDemandFact, type CondensedInsight } from "@fomo/core";
 import { withCors, kstDate, kstSlot, cacheVersion } from "../../../../lib/fomo";
+import { stockInsightCacheControl } from "../../../../lib/stock-insight-cache";
 import { understandStock } from "../../../../lib/theme-understanding";
 import { readLatestSupplyDemand } from "../../../../lib/supply-demand-store";
 
@@ -87,13 +88,10 @@ export async function GET(req: Request) {
     ? { ...payload, officialFacts: [supplyDemandFact(flow), ...(payload.officialFacts ?? [])] }
     : payload;
 
-  return withCors(
-    NextResponse.json(out, {
-      headers: {
-        "Cache-Control": coldFallback
-          ? "public, s-maxage=30, stale-while-revalidate=120"
-          : "public, s-maxage=900, stale-while-revalidate=1800",
-      },
-    })
-  );
+  const headers = new Headers({
+    "Cache-Control": stockInsightCacheControl(coldFallback),
+  });
+  if (coldFallback) headers.set("X-Fomo-Cold-Fallback", "1");
+
+  return withCors(NextResponse.json(out, { headers }));
 }

--- a/apps/web/lib/stock-insight-cache.ts
+++ b/apps/web/lib/stock-insight-cache.ts
@@ -1,0 +1,5 @@
+export function stockInsightCacheControl(coldFallback: boolean): string {
+  return coldFallback
+    ? "no-store, max-age=0"
+    : "public, s-maxage=900, stale-while-revalidate=1800";
+}

--- a/scripts/warm-insights.ts
+++ b/scripts/warm-insights.ts
@@ -12,59 +12,97 @@
  *
  * env: WARM_BASE_URL(배포 API 베이스, 기본 prod). cron: warm-insights.yml(슬롯 시작 09/13/16 KST).
  */
+import { SECTORS, stocksBySector, type StockSector } from "@fomo/core";
 import { collectThemeStocks } from "../apps/web/lib/theme-understanding";
 
 const BASE = (process.env.WARM_BASE_URL || "https://fomo-club-backend.vercel.app").replace(/\/$/, "");
 const MIN_MENTIONS = 2; // 종목 추출 임계(가짜 연관 방지 — 빈도 낮은 종목은 워밍 제외)
 const REQ_TIMEOUT_MS = 60_000; // understandTheme/Stock 의 LLM timeout(45s)보다 여유
+const DISCOVERY_SECTORS: readonly StockSector[] = SECTORS.filter((sector) => sector !== "코인").slice(0, 6);
+const MAX_FRONT_WARM_STOCKS = Number.parseInt(process.env["WARM_FRONT_STOCK_LIMIT"] ?? "60", 10);
+const MAX_DEPTH_WARM_STOCKS = Number.parseInt(process.env["WARM_DEPTH_STOCK_LIMIT"] ?? "24", 10);
+const DRY_RUN = process.env["WARM_DRY_RUN"] === "1";
 
-async function warm(path: string): Promise<void> {
+async function warm(path: string, opts: { blocking?: boolean } = {}): Promise<void> {
   const t0 = Date.now();
   try {
     const res = await fetch(`${BASE}${path}`, {
-      headers: { "x-warm": "1" },
+      headers: opts.blocking ? { "x-warm": "1" } : undefined,
       signal: AbortSignal.timeout(REQ_TIMEOUT_MS),
     });
-    console.log(`  ${res.ok ? "✓" : "✗"} ${res.status} ${Date.now() - t0}ms  ${path}`);
+    const fallback = res.headers.get("x-fomo-cold-fallback") === "1" ? " fallback" : "";
+    console.log(`  ${res.ok ? "✓" : "✗"} ${res.status}${fallback} ${Date.now() - t0}ms  ${path}`);
   } catch (err) {
     console.warn(`  ✗ ERR ${Date.now() - t0}ms  ${path} — ${(err as Error)?.message}`);
   }
 }
 
+function addStock(out: Map<string, string>, stock: string, reason: string): void {
+  const key = stock.trim();
+  if (!key || out.has(key)) return;
+  out.set(key, reason);
+}
+
 async function main() {
   console.log(`[warm-insights] base=${BASE}`);
+  if (DRY_RUN) {
+    const dryStocks = new Map<string, string>();
+    for (const sector of DISCOVERY_SECTORS) {
+      for (const stock of stocksBySector(sector, { requireNaverCode: true }).slice(0, 8)) {
+        addStock(dryStocks, stock.canonical, stock.marquee ? `marquee:${sector}` : `sector:${sector}`);
+      }
+    }
+    console.log(`[warm-insights] dry-run sectors=${DISCOVERY_SECTORS.join(", ")}`);
+    console.log(`[warm-insights] dry-run stocks=${[...dryStocks.keys()].slice(0, MAX_DEPTH_WARM_STOCKS).join(", ")}`);
+    return;
+  }
 
   // 1) 그날 키워드 테마 목록(배포 endpoint — 같은 캐시를 공유한다).
   const kwRes = await fetch(`${BASE}/api/fomo/keywords`, { signal: AbortSignal.timeout(REQ_TIMEOUT_MS) });
-  const kw = (await kwRes.json()) as { cards?: { keyword: string }[] };
-  const themes = [...new Set((kw.cards ?? []).map((c) => c.keyword).filter(Boolean))];
+  const kw = (await kwRes.json()) as { cards?: { keyword: string; surpriseStock?: { canonical?: string } }[] };
+  const keywordCards = kw.cards ?? [];
+  const themes = [...new Set(keywordCards.map((c) => c.keyword).filter(Boolean))];
   console.log(`[warm-insights] 테마 ${themes.length}개: ${themes.join(", ")}`);
 
   // 2) 테마 뎁스 워밍 + 그 테마에 등장한 종목 수집.
-  const stocks = new Set<string>();
+  const stocks = new Map<string, string>();
+  for (const card of keywordCards) {
+    if (card.surpriseStock?.canonical) addStock(stocks, card.surpriseStock.canonical, `surprise:${card.keyword}`);
+  }
   for (const theme of themes) {
     await warm(`/api/fomo/theme-insight?theme=${encodeURIComponent(theme)}`);
     try {
       const extracted = await collectThemeStocks(theme, { minMentions: MIN_MENTIONS });
-      for (const s of extracted) stocks.add(s.canonical);
+      for (const s of extracted) addStock(stocks, s.canonical, `theme:${theme}`);
     } catch (err) {
       console.warn(`  종목 추출 실패: ${theme} — ${(err as Error)?.message}`);
     }
   }
 
-  // 3) 피드 카드용 stock-front lite 워밍 — 신호 캐시(attention/theme-relative)를 먼저 채운다.
-  const stockList = [...stocks];
-  console.log(`[warm-insights] 종목 ${stockList.length}개: ${stockList.join(", ")}`);
+  // 3) 오늘 발견 덱 콜드스타트 후보까지 추가. 키워드에서 뽑힌 종목만 데우면 대표주/섹터 첫 카드가 비어 보일 수 있다.
+  for (const sector of DISCOVERY_SECTORS) {
+    for (const stock of stocksBySector(sector, { requireNaverCode: true }).slice(0, 8)) {
+      addStock(stocks, stock.canonical, stock.marquee ? `marquee:${sector}` : `sector:${sector}`);
+    }
+  }
+
+  // 4) 피드 카드용 stock-front lite 워밍 — 신호 캐시(attention/theme-relative)를 먼저 채운다.
+  const stockList = [...stocks.keys()].slice(0, MAX_FRONT_WARM_STOCKS);
+  const depthStockList = [...stocks.keys()].slice(0, MAX_DEPTH_WARM_STOCKS);
+  console.log(`[warm-insights] 종목 ${stockList.length}개(front): ${stockList.join(", ")}`);
+  console.log(`[warm-insights] 종목 ${depthStockList.length}개(depth): ${depthStockList.join(", ")}`);
   for (const stock of stockList) {
     await warm(`/api/fomo/stock-front?stock=${encodeURIComponent(stock)}&lite=1`);
   }
 
-  // 4) 그날 등장 종목 뎁스 워밍(가장 느렸던 경로 — cold 33초의 주범).
-  for (const stock of stockList) {
-    await warm(`/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}&blocking=1`);
+  // 5) 뎁스 워밍: blocking 으로 Data Cache 를 채운 뒤 일반 URL 도 호출해 화면 경로의 CDN 캐시를 성공 응답으로 채운다.
+  for (const stock of depthStockList) {
+    const path = `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`;
+    await warm(`${path}&blocking=1`, { blocking: true });
+    await warm(path);
   }
 
-  console.log(`[warm-insights] 완료 — 테마 ${themes.length} + 종목 ${stockList.length} 워밍`);
+  console.log(`[warm-insights] 완료 — 테마 ${themes.length} + front ${stockList.length} + depth ${depthStockList.length} 워밍`);
 }
 
 main()


### PR DESCRIPTION
## Summary
- stop caching stock-insight cold fallback responses at CDN level
- keep successful stock-insight responses on the screen route cache
- expand warm-insights to include discovery-deck sector candidates and surprise stocks
- warm stock insight in two steps: blocking Data Cache fill, then normal screen URL fill
- add dry-run support for safe warm script verification

## Verification
- npm test -- apps/web/__tests__/api/fomo/stock-insight-cache.test.ts
- npm run typecheck:web
- npm run typecheck:fomo-web
- npm run lint:web
- npm run build:web
- WARM_DRY_RUN=1 npm run warm:insights
- git diff --check