### PR TITLE
feat(discovery): reinforce spike WHY ranking

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -4,7 +4,10 @@ import {
   buildAxisSignals,
   computeFomoScore,
   discoveryWhy,
+  eligibleUniverse,
+  hasDisplayWhyEvent,
   hasPublicMaterialEvent,
+  investorNetStreak,
   rankDiscoveryCandidates,
   resolveStock,
   sectorOf,
@@ -18,9 +21,11 @@ import {
   type MultiAxisHookSelection,
   type SectorStock,
   type StockCountry,
+  type StockSector,
 } from "@fomo/core";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
+import { readSupplyDemandHistory } from "./supply-demand-store";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -74,6 +79,15 @@ interface RawNaverStock {
   compareToPreviousPrice?: { code?: string; text?: string; name?: string };
   accumulatedTradingValue?: string;
   accumulatedTradingVolume?: string;
+}
+
+interface ThemeMoveSignal {
+  sector: StockSector;
+  rank: number;
+  peerCount: number;
+  averageChangePct: number;
+  relativeChangePct: number;
+  positiveCount: number;
 }
 
 function todayKst(): string {
@@ -184,11 +198,94 @@ function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string
   };
 }
 
+function buildThemeMoveSignals(rows: readonly NaverMarketRow[]): Map<string, ThemeMoveSignal> {
+  const groups = new Map<StockSector, Array<{ ticker: string; changePct: number }>>();
+  for (const row of rows) {
+    const sector = sectorOf(row.canonical);
+    if (!sector || typeof row.changePct !== "number") continue;
+    const current = groups.get(sector) ?? [];
+    current.push({ ticker: row.canonical, changePct: row.changePct });
+    groups.set(sector, current);
+  }
+
+  const out = new Map<string, ThemeMoveSignal>();
+  for (const [sector, peers] of groups) {
+    if (peers.length < 3) continue;
+    const avg = peers.reduce((sum, peer) => sum + peer.changePct, 0) / peers.length;
+    const positiveCount = peers.filter((peer) => peer.changePct > 0).length;
+    const sorted = [...peers].sort((a, b) => b.changePct - a.changePct || a.ticker.localeCompare(b.ticker));
+    sorted.forEach((peer, index) => {
+      out.set(peer.ticker, {
+        sector,
+        rank: index + 1,
+        peerCount: sorted.length,
+        averageChangePct: Math.round(avg * 10) / 10,
+        relativeChangePct: Math.round((peer.changePct - avg) * 10) / 10,
+        positiveCount,
+      });
+    });
+  }
+  return out;
+}
+
+function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
+  if (!theme || typeof row.changePct !== "number" || row.changePct <= 0) return null;
+  const strongTheme = theme.averageChangePct >= 1.5 && theme.positiveCount >= 2;
+  const leadingTheme = theme.rank <= 3 && row.changePct >= 5;
+  if (!strongTheme && !leadingTheme) return null;
+  return {
+    kind: "theme_link",
+    firstSeen: true,
+    strength: Math.min(0.92, 0.48 + Math.max(0, theme.averageChangePct) / 10 + Math.max(0, row.changePct) / 40),
+    source: "FOMO 섹터맵·네이버 시세",
+    asOf,
+    confidence: "M",
+    label: `오늘 ${theme.sector} 흐름이 셌고, 이 종목이 거기 묶여 있어요.`,
+  };
+}
+
+async function eventFromFlow(ticker: string): Promise<DiscoveryEvent | null> {
+  if (!process.env.DATABASE_URL) return null;
+  const history = await readSupplyDemandHistory(ticker, 10);
+  if (history.length === 0) return null;
+  const streak = investorNetStreak(history);
+  const useForeign = Math.abs(streak.foreign) >= Math.abs(streak.institution);
+  const n = useForeign ? streak.foreign : streak.institution;
+  if (n < 2) return null;
+  const actor = useForeign ? "외국인이" : "기관이";
+  return {
+    kind: "flow_entry",
+    firstSeen: true,
+    strength: Math.min(1, 0.52 + n / 10),
+    source: "KRX 수급",
+    asOf: history[0]?.date ?? todayKst(),
+    confidence: "H",
+    label: `${actor} ${n}일째 사는 중이에요.`,
+  };
+}
+
+function eventAxisSignal(event: DiscoveryEvent): AxisSignal | null {
+  if (event.kind !== "theme_link" && event.kind !== "flow_entry" && event.kind !== "disclosure") return null;
+  const axis = event.kind === "theme_link" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
+  const sourceKind = event.kind === "theme_link" ? "market" : "official";
+  const hookText = event.label?.trim();
+  if (!hookText) return null;
+  return {
+    axis,
+    fired: true,
+    strength: event.kind === "theme_link" ? Math.max(0.91, event.strength) : Math.max(0.93, event.strength),
+    rarity: 0,
+    hookText,
+    evidence: [{ text: hookText, sourceKind, source: event.source, asOf: event.asOf }],
+  };
+}
+
 function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): DiscoveryStockPayload {
   const def = resolveStock(candidate.ticker);
   const sector = def ? sectorOf(def.canonical) : undefined;
   const why = discoveryWhy(candidate);
   const hasMaterial = hasPublicMaterialEvent(candidate);
+  const hasDisplayWhy = hasDisplayWhyEvent(candidate);
   return {
     canonical: candidate.ticker,
     market: row.market,
@@ -196,26 +293,40 @@ function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): Disco
     naverCode: row.naverCode,
     marquee: def?.marquee === true,
     sector: sector ?? candidate.sector ?? row.market,
-    whyShown: hasMaterial
+    whyShown: hasDisplayWhy
       ? why
-      : "큰 가격 움직임은 보였지만, 연결된 공개 재료는 아직 확인되지 않았어요.",
-    ...(hasMaterial ? { reason: why } : {}),
+      : "큰 가격 움직임은 보였지만, 연결된 공개 재료는 확인 안 됨.",
+    ...(hasDisplayWhy ? { reason: why } : {}),
   };
 }
 
