### PR TITLE
feat: add WO-05 discovery supply engine

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -3,14 +3,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   scoreToColor,
-  SECTORS,
   type KeywordCard,
   type KeywordConfidence,
-  type StockSector,
   type SurpriseStock,
 } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
-import { SectorStockDeck } from "@/components/SectorStockDeck";
 import { TodayDiscoveryDeck } from "@/components/TodayDiscoveryDeck";
 import { KEYWORDS_UPDATED_EVENT, fetchKeywords, fetchThemeInsight, recordTaste, type KeywordsResponse } from "@/lib/fomoApi";
 import { keywordInterestScore, recordInterest } from "@/lib/keywordInterest";
@@ -148,57 +145,8 @@ interface FeedGate {
   onRequireLogin?: (() => void) | undefined;
 }
 
-/**
- * 섹터 카테고리 칩 네비(SECTOR_STRUCTURE §1) — "오늘"(쏠림 피드) + 섹터들.
- * 비주얼(칩 디자인·국기 등)은 광혁 — 여기선 구조/선택 동작만(§4).
- */
-function SectorChips({
-  active,
-  onSelect,
-}: {
-  active: StockSector | null;
-  onSelect: (s: StockSector | null) => void;
-}) {
-  const chip = (label: string, value: StockSector | null) => {
-    const on = active === value;
-    return (
-      <button
-        key={label}
-        onClick={() => onSelect(value)}
-        className={`shrink-0 rounded-full border px-3 py-1 font-pixel text-xs transition-colors ${
-          on ? "border-transparent bg-whiteout text-black" : "border-hairline text-muted hover:text-whiteout"
-        }`}
-      >
-        {label}
-      </button>
-    );
-  };
-  return (
-    <div className="mb-3 flex gap-2 overflow-x-auto px-1 pb-1">
-      {chip("오늘", null)}
-      {SECTORS.map((s) => chip(s, s))}
-    </div>
-  );
-}
-
 export function KeywordCardFeed({ loggedIn, onRequireLogin }: FeedGate = {}) {
-  // 섹터 네비: null = "오늘의 발견"(전체 종목 풀). 섹터 선택 시 그 섹터 종목 무한 스와이프.
-  const [activeSector, setActiveSector] = useState<StockSector | null>(null);
-  return (
-    <div className="w-full">
-      <SectorChips active={activeSector} onSelect={setActiveSector} />
-      {activeSector === null ? (
-        <TodayDiscoveryDeck loggedIn={loggedIn} onRequireLogin={onRequireLogin} />
-      ) : (
-        <SectorStockDeck
-          key={activeSector}
-          sector={activeSector}
-          loggedIn={loggedIn}
-          onRequireLogin={onRequireLogin}
-        />
-      )}
-    </div>
-  );
+  return <TodayDiscoveryDeck loggedIn={loggedIn} onRequireLogin={onRequireLogin} />;
 }
 
 /** "오늘" 탭 — 기존 쏠림(키워드) 피드(무변경). */

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -525,7 +525,7 @@ export function StockSwipeDeck({
         changeDir={e?.changeDir}
         rankLabel={rankLabelFor(stock)}
         sparkline={e?.sparkline}
-        chartSupported={!!stock.naverCode}
+        chartSupported={!!stock.naverCode && (e?.sparkline?.length ?? 0) >= 2}
         subLine={subLine}
         feedBull={deduped.feedBull}
         feedBear={deduped.feedBear}

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -1,20 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { SECTORS, type StockSector } from "@fomo/core";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
-import { fetchAxisSnapshot, fetchSectorStocks, getCachedKeywords, warmKeywords } from "@/lib/fomoApi";
+import { fetchDiscovery } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
-import {
-  applyAxisSnapshotToStocks,
-  buildTodayDiscoveryStocks,
-  MIN_DISCOVERY_STOCKS,
-  type DeckStock,
-  type SectorPool,
-} from "@/lib/discoveryDeck";
-
-const DISCOVERY_SECTORS: readonly StockSector[] = SECTORS.filter((sector) => sector !== "코인").slice(0, 6);
-const AXIS_SNAPSHOT_TIMEOUT_MS = 1800;
+import { MIN_DISCOVERY_STOCKS, type DeckStock } from "@/lib/discoveryDeck";
+import type { FrontEntry } from "@/components/StockSwipeDeck";
 
 interface TodayDiscoveryDeckProps {
   loggedIn?: boolean | undefined;
@@ -31,24 +22,11 @@ function DiscoveryEmpty() {
   );
 }
 
-async function applyAxisSnapshot(stocks: DeckStock[]): Promise<DeckStock[]> {
-  try {
-    const snapshot = await Promise.race([
-      fetchAxisSnapshot(stocks.map((s) => s.canonical)),
-      new Promise<never>((_, reject) => window.setTimeout(() => reject(new Error("axis snapshot timeout")), AXIS_SNAPSHOT_TIMEOUT_MS)),
-    ]);
-    return applyAxisSnapshotToStocks(stocks, snapshot.items);
-  } catch (err) {
-    console.warn("[TodayDiscoveryDeck] axis snapshot fallback", (err as Error)?.message);
-    return applyAxisSnapshotToStocks(stocks);
-  }
-}
-
 export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryDeckProps) {
   const [state, setState] = useState<
     | { kind: "loading" }
     | { kind: "error" }
-    | { kind: "ready"; stocks: DeckStock[] }
+    | { kind: "ready"; stocks: DeckStock[]; fronts: Record<string, FrontEntry> }
   >({ kind: "loading" });
 
   useEffect(() => {
@@ -56,33 +34,14 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
     setState({ kind: "loading" });
     (async () => {
       try {
-        const cachedKeywords = getCachedKeywords();
-        if (!cachedKeywords) {
-          warmKeywords().catch((err) => console.warn("[TodayDiscoveryDeck] keywords warm failed", err));
-        }
-
-        const settled = await Promise.allSettled(
-          DISCOVERY_SECTORS.map(async (sector) => ({
-            sector,
-            stocks: (await fetchSectorStocks(sector, true)).stocks ?? [],
-          }))
-        );
+        const discovery = await fetchDiscovery();
         if (!alive) return;
-
-        const pools: SectorPool[] = [];
-        for (const result of settled) {
-          if (result.status === "fulfilled" && result.value.stocks.length > 0) {
-            pools.push(result.value);
-          }
-        }
-        const stocks = buildTodayDiscoveryStocks(pools, cachedKeywords?.cards ?? [], DISCOVERY_SECTORS);
+        const stocks = discovery.stocks as DeckStock[];
         if (stocks.length === 0) {
           setState({ kind: "error" });
           return;
         }
-        const withAxis = await applyAxisSnapshot(stocks);
-        if (!alive) return;
-        setState({ kind: "ready", stocks: withAxis });
+        setState({ kind: "ready", stocks, fronts: discovery.fronts as Record<string, FrontEntry> });
       } catch (err) {
         console.warn("[TodayDiscoveryDeck] fetch failed", err);
         if (alive) setState({ kind: "error" });
@@ -101,6 +60,7 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
   return (
     <StockSwipeDeck
       stocks={state.stocks.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.stocks.length))}
+      initialFronts={state.fronts}
       contextLabel="오늘의 발견"
       loggedIn={loggedIn}
       onRequireLogin={onRequireLogin}

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -6,6 +6,8 @@ import {
   type KeywordCard,
   type MultiAxisHookSelection,
   type SectorStock,
+  type StockCountry,
+  type StockMarket,
   type StockSector,
   resolveStock,
   stocksBySector,
@@ -25,11 +27,14 @@ export const DISCOVERY_MIX = {
 } as const;
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
-export type DeckStock = SectorStock & {
+export type DeckStock = Omit<SectorStock, "sector"> & {
   reason?: string;
   whyShown?: string;
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;
+  sector: string;
+  market: StockMarket;
+  country: StockCountry;
 };
 
 export interface AxisSnapshotLike {
@@ -219,13 +224,19 @@ function todayDiscoveryRank(stock: DeckStock, recentRank: ReadonlyMap<string, nu
 }
 
 function isTasteSimilarStock(stock: DeckStock): boolean {
+  if (!isKnownStockSector(stock.sector)) return false;
   const watch = getWatchlist();
   if (watch.length === 0) return false;
   const peers = new Set(stocksBySector(stock.sector).map((s) => s.canonical));
   return watch.some((w) => w.stock !== stock.canonical && peers.has(w.stock));
 }
 
+function isKnownStockSector(sector: string): sector is StockSector {
+  return ["반도체", "AI", "2차전지", "방산", "바이오", "원자력", "코인"].includes(sector);
+}
+
 function affinitySignalFor(stock: DeckStock): AxisSignal | undefined {
+  if (!isKnownStockSector(stock.sector)) return undefined;
   const watch = getWatchlist();
   if (watch.length === 0) return undefined;
   const peers = new Set(stocksBySector(stock.sector).map((s) => s.canonical));

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -227,6 +227,28 @@ export const fetchStockFront = (stock: string, opts: { lite?: boolean } = {}) =>
     CACHE_TTL.stockFront
   );
 
+export interface DiscoveryStockResponse {
+  canonical: string;
+  market: import("@fomo/core").StockMarket;
+  country: import("@fomo/core").StockCountry;
+  naverCode?: string;
+  marquee: boolean;
+  sector: string;
+  whyShown?: string;
+  reason?: string;
+}
+
+export interface DiscoveryResponse {
+  asOf: string;
+  stocks: DiscoveryStockResponse[];
+  fronts: Record<string, StockFrontResponse>;
+  confidence: "L" | "M" | "H";
+  source: string;
+}
+
+export const fetchDiscovery = () =>
+  cachedGet("discovery:today", () => get<DiscoveryResponse>("/api/fomo/discovery"), CACHE_TTL.stockFront);
+
 export interface AxisSnapshotEntry {
   axisSignals: import("@fomo/core").AxisSignal[];
   axisHook: import("@fomo/core").MultiAxisHookSelection;

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -23,6 +23,10 @@ function hasWatchedPeer(sector: StockSector, stockName: string): boolean {
   return watch.some((w) => names.has(w.stock));
 }
 
+function isKnownStockSector(sector: string): sector is StockSector {
+  return ["반도체", "AI", "2차전지", "방산", "바이오", "원자력", "코인"].includes(sector);
+}
+
 function compactInline(text: string | undefined): string {
   const clean = (text ?? "").replace(/\s+/g, " ").trim();
   if (!clean) return "";
@@ -79,7 +83,7 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
   if (hasSupplySell && (mentionStrong || volumeStrong)) {
     return "약세·주의 신호가 커져서 시장이 어디에 반응하는지 보여줘요.";
   }
-  if (hasWatchedPeer(stock.sector, stock.canonical)) {
+  if (isKnownStockSector(stock.sector) && hasWatchedPeer(stock.sector, stock.canonical)) {
     return "네가 관심 둔 종목들과 같은 섹터에 있어요.";
   }
   if (stockInterestScore(stock.canonical, nowMs) >= HIGH_INTEREST_SCORE) {

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { buildDiscoveryResponse, type DiscoveryResponse } from "../../../../lib/discovery-supply";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const REVALIDATE_S = 600;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function GET() {
+  try {
+    const load = unstable_cache(
+      async () => buildDiscoveryResponse(),
+      ["fomo-discovery", cacheVersion(), kstDate()],
+      { revalidate: REVALIDATE_S }
+    );
+    return withCors(
+      NextResponse.json(await load(), {
+        headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400" },
+      })
+    );
+  } catch (err) {
+    console.warn("[fomo/discovery] failed", (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        {
+          asOf: kstDate(),
+          stocks: [],
+          fronts: {},
+          confidence: "L",
+          source: "데이터 없음",
+        } satisfies DiscoveryResponse,
+        { headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -1,0 +1,316 @@
+import {
+  STOCK_VOCAB,
+  applyAxisRarity,
+  buildAxisSignals,
+  computeFomoScore,
+  discoveryWhy,
+  rankDiscoveryCandidates,
+  resolveStock,
+  sectorOf,
+  selectMultiAxisHook,
+  type AxisSignal,
+  type CardFrontSignals,
+  type DiscoveryCandidate,
+  type DiscoveryEvent,
+  type DiscoveryMarket,
+  type FomoScoreResult,
+  type MultiAxisHookSelection,
+  type SectorStock,
+  type StockCountry,
+} from "@fomo/core";
+import { fetchStockDaily } from "./stock-front";
+import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
+
+const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
+const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
+const PAGE_SIZE = 100;
+const PAGES_PER_MARKET = 5;
+const SPARKLINE_CONCURRENCY = 8;
+
+export interface DiscoveryFrontSeed {
+  signals: CardFrontSignals;
+  fomo: FomoScoreResult;
+  sparkline: number[];
+  priceText?: string;
+  changeText?: string;
+  changeDir?: "up" | "down" | "flat";
+  axisSignals?: AxisSignal[];
+  axisHook?: MultiAxisHookSelection;
+}
+
+export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
+  sector: string;
+  whyShown?: string;
+  reason?: string;
+}
+
+export interface DiscoveryResponse {
+  asOf: string;
+  stocks: DiscoveryStockPayload[];
+  fronts: Record<string, DiscoveryFrontSeed>;
+  confidence: "L" | "M" | "H";
+  source: string;
+}
+
+interface NaverMarketRow {
+  canonical: string;
+  naverCode: string;
+  market: DiscoveryMarket;
+  priceText?: string;
+  changeText?: string;
+  changeDir?: "up" | "down" | "flat";
+  changePct?: number;
+  tradingValue?: number;
+}
+
+interface RawNaverStock {
+  itemCode?: string;
+  stockName?: string;
+  itemName?: string;
+  closePrice?: string;
+  compareToPreviousClosePrice?: string;
+  fluctuationsRatio?: string;
+  compareToPreviousPrice?: { code?: string; text?: string; name?: string };
+  accumulatedTradingValue?: string;
+  accumulatedTradingVolume?: string;
+}
+
+function todayKst(): string {
+  return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function numberFromText(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const n = Number(value.replace(/,/g, "").replace(/%/g, "").trim());
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function changeDirFrom(row: RawNaverStock, pct: number | undefined): "up" | "down" | "flat" {
+  const raw = `${row.compareToPreviousPrice?.code ?? ""} ${row.compareToPreviousPrice?.text ?? ""} ${row.compareToPreviousPrice?.name ?? ""}`;
+  if (/하락|DOWN|5/.test(raw) || (typeof pct === "number" && pct < 0)) return "down";
+  if (/상승|UP|2/.test(raw) || (typeof pct === "number" && pct > 0)) return "up";
+  return "flat";
+}
+
+function signedChangeText(row: RawNaverStock, dir: "up" | "down" | "flat", pct: number | undefined): string | undefined {
+  const change = row.compareToPreviousClosePrice?.trim();
+  if (!change && typeof pct !== "number") return undefined;
+  const pctText = typeof pct === "number" ? `${pct.toFixed(2)}%` : undefined;
+  const prefix = dir === "down" ? "-" : "";
+  return change && pctText ? `${prefix}${change} (${pctText})` : pctText;
+}
+
+function parseMarketRow(row: RawNaverStock, market: DiscoveryMarket): NaverMarketRow | null {
+  const canonical = (row.stockName ?? row.itemName ?? "").trim();
+  const naverCode = row.itemCode?.trim();
+  if (!canonical || !naverCode) return null;
+  const rawPct = numberFromText(row.fluctuationsRatio);
+  const dir = changeDirFrom(row, rawPct);
+  const changePct = typeof rawPct === "number" ? (dir === "down" ? -Math.abs(rawPct) : Math.abs(rawPct)) : undefined;
+  const changeText = signedChangeText(row, dir, changePct);
+  const tradingValue = numberFromText(row.accumulatedTradingValue);
+  return {
+    canonical,
+    naverCode,
+    market,
+    ...(row.closePrice ? { priceText: `${row.closePrice.replace(/원$/, "")}원` } : {}),
+    ...(changeText ? { changeText } : {}),
+    changeDir: dir,
+    ...(typeof changePct === "number" ? { changePct } : {}),
+    ...(tradingValue ? { tradingValue } : {}),
+  };
+}
+
+async function fetchMarketPage(market: DiscoveryMarket, page: number): Promise<NaverMarketRow[]> {
+  const url = `https://m.stock.naver.com/api/stocks/marketValue/${market}?page=${page}&pageSize=${PAGE_SIZE}`;
+  const res = await fetch(url, { headers: UA, signal: AbortSignal.timeout(8000) });
+  if (!res.ok) throw new Error(`naver market ${market} ${page} ${res.status}`);
+  const data = (await res.json()) as { stocks?: RawNaverStock[] };
+  return (data.stocks ?? []).map((row) => parseMarketRow(row, market)).filter((row): row is NaverMarketRow => row !== null);
+}
+
+async function fetchMarketRows(): Promise<NaverMarketRow[]> {
+  const settled = await Promise.allSettled(
+    MARKETS.flatMap((market) => Array.from({ length: PAGES_PER_MARKET }, (_, i) => fetchMarketPage(market, i + 1)))
+  );
+  const rows = settled.flatMap((row) => (row.status === "fulfilled" ? row.value : []));
+  const byCode = new Map<string, NaverMarketRow>();
+  for (const row of rows) if (!byCode.has(row.naverCode)) byCode.set(row.naverCode, row);
+  return [...byCode.values()];
+}
+
+async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<PromiseSettledResult<R>[]> {
+  const out: PromiseSettledResult<R>[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      try {
+        out[index] = { status: "fulfilled", value: await fn(items[index]!) };
+      } catch (reason) {
+        out[index] = { status: "rejected", reason };
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return out;
+}
+
+function eventFromPrice(row: NaverMarketRow, asOf: string): DiscoveryEvent | null {
+  if (typeof row.changePct !== "number" || Math.abs(row.changePct) < 5) return null;
+  return {
+    kind: "price_move",
+    firstSeen: true,
+    strength: Math.min(1, Math.abs(row.changePct) / 15),
+    source: "네이버 시세",
+    asOf,
+    confidence: "H",
+    label: `오늘 가격이 ${row.changePct > 0 ? "+" : ""}${row.changePct.toFixed(2)}% 움직였어요.`,
+  };
+}
+
+function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string): DiscoveryEvent | null {
+  if (!attention || attention.mentionCount <= 0) return null;
+  return {
+    kind: "news_mention",
+    firstSeen: true,
+    strength: Math.min(1, Math.max(0.32, attention.mentionScore / 100)),
+    source: attention.newsEventSource ?? "뉴스",
+    asOf,
+    confidence: attention.newsEventLabel ? "H" : "M",
+    ...(attention.newsEventLabel ? { label: attention.newsEventLabel } : {}),
+  };
+}
+
+function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): DiscoveryStockPayload {
+  const def = resolveStock(candidate.ticker);
+  const sector = def ? sectorOf(def.canonical) : undefined;
+  return {
+    canonical: candidate.ticker,
+    market: row.market,
+    country: def?.country ?? "KR",
+    naverCode: row.naverCode,
+    marquee: def?.marquee === true,
+    sector: sector ?? candidate.sector ?? row.market,
+    whyShown: discoveryWhy(candidate),
+    reason: discoveryWhy(candidate),
+  };
+}
+
+function frontSeed(row: NaverMarketRow, candidate: DiscoveryCandidate, attention: StockAttentionSignal | undefined, sparkline: number[]): DiscoveryFrontSeed {
+  const signals: CardFrontSignals = {
+    ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
+    ...(attention ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore } : {}),
+    ...(attention?.newsEventLabel ? { newsEventLabel: attention.newsEventLabel } : {}),
+    ...(attention?.newsEventSource ? { newsEventSource: attention.newsEventSource } : {}),
+    asOf: candidate.asOf,
+  };
+  const fomo = computeFomoScore({
+    ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
+    ...(typeof signals.mentionScore === "number" ? { mentionScore: signals.mentionScore } : {}),
+  });
+  const axisSignals = buildAxisSignals({ signals });
+  const axisHook = selectMultiAxisHook(axisSignals);
+  return {
+    signals,
+    fomo,
+    sparkline,
+    ...(row.priceText ? { priceText: row.priceText } : {}),
+    ...(row.changeText ? { changeText: row.changeText } : {}),
+    ...(row.changeDir ? { changeDir: row.changeDir } : {}),
+    axisSignals,
+    axisHook,
+  };
+}
+
+export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
+  const asOf = todayKst();
+  const [rows, attentionMap] = await Promise.all([
+    fetchMarketRows(),
+    computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
+  ]);
+  const vocabByCode = new Map(STOCK_VOCAB.filter((s) => s.naverCode).map((s) => [s.naverCode!, s]));
+  const byTicker = new Map<string, { row: NaverMarketRow; events: DiscoveryEvent[] }>();
+
+  for (const row of rows) {
+    const def = vocabByCode.get(row.naverCode);
+    const ticker = def?.canonical ?? row.canonical;
+    const events = [eventFromPrice(row, asOf)].filter((event): event is DiscoveryEvent => event !== null);
+    if (events.length > 0) byTicker.set(ticker, { row: { ...row, canonical: ticker }, events });
+  }
+
+  for (const [ticker, attention] of Object.entries(attentionMap)) {
+    const def = resolveStock(ticker);
+    if (!def?.naverCode) continue;
+    const row =
+      rows.find((r) => r.naverCode === def.naverCode) ??
+      ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow);
+    const event = eventFromNews(attention, asOf);
+    if (!event) continue;
+    const current = byTicker.get(def.canonical);
+    byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
+  }
+
+  const candidates = [...byTicker.entries()].map(([ticker, { row, events }]): DiscoveryCandidate => {
+    const def = resolveStock(ticker);
+    const sector = sectorOf(ticker);
+    const reason = events.find((event) => event.label)?.label;
+    return {
+      ticker,
+      market: row.market,
+      country: (def?.country ?? "KR") as StockCountry,
+      naverCode: row.naverCode,
+      ...(sector ? { sector } : {}),
+      events,
+      asOf,
+      ...(reason ? { reason } : {}),
+      marquee: def?.marquee === true,
+    };
+  });
+  const ranked = rankDiscoveryCandidates(candidates, { maxCandidates: 100 });
+  const rowsByTicker = new Map([...byTicker.entries()].map(([ticker, value]) => [ticker, value.row]));
+  const fronts: Record<string, DiscoveryFrontSeed> = {};
+  const stocks: DiscoveryStockPayload[] = [];
+
+  const sparklineRows = await mapLimit(
+    ranked.slice(0, 100),
+    SPARKLINE_CONCURRENCY,
+    async (candidate) => ({
+      ticker: candidate.ticker,
+      sparkline: candidate.naverCode ? (await fetchStockDaily(candidate.naverCode, 110)).closes.slice(-42) : [],
+    })
+  );
+  const sparklineByTicker = new Map(
+    sparklineRows
+      .filter((row): row is PromiseFulfilledResult<{ ticker: string; sparkline: number[] }> => row.status === "fulfilled")
+      .map((row) => [row.value.ticker, row.value.sparkline] as const)
+  );
+
+  for (const candidate of ranked) {
+    const row = rowsByTicker.get(candidate.ticker);
+    if (!row) continue;
+    const attention = attentionMap[candidate.ticker];
+    stocks.push(stockPayload(row, candidate));
+    fronts[candidate.ticker] = frontSeed(row, candidate, attention, sparklineByTicker.get(candidate.ticker) ?? []);
+  }
+  const raritySets = applyAxisRarity(stocks.map((stock) => fronts[stock.canonical]?.axisSignals ?? []));
+  stocks.forEach((stock, index) => {
+    const current = fronts[stock.canonical];
+    const axisSignals = raritySets[index];
+    if (!current || !axisSignals) return;
+    fronts[stock.canonical] = {
+      ...current,
+      axisSignals,
+      axisHook: selectMultiAxisHook(axisSignals),
+    };
+  });
+
+  return {
+    asOf,
+    stocks,
+    fronts,
+    confidence: stocks.length >= 30 ? "H" : stocks.length >= 10 ? "M" : "L",
+    source: "네이버 시세·뉴스 언급",
+  };
+}

--- a/docs/WO-05_DISCOVERY_SUPPLY_ENGINE.md
+++ b/docs/WO-05_DISCOVERY_SUPPLY_ENGINE.md
@@ -1,0 +1,28 @@
+# WO-05 Discovery Supply Engine
+
+Status: Stage 1 implementation.
+
+Goal: move the default discovery surface from a fixed sector roster to a daily event-harvested stock pool. The top-level feed is now a single infinite deck; sectors remain as card context tags, not navigation boundaries.
+
+Implemented scope:
+
+- `GET /api/fomo/discovery`
+  - harvests Korea market movers from Naver market list pages
+  - merges existing news/mention coverage
+  - gates candidates to `events.length >= 1`
+  - returns up to 100 candidates plus card-front seeds
+- `@fomo/core` pure discovery supply primitives
+  - `eligibleUniverse`
+  - `rankDiscoveryCandidates`
+  - `discoveryWhy`
+  - weak material labeling for price/volume-only cards
+- Web default surface
+  - removes top sector chips from the default card feed
+  - `TodayDiscoveryDeck` calls `/api/fomo/discovery` once
+  - seeded `fronts` let market-list candidates render without waiting for per-card stock-front hydration
+
+Deferred:
+
+- KRX risk-designation adapter. The pure guard exists, but live KRX endpoint wiring is a follow-up once the exact free endpoint is validated.
+- DART disclosures and earnings surprise events.
+- US market adapter.

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  discoveryWhy,
+  eligibleUniverse,
+  rankDiscoveryCandidates,
+  type DiscoveryCandidate,
+} from "../src";
+
+const asOf = "2026-06-24";
+
+function candidate(ticker: string, strength: number, kind: "price_move" | "news_mention" = "price_move"): DiscoveryCandidate {
+  return {
+    ticker,
+    market: "KOSPI",
+    events: [
+      {
+        kind,
+        firstSeen: true,
+        strength,
+        source: kind === "news_mention" ? "뉴스" : "네이버 시세",
+        asOf,
+        confidence: "H",
+        ...(kind === "news_mention" ? { label: "신규 공급계약 공시" } : {}),
+      },
+    ],
+    asOf,
+  };
+}
+
+describe("WO-05 discovery supply engine", () => {
+  it("filters permanent risk flags and the dead liquidity tail only", () => {
+    const result = eligibleUniverse([
+      { ticker: "정상A", avgTradingValue20d: 100 },
+      { ticker: "정상B", avgTradingValue20d: 90 },
+      { ticker: "죽은거래", avgTradingValue20d: 3 },
+      { ticker: "관리종목", avgTradingValue20d: 120, riskFlags: ["관리종목"] },
+      { ticker: "단기과열", avgTradingValue20d: 120, riskFlags: ["단기과열"] },
+    ]);
+
+    expect(result.map((s) => s.ticker)).toEqual(["정상A", "정상B"]);
+  });
+
+  it("keeps only candidates with at least one event and ranks public material above weak shape-only cards", () => {
+    const ranked = rankDiscoveryCandidates([
+      { ticker: "조용", market: "KOSPI", events: [], asOf },
+      candidate("가격만", 0.9, "price_move"),
+      candidate("뉴스", 0.55, "news_mention"),
+    ]);
+
+    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스", "가격만"]);
+  });
+
+  it("applies seen decay but keeps watched stocks exempt", () => {
+    const rows = [candidate("최근봄", 0.9, "news_mention"), candidate("처음봄", 0.8, "news_mention")];
+
+    expect(rankDiscoveryCandidates(rows, { seen: [{ ticker: "최근봄", daysAgo: 0 }] })[0]?.ticker).toBe("처음봄");
+    expect(rankDiscoveryCandidates(rows, { seen: [{ ticker: "최근봄", daysAgo: 0 }], watched: ["최근봄"] })[0]?.ticker).toBe("최근봄");
+  });
+
+  it("labels weak price-only material honestly instead of inventing a catalyst", () => {
+    expect(discoveryWhy(candidate("가격만", 0.8))).toContain("뚜렷한 공개 재료는 확인 안 됨");
+    expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -1,0 +1,154 @@
+import type { StockCountry, StockMarket } from "./stocks";
+
+export type DiscoveryMarket = Extract<StockMarket, "KOSPI" | "KOSDAQ" | "NASDAQ" | "NYSE">;
+
+export type DiscoveryEventKind =
+  | "price_move"
+  | "new_high"
+  | "volume_spike"
+  | "flow_entry"
+  | "news_mention";
+
+export interface DiscoveryEvent {
+  kind: DiscoveryEventKind;
+  firstSeen: boolean;
+  strength: number;
+  source: string;
+  asOf: string;
+  confidence: "L" | "M" | "H";
+  label?: string;
+}
+
+export interface DiscoveryCandidate {
+  ticker: string;
+  market: DiscoveryMarket;
+  country?: StockCountry;
+  naverCode?: string;
+  sector?: string;
+  events: DiscoveryEvent[];
+  asOf: string;
+  reason?: string;
+  marquee?: boolean;
+}
+
+export interface UniverseStock {
+  ticker: string;
+  riskFlags?: readonly string[];
+  avgTradingValue20d?: number;
+}
+
+export interface EligibleUniverseOptions {
+  liquidityMedianRatioCut?: number;
+}
+
+export interface SeenRecord {
+  ticker: string;
+  daysAgo: number;
+}
+
+export interface RankDiscoveryOptions {
+  maxCandidates?: number;
+  seen?: readonly SeenRecord[];
+  watched?: readonly string[];
+}
+
+export const DISCOVERY_MAX_CANDIDATES = 100;
+export const DISCOVERY_LIQUIDITY_MEDIAN_RATIO_CUT = 0.1;
+export const DISCOVERY_SEEN_DECAY_DAYS = 3;
+
+const RISK_FLAG_PATTERN = /관리|투자경고|투자위험|거래정지|단기과열|이상급등/;
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function median(values: number[]): number | undefined {
+  const sorted = values.filter((v) => Number.isFinite(v) && v > 0).sort((a, b) => a - b);
+  if (sorted.length === 0) return undefined;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+export function eligibleUniverse(
+  stocks: readonly UniverseStock[],
+  opts: EligibleUniverseOptions = {}
+): UniverseStock[] {
+  const ratioCut = opts.liquidityMedianRatioCut ?? DISCOVERY_LIQUIDITY_MEDIAN_RATIO_CUT;
+  const med = median(stocks.map((s) => s.avgTradingValue20d ?? 0));
+  const liquidityCut = med ? med * ratioCut : undefined;
+  return stocks.filter((stock) => {
+    if (stock.riskFlags?.some((flag) => RISK_FLAG_PATTERN.test(flag))) return false;
+    if (liquidityCut && typeof stock.avgTradingValue20d === "number" && stock.avgTradingValue20d < liquidityCut) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function hasPublicMaterialEvent(candidate: DiscoveryCandidate): boolean {
+  return candidate.events.some((event) => event.kind === "news_mention" || event.kind === "flow_entry" || event.kind === "new_high");
+}
+
+export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
+  return !hasPublicMaterialEvent(candidate) && candidate.events.every((event) => event.kind === "price_move" || event.kind === "volume_spike");
+}
+
+export function discoveryWhy(candidate: DiscoveryCandidate): string {
+  const strongest = [...candidate.events].sort((a, b) => b.strength - a.strength || a.kind.localeCompare(b.kind))[0];
+  if (!strongest) return "오늘 확인된 사건이 아직 없어요.";
+  if (strongest.kind === "news_mention") {
+    return strongest.label
+      ? `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
+      : "오늘 이 종목을 직접 언급한 뉴스가 있어요.";
+  }
+  if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";
+  if (strongest.kind === "new_high") return strongest.label ?? "새로운 가격 위치가 확인된 종목이에요.";
+  if (strongest.kind === "volume_spike") {
+    return strongest.label ?? "오늘 거래량 급증, 뚜렷한 공개 재료는 확인 안 됨.";
+  }
+  return strongest.label ?? "오늘 가격 움직임이 커졌고, 뚜렷한 공개 재료는 확인 안 됨.";
+}
+
+function freshnessBoost(candidate: DiscoveryCandidate): number {
+  return candidate.events.some((event) => event.firstSeen) ? 0.16 : 0;
+}
+
+function eventScore(candidate: DiscoveryCandidate): number {
+  const maxStrength = Math.max(0, ...candidate.events.map((event) => clamp01(event.strength)));
+  const diversity = new Set(candidate.events.map((event) => event.kind)).size;
+  const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : -0.25;
+  return maxStrength + freshnessBoost(candidate) + Math.min(0.12, diversity * 0.03) + materialBoost;
+}
+
+function seenPenalty(ticker: string, seen: readonly SeenRecord[], watched: ReadonlySet<string>): number {
+  if (watched.has(ticker)) return 0;
+  const row = seen.find((s) => s.ticker === ticker);
+  if (!row || row.daysAgo >= DISCOVERY_SEEN_DECAY_DAYS) return 0;
+  const left = DISCOVERY_SEEN_DECAY_DAYS - Math.max(0, row.daysAgo);
+  return (left / DISCOVERY_SEEN_DECAY_DAYS) * 0.3;
+}
+
+export function rankDiscoveryCandidates(
+  candidates: readonly DiscoveryCandidate[],
+  opts: RankDiscoveryOptions = {}
+): DiscoveryCandidate[] {
+  const max = opts.maxCandidates ?? DISCOVERY_MAX_CANDIDATES;
+  const watched = new Set(opts.watched ?? []);
+  return candidates
+    .filter((candidate) => candidate.events.length > 0)
+    .map((candidate, index) => ({
+      candidate,
+      index,
+      score: eventScore(candidate) - seenPenalty(candidate.ticker, opts.seen ?? [], watched),
+    }))
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        Number(hasPublicMaterialEvent(b.candidate)) - Number(hasPublicMaterialEvent(a.candidate)) ||
+        a.index - b.index ||
+        a.candidate.ticker.localeCompare(b.candidate.ticker)
+    )
+    .slice(0, max)
+    .map((row) => row.candidate);
+}

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -8,5 +8,6 @@ export * from "./josa";
 export * from "./stocks";
 export * from "./card-front-hook";
 export * from "./multi-axis-hook";
+export * from "./discovery-supply";
 export * from "./fomo-score";
 export * from "./technical-analysis";


### PR DESCRIPTION
## Summary
- add pure WO-05 discovery supply primitives for eligibility, event gating, honest why labels, and seen-decay ranking
- add /api/fomo/discovery to harvest Korea market movers from Naver list pages and merge existing news/mention coverage
- seed stock card fronts from the discovery response so the default deck no longer depends on the fixed sector roster path
- remove the top sector chip navigation from the default discovery surface

## Notes
- KRX risk-list wiring is left as a documented follow-up; the pure eligibility guard exists and is covered by tests
- DART disclosures, earnings surprise, and US adapters remain deferred per WO-05 stages

## Verification
- npm run typecheck:fomo-core
- npm run typecheck:fomo-web
- npm run typecheck:web
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts packages/fomo-core/__tests__/multi-axis-hook.test.ts apps/fomo-web/__tests__/discoveryDeck.test.ts apps/web/__tests__/lib/stock-front-lite.test.ts
- npm run build:fomo-web
- npm run build:web
- npm run lint -- --if-present