### PR TITLE
fix(fomo): keep discovery vault stable

### DIFF
--- a/apps/fomo-web/__tests__/watchlist.test.ts
+++ b/apps/fomo-web/__tests__/watchlist.test.ts
@@ -24,8 +24,10 @@ describe("watchlist discovery metadata", () => {
     storage.set(
       "fomo_watchlist",
       JSON.stringify([
+        "현대로템",
         { stock: "삼성SDI", ts: 100 },
         { stock: "대주전자재료", ts: 200, sector: "2차전지", reason: "같은 흐름에서 같이 움직인 종목이에요." },
+        { stock: "  우진  " },
         { stock: 123, ts: 300 },
       ])
     );
@@ -33,18 +35,29 @@ describe("watchlist discovery metadata", () => {
     expect(getWatchlist()).toEqual([
       { stock: "대주전자재료", ts: 200, sector: "2차전지", reason: "같은 흐름에서 같이 움직인 종목이에요." },
       { stock: "삼성SDI", ts: 100 },
+      { stock: "우진", ts: 4 },
+      { stock: "현대로템", ts: 1 },
     ]);
   });
 
-  it("upserts discovery metadata by stock", () => {
+  it("keeps an existing discovery item stable when the same stock is saved again", () => {
     installLocalStorage();
 
     upsertWatch("대주전자재료", 100, { sector: "2차전지", reason: "첫 이유" });
     upsertWatch("대주전자재료", 200, { sector: "2차전지", reason: "갱신된 이유" });
 
     expect(getWatchlist()).toEqual([
-      { stock: "대주전자재료", ts: 200, sector: "2차전지", reason: "갱신된 이유" },
+      { stock: "대주전자재료", ts: 100, sector: "2차전지", reason: "첫 이유" },
     ]);
+  });
+
+  it("fills missing metadata without refreshing the saved timestamp", () => {
+    installLocalStorage();
+    storage.set("fomo_watchlist", JSON.stringify([{ stock: "우진", ts: 100 }]));
+
+    upsertWatch("우진", 300, { sector: "원자력", reason: "기관 수급이 이어져요." });
+
+    expect(getWatchlist()).toEqual([{ stock: "우진", ts: 100, sector: "원자력", reason: "기관 수급이 이어져요." }]);
   });
 
   it("toggleWatch stores metadata on add and removes the item on the next toggle", () => {

--- a/apps/fomo-web/components/MyDiscoveryPreview.tsx
+++ b/apps/fomo-web/components/MyDiscoveryPreview.tsx
@@ -3,7 +3,9 @@
 import type { WatchItem } from "@/lib/watchlist";
 
 function relativeTime(ts: number): string {
+  if (!Number.isFinite(ts) || ts <= 0) return "저장됨";
   const mins = Math.floor((Date.now() - ts) / 60_000);
+  if (mins < 0) return "저장됨";
   if (mins < 1) return "방금";
   if (mins < 60) return `${mins}분 전`;
   const hours = Math.floor(mins / 60);

--- a/apps/fomo-web/lib/watchlist.ts
+++ b/apps/fomo-web/lib/watchlist.ts
@@ -15,6 +15,12 @@ export interface WatchItem {
   reason?: string;
 }
 
+function normalizeStock(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const stock = value.trim();
+  return stock.length > 0 ? stock : null;
+}
+
 function read(): WatchItem[] {
   if (typeof window === "undefined") return [];
   try {
@@ -23,13 +29,17 @@ function read(): WatchItem[] {
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
     return parsed
-      .map((item): WatchItem | null => {
+      .map((item, index): WatchItem | null => {
+        const legacyStock = normalizeStock(item);
+        if (legacyStock) return { stock: legacyStock, ts: index + 1 };
         if (!item || typeof item !== "object") return null;
         const row = item as Record<string, unknown>;
-        if (typeof row.stock !== "string" || typeof row.ts !== "number") return null;
+        const stock = normalizeStock(row.stock);
+        if (!stock) return null;
+        const ts = typeof row.ts === "number" && Number.isFinite(row.ts) ? row.ts : index + 1;
         return {
-          stock: row.stock,
-          ts: row.ts,
+          stock,
+          ts,
           ...(typeof row.sector === "string" ? { sector: row.sector } : {}),
           ...(typeof row.reason === "string" ? { reason: row.reason } : {}),
         };
@@ -64,15 +74,26 @@ export function upsertWatch(
   nowMs: number,
   meta: { sector?: string | undefined; reason?: string | undefined } = {}
 ): WatchItem | null {
-  if (typeof window === "undefined" || !stock) return null;
-  const list = read().filter((w) => w.stock !== stock);
+  const normalized = normalizeStock(stock);
+  if (typeof window === "undefined" || !normalized) return null;
+  const list = read();
+  const existingIndex = list.findIndex((w) => w.stock === normalized);
+  const existing = existingIndex >= 0 ? list[existingIndex] : null;
+  const sector = existing?.sector ?? meta.sector;
+  const reason = existing?.reason ?? meta.reason;
   const item: WatchItem = {
-    stock,
-    ts: nowMs,
-    ...(meta.sector ? { sector: meta.sector } : {}),
-    ...(meta.reason ? { reason: meta.reason } : {}),
+    stock: normalized,
+    ts: existing?.ts ?? nowMs,
+    ...(sector ? { sector } : {}),
+    ...(reason ? { reason } : {}),
   };
-  write([...list, item]);
+  if (existingIndex >= 0) {
+    const next = [...list];
+    next[existingIndex] = item;
+    write(next);
+  } else {
+    write([...list, item]);
+  }
   return item;
 }
 


### PR DESCRIPTION
## Summary
- Preserve existing discovery-vault entries when the same stock is saved again
- Keep the original saved timestamp and existing reason/sector instead of refreshing the item
- Recover legacy watchlist rows such as string entries or rows without ts instead of dropping them
- Add regression tests for stable upsert and legacy watchlist reads

## Verification
- npm test -- apps/fomo-web/__tests__/watchlist.test.ts
- npm run build:fomo-web
- npm run typecheck:fomo-web
- npm run lint --workspace @fomo/web --if-present
- git diff --check