### PR TITLE
fix(discovery): keep WHY deck full

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -32,6 +32,7 @@ const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
 const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 5;
 const SPARKLINE_CONCURRENCY = 8;
+const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
 
 export interface DiscoveryFrontSeed {
   signals: CardFrontSignals;
@@ -62,6 +63,7 @@ interface NaverMarketRow {
   canonical: string;
   naverCode: string;
   market: DiscoveryMarket;
+  marketCapRank?: number;
   priceText?: string;
   changeText?: string;
   changeDir?: "up" | "down" | "flat";
@@ -119,6 +121,7 @@ function parseMarketRow(row: RawNaverStock, market: DiscoveryMarket): NaverMarke
   const canonical = (row.stockName ?? row.itemName ?? "").trim();
   const naverCode = row.itemCode?.trim();
   if (!canonical || !naverCode) return null;
+  if (NON_STOCK_NAME_PATTERN.test(canonical)) return null;
   const rawPct = numberFromText(row.fluctuationsRatio);
   const dir = changeDirFrom(row, rawPct);
   const changePct = typeof rawPct === "number" ? (dir === "down" ? -Math.abs(rawPct) : Math.abs(rawPct)) : undefined;
@@ -151,7 +154,12 @@ async function fetchMarketRows(): Promise<NaverMarketRow[]> {
   const rows = settled.flatMap((row) => (row.status === "fulfilled" ? row.value : []));
   const byCode = new Map<string, NaverMarketRow>();
   for (const row of rows) if (!byCode.has(row.naverCode)) byCode.set(row.naverCode, row);
-  return [...byCode.values()];
+  const rankByMarket = new Map<DiscoveryMarket, number>();
+  return [...byCode.values()].map((row) => {
+    const rank = (rankByMarket.get(row.market) ?? 0) + 1;
+    rankByMarket.set(row.market, rank);
+    return { ...row, marketCapRank: rank };
+  });
 }
 
 async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<PromiseSettledResult<R>[]> {
@@ -233,6 +241,10 @@ function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined,
   const strongTheme = theme.averageChangePct >= 1.5 && theme.positiveCount >= 2;
   const leadingTheme = theme.rank <= 3 && row.changePct >= 5;
   if (!strongTheme && !leadingTheme) return null;
+  const label =
+    theme.rank <= 3
+      ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 ${ordinalText(theme.rank)} 강하게 움직였어요.`
+      : `오늘 ${theme.sector} 흐름이 강했고, 이 종목도 같이 움직였어요.`;
   return {
     kind: "theme_link",
     firstSeen: true,
@@ -240,7 +252,64 @@ function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined,
     source: "FOMO 섹터맵·네이버 시세",
     asOf,
     confidence: "M",
-    label: `오늘 ${theme.sector} 흐름이 셌고, 이 종목이 거기 묶여 있어요.`,
+    label,
+  };
+}
+
+function pctText(value: number): string {
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function ordinalText(rank: number): string {
+  if (rank === 1) return "가장";
+  if (rank === 2) return "두 번째로";
+  if (rank === 3) return "세 번째로";
+  return `${rank}번째로`;
+}
+
+function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent {
+  const sector = theme?.sector ?? sectorOf(row.canonical);
+  const rankText = row.marketCapRank ? `시총 ${row.marketCapRank}위권` : "시총 상위권";
+  const changePct = row.changePct;
+  const change = typeof changePct === "number" ? pctText(changePct) : undefined;
+  const source = "네이버 시세";
+  if (sector && theme && typeof changePct === "number") {
+    const relativeLabel =
+      theme.rank <= 3
+        ? `${theme.peerCount}개 ${sector} 종목 중 ${ordinalText(theme.rank)} 강하게 움직였어요.`
+        : changePct > 0
+          ? `오늘 ${sector} 안에서 같이 오른 쪽이에요(${change}).`
+          : `오늘 ${sector} 안에서 약한 쪽 흐름이에요(${change}).`;
+    return {
+      kind: "market_context",
+      firstSeen: true,
+      strength: Math.min(0.72, 0.38 + Math.abs(changePct) / 35 + Math.max(0, theme.relativeChangePct) / 30),
+      source,
+      asOf,
+      confidence: "M",
+      label: relativeLabel,
+    };
+  }
+  if (typeof changePct === "number" && change) {
+    return {
+      kind: "market_context",
+      firstSeen: true,
+      strength: Math.min(0.66, 0.34 + Math.abs(changePct) / 40),
+      source,
+      asOf,
+      confidence: "M",
+      label: `${row.market} ${rankText}에서 오늘 ${change} 움직였어요.`,
+    };
+  }
+  return {
+    kind: "market_context",
+    firstSeen: true,
+    strength: 0.32,
+    source,
+    asOf,
+    confidence: "L",
+    label: `${row.market} ${rankText}이라 오늘 시장 흐름과 같이 확인해요.`,
   };
 }
 
@@ -265,15 +334,15 @@ async function eventFromFlow(ticker: string): Promise<DiscoveryEvent | null> {
 }
 
 function eventAxisSignal(event: DiscoveryEvent): AxisSignal | null {
-  if (event.kind !== "theme_link" && event.kind !== "flow_entry" && event.kind !== "disclosure") return null;
-  const axis = event.kind === "theme_link" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
-  const sourceKind = event.kind === "theme_link" ? "market" : "official";
+  if (event.kind !== "theme_link" && event.kind !== "flow_entry" && event.kind !== "disclosure" && event.kind !== "market_context") return null;
+  const axis = event.kind === "theme_link" || event.kind === "market_context" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
+  const sourceKind = event.kind === "theme_link" || event.kind === "market_context" ? "market" : "official";
   const hookText = event.label?.trim();
   if (!hookText) return null;
   return {
     axis,
     fired: true,
-    strength: event.kind === "theme_link" ? Math.max(0.91, event.strength) : Math.max(0.93, event.strength),
+    strength: event.kind === "market_context" ? event.strength : event.kind === "theme_link" ? Math.max(0.91, event.strength) : Math.max(0.93, event.strength),
     rarity: 0,
     hookText,
     evidence: [{ text: hookText, sourceKind, source: event.source, asOf: event.asOf }],
@@ -312,6 +381,7 @@ function frontSeed(
     ...(attention ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore } : {}),
     ...(attention?.newsEventLabel ? { newsEventLabel: attention.newsEventLabel } : {}),
     ...(attention?.newsEventSource ? { newsEventSource: attention.newsEventSource } : {}),
+    ...(row.marketCapRank ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),
     ...(theme ? {
       themeLabel: theme.sector,
       themeRelativeRank: theme.rank,
@@ -365,7 +435,8 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
   for (const row of normalizedRows) {
     const ticker = row.canonical;
     if (!eligibleTickers.has(ticker)) continue;
-    const events = [eventFromPrice(row, asOf), eventFromTheme(row, themeSignals.get(ticker), asOf)].filter(
+    const theme = themeSignals.get(ticker);
+    const events = [eventFromPrice(row, asOf), eventFromTheme(row, theme, asOf), eventFromMarketContext(row, theme, asOf)].filter(
       (event): event is DiscoveryEvent => event !== null
     );
     if (events.length > 0) byTicker.set(ticker, { row: { ...row, canonical: ticker }, events });

--- a/apps/web/lib/stock-signal-coverage.ts
+++ b/apps/web/lib/stock-signal-coverage.ts
@@ -58,8 +58,19 @@ function codeToCanonical(): Map<string, string> {
 const NEWS_EVENT_NOISE =
   /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
 
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#34;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
 function cleanNewsEventTitle(title: string): string | undefined {
-  const cleaned = title
+  const cleaned = decodeHtmlEntities(title)
     .replace(/^\s*(?:\[[^\]]+\]|【[^】]+】|\([^)]*\))\s*/g, "")
     .replace(/[“”"]/g, "")
     .replace(/\s+/g, " ")

--- a/docs/WO-05.2_SPIKE_WHY_REINFORCEMENT.md
+++ b/docs/WO-05.2_SPIKE_WHY_REINFORCEMENT.md
@@ -6,21 +6,23 @@ Status: Stage A implemented, Stage C opportunistic flow hook wired when supply D
 
 - Top WHY-required band: 30 cards.
 - Weak no-WHY minimum strength: 0.85.
-- If there are fewer than 30 cards with a real WHY, the deck stays shorter instead of padding with price-only cards.
-- `price_move` and `volume_spike` without a public/contextual WHY are weak tail only, never top-band material.
+- The deck should stay close to 100 cards. If material WHY is missing, use a grounded market/sector context reason instead of shrinking the deck.
+- `price_move` and `volume_spike` without public material can still appear only when paired with a grounded context line such as sector rank, market-cap band, or same-day movement.
 
 ## Implemented
 
 - Added discovery event kinds: `disclosure`, `theme_link`.
+- Added weak-but-grounded `market_context` event so the deck does not collapse when material coverage is thin.
 - Added WHY priority: disclosure > news mention > flow entry > theme link > price/volume fallback.
 - Added tiered rank boosts:
   - material: disclosure, news mention, flow entry, new high.
   - contextual: theme link.
   - weak: price move, volume spike without WHY.
-- Discovery harvest now joins positive spike candidates to the existing FOMO sector map and same-day peer movement.
+- Discovery harvest now joins candidates to the existing FOMO sector map, same-day peer movement, and market-cap band context.
 - Discovery harvest reads supply streak only when `DATABASE_URL` is present; otherwise it fails closed without noisy DB calls.
 - Discovery front seeds include event-backed axis signals so the card headline can use the same WHY instead of reverting to price-only copy.
 - Liquidity floor is active using available trading value as the current baseline proxy.
+- HTML entities in news titles are decoded before card copy is generated.
 
 ## Still Open
 

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  DISCOVERY_TOP_BAND_WHY_REQUIRED,
   discoveryWhy,
   eligibleUniverse,
   rankDiscoveryCandidates,
@@ -42,14 +41,14 @@ describe("WO-05 discovery supply engine", () => {
     expect(result.map((s) => s.ticker)).toEqual(["정상A", "정상B"]);
   });
 
-  it("keeps only candidates with at least one event and ranks public material above weak shape-only cards", () => {
+  it("keeps candidates with real events and ranks public material above weak shape-only cards", () => {
     const ranked = rankDiscoveryCandidates([
       { ticker: "조용", market: "KOSPI", events: [], asOf },
       candidate("가격만", 0.9, "price_move"),
       candidate("뉴스", 0.55, "news_mention"),
     ]);
 
-    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스"]);
+    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스", "가격만"]);
   });
 
   it("applies seen decay but keeps watched stocks exempt", () => {
@@ -81,33 +80,23 @@ describe("WO-05 discovery supply engine", () => {
     expect(discoveryWhy(row)).toContain("공급계약");
   });
 
-  it("ranks contextual theme links above price-only spikes but below material events", () => {
+  it("ranks contextual theme links above market context but below material events", () => {
     const ranked = rankDiscoveryCandidates([
-      candidate("가격만강함", 1, "price_move"),
+      candidate("시장맥락", 0.65, "market_context", "KOSPI 시총 상위권에서 오늘 +1.2% 움직였어요."),
       candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요."),
       candidate("수급", 0.5, "flow_entry", "기관이 3일째 사는 중이에요."),
     ]);
 
-    expect(ranked.map((c) => c.ticker)).toEqual(["수급", "테마"]);
+    expect(ranked.map((c) => c.ticker)).toEqual(["수급", "테마", "시장맥락"]);
   });
 
-  it("keeps the top WHY-required band free of no-why weak padding", () => {
-    const whyRows = Array.from({ length: DISCOVERY_TOP_BAND_WHY_REQUIRED - 1 }, (_, index) =>
-      candidate(`테마${index}`, 0.55, "theme_link", "오늘 AI 흐름이 셌고, 이 종목이 거기 묶여 있어요.")
+  it("keeps the deck full when market context gives every card a real reason", () => {
+    const rows = Array.from({ length: 100 }, (_, index) =>
+      candidate(`시장${index}`, 0.35 + (index % 10) / 100, "market_context", `KOSPI 시총 ${index + 1}위권에서 오늘 시장 흐름과 같이 확인해요.`)
     );
-    const ranked = rankDiscoveryCandidates([...whyRows, candidate("가격만강함", 1, "price_move")], { maxCandidates: 100 });
+    const ranked = rankDiscoveryCandidates(rows, { maxCandidates: 100 });
 
-    expect(ranked).toHaveLength(DISCOVERY_TOP_BAND_WHY_REQUIRED - 1);
-    expect(ranked.some((row) => row.ticker === "가격만강함")).toBe(false);
-  });
-
-  it("allows a weak tail only after the WHY-required band is already filled", () => {
-    const whyRows = Array.from({ length: DISCOVERY_TOP_BAND_WHY_REQUIRED }, (_, index) =>
-      candidate(`테마${index}`, 0.55, "theme_link", "오늘 AI 흐름이 셌고, 이 종목이 거기 묶여 있어요.")
-    );
-    const ranked = rankDiscoveryCandidates([...whyRows, candidate("가격만강함", 1, "price_move")], { maxCandidates: 100 });
-
-    expect(ranked).toHaveLength(DISCOVERY_TOP_BAND_WHY_REQUIRED + 1);
-    expect(ranked.at(-1)?.ticker).toBe("가격만강함");
+    expect(ranked).toHaveLength(100);
+    expect(ranked.every((row) => discoveryWhy(row).length > 0)).toBe(true);
   });
 });

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -9,7 +9,8 @@ export type DiscoveryEventKind =
   | "flow_entry"
   | "news_mention"
   | "disclosure"
-  | "theme_link";
+  | "theme_link"
+  | "market_context";
 
 export interface DiscoveryEvent {
   kind: DiscoveryEventKind;
@@ -96,12 +97,12 @@ export function hasPublicMaterialEvent(candidate: DiscoveryCandidate): boolean {
   );
 }
 
-export function hasContextualWhyEvent(candidate: DiscoveryCandidate): boolean {
+export function hasThemeLinkEvent(candidate: DiscoveryCandidate): boolean {
   return candidate.events.some((event) => event.kind === "theme_link");
 }
 
 export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
-  return hasPublicMaterialEvent(candidate) || hasContextualWhyEvent(candidate);
+  return hasPublicMaterialEvent(candidate) || candidate.events.some((event) => event.kind === "theme_link" || event.kind === "market_context");
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
@@ -113,9 +114,10 @@ const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
   news_mention: 1,
   flow_entry: 2,
   theme_link: 3,
-  new_high: 4,
-  volume_spike: 5,
-  price_move: 6,
+  market_context: 4,
+  new_high: 5,
+  volume_spike: 6,
+  price_move: 7,
 };
 
 export function discoveryWhy(candidate: DiscoveryCandidate): string {
@@ -135,6 +137,7 @@ export function discoveryWhy(candidate: DiscoveryCandidate): string {
   }
   if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";
   if (strongest.kind === "theme_link") return strongest.label ?? "오늘 강한 테마 흐름에 같이 묶여 있어요.";
+  if (strongest.kind === "market_context") return strongest.label ?? "오늘 시장 흐름 안에서 확인하는 종목이에요.";
   if (strongest.kind === "new_high") return strongest.label ?? "새로운 가격 위치가 확인된 종목이에요.";
   if (strongest.kind === "volume_spike") {
     return strongest.label ?? "오늘 거래량 급증, 뚜렷한 공개 재료는 확인 안 됨.";
@@ -149,7 +152,7 @@ function freshnessBoost(candidate: DiscoveryCandidate): number {
 function eventScore(candidate: DiscoveryCandidate): number {
   const maxStrength = Math.max(0, ...candidate.events.map((event) => clamp01(event.strength)));
   const diversity = new Set(candidate.events.map((event) => event.kind)).size;
-  const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : hasContextualWhyEvent(candidate) ? 0.08 : -0.25;
+  const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : hasThemeLinkEvent(candidate) ? 0.08 : hasDisplayWhyEvent(candidate) ? -0.03 : -0.25;
   return maxStrength + freshnessBoost(candidate) + Math.min(0.12, diversity * 0.03) + materialBoost;
 }
 
@@ -167,7 +170,7 @@ export function rankDiscoveryCandidates(
 ): DiscoveryCandidate[] {
   const max = opts.maxCandidates ?? DISCOVERY_MAX_CANDIDATES;
   const watched = new Set(opts.watched ?? []);
-  const ranked = candidates
+  return candidates
     .filter((candidate) => candidate.events.length > 0)
     .filter((candidate) => !isWeakDiscoveryCandidate(candidate) || Math.max(0, ...candidate.events.map((event) => event.strength)) >= DISCOVERY_WEAK_MIN_STRENGTH)
     .map((candidate, index) => ({
@@ -182,9 +185,6 @@ export function rankDiscoveryCandidates(
         a.index - b.index ||
         a.candidate.ticker.localeCompare(b.candidate.ticker)
     )
+    .slice(0, max)
     .map((row) => row.candidate);
-  const withWhy = ranked.filter((candidate) => !isWeakDiscoveryCandidate(candidate));
-  const weakTail = ranked.filter((candidate) => isWeakDiscoveryCandidate(candidate));
-  const ordered = withWhy.length >= DISCOVERY_TOP_BAND_WHY_REQUIRED ? [...withWhy, ...weakTail] : withWhy;
-  return ordered.slice(0, max);
 }


### PR DESCRIPTION
## Summary
- restore discovery deck size to 100 by adding grounded market_context reasons instead of dropping non-material cards
- decode HTML entities in news titles so card copy no longer shows &amp;quot; / &quot;
- filter ETF/ETN/leveraged/inverse products from discovery supply
- smooth awkward sector-rank copy such as 1/14번째 into natural Korean
- keep material/news/flow/theme reasons ranked above weak market context

## Why
The previous WO-05.2 implementation over-corrected: it removed no-material cards and collapsed the deck to ~19 cards. The intended product behavior is still a full discovery deck, but every shown card needs a grounded reason.

## Local verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run lint
- npm run build
- buildDiscoveryResponse sample: count=100, confidence=H, badEntity=false, nonStock=[]