-function frontSeed(row: NaverMarketRow, candidate: DiscoveryCandidate, attention: StockAttentionSignal | undefined, sparkline: number[]): DiscoveryFrontSeed {
+function frontSeed(
+  row: NaverMarketRow,
+  candidate: DiscoveryCandidate,
+  attention: StockAttentionSignal | undefined,
+  theme: ThemeMoveSignal | undefined,
+  sparkline: number[]
+): DiscoveryFrontSeed {
   const signals: CardFrontSignals = {
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
     ...(attention ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore } : {}),
     ...(attention?.newsEventLabel ? { newsEventLabel: attention.newsEventLabel } : {}),
     ...(attention?.newsEventSource ? { newsEventSource: attention.newsEventSource } : {}),
+    ...(theme ? {
+      themeLabel: theme.sector,
+      themeRelativeRank: theme.rank,
+      themePeerCount: theme.peerCount,
+      themeAverageChangePct: theme.averageChangePct,
+      themeRelativeChangePct: theme.relativeChangePct,
+    } : {}),
     asOf: candidate.asOf,
   };
   const fomo = computeFomoScore({
     ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
     ...(typeof signals.mentionScore === "number" ? { mentionScore: signals.mentionScore } : {}),
   });
-  const axisSignals = buildAxisSignals({ signals });
+  const eventSignals = candidate.events.map(eventAxisSignal).filter((signal): signal is AxisSignal => signal !== null);
+  const axisSignals = [...buildAxisSignals({ signals }), ...eventSignals];
   const axisHook = selectMultiAxisHook(axisSignals);
   return {
     signals,
@@ -236,20 +347,36 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
   ]);
   const vocabByCode = new Map(STOCK_VOCAB.filter((s) => s.naverCode).map((s) => [s.naverCode!, s]));
+  const normalizedRows = rows.map((row) => {
+    const def = vocabByCode.get(row.naverCode);
+    return { ...row, canonical: def?.canonical ?? row.canonical };
+  });
+  const eligibleTickers = new Set(
+    eligibleUniverse(
+      normalizedRows.map((row) => ({
+        ticker: row.canonical,
+        ...(typeof row.tradingValue === "number" ? { avgTradingValue20d: row.tradingValue } : {}),
+      }))
+    ).map((row) => row.ticker)
+  );
+  const themeSignals = buildThemeMoveSignals(normalizedRows);
   const byTicker = new Map<string, { row: NaverMarketRow; events: DiscoveryEvent[] }>();
 
