### PR TITLE
Fix numeric font fallback and duplicate change signs

### DIFF
--- a/apps/fomo-web/app/globals.css
+++ b/apps/fomo-web/app/globals.css
@@ -1,5 +1,4 @@
-/* 본문 Pretendard / 모든 숫자 JetBrains Mono(또렷) — @import는 Tailwind보다 먼저.
- * 숫자는 JetBrains Mono(가독성). 한글은 글리프 없어 Pretendard 폴백. 픽셀 폰트는 가독성 문제로 폐기. */
+/* 본문·숫자 Pretendard / 로고성 pixel-display만 JetBrains Mono — @import는 Tailwind보다 먼저. */
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;700;800&display=swap");
 

--- a/apps/fomo-web/app/insight/[id]/page.tsx
+++ b/apps/fomo-web/app/insight/[id]/page.tsx
@@ -49,7 +49,7 @@ export default async function InsightPage({ params }: { params: Promise<{ id: st
       {d?.metric && (
         <div className="mt-6 rounded-2xl border border-hairline bg-surface px-5 py-5">
           <p className="text-xs text-muted">{d.metric.label}</p>
-          <p className={`mt-1 font-pixel text-4xl leading-none ${changeColor}`}>{d.metric.value}</p>
+          <p className={`mt-1 text-4xl font-bold leading-none ${changeColor}`}>{d.metric.value}</p>
         </div>
       )}
 

--- a/apps/fomo-web/components/EmotionCalendar.tsx
+++ b/apps/fomo-web/components/EmotionCalendar.tsx
@@ -57,7 +57,7 @@ export function EmotionCalendar({ data }: { data: CalendarResponse }) {
       <p className="mb-3 mt-0.5 text-xs text-muted">
         {stats.filled > 0 ? (
           <>
-            이번 달 <span className="font-pixel text-whiteout">{stats.filled}</span>
+            이번 달 <span className="font-semibold text-whiteout">{stats.filled}</span>
             칸을 칠했어요
             {stats.streak >= 2 ? (
               <>
@@ -108,7 +108,7 @@ export function EmotionCalendar({ data }: { data: CalendarResponse }) {
               }}
             >
               <span
-                className="font-pixel"
+                className="font-medium"
                 style={{ color: color ?? (cell.isToday ? "#FAFAFA" : "#6A6A6A") }}
               >
                 {day}

--- a/apps/fomo-web/components/EmotionGate.tsx
+++ b/apps/fomo-web/components/EmotionGate.tsx
@@ -109,7 +109,7 @@ export function EmotionGate({
       <div className="mt-3 flex flex-col items-center">
         {score != null ? (
           <>
-            <p className="font-pixel text-4xl leading-none text-whiteout">{score}</p>
+            <p className="text-4xl font-bold leading-none text-whiteout">{score}</p>
             <p className="mt-1.5 font-pixel text-xs text-muted">
               FOMO INDEX · {state}
             </p>

--- a/apps/fomo-web/components/FullPageLoading.tsx
+++ b/apps/fomo-web/components/FullPageLoading.tsx
@@ -67,7 +67,7 @@ export function FullPageLoading({
             style={{ width: `${pct}%` }}
           />
         </div>
-        <span className="font-pixel text-xs tabular-nums text-muted">{pct}%</span>
+        <span className="text-xs font-medium tabular-nums text-muted">{pct}%</span>
       </div>
       <p className="text-sm leading-6 text-muted">{label}</p>
     </div>

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -96,7 +96,7 @@ export function HomeView({
               </span>
               <span className="font-pixel text-[11px] text-muted">{index.state}</span>
               {!isFullFallback && index.prevDayDelta !== 0 && (
-                <span className="inline-flex items-center gap-0.5 font-pixel text-[11px]" style={{ color }}>
+                <span className="inline-flex items-center gap-0.5 text-[11px] font-medium" style={{ color }}>
                   · 어제보다
                   {index.prevDayDelta > 0 ? <CaretUpIcon size={10} /> : <CaretDownIcon size={10} />}
                   {index.prevDayDelta > 0 ? `+${index.prevDayDelta}` : `${index.prevDayDelta}`}

--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -69,7 +69,7 @@ function SectorFace({ card, progress }: { card: KeywordCard; progress?: string }
       <p className="mt-6 text-lg leading-8 text-whiteout">{card.comment}</p>
       <div className="mt-auto flex items-center justify-between pt-6">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
-        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+        {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
       </div>
     </div>
   );
@@ -100,7 +100,7 @@ function StockFace({
       </p>
       <div className="mt-auto flex items-center justify-between pt-6">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
-        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+        {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
       </div>
     </div>
   );

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -96,7 +96,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
         <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
           <div className="flex items-center gap-2.5">
             <span className="text-lg font-bold text-whiteout">{card.keyword}</span>
-            <span className="font-pixel text-sm" style={{ color }}>
+            <span className="text-sm font-semibold" style={{ color }}>
               포모 {card.fomoScore}
             </span>
           </div>
@@ -382,13 +382,18 @@ function copyRestates(a: string | undefined, b: string | undefined): boolean {
   return !!left && !!right && (left.includes(right) || right.includes(left));
 }
 
+function normalizeChangeText(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  return text.replace(/^--+/, "-").replace(/^\+\++/, "+");
+}
+
 /**
  * 종목 기본 정보 블록(바닥) — 항상 렌더. 주가·회사개요·시총·핵심지표·연간 재무.
  * "정확한 숫자 + 쉬운 라벨"(EPS→'한 주가 번 돈') 둘 다. 없는 값은 생략(가짜 금지), 추정치·출처 표기.
  */
 function StockPriceHeader({ basics, front }: { basics: StockBasics | null; front: StockFrontResponse | null }) {
   const priceText = basics?.priceText ?? front?.priceText;
-  const changeText = basics?.changeText ?? front?.changeText;
+  const changeText = normalizeChangeText(basics?.changeText ?? front?.changeText);
   const changeDir = basics?.changeDir ?? front?.changeDir;
   if (!basics && !front) {
     return (
@@ -618,10 +623,10 @@ function buildReadPoints(front: StockFrontResponse | null, insight: CondensedIns
 
   if (front) {
     if (front.changeDir === "up" && front.changeText) {
-      bull.push({ text: `오늘 가격은 ${front.changeText} 상승으로 움직였어요.`, source: "가격" });
+      bull.push({ text: `오늘 가격은 ${normalizeChangeText(front.changeText)} 상승으로 움직였어요.`, source: "가격" });
     }
     if (front.changeDir === "down" && front.changeText) {
-      bear.push({ text: `오늘 가격은 ${front.changeText} 하락으로 움직였어요.`, source: "가격" });
+      bear.push({ text: `오늘 가격은 ${normalizeChangeText(front.changeText)} 하락으로 움직였어요.`, source: "가격" });
     }
     const ta = signalFromTa(front);
     if (ta?.side === "bull") bull.push({ text: ta.text, source: "차트" });

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -57,7 +57,7 @@ export function KeywordHistory() {
                 <span aria-hidden>{h.emoji}</span>
               </div>
               <div className="flex items-center gap-3">
-                <span className="font-pixel text-sm" style={{ color }}>
+                <span className="text-sm font-semibold" style={{ color }}>
                   {h.fomoScore}
                 </span>
                 <span className="text-[11px] text-muted">{relativeTime(h.ts)}</span>

--- a/apps/fomo-web/components/MarketCarousel.tsx
+++ b/apps/fomo-web/components/MarketCarousel.tsx
@@ -54,7 +54,7 @@ export function MarketCarousel({ markets }: { markets: MarketScore[] }) {
         </div>
         {/* FOMO 체감 점수 */}
         <div key={`${m.key}-r`} className="fomo-rise flex items-baseline gap-1.5">
-          <span className="font-pixel text-3xl leading-none" style={{ color }}>
+          <span className="text-3xl font-bold leading-none" style={{ color }}>
             {m.score}
           </span>
           <span className="font-pixel text-[11px] text-muted">{m.state}</span>

--- a/apps/fomo-web/components/MyDiscoveryPreview.tsx
+++ b/apps/fomo-web/components/MyDiscoveryPreview.tsx
@@ -25,7 +25,7 @@ export function MyDiscoveryPreview({
     <section className="mb-6">
       <div className="mb-3 flex items-center justify-between px-1">
         <p className="text-xs text-muted">내 발굴함</p>
-        <span className="font-pixel text-[10px] text-muted">{items.length}</span>
+        <span className="text-[10px] font-medium text-muted">{items.length}</span>
       </div>
       <div className="flex flex-col gap-2.5">
         {items.slice(0, 8).map((item) => (

--- a/apps/fomo-web/components/NewsFeed.tsx
+++ b/apps/fomo-web/components/NewsFeed.tsx
@@ -88,7 +88,7 @@ function NewsCard({ article }: { article: ScoredArticle }) {
       <div className="mb-1.5 flex items-center gap-2">
         {/* FOMO 점수 배지 — 색=구간 감정색, 숫자가 정렬 기준 */}
         <span
-          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-pixel text-[11px]"
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold"
           style={{ color, backgroundColor: `${color}1A` }}
           aria-label={`FOMO 점수 ${article.fomoScore}`}
         >

--- a/apps/fomo-web/components/StockCardFeed.tsx
+++ b/apps/fomo-web/components/StockCardFeed.tsx
@@ -90,7 +90,7 @@ function StockCardSlide({
 
         {/* 현재가 + 등락 */}
         <div className="mt-4 flex items-baseline gap-2">
-          <span className="font-pixel text-3xl leading-none text-whiteout">{card.priceText}</span>
+          <span className="text-3xl font-bold leading-none text-whiteout">{card.priceText}</span>
         </div>
         <p className="mt-1.5 text-sm" style={{ color }}>
           {changeText(card.changePct)}
@@ -102,7 +102,7 @@ function StockCardSlide({
         {/* 더보기 + 진행 표시 (거래 버튼 없음) */}
         <div className="mt-5 flex items-center justify-between">
           <span className="font-pixel text-[11px] text-muted">더보기 →</span>
-          <span className="font-pixel text-[11px] text-muted">
+          <span className="text-[11px] font-medium text-muted">
             {index + 1} / {total}
           </span>
         </div>
@@ -128,7 +128,7 @@ function DepthPage({ card, onClose }: { card: StockCard; onClose: () => void }) 
             </span>
             <div>
               <p className="text-sm font-semibold text-whiteout">{card.name}</p>
-              <p className="font-pixel text-[11px]" style={{ color }}>
+              <p className="text-[11px] font-medium" style={{ color }}>
                 {card.priceText} · {changeText(card.changePct)}
               </p>
             </div>

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -71,6 +71,11 @@ const MARKET_LABEL: Record<string, string> = {
   COIN: "코인",
 };
 
+function normalizeChangeText(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  return text.replace(/^--+/, "-").replace(/^\+\++/, "+");
+}
+
 /** 종목 로고 — 네이버 심볼 이미지(불러와지면), 실패 시 이니셜 원형 폴백. */
 function LogoBadge({ name, code }: { name: string; code?: string | undefined }) {
   const [failed, setFailed] = useState(false);
@@ -228,6 +233,7 @@ function StockCardFace({
   why?: string | undefined;
   progress?: string | undefined;
 }) {
+  const displayChangeText = normalizeChangeText(changeText);
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* 1행 — 정체성: 로고 + 종목명 + 시장·시총순위 */}
@@ -249,11 +255,11 @@ function StockCardFace({
       {priceText && (
         <div className="mt-2.5 flex shrink-0 items-baseline gap-2">
           <span className="text-lg font-bold text-whiteout">{priceText}</span>
-          {changeText && (
+          {displayChangeText && (
             <span className="inline-flex items-center gap-1 text-sm font-medium tabular-nums" style={{ color: DIR_COLOR[changeDir ?? "flat"] }}>
               {changeDir === "up" && <CaretUpIcon size={11} />}
               {changeDir === "down" && <CaretDownIcon size={11} />}
-              {changeText}
+              {displayChangeText}
             </span>
           )}
         </div>
@@ -314,7 +320,7 @@ function StockCardFace({
 
       <div className="mt-auto flex shrink-0 items-center justify-between pt-2">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
-        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+        {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
       </div>
     </div>
   );
@@ -363,7 +369,7 @@ function StockCardLoadingFace({
 
       <div className="mt-auto flex items-center justify-between pt-6">
         <span className="font-pixel text-[11px] text-muted">신호 확인 중</span>
-        {progress && <span className="font-pixel text-[11px] text-muted">{progress}</span>}
+        {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
       </div>
     </div>
   );

--- a/apps/fomo-web/components/cards/ChartCardBody.tsx
+++ b/apps/fomo-web/components/cards/ChartCardBody.tsx
@@ -42,8 +42,8 @@ export function ChartCardBody({ chart }: { chart: ChartCard }) {
       <div className="mt-5">
         <p className="font-pixel text-sm text-muted">{chart.label}</p>
         <div className="mt-1 flex items-baseline gap-2">
-          <span className="font-pixel text-3xl leading-none text-whiteout">{fmtValue(chart.value)}</span>
-          <span className="font-pixel text-sm" style={{ color }}>
+          <span className="text-3xl font-bold leading-none text-whiteout">{fmtValue(chart.value)}</span>
+          <span className="text-sm font-medium" style={{ color }}>
             {pct(chart.changePct)}
           </span>
         </div>

--- a/apps/fomo-web/components/cards/NewsCardBody.tsx
+++ b/apps/fomo-web/components/cards/NewsCardBody.tsx
@@ -41,7 +41,7 @@ export function NewsCardBody({ article }: { article: ScoredArticle }) {
       {/* 점수 배지 + 카테고리 */}
       <div className="mt-4 flex items-center gap-2">
         <span
-          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-pixel text-[11px]"
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold"
           style={{ color, backgroundColor: `${color}1A` }}
         >
           <span aria-hidden>{scoreToEmoji(article.fomoScore)}</span>

--- a/apps/fomo-web/tailwind.config.ts
+++ b/apps/fomo-web/tailwind.config.ts
@@ -50,10 +50,10 @@ const config: Config = {
       fontFamily: {
         body: ["Pretendard", "system-ui", "sans-serif"],
         sans: ["Pretendard", "system-ui", "sans-serif"],
-        // 모든 숫자(점수·가격·등락·온도 등) = 또렷한 모노 JetBrains Mono. 픽셀 폰트는 가독성 떨어져 폐기.
-        // 한글은 JetBrains 글리프 없어 Pretendard 폴백(= 한글 모노 안 박힘). pixel/display/mono/number 전부 동일.
-        number: ["JetBrains Mono", "Pretendard", "monospace"],
-        mono: ["JetBrains Mono", "Pretendard", "monospace"],
+        // 숫자(점수·가격·등락·온도 등)는 본문과 같은 Pretendard로 통일한다.
+        // JetBrains Mono는 로고성 pixel/display 텍스트에만 남긴다.
+        number: ["Pretendard", "system-ui", "sans-serif"],
+        mono: ["Pretendard", "system-ui", "sans-serif"],
         pixel: ["JetBrains Mono", "Pretendard", "monospace"],
         display: ["JetBrains Mono", "Pretendard", "monospace"],
       },

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -125,7 +125,7 @@ function changeDirFrom(row: RawNaverStock, pct: number | undefined): "up" | "dow
 }
 
 function signedChangeText(row: RawNaverStock, dir: "up" | "down" | "flat", pct: number | undefined): string | undefined {
-  const change = row.compareToPreviousClosePrice?.trim();
+  const change = row.compareToPreviousClosePrice?.trim().replace(/^[+-]+/, "");
   if (!change && typeof pct !== "number") return undefined;
   const pctText = typeof pct === "number" ? `${pct.toFixed(2)}%` : undefined;
   const prefix = dir === "down" ? "-" : "";

--- a/packages/fomo-core/__tests__/stock-basics.test.ts
+++ b/packages/fomo-core/__tests__/stock-basics.test.ts
@@ -38,6 +38,7 @@ describe("parseNaverStockBasic — 주가·등락(객관 사실)", () => {
   });
   it("하락 방향", () => {
     expect(parseNaverStockBasic({ closePrice: "100", fluctuationsRatio: "-1.2", compareToPreviousClosePrice: "-5" }).changeDir).toBe("down");
+    expect(parseNaverStockBasic({ closePrice: "100", fluctuationsRatio: "-1.2", compareToPreviousClosePrice: "-5" }).changeText).toBe("5 (-1.2%)");
   });
 });
 

--- a/packages/fomo-core/src/stock-basics.ts
+++ b/packages/fomo-core/src/stock-basics.ts
@@ -109,7 +109,7 @@ export function parseNaverStockBasic(json: unknown): Partial<StockBasics> {
   const change = d.compareToPreviousClosePrice ?? d.compareToPreviousPrice;
   if (change !== undefined && change !== null && `${change}`.trim()) {
     const r = ratio !== undefined && ratio !== null ? ` (${ratio}%)` : "";
-    out.changeText = `${`${change}`.replace(/^-/, "")}${r}`;
+    out.changeText = `${`${change}`.replace(/^[+-]+/, "")}${r}`;
   }
   const code = typeof d.compareToPreviousClosePrice === "object" ? null : null; // (구조 변동 방어)
   void code;


### PR DESCRIPTION
## Summary
- normalize numeric font tokens so FOMO scores, prices, change rates, progress counts, and small numeric badges render with the same Pretendard/system number face
- keep JetBrains Mono only for logo/pixel-display labels
- strip duplicated source signs from discovery/stock-basics change text and defensively collapse cached `--` in card/depth rendering

## Verification
- npm test -- packages/fomo-core/__tests__/stock-basics.test.ts
- npm run typecheck
- npm run build
- live discovery sample: 100 cards, bad `--` changeText count = 0