### PR TITLE
fix(fomo): tune undo and depth market UI

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -60,10 +60,9 @@ export function HomeView({
   }, []);
 
   /**
-   * 전체 폴백 판정: 4개 Heat가 모두 중립 기본값(market/community/emotion=15, whale=0)이고
-   * aiSummary가 비어 있으면, 실제 데이터 없이 산출된 폴백 상태다.
-   * 이 상태를 "진짜 숫자처럼" 노출하면 정직한 숫자 원칙(PRODUCT_TRUTH §4) 위반.
-   * @author 안티그래비티
+   * 전체 폴백 판정: 기본 온도만 있는 상태다.
+   * 이 경우에도 "수집 중"으로 고정하지 않고 온도 자체는 보여주되, 어제 대비처럼
+   * 실제 비교 데이터가 필요한 디테일만 숨긴다.
    */
   const isFullFallback = index
     ? index.components.market === 15 &&
@@ -87,8 +86,8 @@ export function HomeView({
           </button>
         </div>
 
-        {/* 시장 온도(FOMO Index) — 전체 폴백이면 정직하게 "수집 중" 표시 @author 안티그래비티 */}
-        {index && !isFullFallback && (
+        {/* 시장 온도(FOMO Index) */}
+        {index ? (
           <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <div className="flex items-baseline gap-2">
@@ -96,7 +95,7 @@ export function HomeView({
                 {index.score}
               </span>
               <span className="font-pixel text-[11px] text-muted">{index.state}</span>
-              {index.prevDayDelta !== 0 && (
+              {!isFullFallback && index.prevDayDelta !== 0 && (
                 <span className="inline-flex items-center gap-0.5 font-pixel text-[11px]" style={{ color }}>
                   · 어제보다
                   {index.prevDayDelta > 0 ? <CaretUpIcon size={10} /> : <CaretDownIcon size={10} />}
@@ -105,8 +104,7 @@ export function HomeView({
               )}
             </div>
           </div>
-        )}
-        {index && isFullFallback && (
+        ) : (
           <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <span className="font-pixel text-[11px] text-muted">데이터 수집 중…</span>

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -367,9 +367,9 @@ function StockPriceHeader({ basics, front }: { basics: StockBasics | null; front
       </div>
       {priceText ? (
         <div className="mt-2">
-          <span className="text-5xl font-bold leading-none text-whiteout">{priceText}</span>
+          <span className="text-[32px] font-bold leading-none text-whiteout">{priceText}</span>
           {changeText && (
-            <span className="ml-2 align-baseline text-sm" style={up || down ? { color: up ? "#ff5a5f" : "#4f8cff" } : undefined}>
+            <span className="ml-2 align-baseline font-number text-sm font-medium tabular-nums" style={up || down ? { color: up ? "#ff5a5f" : "#4f8cff" } : undefined}>
               {up ? "▲" : down ? "▼" : ""} {changeText}
             </span>
           )}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -241,7 +241,7 @@ function StockCardFace({
         <div className="mt-2.5 flex shrink-0 items-baseline gap-2">
           <span className="text-lg font-bold text-whiteout">{priceText}</span>
           {changeText && (
-            <span className="inline-flex items-center gap-1 font-pixel text-sm" style={{ color: DIR_COLOR[changeDir ?? "flat"] }}>
+            <span className="inline-flex items-center gap-1 font-number text-sm font-medium tabular-nums" style={{ color: DIR_COLOR[changeDir ?? "flat"] }}>
               {changeDir === "up" && <CaretUpIcon size={11} />}
               {changeDir === "down" && <CaretDownIcon size={11} />}
               {changeText}
@@ -379,6 +379,7 @@ export function StockSwipeDeck({
   const [idx, setIdx] = useState(0);
   const [dx, setDx] = useState(0);
   const [exiting, setExiting] = useState<null | "left" | "right">(null);
+  const [restoring, setRestoring] = useState(false);
   const [selected, setSelected] = useState<DeckStock | null>(null);
   const [undoEntry, setUndoEntry] = useState<UndoEntry | null>(null);
   const dragging = useRef(false);
@@ -542,10 +543,18 @@ export function StockSwipeDeck({
 
   const undoLast = useCallback(() => {
     if (!undoEntry || exiting) return;
-    setDx(0);
+    const fromX = undoEntry.dir === "right" ? 72 : -72;
     setExiting(null);
     setIdx(undoEntry.idx);
     setUndoEntry(null);
+    if (prefersReducedMotion()) {
+      setDx(0);
+      return;
+    }
+    setRestoring(true);
+    setDx(fromX);
+    window.setTimeout(() => setDx(0), 20);
+    window.setTimeout(() => setRestoring(false), EXIT_MS + 40);
   }, [undoEntry, exiting]);
 
   const openDepth = (stock: DeckStock, source: "card" | "interest_button" = "card") => {
@@ -569,7 +578,7 @@ export function StockSwipeDeck({
   };
 
   const onPointerDown = (e: React.PointerEvent) => {
-    if (exiting) return;
+    if (exiting || restoring) return;
     if (!front[at(idx).canonical]) return;
     dragging.current = true;
     moved.current = false;
@@ -639,7 +648,7 @@ export function StockSwipeDeck({
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onClick={() => {
-            if (topReady && !moved.current && !exiting) openDepth(top, "card");
+            if (topReady && !moved.current && !exiting && !restoring) openDepth(top, "card");
           }}
           className="glass-card absolute inset-0 z-10 cursor-pointer overflow-hidden rounded-2xl px-6 py-7"
           style={{ transform: topTransform, transition: topTransition }}
@@ -662,25 +671,25 @@ export function StockSwipeDeck({
 
       <div className="mt-4 flex items-center justify-center gap-4">
         <button
+          onClick={undoLast}
+          disabled={!!exiting || restoring || !undoEntry}
+          aria-label={undoEntry ? `${undoEntry.stock.canonical} 카드로 돌아가기` : "이전 카드 없음"}
+          title={undoEntry ? `${undoEntry.stock.canonical} 다시 보기` : "이전 카드 없음"}
+          className="flex h-14 w-14 items-center justify-center rounded-full border border-hairline-soft bg-surface-raised text-muted transition-colors hover:text-whiteout disabled:opacity-30"
+        >
+          <UndoIcon size={24} />
+        </button>
+        <button
           onClick={() => advance("left")}
-          disabled={!!exiting || !topReady}
+          disabled={!!exiting || restoring || !topReady}
           aria-label="덜 관심"
           className="flex h-14 w-14 items-center justify-center rounded-full border border-hairline-soft bg-surface-raised text-xl text-muted transition-colors hover:text-whiteout disabled:opacity-40"
         >
           ✕
         </button>
         <button
-          onClick={undoLast}
-          disabled={!!exiting || !undoEntry}
-          aria-label={undoEntry ? `${undoEntry.stock.canonical} 카드로 돌아가기` : "이전 카드 없음"}
-          title={undoEntry ? `${undoEntry.stock.canonical} 다시 보기` : "이전 카드 없음"}
-          className="flex h-12 w-12 items-center justify-center rounded-full border border-hairline-soft bg-surface-raised text-muted transition-colors hover:text-whiteout disabled:opacity-30"
-        >
-          <UndoIcon size={20} />
-        </button>
-        <button
           onClick={() => openDepth(top, "interest_button")}
-          disabled={!!exiting || !topReady}
+          disabled={!!exiting || restoring || !topReady}
           aria-label="관심 — 자세히 보기"
           className="flex h-14 flex-1 items-center justify-center rounded-full text-sm font-bold text-canvas transition-opacity disabled:opacity-40"
           style={{ backgroundColor: NEON }}

--- a/apps/fomo-web/components/icons.tsx
+++ b/apps/fomo-web/components/icons.tsx
@@ -54,8 +54,8 @@ export function CaretDownIcon({ size = 12, className }: IconProps) {
 export function UndoIcon({ size = 18, className }: IconProps) {
   return (
     <svg {...base(size)} className={className} fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <path d="M9 7H4v5" />
-      <path d="M4 12a8 8 0 1 0 2.34-5.66L4 8.68" />
+      <path d="M9 14 4 9l5-5" />
+      <path d="M4 9h10a6 6 0 1 1-4.25 10.25" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Resize the stock depth price header to 32px and apply the shared number font to price-change text
- Reorder and resize deck controls so undo sits far left and matches the X button
- Add a visible undo restore animation while respecting reduced-motion settings
- Show market temperature when fallback index data exists instead of pinning the strip to data-collecting

## Verification
- npm run typecheck:fomo-web
- npm run lint --workspace @fomo/web --if-present
- npm run build:fomo-web
- git diff --check