-  for (const row of rows) {
-    const def = vocabByCode.get(row.naverCode);
-    const ticker = def?.canonical ?? row.canonical;
-    const events = [eventFromPrice(row, asOf)].filter((event): event is DiscoveryEvent => event !== null);
+  for (const row of normalizedRows) {
+    const ticker = row.canonical;
+    if (!eligibleTickers.has(ticker)) continue;
+    const events = [eventFromPrice(row, asOf), eventFromTheme(row, themeSignals.get(ticker), asOf)].filter(
+      (event): event is DiscoveryEvent => event !== null
+    );
     if (events.length > 0) byTicker.set(ticker, { row: { ...row, canonical: ticker }, events });
   }
 
   for (const [ticker, attention] of Object.entries(attentionMap)) {
     const def = resolveStock(ticker);
     if (!def?.naverCode) continue;
+    if (!eligibleTickers.has(def.canonical)) continue;
     const row =
-      rows.find((r) => r.naverCode === def.naverCode) ??
+      normalizedRows.find((r) => r.naverCode === def.naverCode) ??
       ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow);
     const event = eventFromNews(attention, asOf);
     if (!event) continue;
@@ -257,10 +384,18 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
   }
 
+  const flowRows = await mapLimit([...byTicker.keys()], 8, async (ticker) => ({ ticker, event: await eventFromFlow(ticker) }));
+  for (const result of flowRows) {
+    if (result.status !== "fulfilled" || !result.value.event) continue;
+    const current = byTicker.get(result.value.ticker);
+    if (!current) continue;
+    byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
+  }
+
   const candidates = [...byTicker.entries()].map(([ticker, { row, events }]): DiscoveryCandidate => {
     const def = resolveStock(ticker);
     const sector = sectorOf(ticker);
-    const reason = events.find((event) => event.label)?.label;
+    const reason = discoveryWhy({ ticker, market: row.market, events, asOf });
     return {
       ticker,
       market: row.market,
@@ -269,7 +404,7 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
       ...(sector ? { sector } : {}),
       events,
       asOf,
-      ...(reason ? { reason } : {}),
+      ...(hasDisplayWhyEvent({ ticker, market: row.market, events, asOf }) ? { reason } : {}),
       marquee: def?.marquee === true,
     };
   });
@@ -297,7 +432,7 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     if (!row) continue;
     const attention = attentionMap[candidate.ticker];
     stocks.push(stockPayload(row, candidate));
