### PR TITLE
feat: add WO-04 multi-axis hook selector

### DIFF
--- a/apps/fomo-web/__tests__/discoveryDeck.test.ts
+++ b/apps/fomo-web/__tests__/discoveryDeck.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { KeywordCard, SectorStock, StockSector } from "@fomo/core";
-import { buildTodayDiscoveryStocks, MAX_DISCOVERY_STOCKS } from "../lib/discoveryDeck";
+import type { AxisSignal, HookAxis, KeywordCard, MultiAxisHookSelection, SectorStock, StockSector } from "@fomo/core";
+import { applyAxisSnapshotToStocks, buildTodayDiscoveryStocks, MAX_DISCOVERY_STOCKS } from "../lib/discoveryDeck";
 
 const storage = new Map<string, string>();
 
@@ -102,5 +102,43 @@ describe("buildTodayDiscoveryStocks", () => {
 
     expect(first20).not.toContain("테스트0");
     expect(first20).not.toContain("테스트1");
+  });
+
+  it("applies axis snapshot order while avoiding three identical hook axes in a row", () => {
+    installLocalStorage();
+    const stocks = Array.from({ length: 7 }, (_, i) => stock(i, i < 3 ? "AI" : i < 5 ? "반도체" : "방산"));
+    const axisOf = (i: number): HookAxis => (i < 3 ? "flow" : i < 5 ? "price" : i === 5 ? "herd" : "time");
+    const snapshot = Object.fromEntries(
+      stocks.map((s, i) => [
+        s.canonical,
+        {
+          axisHook: {
+            axis: axisOf(i),
+            hookText: `${s.canonical} 축 사실이에요.`,
+            strength: 0.8 - i * 0.01,
+            rarity: 0,
+            evidence: [],
+            axisSignals: [],
+          } satisfies MultiAxisHookSelection,
+          axisSignals: [
+            {
+              axis: axisOf(i),
+              fired: true,
+              strength: 0.8 - i * 0.01,
+              rarity: 0,
+              hookText: `${s.canonical} 축 사실이에요.`,
+              evidence: [{ text: "실측", sourceKind: "market", source: "테스트", asOf: "오늘 기준" }],
+            },
+          ] satisfies AxisSignal[],
+        },
+      ])
+    );
+
+    const result = applyAxisSnapshotToStocks(stocks, snapshot);
+    const axes = result.map((s) => s.axisHook?.axis);
+
+    for (let i = 2; i < axes.length; i += 1) {
+      expect([axes[i - 2], axes[i - 1], axes[i]]).not.toEqual([axes[i], axes[i], axes[i]]);
+    }
   });
 });

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -338,6 +338,8 @@ export interface StockContext {
   sourceUrl?: string;
   /** 어느 테마(키워드) 흐름에서 떴는지. */
   fromTheme?: string;
+  /** 피드 60장 기준 다축 셀렉터가 고른 카드 헤드라인. 상세에서도 같은 관통선을 유지한다. */
+  axisHeadline?: string | undefined;
 }
 
 /**
@@ -466,7 +468,7 @@ const DETAIL_TONE_COLOR: Record<FomoTone, string> = {
  * 포모 상태 히어로(척추 ③ 주인공) — 큰 포모 점수(C) + 라벨 + 근거등급 + 왜(해부).
  * 카드(②)와 *동일 출처*(fetchStockFront 의 FomoScoreResult). 강도 비례 톤, 예측·판정 0.
  */
