### PR TITLE
fix(discovery): restore fast same-origin deck loading

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -37,9 +37,11 @@ describe("FOMO Web browser auth security", () => {
 
   it("only proxies explicitly allowed authenticated routes and methods", () => {
     expect(isAllowedProxyRequest("auth/login", "POST")).toBe(true);
+    expect(isAllowedProxyRequest("discovery", "GET")).toBe(true);
     expect(isAllowedProxyRequest("emotions/calendar", "GET")).toBe(true);
     expect(isAllowedProxyRequest("account", "DELETE")).toBe(true);
     expect(isAllowedProxyRequest("auth/login", "GET")).toBe(false);
+    expect(isAllowedProxyRequest("discovery", "POST")).toBe(false);
     expect(isAllowedProxyRequest("../runtime/state", "GET")).toBe(false);
     expect(isAllowedProxyRequest("feed", "GET")).toBe(false);
   });

--- a/apps/fomo-web/app/api/fomo/[...path]/route.ts
+++ b/apps/fomo-web/app/api/fomo/[...path]/route.ts
@@ -132,7 +132,7 @@ async function proxy(request: NextRequest, context: { params: Promise<{ path: st
   } catch (error) {
     const timedOut = error instanceof Error && error.name === "TimeoutError";
     return noStoreJson(
-      { error: timedOut ? "인증 서버 응답 시간이 초과되었습니다." : "인증 서버에 연결할 수 없습니다." },
+      { error: timedOut ? "데이터 서버 응답 시간이 초과되었습니다." : "데이터 서버에 연결할 수 없습니다." },
       { status: timedOut ? 504 : 502 }
     );
   }

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -43,7 +43,9 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
         }
         setState({ kind: "ready", stocks, fronts: discovery.fronts as Record<string, FrontEntry> });
       } catch (err) {
-        console.warn("[TodayDiscoveryDeck] fetch failed", err);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[TodayDiscoveryDeck] fetch failed", err);
+        }
         if (alive) setState({ kind: "error" });
       }
     })();

--- a/apps/fomo-web/lib/auth-proxy.ts
+++ b/apps/fomo-web/lib/auth-proxy.ts
@@ -6,6 +6,7 @@ const ALLOWED_PROXY_REQUESTS = new Map<string, ReadonlySet<string>>([
   ["auth/register", new Set(["POST"])],
   ["auth/logout", new Set(["POST"])],
   ["auth/session", new Set(["GET"])],
+  ["discovery", new Set(["GET"])],
   ["emotions/calendar", new Set(["GET"])],
   ["emotions/link", new Set(["POST"])],
   ["emotions/vote", new Set(["POST"])],

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -65,6 +65,12 @@ async function get<T>(path: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+async function getSameOrigin<T>(path: string): Promise<T> {
+  const res = await fetch(path, { cache: "no-store", credentials: "same-origin" });
+  if (!res.ok) throw new Error(`GET ${path} ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
 export const fetchIndex = () => get<FomoIndexResponse>("/api/fomo/index");
 export const fetchToday = () => get<TallyResponse>("/api/fomo/emotions/today");
 /** 롤링 배너 + 홈 상단 캐러셀용 시장 점수(나스닥·비트코인·코스피). */
@@ -247,7 +253,7 @@ export interface DiscoveryResponse {
 }
 
 export const fetchDiscovery = () =>
-  cachedGet("discovery:today", () => get<DiscoveryResponse>("/api/fomo/discovery"), CACHE_TTL.stockFront);
+  cachedGet("discovery:today", () => getSameOrigin<DiscoveryResponse>("/api/fomo/discovery"), CACHE_TTL.stockFront);
 
 export interface AxisSnapshotEntry {
   axisSignals: import("@fomo/core").AxisSignal[];

--- a/apps/web/lib/dart-disclosures.ts
+++ b/apps/web/lib/dart-disclosures.ts
@@ -31,6 +31,7 @@ const DART_ROUTINE_REPORT =
   /사업보고서|반기보고서|분기보고서|증권발행실적|투자설명서|첨부정정|정정신고|임원ㆍ주요주주|임원·주요주주|주식등의대량보유|최대주주등소유주식변동/i;
 
 function dartKey(): string | undefined {
+  if (process.env.DISCOVERY_DART_LIVE !== "1") return undefined;
   return process.env.DART_API_KEY || process.env.DART_CRTFC_KEY;
 }
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -38,11 +38,15 @@ const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
 const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 5;
 const SPARKLINE_CONCURRENCY = 8;
-const TARGETED_MATERIAL_CANDIDATE_LIMIT = 18;
-const TARGETED_MATERIAL_CONCURRENCY = 6;
+const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL === "1";
+const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED ? 12 : 0;
+const TARGETED_MATERIAL_CONCURRENCY = 4;
 const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
 const MATERIAL_NEWS_NOISE =
   /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
+const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_ENABLED
+  ? "네이버 시세·종목뉴스·리서치·DART 공시"
+  : "네이버 시세·뉴스 언급";
 
 export interface DiscoveryFrontSeed {
   signals: CardFrontSignals;
@@ -646,6 +650,6 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     stocks,
     fronts,
     confidence: stocks.length >= 30 ? "H" : stocks.length >= 10 ? "M" : "L",
-    source: "네이버 시세·종목뉴스·리서치·DART 공시",
+    source: DISCOVERY_SOURCE_LABEL,
   };
 }


### PR DESCRIPTION
## Summary
- Disable live targeted stock-news/research and DART enrichment by default so discovery does not time out on Vercel.
- Route the Today discovery request through the same-origin fomo-web proxy to avoid browser CORS exposure on upstream failures.
- Allow GET /api/fomo/discovery in the proxy allow-list and suppress production console stack warnings for deck fetch failures.
- Keep richer enrichment available only behind explicit env flags: DISCOVERY_TARGETED_MATERIAL=1 and DISCOVERY_DART_LIVE=1.

## Root cause
Production /api/fomo/discovery was returning Vercel FUNCTION_INVOCATION_TIMEOUT 504. That platform error response had no Access-Control-Allow-Origin header, so the browser surfaced it as CORS and the discovery deck rendered empty.

## Verification
- npm test -- apps/fomo-web/__tests__/browser-auth-security.test.ts
- npm run typecheck
- npm run lint
- npm run build
- Live buildDiscoveryResponse: count=100, confidence=H, ms≈598