-    fronts[candidate.ticker] = frontSeed(row, candidate, attention, sparklineByTicker.get(candidate.ticker) ?? []);
+    fronts[candidate.ticker] = frontSeed(row, candidate, attention, themeSignals.get(candidate.ticker), sparklineByTicker.get(candidate.ticker) ?? []);
   }
   const raritySets = applyAxisRarity(stocks.map((stock) => fronts[stock.canonical]?.axisSignals ?? []));
   stocks.forEach((stock, index) => {

--- a/apps/web/lib/stock-signal-coverage.ts
+++ b/apps/web/lib/stock-signal-coverage.ts
@@ -56,7 +56,7 @@ function codeToCanonical(): Map<string, string> {
 }
 
 const NEWS_EVENT_NOISE =
-  /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
+  /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
 
 function cleanNewsEventTitle(title: string): string | undefined {
   const cleaned = title

--- a/docs/WO-05.2_SPIKE_WHY_REINFORCEMENT.md
+++ b/docs/WO-05.2_SPIKE_WHY_REINFORCEMENT.md
@@ -1,0 +1,36 @@
+# WO-05.2 Spike WHY Reinforcement
+
+Status: Stage A implemented, Stage C opportunistic flow hook wired when supply DB is available.
+
+## Decisions
+
+- Top WHY-required band: 30 cards.
+- Weak no-WHY minimum strength: 0.85.
+- If there are fewer than 30 cards with a real WHY, the deck stays shorter instead of padding with price-only cards.
+- `price_move` and `volume_spike` without a public/contextual WHY are weak tail only, never top-band material.
+
+## Implemented
+
+- Added discovery event kinds: `disclosure`, `theme_link`.
+- Added WHY priority: disclosure > news mention > flow entry > theme link > price/volume fallback.
+- Added tiered rank boosts:
+  - material: disclosure, news mention, flow entry, new high.
+  - contextual: theme link.
+  - weak: price move, volume spike without WHY.
+- Discovery harvest now joins positive spike candidates to the existing FOMO sector map and same-day peer movement.
+- Discovery harvest reads supply streak only when `DATABASE_URL` is present; otherwise it fails closed without noisy DB calls.
+- Discovery front seeds include event-backed axis signals so the card headline can use the same WHY instead of reverting to price-only copy.
+- Liquidity floor is active using available trading value as the current baseline proxy.
+
+## Still Open
+
+- Stage B: DART disclosure list ingestion. Requires DART source/key decision and cache policy.
+- Stage D: reverse stock-specific news matching beyond the already-loaded corpus, with strict request caps.
+- Full KRX risk flag feed for managed/warning/halted/short-term-overheat names.
+
+## Guardrails
+
+- No causal wording. Use co-occurrence wording such as "흐름이 셌고, 이 종목이 거기 묶여 있어요."
+- No buy/sell/target/prediction language.
+- No community source as evidence.
+- If no WHY is found, say it honestly and demote/drop.

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  DISCOVERY_TOP_BAND_WHY_REQUIRED,
   discoveryWhy,
   eligibleUniverse,
   rankDiscoveryCandidates,
+  type DiscoveryEventKind,
   type DiscoveryCandidate,
 } from "../src";
 
 const asOf = "2026-06-24";
 
-function candidate(ticker: string, strength: number, kind: "price_move" | "news_mention" = "price_move"): DiscoveryCandidate {
+function candidate(ticker: string, strength: number, kind: DiscoveryEventKind = "price_move", label?: string): DiscoveryCandidate {
   return {
     ticker,
     market: "KOSPI",
@@ -20,7 +22,7 @@ function candidate(ticker: string, strength: number, kind: "price_move" | "news_
         source: kind === "news_mention" ? "뉴스" : "네이버 시세",
         asOf,
         confidence: "H",
-        ...(kind === "news_mention" ? { label: "신규 공급계약 공시" } : {}),
+        ...(label ?? kind === "news_mention" ? { label: label ?? "신규 공급계약 공시" } : {}),
       },
     ],
     asOf,
@@ -47,7 +49,7 @@ describe("WO-05 discovery supply engine", () => {
       candidate("뉴스", 0.55, "news_mention"),
     ]);
 
-    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스", "가격만"]);
+    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스"]);
   });
 
   it("applies seen decay but keeps watched stocks exempt", () => {
@@ -60,5 +62,52 @@ describe("WO-05 discovery supply engine", () => {
   it("labels weak price-only material honestly instead of inventing a catalyst", () => {
     expect(discoveryWhy(candidate("가격만", 0.8))).toContain("뚜렷한 공개 재료는 확인 안 됨");
     expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
+  });
+
+  it("selects WHY by source strength order before raw numeric strength", () => {
+    const row: DiscoveryCandidate = {
+      ticker: "동시보유",
+      market: "KOSPI",
+      asOf,
+      events: [
+        { kind: "price_move", firstSeen: true, strength: 1, source: "가격", asOf, confidence: "H", label: "오늘 가격이 +20.00% 움직였어요." },
+        { kind: "theme_link", firstSeen: true, strength: 0.7, source: "섹터맵", asOf, confidence: "M", label: "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요." },
+        { kind: "flow_entry", firstSeen: true, strength: 0.55, source: "KRX 수급", asOf, confidence: "H", label: "외국인이 2일째 사는 중이에요." },
+        { kind: "news_mention", firstSeen: true, strength: 0.45, source: "뉴스", asOf, confidence: "H", label: "단독 기사" },
+        { kind: "disclosure", firstSeen: true, strength: 0.35, source: "DART", asOf, confidence: "H", label: "공급계약" },
+      ],
+    };
+
+    expect(discoveryWhy(row)).toContain("공급계약");
+  });
+
+  it("ranks contextual theme links above price-only spikes but below material events", () => {
+    const ranked = rankDiscoveryCandidates([
+      candidate("가격만강함", 1, "price_move"),
+      candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요."),
+      candidate("수급", 0.5, "flow_entry", "기관이 3일째 사는 중이에요."),
+    ]);
+
+    expect(ranked.map((c) => c.ticker)).toEqual(["수급", "테마"]);
+  });
+
+  it("keeps the top WHY-required band free of no-why weak padding", () => {
+    const whyRows = Array.from({ length: DISCOVERY_TOP_BAND_WHY_REQUIRED - 1 }, (_, index) =>
+      candidate(`테마${index}`, 0.55, "theme_link", "오늘 AI 흐름이 셌고, 이 종목이 거기 묶여 있어요.")
+    );
+    const ranked = rankDiscoveryCandidates([...whyRows, candidate("가격만강함", 1, "price_move")], { maxCandidates: 100 });
+
+    expect(ranked).toHaveLength(DISCOVERY_TOP_BAND_WHY_REQUIRED - 1);
+    expect(ranked.some((row) => row.ticker === "가격만강함")).toBe(false);
+  });
+
+  it("allows a weak tail only after the WHY-required band is already filled", () => {
+    const whyRows = Array.from({ length: DISCOVERY_TOP_BAND_WHY_REQUIRED }, (_, index) =>
+      candidate(`테마${index}`, 0.55, "theme_link", "오늘 AI 흐름이 셌고, 이 종목이 거기 묶여 있어요.")
+    );
+    const ranked = rankDiscoveryCandidates([...whyRows, candidate("가격만강함", 1, "price_move")], { maxCandidates: 100 });
+
+    expect(ranked).toHaveLength(DISCOVERY_TOP_BAND_WHY_REQUIRED + 1);
+    expect(ranked.at(-1)?.ticker).toBe("가격만강함");
   });
 });

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -7,7 +7,9 @@ export type DiscoveryEventKind =
   | "new_high"
   | "volume_spike"
   | "flow_entry"
-  | "news_mention";
+  | "news_mention"
+  | "disclosure"
+  | "theme_link";
 
 export interface DiscoveryEvent {
   kind: DiscoveryEventKind;
@@ -55,6 +57,8 @@ export interface RankDiscoveryOptions {
 export const DISCOVERY_MAX_CANDIDATES = 100;
 export const DISCOVERY_LIQUIDITY_MEDIAN_RATIO_CUT = 0.1;
 export const DISCOVERY_SEEN_DECAY_DAYS = 3;
+export const DISCOVERY_TOP_BAND_WHY_REQUIRED = 30;
+export const DISCOVERY_WEAK_MIN_STRENGTH = 0.85;
 
 const RISK_FLAG_PATTERN = /관리|투자경고|투자위험|거래정지|단기과열|이상급등/;
 
@@ -87,22 +91,50 @@ export function eligibleUniverse(
 }
 
 export function hasPublicMaterialEvent(candidate: DiscoveryCandidate): boolean {
-  return candidate.events.some((event) => event.kind === "news_mention" || event.kind === "flow_entry" || event.kind === "new_high");
+  return candidate.events.some((event) =>
+    event.kind === "disclosure" || event.kind === "news_mention" || event.kind === "flow_entry" || event.kind === "new_high"
+  );
+}
+
+export function hasContextualWhyEvent(candidate: DiscoveryCandidate): boolean {
+  return candidate.events.some((event) => event.kind === "theme_link");
+}
+
+export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
+  return hasPublicMaterialEvent(candidate) || hasContextualWhyEvent(candidate);
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
-  return !hasPublicMaterialEvent(candidate) && candidate.events.every((event) => event.kind === "price_move" || event.kind === "volume_spike");
+  return !hasDisplayWhyEvent(candidate) && candidate.events.every((event) => event.kind === "price_move" || event.kind === "volume_spike");
 }
 
+const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
+  disclosure: 0,
+  news_mention: 1,
+  flow_entry: 2,
+  theme_link: 3,
+  new_high: 4,
+  volume_spike: 5,
+  price_move: 6,
+};
+
 export function discoveryWhy(candidate: DiscoveryCandidate): string {
-  const strongest = [...candidate.events].sort((a, b) => b.strength - a.strength || a.kind.localeCompare(b.kind))[0];
+  const strongest = [...candidate.events].sort(
+    (a, b) => WHY_KIND_PRIORITY[a.kind] - WHY_KIND_PRIORITY[b.kind] || b.strength - a.strength || a.kind.localeCompare(b.kind)
+  )[0];
   if (!strongest) return "오늘 확인된 사건이 아직 없어요.";
+  if (strongest.kind === "disclosure") {
+    return strongest.label
+      ? `오늘 공시가 확인됐어요: ${strongest.label}`
+      : "오늘 이 종목의 공시가 확인됐어요.";
+  }
   if (strongest.kind === "news_mention") {
     return strongest.label
       ? `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
       : "오늘 이 종목을 직접 언급한 뉴스가 있어요.";
   }
   if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";
+  if (strongest.kind === "theme_link") return strongest.label ?? "오늘 강한 테마 흐름에 같이 묶여 있어요.";
   if (strongest.kind === "new_high") return strongest.label ?? "새로운 가격 위치가 확인된 종목이에요.";
   if (strongest.kind === "volume_spike") {
     return strongest.label ?? "오늘 거래량 급증, 뚜렷한 공개 재료는 확인 안 됨.";
@@ -117,7 +149,7 @@ function freshnessBoost(candidate: DiscoveryCandidate): number {
 function eventScore(candidate: DiscoveryCandidate): number {
   const maxStrength = Math.max(0, ...candidate.events.map((event) => clamp01(event.strength)));
   const diversity = new Set(candidate.events.map((event) => event.kind)).size;
-  const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : -0.25;
+  const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : hasContextualWhyEvent(candidate) ? 0.08 : -0.25;
   return maxStrength + freshnessBoost(candidate) + Math.min(0.12, diversity * 0.03) + materialBoost;
 }
 
@@ -135,8 +167,9 @@ export function rankDiscoveryCandidates(
 ): DiscoveryCandidate[] {
   const max = opts.maxCandidates ?? DISCOVERY_MAX_CANDIDATES;
   const watched = new Set(opts.watched ?? []);
-  return candidates
+  const ranked = candidates
     .filter((candidate) => candidate.events.length > 0)
+    .filter((candidate) => !isWeakDiscoveryCandidate(candidate) || Math.max(0, ...candidate.events.map((event) => event.strength)) >= DISCOVERY_WEAK_MIN_STRENGTH)
     .map((candidate, index) => ({
       candidate,
       index,
@@ -149,6 +182,9 @@ export function rankDiscoveryCandidates(
         a.index - b.index ||
         a.candidate.ticker.localeCompare(b.candidate.ticker)
     )
-    .slice(0, max)
     .map((row) => row.candidate);
+  const withWhy = ranked.filter((candidate) => !isWeakDiscoveryCandidate(candidate));
+  const weakTail = ranked.filter((candidate) => isWeakDiscoveryCandidate(candidate));
+  const ordered = withWhy.length >= DISCOVERY_TOP_BAND_WHY_REQUIRED ? [...withWhy, ...weakTail] : withWhy;
+  return ordered.slice(0, max);
 }


### PR DESCRIPTION
## Summary
- add WO-05.2 discovery WHY tiers: disclosure/news/flow/theme/contextual vs weak price-only events
- join spike candidates to existing sector movement to create theme_link WHY without new source cost
- wire optional supply streak flow_entry when DATABASE_URL is available, fail-closed otherwise
- demote/drop no-WHY price-only cards: top 30 require real WHY, no padding to 100 if real cards are fewer
- align discovery front axis hooks with event-backed WHY so card headlines do not fall back to price-only copy

## Decisions
- top WHY-required band: 30 cards
- weak no-WHY threshold: 0.85 strength
- Stage A shipped now; DART disclosure and capped reverse news fetch remain follow-up

## Local sample
- buildDiscoveryResponse returned 22 real cards in local sample, confidence M
- first 12 sampled cards all had non-empty reason/whyShown
- no local DB noise when DATABASE_URL is absent

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run lint
- npm run build