### PR TITLE
Align change rate font with price text

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -411,7 +411,7 @@ function StockPriceHeader({ basics, front }: { basics: StockBasics | null; front
         <div className="mt-2">
           <span className="text-[32px] font-bold leading-none text-whiteout">{priceText}</span>
           {changeText && (
-            <span className="ml-2 align-baseline font-number text-sm font-medium tabular-nums" style={up || down ? { color: up ? "#ff5a5f" : "#4f8cff" } : undefined}>
+            <span className="ml-2 align-baseline text-sm font-medium tabular-nums" style={up || down ? { color: up ? "#ff5a5f" : "#4f8cff" } : undefined}>
               {up ? "▲" : down ? "▼" : ""} {changeText}
             </span>
           )}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -250,7 +250,7 @@ function StockCardFace({
         <div className="mt-2.5 flex shrink-0 items-baseline gap-2">
           <span className="text-lg font-bold text-whiteout">{priceText}</span>
           {changeText && (
-            <span className="inline-flex items-center gap-1 font-number text-sm font-medium tabular-nums" style={{ color: DIR_COLOR[changeDir ?? "flat"] }}>
+            <span className="inline-flex items-center gap-1 text-sm font-medium tabular-nums" style={{ color: DIR_COLOR[changeDir ?? "flat"] }}>
               {changeDir === "up" && <CaretUpIcon size={11} />}
               {changeDir === "down" && <CaretDownIcon size={11} />}
               {changeText}


### PR DESCRIPTION
## Summary
- remove the number font class from change-rate text on the main stock card
- remove the same number font class from change-rate text in stock depth
- keep tabular spacing and existing up/down colors intact

## Verification
- npm run build:fomo-web
- npm run typecheck:fomo-web