### PR TITLE
Fix card copy dedupe and depth seed fallback

### DIFF
--- a/apps/fomo-web/__tests__/cardCopyDedupe.test.ts
+++ b/apps/fomo-web/__tests__/cardCopyDedupe.test.ts
@@ -29,4 +29,26 @@ describe("dedupeCardCopy", () => {
     expect(copy.why).toBe("‘바이오’ 흐름에서 같이 잡힌 원문 근거가 있어요: 신약개발 해법은 AI·오픈이노베이션");
     expect(copy.feedBull).toBeUndefined();
   });
+
+  it("hides repeated price copy across headline, reason, and subline", () => {
+    const copy = dedupeCardCopy({
+      headline: "오늘 가격이 +18.9% 움직였어요.",
+      why: "오늘 가격이 +18.86% 움직였어요.",
+      subLine: "오늘 가격이 +18.86% 움직였어요.",
+    });
+
+    expect(copy.why).toBeUndefined();
+    expect(copy.subLine).toBeUndefined();
+  });
+
+  it("keeps a non-overlapping reason while removing a repeated subline", () => {
+    const copy = dedupeCardCopy({
+      headline: "오늘 가격이 +29.9% 움직였어요.",
+      why: "큰 가격 움직임은 보였지만, 연결된 공개 재료는 아직 확인되지 않았어요.",
+      subLine: "오늘 가격이 +29.91% 움직였어요.",
+    });
+
+    expect(copy.why).toBe("큰 가격 움직임은 보였지만, 연결된 공개 재료는 아직 확인되지 않았어요.");
+    expect(copy.subLine).toBeUndefined();
+  });
 });

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -340,6 +340,46 @@ export interface StockContext {
   fromTheme?: string;
   /** 피드 60장 기준 다축 셀렉터가 고른 카드 헤드라인. 상세에서도 같은 관통선을 유지한다. */
   axisHeadline?: string | undefined;
+  /** 발견 덱이 이미 가진 가격·포모·차트 seed. 상세 fetch 실패 시 비어 보이지 않게 한다. */
+  frontSeed?: StockFrontResponse | undefined;
+}
+
+function hasUsableFront(front: StockFrontResponse | null | undefined): front is StockFrontResponse {
+  if (!front) return false;
+  return (
+    !!front.priceText ||
+    !!front.changeText ||
+    (front.sparkline?.length ?? 0) >= 2 ||
+    Object.keys(front.signals ?? {}).length > 0
+  );
+}
+
+function mergeFrontSeed(
+  seed: StockFrontResponse | null | undefined,
+  fresh: StockFrontResponse | null | undefined
+): StockFrontResponse | null {
+  if (!hasUsableFront(seed)) return fresh ?? null;
+  if (!hasUsableFront(fresh)) return seed;
+  return {
+    signals: { ...seed.signals, ...fresh.signals },
+    fomo: fresh.fomo ?? seed.fomo,
+    ...(fresh.taFact ?? seed.taFact ? { taFact: fresh.taFact ?? seed.taFact } : {}),
+    sparkline: fresh.sparkline.length >= 2 ? fresh.sparkline : seed.sparkline,
+    ...(fresh.priceText ?? seed.priceText ? { priceText: fresh.priceText ?? seed.priceText } : {}),
+    ...(fresh.changeText ?? seed.changeText ? { changeText: fresh.changeText ?? seed.changeText } : {}),
+    ...(fresh.changeDir ?? seed.changeDir ? { changeDir: fresh.changeDir ?? seed.changeDir } : {}),
+    ...(fresh.feedBull ?? seed.feedBull ? { feedBull: fresh.feedBull ?? seed.feedBull } : {}),
+    ...(fresh.feedBear ?? seed.feedBear ? { feedBear: fresh.feedBear ?? seed.feedBear } : {}),
+    ...(fresh.axisSignals?.length ? { axisSignals: fresh.axisSignals } : seed.axisSignals?.length ? { axisSignals: seed.axisSignals } : {}),
+    ...(fresh.axisHook ?? seed.axisHook ? { axisHook: fresh.axisHook ?? seed.axisHook } : {}),
+  };
+}
+
+function copyRestates(a: string | undefined, b: string | undefined): boolean {
+  const clean = (text: string | undefined) => (text ?? "").replace(/\s+/g, "").replace(/[‘’'".,:·…]/g, "");
+  const left = clean(a);
+  const right = clean(b);
+  return !!left && !!right && (left.includes(right) || right.includes(left));
 }
 
 /**
@@ -777,8 +817,8 @@ export function StockInsightView({
   const [basics, setBasics] = useState<StockBasics | null>(null);
   const [basicsLoaded, setBasicsLoaded] = useState(false);
   // 포모 상태(히어로) — 카드(②)와 동일 출처(FomoScoreResult). 단일 출처 보장.
-  const [front, setFront] = useState<StockFrontResponse | null>(null);
-  const [frontLoaded, setFrontLoaded] = useState(false);
+  const [front, setFront] = useState<StockFrontResponse | null>(context?.frontSeed ?? null);
+  const [frontLoaded, setFrontLoaded] = useState(!!context?.frontSeed);
   // 종목 관심(C) — 명시적 취향 입력. 진입 자체도 암묵 신호(view_depth)로 적재됨.
   const [watched, setWatchedState] = useState(false);
 
@@ -797,16 +837,17 @@ export function StockInsightView({
 
   useEffect(() => {
     let alive = true;
+    const seed = context?.frontSeed ?? null;
     setLoading(true);
     setInsight(null);
     setBasics(null);
-    setFront(null);
+    setFront(seed);
     setBasicsLoaded(false);
-    setFrontLoaded(false);
+    setFrontLoaded(!!seed);
     // 가격 헤더만 먼저 허용하고, 아래 가변 섹션은 세 요청이 모두 끝난 뒤 한 번에 연다.
     fetchStockFront(stock)
-      .then((r) => alive && setFront(r))
-      .catch(() => alive && setFront(null))
+      .then((r) => alive && setFront(mergeFrontSeed(seed, r)))
+      .catch(() => alive && setFront(seed))
       .finally(() => alive && setFrontLoaded(true));
     fetchStockBasics(stock)
       .then((r) => alive && setBasics(r))
@@ -819,11 +860,15 @@ export function StockInsightView({
     return () => {
       alive = false;
     };
-  }, [stock]);
+  }, [stock, context?.frontSeed]);
 
   const hasInsight =
     !!insight && insight.confidence !== "insufficient" && insight.bull.length + insight.bear.length > 0;
   const detailsReady = !loading && basicsLoaded && frontLoaded;
+  const contextReason =
+    context?.reason && !copyRestates(context.reason, context.axisHeadline)
+      ? context.reason
+      : undefined;
 
   return (
     <div className="fixed inset-0 z-[70] bg-black">
@@ -851,13 +896,13 @@ export function StockInsightView({
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
           {/* B — "왜 너한테 보여줬나" 상단 한 줄(추천 맥락이 있으면). 납득 먼저. */}
-          {context?.reason && (
+          {contextReason && (
             <div className="mb-5 rounded-lg border border-hairline bg-surface px-3 py-2">
               <span className="block text-[11px] text-muted">
-                {context.fromTheme ? `‘${cleanText(context.fromTheme)}’ 흐름에서 보여주는 이유` : "보여주는 이유"}
+                {context?.fromTheme ? `‘${cleanText(context.fromTheme)}’ 흐름에서 보여주는 이유` : "보여주는 이유"}
               </span>
-              <span className="mt-1 block text-sm leading-6 text-whiteout">{cleanText(context.reason)}</span>
-              {context.sourceUrl && (
+              <span className="mt-1 block text-sm leading-6 text-whiteout">{cleanText(contextReason)}</span>
+              {context?.sourceUrl && (
                 <a href={context.sourceUrl} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
                   ↳ {cleanText(context.sourceLabel ?? "원문")} · 원문 보기 →
                 </a>

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -12,7 +12,7 @@ import type {
 } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
-import type { FeedSignalPoint } from "@/lib/fomoApi";
+import type { FeedSignalPoint, StockFrontResponse } from "@/lib/fomoApi";
 import { recordStockInterest } from "@/lib/stockInterest";
 import { upsertWatch } from "@/lib/watchlist";
 import type { DeckStock } from "@/lib/discoveryDeck";
@@ -301,7 +301,7 @@ function StockCardFace({
 
       <FeedSignalStrip bull={feedBull} bear={feedBear} />
 
-      {subLine && !feedBull && !feedBear && (
+      {subLine && !why && !feedBull && !feedBear && (
         <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
           <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
             {subLine}
@@ -510,13 +510,14 @@ export function StockSwipeDeck({
     if (!e) {
       return <StockCardLoadingFace stock={stock} themeLabel={stock.sector} progress={progress} />;
     }
-    const { view, subLine, usedReasonHeadline } = cardFor(stock);
+    const { view, subLine } = cardFor(stock);
     const deduped = dedupeCardCopy({
       headline: view.headline,
       why: whyFor(stock),
       feedBull: e?.feedBull,
       feedBear: e?.feedBear,
-      preserveGroundedReason: !!stock.reason && !usedReasonHeadline,
+      subLine,
+      preserveGroundedReason: false,
     });
     return (
       <StockCardFace
@@ -529,7 +530,7 @@ export function StockSwipeDeck({
         rankLabel={rankLabelFor(stock)}
         sparkline={e?.sparkline}
         chartSupported={!!stock.naverCode && (e?.sparkline?.length ?? 0) >= 2}
-        subLine={subLine}
+        subLine={deduped.subLine}
         feedBull={deduped.feedBull}
         feedBear={deduped.feedBear}
         why={deduped.why}
@@ -831,6 +832,7 @@ export function StockSwipeDeck({
           context={{
             fromTheme: selected.sector,
             reason: whyFor(selected),
+            ...(front[selected.canonical] ? { frontSeed: front[selected.canonical] as StockFrontResponse } : {}),
             ...(axisHeadlineFor(selected) ? { axisHeadline: axisHeadlineFor(selected) } : {}),
           }}
           onClose={closeDepth}

--- a/apps/fomo-web/lib/cardCopyDedupe.ts
+++ b/apps/fomo-web/lib/cardCopyDedupe.ts
@@ -16,6 +16,7 @@ interface DedupeInput {
   why: string;
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
+  subLine?: string | undefined;
   preserveGroundedReason?: boolean | undefined;
 }
 
@@ -23,6 +24,7 @@ interface DedupeOutput {
   why?: string | undefined;
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
+  subLine?: string | undefined;
 }
 
 function normalizeCopy(text: string | undefined): string {
@@ -44,6 +46,21 @@ function clustersFor(text: string | undefined): Set<CopyCluster> {
   return clusters;
 }
 
+function priceMoveOverlap(a: string | undefined, b: string | undefined): boolean {
+  const left = a ?? "";
+  const right = b ?? "";
+  const leftPct = [...left.matchAll(/[+-]?\d+(?:\.\d+)?(?=%)/g)].map((m) => Number(m[0]));
+  const rightPct = [...right.matchAll(/[+-]?\d+(?:\.\d+)?(?=%)/g)].map((m) => Number(m[0]));
+  if (
+    leftPct.some((l) => rightPct.some((r) => Number.isFinite(l) && Number.isFinite(r) && Math.abs(l - r) <= 0.2))
+  ) {
+    return true;
+  }
+  const publicMaterialCaveat = /공개\s*재료|재료.*확인/.test(left) || /공개\s*재료|재료.*확인/.test(right);
+  if (publicMaterialCaveat) return false;
+  return /오늘.*가격/.test(left) && /오늘.*가격/.test(right) && /(움직|상승|하락|올랐|빠졌)/.test(left) && /(움직|상승|하락|올랐|빠졌)/.test(right);
+}
+
 function hasMaterialOverlap(a: string | undefined, b: string | undefined): boolean {
   const left = normalizeCopy(a);
   const right = normalizeCopy(b);
@@ -57,6 +74,7 @@ function hasMaterialOverlap(a: string | undefined, b: string | undefined): boole
   if (aClusters.has("news") && bClusters.has("news")) return true;
   if (aClusters.has("mention") && bClusters.has("mention")) return true;
   if (aClusters.has("theme") && bClusters.has("theme")) return true;
+  if (aClusters.has("price") && bClusters.has("price") && priceMoveOverlap(a, b)) return true;
   if (aClusters.has("volume") && bClusters.has("volume")) return true;
   if (aClusters.has("position") && bClusters.has("position")) return true;
   return false;
@@ -67,6 +85,7 @@ export function dedupeCardCopy({
   why,
   feedBull,
   feedBear,
+  subLine,
   preserveGroundedReason = false,
 }: DedupeInput): DedupeOutput {
   const whyRestatesHeadline = !preserveGroundedReason && hasMaterialOverlap(headline, why);
@@ -80,10 +99,19 @@ export function dedupeCardCopy({
   const shouldHideBear =
     !!feedBear &&
     (hasMaterialOverlap(headline, bearText) || (!!visibleWhy && hasMaterialOverlap(visibleWhy, bearText)));
+  const visibleBull = shouldHideBull ? undefined : feedBull;
+  const visibleBear = shouldHideBear ? undefined : feedBear;
+  const shouldHideSubLine =
+    !!subLine &&
+    (hasMaterialOverlap(headline, subLine) ||
+      (!!visibleWhy && hasMaterialOverlap(visibleWhy, subLine)) ||
+      (!!visibleBull && hasMaterialOverlap(visibleBull.text, subLine)) ||
+      (!!visibleBear && hasMaterialOverlap(visibleBear.text, subLine)));
 
   return {
     ...(visibleWhy ? { why: visibleWhy } : {}),
-    ...(!shouldHideBull && feedBull ? { feedBull } : {}),
-    ...(!shouldHideBear && feedBear ? { feedBear } : {}),
+    ...(visibleBull ? { feedBull: visibleBull } : {}),
+    ...(visibleBear ? { feedBear: visibleBear } : {}),
+    ...(!shouldHideSubLine && subLine ? { subLine } : {}),
   };
 }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -4,6 +4,7 @@ import {
   buildAxisSignals,
   computeFomoScore,
   discoveryWhy,
+  hasPublicMaterialEvent,
   rankDiscoveryCandidates,
   resolveStock,
   sectorOf,
@@ -186,6 +187,8 @@ function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string
 function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): DiscoveryStockPayload {
   const def = resolveStock(candidate.ticker);
   const sector = def ? sectorOf(def.canonical) : undefined;
+  const why = discoveryWhy(candidate);
+  const hasMaterial = hasPublicMaterialEvent(candidate);
   return {
     canonical: candidate.ticker,
     market: row.market,
@@ -193,8 +196,10 @@ function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): Disco
     naverCode: row.naverCode,
     marquee: def?.marquee === true,
     sector: sector ?? candidate.sector ?? row.market,
-    whyShown: discoveryWhy(candidate),
-    reason: discoveryWhy(candidate),
+    whyShown: hasMaterial
+      ? why
+      : "큰 가격 움직임은 보였지만, 연결된 공개 재료는 아직 확인되지 않았어요.",
+    ...(hasMaterial ? { reason: why } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- hide repeated card copy across headline, reason, signal strip, and subline
- stop copying weak price-only discovery copy into stock reason; show honest no-public-material reason instead
- pass card stock-front seed into stock depth so price/chart/read points stay populated when fresh detail fetch is sparse

## Verification
- npm test -- apps/fomo-web/__tests__/cardCopyDedupe.test.ts packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck:fomo-web
- npm run typecheck:web
- npm run build:fomo-web
- npm run build:web
- npm run lint -- --if-present