### PR TITLE
feat(discovery): boost stock-specific material sources

### DIFF
--- a/apps/web/lib/dart-disclosures.ts
+++ b/apps/web/lib/dart-disclosures.ts
@@ -1,0 +1,100 @@
+import { STOCK_VOCAB, decodeHtmlEntities } from "@fomo/core";
+
+export interface DartDisclosureHit {
+  ticker: string;
+  label: string;
+  source: string;
+  asOf: string;
+}
+
+interface DartListItem {
+  stock_code?: string;
+  corp_name?: string;
+  report_nm?: string;
+  rcept_dt?: string;
+}
+
+interface DartListResponse {
+  status?: string;
+  message?: string;
+  list?: DartListItem[];
+  page_no?: number;
+  total_page?: number;
+}
+
+const DART_LIST_URL = "https://opendart.fss.or.kr/api/list.json";
+const DART_PAGE_COUNT = 100;
+const DART_MAX_PAGES = 3;
+const DART_MATERIAL_REPORT =
+  /단일판매|공급계약|수주|주요사항보고|유상증자|무상증자|자기주식|타법인|합병|분할|영업양수|영업양도|소송|조회공시|투자판단|시설투자|신규시설|특허권|임상|기술이전|라이선스/i;
+const DART_ROUTINE_REPORT =
+  /사업보고서|반기보고서|분기보고서|증권발행실적|투자설명서|첨부정정|정정신고|임원ㆍ주요주주|임원·주요주주|주식등의대량보유|최대주주등소유주식변동/i;
+
+function dartKey(): string | undefined {
+  return process.env.DART_API_KEY || process.env.DART_CRTFC_KEY;
+}
+
+function yyyymmdd(date: string): string {
+  return date.replace(/-/g, "").slice(0, 8);
+}
+
+function isoFromDartDate(date: string | undefined, fallback: string): string {
+  if (!date || !/^\d{8}$/.test(date)) return fallback;
+  return `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+}
+
+function cleanReportName(name: string | undefined): string | undefined {
+  const cleaned = decodeHtmlEntities(name ?? "")
+    .replace(/^\s*(?:\[[^\]]+\]|\([^)]*\))\s*/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned || DART_ROUTINE_REPORT.test(cleaned) || !DART_MATERIAL_REPORT.test(cleaned)) return undefined;
+  return cleaned.length > 44 ? `${cleaned.slice(0, 42).trim()}…` : cleaned;
+}
+
+async function fetchDartPage(key: string, date: string, page: number): Promise<DartListResponse | null> {
+  const url = new URL(DART_LIST_URL);
+  url.searchParams.set("crtfc_key", key);
+  url.searchParams.set("bgn_de", yyyymmdd(date));
+  url.searchParams.set("end_de", yyyymmdd(date));
+  url.searchParams.set("page_no", String(page));
+  url.searchParams.set("page_count", String(DART_PAGE_COUNT));
+  url.searchParams.set("sort", "date");
+  url.searchParams.set("sort_mth", "desc");
+  const res = await fetch(url.toString(), {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(8_000),
+    next: { revalidate: 900 },
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as DartListResponse;
+}
+
+export async function fetchDartDisclosuresByStock(asOf: string): Promise<Record<string, DartDisclosureHit>> {
+  const key = dartKey();
+  if (!key) return {};
+
+  const byCode = new Map(STOCK_VOCAB.filter((stock) => stock.naverCode).map((stock) => [stock.naverCode!, stock.canonical]));
+  const out: Record<string, DartDisclosureHit> = {};
+
+  for (let page = 1; page <= DART_MAX_PAGES; page += 1) {
+    const data = await fetchDartPage(key, asOf, page).catch(() => null);
+    if (!data?.list?.length || (data.status && data.status !== "000")) break;
+    for (const item of data.list) {
+      const code = item.stock_code?.trim();
+      const ticker = code ? byCode.get(code) : undefined;
+      if (!ticker || out[ticker]) continue;
+      const label = cleanReportName(item.report_nm);
+      if (!label) continue;
+      out[ticker] = {
+        ticker,
+        label,
+        source: "DART 공시",
+        asOf: isoFromDartDate(item.rcept_dt, asOf),
+      };
+    }
+    if (typeof data.total_page === "number" && page >= data.total_page) break;
+  }
+
+  return out;
+}

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -3,15 +3,18 @@ import {
   applyAxisRarity,
   buildAxisSignals,
   computeFomoScore,
+  decodeHtmlEntities,
   discoveryWhy,
   eligibleUniverse,
   hasDisplayWhyEvent,
   hasPublicMaterialEvent,
+  isFrontHookSafe,
   investorNetStreak,
   rankDiscoveryCandidates,
   resolveStock,
   sectorOf,
   selectMultiAxisHook,
+  stockMatchesText,
   type AxisSignal,
   type CardFrontSignals,
   type DiscoveryCandidate,
@@ -22,7 +25,10 @@ import {
   type SectorStock,
   type StockCountry,
   type StockSector,
+  type RawArticle,
 } from "@fomo/core";
+import { fetchDartDisclosuresByStock, type DartDisclosureHit } from "./dart-disclosures";
+import { fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
 import { readSupplyDemandHistory } from "./supply-demand-store";
@@ -32,7 +38,11 @@ const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
 const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 5;
 const SPARKLINE_CONCURRENCY = 8;
+const TARGETED_MATERIAL_CANDIDATE_LIMIT = 18;
+const TARGETED_MATERIAL_CONCURRENCY = 6;
 const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
+const MATERIAL_NEWS_NOISE =
+  /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
 
 export interface DiscoveryFrontSeed {
   signals: CardFrontSignals;
@@ -206,6 +216,60 @@ function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string
   };
 }
 
+function cleanMaterialTitle(title: string): string | undefined {
+  const cleaned = decodeHtmlEntities(title)
+    .replace(/^\s*(?:\[[^\]]+\]|【[^】]+】|\([^)]*\))\s*/g, "")
+    .replace(/[“”"]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?。]+$/g, "")
+    .trim();
+  if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned)) return undefined;
+  if (/[\[\]{}<>]/.test(cleaned)) return undefined;
+  const compact = cleaned.length > 46 ? `${cleaned.slice(0, 44).trim()}…` : cleaned;
+  return isFrontHookSafe(`${compact} 소식이 나왔어요.`) ? compact : undefined;
+}
+
+function isStockArticle(canonical: string, article: RawArticle): boolean {
+  return stockMatchesText(canonical, `${article.title} ${article.summary ?? ""}`);
+}
+
+function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
+  const label = cleanMaterialTitle(article.title);
+  if (!label) return null;
+  const isResearch = /리서치|증권|투자증권|자산운용|Research/i.test(`${article.source} ${article.category ?? ""}`);
+  return {
+    kind: "news_mention",
+    firstSeen: true,
+    strength: isResearch ? 0.82 : 0.88,
+    source: article.source || sourceFallback,
+    asOf: article.publishedAt?.slice(0, 10) || asOf,
+    confidence: "H",
+    label,
+  };
+}
+
+async function eventFromTargetedMaterial(row: NaverMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
+  if (!/^\d{6}$/.test(row.naverCode)) return null;
+  const [newsResult, researchResult] = await Promise.allSettled([
+    fetchNaverStockNews(row.naverCode, 8),
+    fetchNaverCompanyResearch(row.naverCode, row.canonical, 4),
+  ]);
+
+  const stockNews =
+    newsResult.status === "fulfilled"
+      ? newsResult.value.find((article) => isStockArticle(row.canonical, article))
+      : undefined;
+  if (stockNews) return materialEventFromArticle(stockNews, asOf, "네이버 종목뉴스");
+
+  const research =
+    researchResult.status === "fulfilled"
+      ? researchResult.value.find((article) => isStockArticle(row.canonical, article))
+      : undefined;
+  if (research) return materialEventFromArticle(research, asOf, "네이버 증권 리서치");
+
+  return null;
+}
+
 function buildThemeMoveSignals(rows: readonly NaverMarketRow[]): Map<string, ThemeMoveSignal> {
   const groups = new Map<StockSector, Array<{ ticker: string; changePct: number }>>();
   for (const row of rows) {
@@ -334,15 +398,34 @@ async function eventFromFlow(ticker: string): Promise<DiscoveryEvent | null> {
 }
 
 function eventAxisSignal(event: DiscoveryEvent): AxisSignal | null {
-  if (event.kind !== "theme_link" && event.kind !== "flow_entry" && event.kind !== "disclosure" && event.kind !== "market_context") return null;
-  const axis = event.kind === "theme_link" || event.kind === "market_context" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
-  const sourceKind = event.kind === "theme_link" || event.kind === "market_context" ? "market" : "official";
+  if (
+    event.kind !== "theme_link" &&
+    event.kind !== "flow_entry" &&
+    event.kind !== "disclosure" &&
+    event.kind !== "news_mention" &&
+    event.kind !== "market_context"
+  ) return null;
+  const axis =
+    event.kind === "theme_link" || event.kind === "market_context" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
+  const sourceKind =
+    event.kind === "theme_link" || event.kind === "market_context"
+      ? "market"
+      : event.kind === "news_mention"
+        ? "news"
+        : "official";
   const hookText = event.label?.trim();
   if (!hookText) return null;
   return {
     axis,
     fired: true,
-    strength: event.kind === "market_context" ? event.strength : event.kind === "theme_link" ? Math.max(0.91, event.strength) : Math.max(0.93, event.strength),
+    strength:
+      event.kind === "market_context"
+        ? event.strength
+        : event.kind === "theme_link"
+          ? Math.max(0.91, event.strength)
+          : event.kind === "news_mention"
+            ? Math.max(0.94, event.strength)
+            : Math.max(0.93, event.strength),
     rarity: 0,
     hookText,
     evidence: [{ text: hookText, sourceKind, source: event.source, asOf: event.asOf }],
@@ -455,6 +538,47 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
   }
 
+  const disclosureMap = await fetchDartDisclosuresByStock(asOf).catch((): Record<string, DartDisclosureHit> => ({}));
+  for (const [ticker, disclosure] of Object.entries(disclosureMap)) {
+    const def = resolveStock(ticker);
+    if (!def?.naverCode || !eligibleTickers.has(def.canonical)) continue;
+    const row =
+      normalizedRows.find((r) => r.naverCode === def.naverCode) ??
+      ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow);
+    const current = byTicker.get(def.canonical);
+    const event: DiscoveryEvent = {
+      kind: "disclosure",
+      firstSeen: true,
+      strength: 0.96,
+      source: disclosure.source,
+      asOf: disclosure.asOf,
+      confidence: "H",
+      label: disclosure.label,
+    };
+    byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
+  }
+
+  const targetedRows = [...byTicker.entries()]
+    .filter(([, value]) => !value.events.some((event) => event.kind === "disclosure" || event.kind === "news_mention"))
+    .sort((a, b) => {
+      const aPct = Math.abs(a[1].row.changePct ?? 0);
+      const bPct = Math.abs(b[1].row.changePct ?? 0);
+      const aHasTheme = Number(a[1].events.some((event) => event.kind === "theme_link"));
+      const bHasTheme = Number(b[1].events.some((event) => event.kind === "theme_link"));
+      return bHasTheme - aHasTheme || bPct - aPct || a[0].localeCompare(b[0]);
+    })
+    .slice(0, TARGETED_MATERIAL_CANDIDATE_LIMIT);
+  const targetedMaterial = await mapLimit(targetedRows, TARGETED_MATERIAL_CONCURRENCY, async ([ticker, value]) => ({
+    ticker,
+    event: await eventFromTargetedMaterial(value.row, asOf),
+  }));
+  for (const result of targetedMaterial) {
+    if (result.status !== "fulfilled" || !result.value.event) continue;
+    const current = byTicker.get(result.value.ticker);
+    if (!current) continue;
+    byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
+  }
+
   const flowRows = await mapLimit([...byTicker.keys()], 8, async (ticker) => ({ ticker, event: await eventFromFlow(ticker) }));
   for (const result of flowRows) {
     if (result.status !== "fulfilled" || !result.value.event) continue;
@@ -522,6 +646,6 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     stocks,
     fronts,
     confidence: stocks.length >= 30 ? "H" : stocks.length >= 10 ? "M" : "L",
-    source: "네이버 시세·뉴스 언급",
+    source: "네이버 시세·종목뉴스·리서치·DART 공시",
   };
 }

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -63,6 +63,14 @@ describe("WO-05 discovery supply engine", () => {
     expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
   });
 
+  it("names research evidence as research instead of news", () => {
+    const row = candidate("리서치", 0.7, "news_mention", "신규 설비 증설 점검");
+    row.events[0]!.source = "한화투자증권 리서치";
+
+    expect(discoveryWhy(row)).toContain("직접 다룬 리서치");
+    expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
+  });
+
   it("selects WHY by source strength order before raw numeric strength", () => {
     const row: DiscoveryCandidate = {
       ticker: "동시보유",

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -131,6 +131,12 @@ export function discoveryWhy(candidate: DiscoveryCandidate): string {
       : "오늘 이 종목의 공시가 확인됐어요.";
   }
   if (strongest.kind === "news_mention") {
+    const isResearch = /리서치|증권|투자증권|자산운용|Research/i.test(strongest.source);
+    if (isResearch) {
+      return strongest.label
+        ? `오늘 이 종목을 직접 다룬 리서치가 있어요: ${strongest.label}`
+        : "오늘 이 종목을 직접 다룬 리서치가 있어요.";
+    }
     return strongest.label
       ? `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
       : "오늘 이 종목을 직접 언급한 뉴스가 있어요.";


### PR DESCRIPTION
## Summary
- Add fail-closed DART disclosure harvesting for official material WHY when DART_API_KEY/DART_CRTFC_KEY is configured.
- Enrich top discovery candidates with targeted Naver stock news and company research, capped for cost and latency.
- Promote news/research/disclosure events into multi-axis hook candidates so card headlines surface actual material instead of falling back to price shape.
- Split research copy from news copy in discoveryWhy.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run lint
- npm run build
- Live discovery sample: count=100, confidence=H, material=31, weak=0, html entity issues=0

## Notes
- DART is fail-closed without API key; no fake disclosure data is generated.
- Targeted material lookup is capped at 18 candidates with concurrency 6 to protect response time.