-function FomoHero({ front, rankLabel }: { front: StockFrontResponse | null; rankLabel?: string }) {
+function FomoHero({ front, rankLabel, headlineOverride }: { front: StockFrontResponse | null; rankLabel?: string; headlineOverride?: string }) {
   if (!front) {
     return <div className="h-24 animate-pulse rounded-xl border border-hairline bg-surface" />;
   }
@@ -477,6 +479,7 @@ function FomoHero({ front, rankLabel }: { front: StockFrontResponse | null; rank
     ...(front.taFact ? { taFact: front.taFact } : {}),
   });
   const view = { ...fomoCardView(fomo), headline: hook.headline };
+  view.headline = headlineOverride ?? front.axisHook?.hookText ?? view.headline;
   const tone = DETAIL_TONE_COLOR[view.tone] ?? "#94A3B8";
   const grade = confidenceGrade(fomo.confidence);
   return (
@@ -879,6 +882,7 @@ export function StockInsightView({
           <div className="mt-6">
             <FomoHero
               front={front}
+              {...(context?.axisHeadline ? { headlineOverride: context.axisHeadline } : {})}
               {...(front?.signals.marketCapRank ? { rankLabel: `시총 ${front.signals.marketCapRank.rank}위` } : {})}
             />
           </div>

--- a/apps/fomo-web/components/SectorStockDeck.tsx
+++ b/apps/fomo-web/components/SectorStockDeck.tsx
@@ -4,13 +4,28 @@ import { useEffect, useState } from "react";
 import type { StockSector } from "@fomo/core";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
-import { fetchSectorStocks, getCachedKeywords, warmKeywords } from "@/lib/fomoApi";
-import { buildSectorDiscoveryStocks, type DeckStock } from "@/lib/discoveryDeck";
+import { fetchAxisSnapshot, fetchSectorStocks, getCachedKeywords, warmKeywords } from "@/lib/fomoApi";
+import { applyAxisSnapshotToStocks, buildSectorDiscoveryStocks, type DeckStock } from "@/lib/discoveryDeck";
 
 interface SectorDeckProps {
   sector: StockSector;
   loggedIn?: boolean | undefined;
   onRequireLogin?: (() => void) | undefined;
+}
+
+const AXIS_SNAPSHOT_TIMEOUT_MS = 1800;
+
+async function applyAxisSnapshot(stocks: DeckStock[]): Promise<DeckStock[]> {
+  try {
+    const snapshot = await Promise.race([
+      fetchAxisSnapshot(stocks.map((s) => s.canonical)),
+      new Promise<never>((_, reject) => window.setTimeout(() => reject(new Error("axis snapshot timeout")), AXIS_SNAPSHOT_TIMEOUT_MS)),
+    ]);
+    return applyAxisSnapshotToStocks(stocks, snapshot.items);
+  } catch (err) {
+    console.warn("[SectorStockDeck] axis snapshot fallback", (err as Error)?.message);
+    return applyAxisSnapshotToStocks(stocks);
+  }
 }
 
 /**
@@ -40,7 +55,9 @@ export function SectorStockDeck({ sector, loggedIn, onRequireLogin }: SectorDeck
           return;
         }
         const stocks = buildSectorDiscoveryStocks(poolRes.stocks, cachedKeywords?.cards ?? [], sector);
-        setState({ kind: "ready", stocks: stocks.length ? stocks : poolRes.stocks });
+        const withAxis = await applyAxisSnapshot(stocks.length ? stocks : poolRes.stocks);
+        if (!alive) return;
+        setState({ kind: "ready", stocks: withAxis });
       } catch (err) {
         console.warn("[SectorStockDeck] fetch failed", err);
         if (alive) setState({ kind: "error" });

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
-import { fomoCardView, computeFomoScore, selectFomoHook, sparklinePath } from "@fomo/core";
-import type { CardFrontSignals, FomoScoreResult, FomoCardView, TaFact } from "@fomo/core";
+import { fomoCardView, computeFomoScore, selectFomoHook, selectMultiAxisHook, sparklinePath } from "@fomo/core";
+import type {
+  AxisSignal,
+  CardFrontSignals,
+  FomoScoreResult,
+  FomoCardView,
+  MultiAxisHookSelection,
+  TaFact,
+} from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import type { FeedSignalPoint } from "@/lib/fomoApi";
@@ -39,6 +46,8 @@ export type FrontEntry = {
   changeDir?: "up" | "down" | "flat";
   feedBull?: FeedSignalPoint;
   feedBear?: FeedSignalPoint;
+  axisSignals?: AxisSignal[];
+  axisHook?: MultiAxisHookSelection;
 };
 
 type UndoEntry = {
@@ -425,6 +434,8 @@ export function StockSwipeDeck({
               ...(d.changeDir ? { changeDir: d.changeDir } : {}),
               ...(d.feedBull ? { feedBull: d.feedBull } : {}),
               ...(d.feedBear ? { feedBear: d.feedBear } : {}),
+              ...(d.axisSignals ? { axisSignals: d.axisSignals } : {}),
+              ...(d.axisHook ? { axisHook: d.axisHook } : {}),
             },
           }))
         )
@@ -455,18 +466,22 @@ export function StockSwipeDeck({
       ...(e?.signals ?? {}),
       ...(!e?.signals.newsEventLabel && reasonHeadlineSeed ? { newsEventLabel: reasonHeadlineSeed } : {}),
     };
-    const hook = selectFomoHook({
+    const legacyHook = selectFomoHook({
       fomo,
       signals: signalsForHook,
       ...(e?.taFact ? { taFact: e.taFact } : {}),
     });
+    const axisHook =
+      stock.axisHook ??
+      e?.axisHook ??
+      (e?.axisSignals ? selectMultiAxisHook(e.axisSignals) : undefined);
     const baseView = fomoCardView(fomo, { sector: stock.sector, ...(stock.reason ? { reason: stock.reason } : {}) });
-    const view = { ...baseView, headline: hook.headline };
-    const usedReasonHeadline = !!reasonHeadlineSeed && !e?.signals.newsEventLabel && hook.kind === "news_event";
+    const view = { ...baseView, headline: axisHook?.hookText ?? legacyHook.headline };
+    const usedReasonHeadline = !!reasonHeadlineSeed && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
     const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);
     return {
       view,
-      ...(evidenceLine || hook.subLine ? { subLine: evidenceLine ?? hook.subLine } : {}),
+      ...(evidenceLine || legacyHook.subLine ? { subLine: evidenceLine ?? legacyHook.subLine } : {}),
       ...(usedReasonHeadline ? { usedReasonHeadline } : {}),
     };
   };
@@ -482,6 +497,8 @@ export function StockSwipeDeck({
       signals: e?.signals,
     });
   };
+  const axisHeadlineFor = (stock: DeckStock): string | undefined =>
+    stock.axisHook?.hookText ?? front[stock.canonical]?.axisHook?.hookText;
   const saveDiscovery = (stock: DeckStock) => {
     upsertWatch(stock.canonical, Date.now(), { sector: stock.sector, reason: whyFor(stock) });
   };
@@ -756,7 +773,11 @@ export function StockSwipeDeck({
       {selected && (
         <StockInsightView
           stock={selected.canonical}
-          context={{ fromTheme: selected.sector, reason: whyFor(selected) }}
+          context={{
+            fromTheme: selected.sector,
+            reason: whyFor(selected),
+            ...(axisHeadlineFor(selected) ? { axisHeadline: axisHeadlineFor(selected) } : {}),
+          }}
           onClose={closeDepth}
         />
       )}

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from "react";
 import { SECTORS, type StockSector } from "@fomo/core";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
-import { fetchSectorStocks, getCachedKeywords, warmKeywords } from "@/lib/fomoApi";
+import { fetchAxisSnapshot, fetchSectorStocks, getCachedKeywords, warmKeywords } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import {
+  applyAxisSnapshotToStocks,
   buildTodayDiscoveryStocks,
   MIN_DISCOVERY_STOCKS,
   type DeckStock,
@@ -13,6 +14,7 @@ import {
 } from "@/lib/discoveryDeck";
 
 const DISCOVERY_SECTORS: readonly StockSector[] = SECTORS.filter((sector) => sector !== "코인").slice(0, 6);
+const AXIS_SNAPSHOT_TIMEOUT_MS = 1800;
 
 interface TodayDiscoveryDeckProps {
   loggedIn?: boolean | undefined;
@@ -27,6 +29,19 @@ function DiscoveryEmpty() {
       잠깐 뒤 다시 들어와 주세요.
     </div>
   );
+}
+
+async function applyAxisSnapshot(stocks: DeckStock[]): Promise<DeckStock[]> {
+  try {
+    const snapshot = await Promise.race([
+      fetchAxisSnapshot(stocks.map((s) => s.canonical)),
+      new Promise<never>((_, reject) => window.setTimeout(() => reject(new Error("axis snapshot timeout")), AXIS_SNAPSHOT_TIMEOUT_MS)),
+    ]);
+    return applyAxisSnapshotToStocks(stocks, snapshot.items);
+  } catch (err) {
+    console.warn("[TodayDiscoveryDeck] axis snapshot fallback", (err as Error)?.message);
+    return applyAxisSnapshotToStocks(stocks);
+  }
 }
 
 export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryDeckProps) {
@@ -65,7 +80,9 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
           setState({ kind: "error" });
           return;
         }
-        setState({ kind: "ready", stocks });
+        const withAxis = await applyAxisSnapshot(stocks);
+        if (!alive) return;
+        setState({ kind: "ready", stocks: withAxis });
       } catch (err) {
         console.warn("[TodayDiscoveryDeck] fetch failed", err);
         if (alive) setState({ kind: "error" });

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -1,4 +1,15 @@
-import { resolveStock, stocksBySector, type KeywordCard, type SectorStock, type StockSector } from "@fomo/core";
+import {
+  affinityAxisSignal,
+  rankMultiAxisFeed,
+  selectMultiAxisHook,
+  type AxisSignal,
+  type KeywordCard,
+  type MultiAxisHookSelection,
+  type SectorStock,
+  type StockSector,
+  resolveStock,
+  stocksBySector,
+} from "@fomo/core";
 import { getWatchlist } from "./watchlist";
 import { recentSeenStocks, stockInteractionSummary, stockInterestScore } from "./stockInterest";
 
@@ -14,7 +25,17 @@ export const DISCOVERY_MIX = {
 } as const;
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
-export type DeckStock = SectorStock & { reason?: string; whyShown?: string };
+export type DeckStock = SectorStock & {
+  reason?: string;
+  whyShown?: string;
+  axisSignals?: AxisSignal[];
+  axisHook?: MultiAxisHookSelection;
+};
+
+export interface AxisSnapshotLike {
+  axisSignals: AxisSignal[];
+  axisHook: MultiAxisHookSelection;
+}
 
 export interface SectorPool {
   sector: StockSector;
@@ -202,4 +223,46 @@ function isTasteSimilarStock(stock: DeckStock): boolean {
   if (watch.length === 0) return false;
   const peers = new Set(stocksBySector(stock.sector).map((s) => s.canonical));
   return watch.some((w) => w.stock !== stock.canonical && peers.has(w.stock));
+}
+
+function affinitySignalFor(stock: DeckStock): AxisSignal | undefined {
+  const watch = getWatchlist();
+  if (watch.length === 0) return undefined;
+  const peers = new Set(stocksBySector(stock.sector).map((s) => s.canonical));
+  const peerWatch = watch.find((w) => w.stock !== stock.canonical && peers.has(w.stock));
+  if (!peerWatch) return undefined;
+  return affinityAxisSignal({
+    fired: true,
+    strength: 0.72,
+    hookText: "네가 관심 둔 종목들과 같은 섹터에 있어요.",
+    evidenceText: `${stock.sector} 관심 종목 기반`,
+  });
+}
+
+function mergeAffinitySignal(signals: readonly AxisSignal[], affinity?: AxisSignal): AxisSignal[] {
+  const withoutAffinity = signals.filter((s) => s.axis !== "affinity");
+  return affinity ? [...withoutAffinity, affinity] : [...withoutAffinity];
+}
+
+export function applyAxisSnapshotToStocks(
+  stocks: readonly DeckStock[],
+  snapshot: Record<string, AxisSnapshotLike> = {}
+): DeckStock[] {
+  const enriched = stocks.map((stock) => {
+    const snap = snapshot[stock.canonical];
+    const axisSignals = mergeAffinitySignal(snap?.axisSignals ?? stock.axisSignals ?? [], affinitySignalFor(stock));
+    return {
+      ...stock,
+      ...(axisSignals.length > 0 ? { axisSignals, axisHook: selectMultiAxisHook(axisSignals) } : {}),
+    };
+  });
+  if (!enriched.some((stock) => stock.axisSignals?.some((signal) => signal.fired))) return enriched;
+  return rankMultiAxisFeed(enriched, {
+    getSignals: (stock) => stock.axisSignals,
+    getKey: (stock) => stock.canonical,
+  }).map(({ item, hook }) => ({
+    ...item,
+    axisHook: hook,
+    axisSignals: hook.axisSignals,
+  }));
 }

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -198,6 +198,7 @@ export const fetchStockBasics = (stock: string) =>
 export type { CardFrontSignals } from "@fomo/core";
 export type { FomoScoreResult } from "@fomo/core";
 export type { TaFact } from "@fomo/core";
+export type { AxisSignal, MultiAxisHookSelection } from "@fomo/core";
 export interface StockFrontResponse {
   signals: import("@fomo/core").CardFrontSignals;
   fomo: import("@fomo/core").FomoScoreResult;
@@ -208,6 +209,8 @@ export interface StockFrontResponse {
   changeDir?: "up" | "down" | "flat";
   feedBull?: FeedSignalPoint;
   feedBear?: FeedSignalPoint;
+  axisSignals?: import("@fomo/core").AxisSignal[];
+  axisHook?: import("@fomo/core").MultiAxisHookSelection;
 }
 
 export interface FeedSignalPoint {
@@ -223,6 +226,24 @@ export const fetchStockFront = (stock: string, opts: { lite?: boolean } = {}) =>
       ),
     CACHE_TTL.stockFront
   );
+
+export interface AxisSnapshotEntry {
+  axisSignals: import("@fomo/core").AxisSignal[];
+  axisHook: import("@fomo/core").MultiAxisHookSelection;
+}
+
+export interface AxisSnapshotResponse {
+  items: Record<string, AxisSnapshotEntry>;
+}
+
+export const fetchAxisSnapshot = (stocks: readonly string[]) => {
+  const unique = [...new Set(stocks.map((s) => s.trim()).filter(Boolean))].slice(0, 60);
+  return cachedGet(
+    `axis-snapshot:${unique.join("|")}`,
+    () => get<AxisSnapshotResponse>(`/api/fomo/axis-snapshot?stocks=${encodeURIComponent(unique.join(","))}`),
+    CACHE_TTL.stockFront
+  );
+};
 
 /** 섹터 → 종목 풀(섹터구조 ②). 콜드스타트 노출 순. baseline=true 면 baseline 보장(국내) 종목만. */
 export type { StockSector, SectorStock } from "@fomo/core";

--- a/apps/web/__tests__/lib/stock-front-lite.test.ts
+++ b/apps/web/__tests__/lib/stock-front-lite.test.ts
@@ -53,6 +53,8 @@ describe("assembleStockFront lite", () => {
     expect(front.taFact).toBeUndefined();
     expect(front.fomo.inputs.volume).toBeDefined();
     expect(front.fomo.inputs.price).toBeDefined();
+    expect(front.axisSignals?.some((signal) => signal.fired)).toBe(true);
+    expect(front.axisHook?.hookText).toBeTruthy();
   });
 
   it("카드 경량 경로에서도 캐시된 coverage와 강세·약세 1줄을 반환한다", async () => {
@@ -82,5 +84,7 @@ describe("assembleStockFront lite", () => {
     expect(front.signals.themeRelativeRank).toBe(6);
     expect(front.feedBull).toEqual({ text: "오늘 이 종목을 직접 언급한 뉴스가 있어요.", source: "뉴스" });
     expect(front.feedBear).toEqual({ text: "반도체 평균보다 덜 움직였어요.", source: "테마" });
+    expect(front.axisSignals?.some((signal) => signal.axis === "time" && signal.fired)).toBe(true);
+    expect(front.axisHook?.axis).toBe("time");
   });
 });

--- a/apps/web/app/api/fomo/axis-snapshot/route.ts
+++ b/apps/web/app/api/fomo/axis-snapshot/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import {
+  applyAxisRarity,
+  resolveStock,
+  sectorOf,
+  selectMultiAxisHook,
+  type AxisSignal,
+  type MultiAxisHookSelection,
+  type StockSector,
+} from "@fomo/core";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { assembleStockFront } from "../../../../lib/stock-front";
+import {
+  computeStockAttentionSignals,
+  computeThemeRelativeSignals,
+  type StockAttentionSignal,
+  type ThemeRelativeSignal,
+} from "../../../../lib/stock-signal-coverage";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const REVALIDATE_S = 600;
+const MAX_STOCKS = 60;
+
+export interface AxisSnapshotItem {
+  axisSignals: AxisSignal[];
+  axisHook: MultiAxisHookSelection;
+}
+
+export interface AxisSnapshotResponse {
+  items: Record<string, AxisSnapshotItem>;
+}
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+async function getAttentionMap(): Promise<Record<string, StockAttentionSignal>> {
+  const load = unstable_cache(
+    async () => computeStockAttentionSignals(),
+    ["fomo-stock-attention", cacheVersion(), kstDate()],
+    { revalidate: 1800 }
+  );
+  return load();
+}
+
+async function getThemeRelativeMap(sector: StockSector): Promise<Record<string, ThemeRelativeSignal>> {
+  const load = unstable_cache(
+    async () => computeThemeRelativeSignals(sector),
+    ["fomo-theme-relative", cacheVersion(), kstDate(), sector],
+    { revalidate: 1800 }
+  );
+  return load();
+}
+
+function parseStocks(req: Request): string[] {
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("stocks") ?? "";
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const part of raw.split(",")) {
+    const stock = part.trim();
+    if (!stock || seen.has(stock)) continue;
+    seen.add(stock);
+    out.push(stock);
+    if (out.length >= MAX_STOCKS) break;
+  }
+  return out;
+}
+
+async function buildSnapshot(stocks: readonly string[]): Promise<AxisSnapshotResponse> {
+  const attentionMap = await getAttentionMap().catch((): Record<string, StockAttentionSignal> => ({}));
+  const sectorMaps = new Map<StockSector, Record<string, ThemeRelativeSignal>>();
+  const rows = await Promise.allSettled(
+    stocks.map(async (stock) => {
+      const def = resolveStock(stock);
+      const canonical = def?.canonical ?? stock;
+      const sector = def ? sectorOf(def.canonical) : undefined;
+      let themeRelativeMap: Record<string, ThemeRelativeSignal> = {};
+      if (sector) {
+        const cached = sectorMaps.get(sector);
+        if (cached) {
+          themeRelativeMap = cached;
+        } else {
+          themeRelativeMap = await getThemeRelativeMap(sector).catch((): Record<string, ThemeRelativeSignal> => ({}));
+          sectorMaps.set(sector, themeRelativeMap);
+        }
+      }
+      const front = await assembleStockFront(
+        canonical,
+        {},
+        {
+          ...(attentionMap[canonical] ? { attention: attentionMap[canonical] } : {}),
+          ...(themeRelativeMap[canonical] ? { themeRelative: themeRelativeMap[canonical] } : {}),
+        },
+        { lite: true }
+      );
+      return { canonical, axisSignals: front.axisSignals ?? [] };
+    })
+  );
+
+  const ok = rows
+    .filter((row): row is PromiseFulfilledResult<{ canonical: string; axisSignals: AxisSignal[] }> => row.status === "fulfilled")
+    .map((row) => row.value)
+    .filter((row) => row.axisSignals.length > 0);
+  const withRarity = applyAxisRarity(ok.map((row) => row.axisSignals));
+  const items: Record<string, AxisSnapshotItem> = {};
+  ok.forEach((row, index) => {
+    const axisSignals = withRarity[index] ?? row.axisSignals;
+    items[row.canonical] = {
+      axisSignals,
+      axisHook: selectMultiAxisHook(axisSignals),
+    };
+  });
+  return { items };
+}
+
+export async function GET(req: Request) {
+  const stocks = parseStocks(req);
+  if (stocks.length === 0) {
+    return withCors(NextResponse.json({ error: "stocks required" }, { status: 400 }));
+  }
+  try {
+    const load = unstable_cache(
+      async () => buildSnapshot(stocks),
+      ["fomo-axis-snapshot", cacheVersion(), kstDate(), stocks.join("|")],
+      { revalidate: REVALIDATE_S }
+    );
+    return withCors(
+      NextResponse.json(await load(), {
+        headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400" },
+      })
+    );
+  } catch (err) {
+    console.warn("[axis-snapshot] failed", (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        { items: {} } satisfies AxisSnapshotResponse,
+        { headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -6,12 +6,16 @@ import {
   signalsFromBasics,
   investorNetStreak,
   computeFomoScore,
+  buildAxisSignals,
+  selectMultiAxisHook,
   computeTechnicalAnalysis,
   selectTaFact,
   type CardFrontSignals,
   type FomoScoreResult,
   type DailyOhlcv,
   type TaFact,
+  type AxisSignal,
+  type MultiAxisHookSelection,
 } from "@fomo/core";
 import { fetchStockBasics, fetchStockBasicsLite } from "./stock-basics";
 import { readSupplyDemandHistory } from "./supply-demand-store";
@@ -148,6 +152,10 @@ export interface StockFrontData {
   feedBull?: FeedSignalPoint;
   /** 피드 카드용 약세·주의 쪽 균형 사실 1줄. 원문/숫자가 있을 때만 채운다. */
   feedBear?: FeedSignalPoint;
+  /** 다축 후킹 후보. 단일 종목 응답에서는 rarity=0, 피드 batch 에서 후보군 기준으로 재계산한다. */
+  axisSignals?: AxisSignal[];
+  /** 다축 후킹 대표 문장. 카드/상세 헤드라인의 우선 출처. */
+  axisHook?: MultiAxisHookSelection;
 }
 
 export interface StockFrontOptions {
@@ -296,6 +304,8 @@ export async function assembleStockFront(
   });
   const taFact = ta ? selectTaFact(fomo, ta) : undefined;
   const feedPoints = buildFeedPoints(signals, basics?.changeDir, basics?.changeText);
+  const axisSignals = buildAxisSignals({ signals });
+  const axisHook = selectMultiAxisHook(axisSignals);
 
   return {
     signals,
@@ -307,5 +317,7 @@ export async function assembleStockFront(
     ...(basics?.changeDir ? { changeDir: basics.changeDir } : {}),
     ...(feedPoints.bull ? { feedBull: feedPoints.bull } : {}),
     ...(feedPoints.bear ? { feedBear: feedPoints.bear } : {}),
+    axisSignals,
+    axisHook,
   };
 }

--- a/packages/fomo-core/__tests__/multi-axis-hook.test.ts
+++ b/packages/fomo-core/__tests__/multi-axis-hook.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAxisRarity,
+  buildAxisSignals,
+  rankMultiAxisFeed,
+  selectMultiAxisHook,
+  type AxisSignal,
+  type HookAxis,
+} from "../src";
+
+function sig(axis: HookAxis, strength: number, text: string): AxisSignal {
+  return {
+    axis,
+    fired: true,
+    strength,
+    rarity: 0,
+    hookText: text,
+    evidence: [{ text, sourceKind: "market", source: "테스트", asOf: "오늘 기준" }],
+  };
+}
+
+function item(id: string, axis: HookAxis, strength: number) {
+  return { id, signals: [sig(axis, strength, `${id} 축 사실이에요.`)] };
+}
+
+describe("multi-axis hook selector", () => {
+  it("희소성이 높은 축을 기본 우선으로 선택하고 결정적으로 반복된다", () => {
+    const sets = applyAxisRarity([
+      [sig("flow", 0.7, "기관이 4일째 사는 중이에요."), sig("time", 0.58, "공급계약 공시 소식이 나왔어요.")],
+      [sig("flow", 0.7, "기관이 3일째 사는 중이에요.")],
+      [sig("flow", 0.68, "외국인이 3일째 사는 중이에요.")],
+      [sig("flow", 0.66, "기관이 5일째 사는 중이에요.")],
+    ]);
+
+    const first = selectMultiAxisHook(sets[0]);
+    const second = selectMultiAxisHook(sets[0]);
+
+    expect(first.axis).toBe("time");
+    expect(first).toEqual(second);
+  });
+
+  it("strength override는 흔한 축이어도 대표 축으로 끌어올린다", () => {
+    const sets = applyAxisRarity([
+      [sig("flow", 0.95, "기관이 9일째 사는 중이에요."), sig("time", 0.62, "공급계약 공시 소식이 나왔어요.")],
+      [sig("flow", 0.65, "외국인이 3일째 사는 중이에요.")],
+      [sig("flow", 0.64, "기관이 3일째 사는 중이에요.")],
+      [sig("flow", 0.63, "외국인이 4일째 사는 중이에요.")],
+    ]);
+
+    expect(selectMultiAxisHook(sets[0]).axis).toBe("flow");
+  });
+
+  it("피드 정렬은 동일 축이 MAX_AXIS_RUN을 초과해 연속되지 않게 만든다", () => {
+    const rows = [
+      item("a", "flow", 0.81),
+      item("b", "flow", 0.8),
+      item("c", "flow", 0.79),
+      item("d", "price", 0.78),
+      item("e", "price", 0.77),
+      item("f", "herd", 0.76),
+      item("g", "time", 0.75),
+    ];
+
+    const ranked = rankMultiAxisFeed(rows, {
+      getSignals: (row) => row.signals,
+      getKey: (row) => row.id,
+      maxAxisRun: 2,
+      interleaveEvery: 3,
+    });
+    const axes = ranked.map((row) => row.hook.axis);
+
+    for (let i = 2; i < axes.length; i += 1) {
+      expect([axes[i - 2], axes[i - 1], axes[i]]).not.toEqual([axes[i], axes[i], axes[i]]);
+    }
+    expect(rankMultiAxisFeed(rows, { getSignals: (row) => row.signals, getKey: (row) => row.id })).toEqual(
+      rankMultiAxisFeed(rows, { getSignals: (row) => row.signals, getKey: (row) => row.id })
+    );
+  });
+
+  it("evidence에는 커뮤니티 sourceKind를 만들지 않고 투자조언 금칙어를 피한다", () => {
+    const signals = buildAxisSignals({
+      signals: {
+        foreignNetStreak: 4,
+        newsEventLabel: "신규 공급계약 공시",
+        newsEventSource: "거래소",
+        themeLabel: "방산",
+        themeRelativeRank: 1,
+        themePeerCount: 5,
+        changePct: 3.2,
+      },
+    });
+    const joined = signals
+      .flatMap((signal) => [signal.hookText, ...signal.evidence.map((e) => `${e.text} ${e.sourceKind}`)])
+      .join(" ");
+
+    expect(joined).not.toMatch(/community|매수|매도|목표가|급등\s?임박|추천|텐베거/);
+  });
+
+  it("schedule 데이터가 없으면 D-day를 지어내지 않는다", () => {
+    const empty = buildAxisSignals({ signals: {} });
+    const timeAxis = empty.find((signal) => signal.axis === "time");
+
+    expect(timeAxis?.fired).toBe(false);
+    expect(selectMultiAxisHook(empty).axis).toBe("fallback");
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -7,5 +7,6 @@ export * from "./comment";
 export * from "./josa";
 export * from "./stocks";
 export * from "./card-front-hook";
+export * from "./multi-axis-hook";
 export * from "./fomo-score";
 export * from "./technical-analysis";

--- a/packages/fomo-core/src/keyword-cards/multi-axis-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/multi-axis-hook.ts
@@ -1,0 +1,350 @@
+import { isFrontHookSafe, type CardFrontSignals } from "./card-front-hook";
+
+export type HookAxis = "price" | "flow" | "time" | "herd" | "affinity";
+
+export type EvidenceSourceKind = "official" | "news" | "market" | "user";
+
+export interface AxisEvidence {
+  text: string;
+  sourceKind: EvidenceSourceKind;
+  source: string;
+  asOf: string;
+}
+
+export interface AxisSignal {
+  axis: HookAxis;
+  fired: boolean;
+  strength: number;
+  rarity: number;
+  hookText: string;
+  evidence: AxisEvidence[];
+}
+
+export interface MultiAxisHookSelection {
+  axis: HookAxis | "fallback";
+  hookText: string;
+  strength: number;
+  rarity: number;
+  evidence: AxisEvidence[];
+  axisSignals: AxisSignal[];
+}
+
+export interface AffinityAxisInput {
+  fired: boolean;
+  strength: number;
+  hookText: string;
+  evidenceText?: string;
+  asOf?: string;
+}
+
+export interface MultiAxisFeedRankOptions<T> {
+  getSignals: (item: T) => readonly AxisSignal[] | undefined;
+  getKey: (item: T) => string;
+  interleaveEvery?: number;
+  maxAxisRun?: number;
+}
+
+export interface MultiAxisRanked<T> {
+  item: T;
+  hook: MultiAxisHookSelection;
+}
+
+export const AXIS_STRENGTH_OVERRIDE = 0.9;
+export const AXIS_RARITY_WEIGHT = 0.65;
+export const AXIS_STRENGTH_WEIGHT = 0.35;
+export const INTERLEAVE_EVERY = 6;
+export const MAX_AXIS_RUN = 2;
+
+const AXIS_ORDER: Record<HookAxis | "fallback", number> = {
+  time: 0,
+  flow: 1,
+  herd: 2,
+  price: 3,
+  affinity: 4,
+  fallback: 5,
+};
+
+const FORBIDDEN_HOOK_TEXT = /매수|매도|목표가|급등\s?임박|폭등|추천|사라|팔아라|오를\s?것|수익|텐베거/;
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function pctText(p: number): string {
+  const sign = p > 0 ? "+" : p < 0 ? "-" : "";
+  return `${sign}${Math.abs(p).toFixed(1)}%`;
+}
+
+function ratioText(ratio: number): string {
+  const rounded = Math.round(ratio * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function asOfLabel(asOf?: string): string {
+  return asOf?.trim() ? `${asOf.trim()} 기준` : "오늘 기준";
+}
+
+function safeHookText(text: string): boolean {
+  return isFrontHookSafe(text) && !FORBIDDEN_HOOK_TEXT.test(text);
+}
+
+function signal(
+  axis: HookAxis,
+  fired: boolean,
+  strength: number,
+  hookText: string,
+  evidence: AxisEvidence[]
+): AxisSignal {
+  const clean = hookText.trim();
+  const safe = clean.length > 0 && safeHookText(clean) && evidence.every((e) => e.sourceKind !== "news" || e.source.trim());
+  return {
+    axis,
+    fired: fired && safe,
+    strength: fired && safe ? clamp01(strength) : 0,
+    rarity: 0,
+    hookText: fired && safe ? clean : "",
+    evidence: fired && safe ? evidence : [],
+  };
+}
+
+function priceAxis(signals: CardFrontSignals, asOf: string): AxisSignal {
+  const evidence = (text: string, source: string): AxisEvidence[] => [{ text, sourceKind: "market", source, asOf }];
+  if (signals.near52WeekHigh) {
+    return signal("price", true, 0.74, "최근 1년 중 가장 높은 가격대까지 왔어요.", evidence("52주 고가권", "가격"));
+  }
+  if (signals.near52WeekLow) {
+    return signal("price", true, 0.64, "최근 1년 낮은 가격대에 가까워요.", evidence("52주 저가권", "가격"));
+  }
+  if (typeof signals.volumeRatio === "number" && signals.volumeRatio >= 1.8) {
+    return signal(
+      "price",
+      true,
+      Math.min(1, 0.42 + signals.volumeRatio / 5),
+      `거래가 평소 ${ratioText(signals.volumeRatio)}배로 늘었어요.`,
+      evidence(`평소 대비 거래량 ${ratioText(signals.volumeRatio)}배`, "거래량")
+    );
+  }
+  if (typeof signals.changePct === "number" && Math.abs(signals.changePct) >= 5) {
+    return signal(
+      "price",
+      true,
+      Math.min(0.86, 0.46 + Math.abs(signals.changePct) / 18),
+      `오늘 가격이 ${pctText(signals.changePct)} 움직였어요.`,
+      evidence(`등락률 ${pctText(signals.changePct)}`, "가격")
+    );
+  }
+  return signal("price", false, 0, "", []);
+}
+
+function flowAxis(signals: CardFrontSignals, asOf: string): AxisSignal {
+  const fs = signals.foreignNetStreak ?? 0;
+  const is = signals.institutionNetStreak ?? 0;
+  const foreignStrong = Math.abs(fs) >= 3;
+  const instStrong = Math.abs(is) >= 3;
+  if (!foreignStrong && !instStrong) return signal("flow", false, 0, "", []);
+
+  const useForeign = Math.abs(fs) >= Math.abs(is);
+  const n = useForeign ? Math.abs(fs) : Math.abs(is);
+  const actor = useForeign ? "외국인이" : "기관이";
+  const verb = (useForeign ? fs : is) > 0 ? "사는 중이에요." : "파는 중이에요.";
+  return signal("flow", true, Math.min(1, 0.48 + n / 10), `${actor} ${n}일째 ${verb}`, [
+    { text: `${actor} ${n}일 연속 ${verb.replace(" 중이에요.", "")}`, sourceKind: "official", source: "KRX 수급", asOf },
+  ]);
+}
+
+function timeAxis(signals: CardFrontSignals, asOf: string): AxisSignal {
+  const schedule = (signals.catalysts ?? []).find((c) => c.kind === "schedule" && c.label.trim());
+  if (schedule) {
+    const text = schedule.when ? `${schedule.when} ${schedule.label}가 있어요.` : `${schedule.label} 일정이 있어요.`;
+    return signal("time", true, 0.86, text, [
+      { text: schedule.when ? `${schedule.when} ${schedule.label}` : schedule.label, sourceKind: "official", source: "일정", asOf },
+    ]);
+  }
+  const label = signals.newsEventLabel?.trim();
+  if (!label || label === "재료") return signal("time", false, 0, "", []);
+  const compact = label.length > 38 ? `${label.slice(0, 37)}…` : label;
+  return signal("time", true, 0.84, `${compact} 소식이 나왔어요.`, [
+    { text: compact, sourceKind: "news", source: signals.newsEventSource ?? "뉴스", asOf },
+  ]);
+}
+
+function herdAxis(signals: CardFrontSignals, asOf: string): AxisSignal {
+  const peerCount = signals.themePeerCount ?? 0;
+  const rank = signals.themeRelativeRank;
+  const pct = signals.changePct;
+  const avg = signals.themeAverageChangePct;
+  const delta = signals.themeRelativeChangePct;
+  const theme = signals.themeLabel?.trim() || "같은 테마";
+  if (peerCount < 3 || typeof rank !== "number" || typeof pct !== "number") {
+    return signal("herd", false, 0, "", []);
+  }
+  if (rank === 1 && pct > 0) {
+    return signal("herd", true, 0.76, `오늘 ${theme} 종목 중 가장 많이 올랐어요(${pctText(pct)}).`, [
+      { text: `${theme} ${rank}/${peerCount}, 등락률 ${pctText(pct)}`, sourceKind: "market", source: "섹터 상대강도", asOf },
+    ]);
+  }
+  if (typeof avg === "number" && typeof delta === "number" && avg <= -2 && delta >= 3) {
+    return signal("herd", true, Math.min(0.82, 0.52 + delta / 18), `${theme}가 빠지는 날, 상대적으로 덜 빠졌어요.`, [
+      { text: `${theme} 평균 ${pctText(avg)}, 상대 ${pctText(delta)}`, sourceKind: "market", source: "섹터 상대강도", asOf },
+    ]);
+  }
+  return signal("herd", false, 0, "", []);
+}
+
+export function affinityAxisSignal(input: AffinityAxisInput): AxisSignal {
+  return signal("affinity", input.fired, input.strength, input.hookText, [
+    {
+      text: input.evidenceText ?? "사용자의 관심 종목 섹터와의 유사성",
+      sourceKind: "user",
+      source: "내 발굴함",
+      asOf: asOfLabel(input.asOf),
+    },
+  ]);
+}
+
+export function buildAxisSignals({
+  signals = {},
+  asOf,
+  affinity,
+}: {
+  signals?: CardFrontSignals;
+  asOf?: string;
+  affinity?: AffinityAxisInput;
+}): AxisSignal[] {
+  const date = asOfLabel(asOf ?? signals.asOf);
+  return [
+    priceAxis(signals, date),
+    flowAxis(signals, date),
+    timeAxis(signals, date),
+    herdAxis(signals, date),
+    affinity ? affinityAxisSignal({ ...affinity, asOf: date }) : signal("affinity", false, 0, "", []),
+  ];
+}
+
+export function applyAxisRarity(signalSets: readonly (readonly AxisSignal[])[]): AxisSignal[][] {
+  const universe = Math.max(1, signalSets.length);
+  const counts = new Map<HookAxis, number>();
+  for (const set of signalSets) {
+    const firedAxes = new Set(set.filter((s) => s.fired).map((s) => s.axis));
+    for (const axis of firedAxes) counts.set(axis, (counts.get(axis) ?? 0) + 1);
+  }
+  return signalSets.map((set) =>
+    set.map((s) => ({
+      ...s,
+      rarity: s.fired ? clamp01(1 - (counts.get(s.axis) ?? 0) / universe) : 0,
+    }))
+  );
+}
+
+function selectionScore(s: AxisSignal): number {
+  return s.rarity * AXIS_RARITY_WEIGHT + s.strength * AXIS_STRENGTH_WEIGHT;
+}
+
+export function selectMultiAxisHook(axisSignals: readonly AxisSignal[] = []): MultiAxisHookSelection {
+  const fired = axisSignals.filter((s) => s.fired && s.hookText);
+  const sorted =
+    fired.some((s) => s.strength >= AXIS_STRENGTH_OVERRIDE)
+      ? [...fired].sort(
+          (a, b) => b.strength - a.strength || b.rarity - a.rarity || AXIS_ORDER[a.axis] - AXIS_ORDER[b.axis]
+        )
+      : [...fired].sort(
+          (a, b) =>
+            selectionScore(b) - selectionScore(a) ||
+            b.strength - a.strength ||
+            AXIS_ORDER[a.axis] - AXIS_ORDER[b.axis]
+        );
+  const top = sorted[0];
+  if (!top) {
+    return {
+      axis: "fallback",
+      hookText: "아직 조용한 자리예요.",
+      strength: 0,
+      rarity: 0,
+      evidence: [],
+      axisSignals: [...axisSignals],
+    };
+  }
+  return {
+    axis: top.axis,
+    hookText: top.hookText,
+    strength: top.strength,
+    rarity: top.rarity,
+    evidence: top.evidence,
+    axisSignals: [...axisSignals],
+  };
+}
+
+function compareRanked<T>(a: MultiAxisRanked<T> & { index: number; key: string }, b: MultiAxisRanked<T> & { index: number; key: string }): number {
+  return (
+    b.hook.rarity - a.hook.rarity ||
+    b.hook.strength - a.hook.strength ||
+    AXIS_ORDER[a.hook.axis] - AXIS_ORDER[b.hook.axis] ||
+    a.index - b.index ||
+    a.key.localeCompare(b.key)
+  );
+}
+
+function breakAxisRuns<T>(rows: MultiAxisRanked<T>[], maxAxisRun: number): MultiAxisRanked<T>[] {
+  if (maxAxisRun <= 0) return [...rows];
+  const remaining = [...rows];
+  const out: MultiAxisRanked<T>[] = [];
+  const wouldExceedRun = (axis: HookAxis | "fallback") => {
+    if (axis === "fallback" || out.length < maxAxisRun) return false;
+    return out.slice(-maxAxisRun).every((row) => row.hook.axis === axis);
+  };
+  const leavesFeasible = (candidateIndex: number) => {
+    const after = remaining.filter((_, index) => index !== candidateIndex);
+    const total = after.length;
+    if (total === 0) return true;
+    const counts = new Map<HookAxis | "fallback", number>();
+    for (const row of after) counts.set(row.hook.axis, (counts.get(row.hook.axis) ?? 0) + 1);
+    let maxCount = 0;
+    for (const count of counts.values()) maxCount = Math.max(maxCount, count);
+    const otherCount = total - maxCount;
+    return maxCount <= (otherCount + 1) * maxAxisRun;
+  };
+  while (remaining.length > 0) {
+    let nextIndex = remaining.findIndex((row, index) => !wouldExceedRun(row.hook.axis) && leavesFeasible(index));
+    if (nextIndex < 0) nextIndex = remaining.findIndex((row) => !wouldExceedRun(row.hook.axis));
+    if (nextIndex < 0) nextIndex = 0;
+    out.push(remaining.splice(nextIndex, 1)[0]!);
+  }
+  return out;
+}
+
+export function rankMultiAxisFeed<T>(
+  items: readonly T[],
+  options: MultiAxisFeedRankOptions<T>
+): MultiAxisRanked<T>[] {
+  const interleaveEvery = options.interleaveEvery ?? INTERLEAVE_EVERY;
+  const maxAxisRun = options.maxAxisRun ?? MAX_AXIS_RUN;
+  const withRarity = applyAxisRarity(items.map((item) => options.getSignals(item) ?? []));
+  const enriched = items.map((item, index) => ({
+    item,
+    index,
+    key: options.getKey(item),
+    hook: selectMultiAxisHook(withRarity[index] ?? []),
+  }));
+  const raritySorted = [...enriched].sort(compareRanked);
+  const strengthSorted = [...enriched].sort(
+    (a, b) => b.hook.strength - a.hook.strength || b.hook.rarity - a.hook.rarity || a.index - b.index || a.key.localeCompare(b.key)
+  );
+  const used = new Set<string>();
+  const out: typeof enriched = [];
+  const push = (row: (typeof enriched)[number]) => {
+    if (used.has(row.key)) return;
+    used.add(row.key);
+    out.push(row);
+  };
+  let rarityIndex = 0;
+  while (out.length < enriched.length && rarityIndex < raritySorted.length) {
+    if (out.length > 0 && out.length % interleaveEvery === 0) {
+      const strong = strengthSorted.find((row) => !used.has(row.key));
+      if (strong) push(strong);
+    }
+    push(raritySorted[rarityIndex++]!);
+  }
+  for (const row of strengthSorted) push(row);
+  return breakAxisRuns(out, maxAxisRun).map(({ item, hook }) => ({ item, hook }));
+}


### PR DESCRIPTION
## Summary
- add a pure @fomo/core multi-axis hook selector for price, flow, time, herd, and affinity axes
- add /api/fomo/axis-snapshot to compute feed-level rarity from cached stock-front signals
- apply axis snapshot ordering to today/sector discovery decks with timeout fallback
- prefer axisHook headlines on card fronts and preserve the same headline in stock depth context

## Verification
- npm run typecheck:fomo-core
- npm run typecheck:fomo-web
- npm run typecheck:web
- npm test -- packages/fomo-core/__tests__/multi-axis-hook.test.ts apps/fomo-web/__tests__/discoveryDeck.test.ts apps/web/__tests__/lib/stock-front-lite.test.ts
- npm run build:fomo-web
- npm run build:web
- npm run lint -- --if-present