### PR TITLE
Fix FOMO score saturation for price-only movers

### DIFF
--- a/packages/fomo-core/__tests__/fomo-score.test.ts
+++ b/packages/fomo-core/__tests__/fomo-score.test.ts
@@ -11,6 +11,7 @@ import {
   rankFeedByFomo,
   isFrontHookSafe,
   C_WEIGHTS,
+  FOMO_SCORE_CAPS,
   type FomoScoreInputs,
 } from "../src";
 
@@ -76,14 +77,25 @@ describe("computeFomoScore — 포모 점수 엔진(§2)", () => {
   });
 
   it("가중치대로 — 거래량(45)이 언급(20)보다 C에 크게 기여", () => {
-    const volOnly = computeFomoScore({ volumeRatio: 3.5 }).fomoScore; // 100 * 45/45
-    const mentionOnly = computeFomoScore({ mentionScore: 100 }).fomoScore; // 100 * 20/20
-    // 둘 다 단독이면 100점(재정규화)이지만, 같이 있을 때 거래량 만점·언급 0이 언급만점·거래량0보다 높아야
+    const volOnly = computeFomoScore({ volumeRatio: 3.5 }).fomoScore;
+    const mentionOnly = computeFomoScore({ mentionScore: 100 }).fomoScore;
+    // 단일축은 100점 포화를 막고, 같이 있을 때 거래량 만점·언급 0이 언급만점·거래량0보다 높아야 한다.
     const volHi = computeFomoScore({ volumeRatio: 3.5, mentionScore: 0 }).fomoScore;
     const mentionHi = computeFomoScore({ volumeRatio: 1, mentionScore: 100 }).fomoScore;
     expect(volHi).toBeGreaterThan(mentionHi);
-    expect(volOnly).toBe(100);
-    expect(mentionOnly).toBe(100);
+    expect(volOnly).toBe(FOMO_SCORE_CAPS.singleVolume);
+    expect(mentionOnly).toBe(FOMO_SCORE_CAPS.singleMention);
+  });
+
+  it("가격 단일축은 100으로 포화되지 않고, 큰 하락은 heat 만점이 아니라 cooling 상태로 분리", () => {
+    const spike = computeFomoScore({ changePct: 18.86 });
+    const plunge = computeFomoScore({ changePct: -16.67 });
+
+    expect(spike.fomoScore).toBe(FOMO_SCORE_CAPS.singlePrice);
+    expect(spike.label).toBe("lone");
+    expect(plunge.fomoScore).toBeLessThan(FOMO_SCORE_CAPS.singlePrice);
+    expect(plunge.label).toBe("cooling");
+    expect(plunge.priceMove).toBe("down");
   });
 
   it("💎 incoming — C<60 & L≥60 에서만 (수급 선행)", () => {

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -28,6 +28,10 @@ export const FOMO_AXIS_THRESHOLDS = {
 } as const;
 /** 정규화 기준점 — 거래량 3.5배=만점, 등락 8%=만점, 수급 5일연속·시총대비 1%=만점. */
 export const FOMO_NORM = { volTopX: 3.5, priceTopPct: 8, streakTopDays: 5, ratioTopPct: 0.01 } as const;
+/** 낮은 근거/단일축 카드가 100점으로 포화되는 것을 막는 상한. */
+export const FOMO_SCORE_CAPS = { singleVolume: 75, singlePrice: 60, singleMention: 60 } as const;
+/** 큰 하락은 가격축 상태 신호이지만 heat 점수로는 낮게 반영한다. */
+export const FOMO_PRICE_DOWN_HEAT_RATIO = 0.35;
 /** 매집 다이버전스(§6.4 — 거래량↑·가격 평탄 = 조용히 담는 중). 광혁 튜닝 전 기본 off. */
 export const ACCUMULATION = { enabled: false, volMin: 1.8, priceFlatMax: 2, leadBonus: 8 } as const;
 /** 볼린저 스퀴즈(§6.4 — 변동성 압축). L 보조 입력. 광혁 튜닝 전 기본 off. */
@@ -107,10 +111,29 @@ const clamp100 = (x: number) => (x < 0 ? 0 : x > 100 ? 100 : x);
 function volTo100(ratio: number): number {
   return clamp01((ratio - 1) / (FOMO_NORM.volTopX - 1)) * 100;
 }
-function priceTo100(changePct?: number, trendStrength?: number): number {
+function priceAxisTo100(changePct?: number, trendStrength?: number): number {
   const fromPct = typeof changePct === "number" ? clamp01(Math.abs(changePct) / FOMO_NORM.priceTopPct) : 0;
   const fromTrend = typeof trendStrength === "number" ? clamp01(trendStrength) : 0;
   return Math.max(fromPct, fromTrend) * 100;
+}
+function priceHeatTo100(changePct?: number, trendStrength?: number): number {
+  if (typeof changePct === "number" && changePct < 0) {
+    return clamp01(Math.abs(changePct) / FOMO_NORM.priceTopPct) * FOMO_PRICE_DOWN_HEAT_RATIO * 100;
+  }
+  return priceAxisTo100(changePct, trendStrength);
+}
+function capLowEvidenceScore(score: number, inputs: FomoScoreResult["inputs"]): number {
+  const present = [
+    inputs.volume !== undefined ? "volume" : undefined,
+    inputs.price !== undefined ? "price" : undefined,
+    inputs.mention !== undefined ? "mention" : undefined,
+  ].filter(Boolean);
+  if (present.length !== 1) return score;
+  const only = present[0];
+  if (only === "volume") return Math.min(score, FOMO_SCORE_CAPS.singleVolume);
+  if (only === "price") return Math.min(score, FOMO_SCORE_CAPS.singlePrice);
+  if (only === "mention") return Math.min(score, FOMO_SCORE_CAPS.singleMention);
+  return score;
 }
 /** 순매수(양의 streak)만 선행 신호에 기여 — 순매도는 L=0(식는 신호는 방향이 담당). */
 function supplyTo100(streak?: number, ratio?: number): number | undefined {
@@ -187,7 +210,7 @@ export function computeFomoScore(input: FomoScoreInputs = {}, tuning: FomoScoreT
     cDen += C_WEIGHTS.volume;
   }
   if (typeof input.changePct === "number" || typeof input.trendStrength === "number") {
-    inputs.price = priceTo100(input.changePct, input.trendStrength);
+    inputs.price = priceHeatTo100(input.changePct, input.trendStrength);
     cNum += inputs.price * C_WEIGHTS.price;
     cDen += C_WEIGHTS.price;
   }
@@ -196,9 +219,13 @@ export function computeFomoScore(input: FomoScoreInputs = {}, tuning: FomoScoreT
     cNum += inputs.mention * C_WEIGHTS.mention;
     cDen += C_WEIGHTS.mention;
   }
-  const C = cDen > 0 ? Math.round(cNum / cDen) : 0;
+  const rawC = cDen > 0 ? Math.round(cNum / cDen) : 0;
+  const C = capLowEvidenceScore(rawC, inputs);
   const confidence = clamp01(cDen / (C_WEIGHTS.volume + C_WEIGHTS.price + C_WEIGHTS.mention));
-  const priceAxis = Math.round(inputs.price ?? 0);
+  const priceAxis =
+    typeof input.changePct === "number" || typeof input.trendStrength === "number"
+      ? Math.round(priceAxisTo100(input.changePct, input.trendStrength))
+      : 0;
   const aDen =
     (inputs.volume !== undefined ? C_WEIGHTS.volume : 0) + (inputs.mention !== undefined ? C_WEIGHTS.mention : 0);
   const attentionAxis =
@@ -264,7 +291,7 @@ export function computeFomoScore(input: FomoScoreInputs = {}, tuning: FomoScoreT
 
   // ── 상태 라벨(임계값 §2, 빈틈 없이) ──
   let label: FomoLabel;
-  if ((strongDown || priceMove === "down") && C >= FOMO_THRESHOLDS.warm) label = "cooling";
+  if (strongDown || priceMove === "down") label = "cooling";
   else if (priceMove === "flat" && (attentionStrong || leadStrong)) label = "incoming";
   else if (priceMove === "up" && attentionStrong) label = "hot";
   else if (priceMove === "up" && !attentionStrong) label = "lone";


### PR DESCRIPTION
## Summary
- cap single-axis / low-evidence FOMO scores so price-only discovery cards no longer saturate at 100
- make negative price moves contribute less to heat while still preserving the down price axis for cooling state
- keep score/label coherence: large drops now show cooling with lower scores instead of 100 + cooling

## Product default chosen
- price-only cap: 60
- volume-only cap: 75
- mention-only cap: 60
- large negative price heat ratio: 0.35

## Verification
- npm test -- packages/fomo-core/__tests__/fomo-score.test.ts
- npm test -- packages/fomo-core/__tests__/stock-basics.test.ts
- npm run typecheck
- npm run build
- live discovery sample after patch: 100 cards, score=100 count 1; -16% movers score 35 + cooling