### PR TITLE
feat(ai): 공용 AI 클라이언트 통합 + opik 관측·평가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@ AI_API_URL="https://models.github.ai/inference/chat/completions"
 AI_API_KEY="USE_GITHUB_TOKEN"
 AI_MODEL="openai/gpt-4.1"
 AI_TEMPERATURE="0.2"
+# opik — LLM 호출 관측·평가(comet-ml/opik). 모든 callAI(@fomo/shared)가 자동 추적.
+# 미설정 시 추적만 생략(fail-open, 제품 정상). self-host(docker) 또는 클라우드(comet.com) 둘 다 가능.
+OPIK_API_KEY=""                            # 클라우드(comet.com) 키. self-host면 비워도 됨
+OPIK_URL_OVERRIDE=""                       # self-host 엔드포인트(예: http://localhost:5173/api). 둘 중 하나 있으면 추적 활성
+OPIK_PROJECT_NAME="fomo-club"             # opik 프로젝트명
+OPIK_WORKSPACE=""                          # 클라우드 워크스페이스(self-host는 "default")
 # FRED(미 연준 공식 데이터, DATA_ENGINE_STRATEGY C-2). 없어도 키리스(fredgraph.csv)로 동작.
 # 키 발급(무료): https://fred.stlouisfed.org/docs/api/api_key.html → 설정 시 공식 JSON API 로 업그레이드.
 FRED_API_KEY=""

--- a/apps/web/lib/fomo-comment.ts
+++ b/apps/web/lib/fomo-comment.ts
@@ -1,27 +1,19 @@
 import { fomoCommentFallback, parseFomoComments, type ScoredArticle } from "@fomo/core";
+import { callAI, isAiConfigured } from "@fomo/shared";
 
 /**
  * 기사별 포모 한 줄 코멘트 (LLM). docs/PIVOT_FEED_FIRST.md.
  *
- * fomo-translate.ts 와 동형: AI_API_URL + 키해소(AI_API_KEY→GITHUB_TOKEN) + 배치 1콜 + id별 인메모리 캐시.
+ * fomo-translate.ts 와 동형: 공용 callAI(@fomo/shared) + 배치 1콜 + id별 인메모리 캐시.
  * 톤: 담담한 솔직함, "너만 그런 거 아니야". 투자조언/단정 금지.
  * 미설정/실패/미커버 기사는 fomoCommentFallback(규칙)으로 항상 채운다 — 빈 코멘트 없음.
  */
 
-const AI_API_URL = process.env["AI_API_URL"] ?? "";
 const COMMENT_MODEL = process.env["AI_TRANSLATE_MODEL"] ?? "openai/gpt-4.1-mini";
 const MAX_COMMENT = 20;
 
 const cache = new Map<string, string>();
 const CACHE_MAX = 1000;
-
-function resolveAiKey(): string {
-  const configured = process.env["AI_API_KEY"] ?? "";
-  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
-    return process.env["GITHUB_TOKEN"] ?? "";
-  }
-  return configured;
-}
 
 function buildPrompt(items: { id: string; title: string }[]): string {
   return [
@@ -34,43 +26,26 @@ function buildPrompt(items: { id: string; title: string }[]): string {
   ].join("\n");
 }
 
-interface LlmResponse {
-  choices?: Array<{ message?: { content?: string } }>;
-}
-
 /** 기사들의 comment 를 채워 반환. LLM 우선, 미커버/실패는 규칙 폴백으로 항상 채움. */
 export async function addFomoComments(articles: ScoredArticle[]): Promise<ScoredArticle[]> {
-  const apiKey = resolveAiKey();
-
   // LLM 시도(설정돼 있을 때, 미캐시분만).
-  if (AI_API_URL && apiKey) {
+  if (isAiConfigured()) {
     const uncached = articles
       .filter((a) => !cache.has(a.id))
       .slice(0, MAX_COMMENT)
       .map((a) => ({ id: a.id, title: a.title }));
     if (uncached.length > 0) {
-      try {
-        const res = await fetch(AI_API_URL, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-          body: JSON.stringify({
-            model: COMMENT_MODEL,
-            temperature: 0.5,
-            messages: [{ role: "user", content: buildPrompt(uncached) }],
-          }),
-          signal: AbortSignal.timeout(25_000),
-        });
-        if (res.ok) {
-          const data = (await res.json()) as LlmResponse;
-          for (const c of parseFomoComments(data.choices?.[0]?.message?.content ?? "")) {
-            cache.set(c.id, c.comment);
-          }
-          if (cache.size > CACHE_MAX) cache.clear();
-        } else {
-          console.warn("[fomo/comment] LLM", res.status);
+      const res = await callAI({
+        model: COMMENT_MODEL,
+        temperature: 0.5,
+        messages: [{ role: "user", content: buildPrompt(uncached) }],
+        trace: "fomo-comment",
+      });
+      if (res.ok) {
+        for (const c of parseFomoComments(res.content)) {
+          cache.set(c.id, c.comment);
         }
-      } catch (err) {
-        console.warn("[fomo/comment] error", err);
+        if (cache.size > CACHE_MAX) cache.clear();
       }
     }
   }

--- a/apps/web/lib/fomo-keyword-comment.ts
+++ b/apps/web/lib/fomo-keyword-comment.ts
@@ -6,11 +6,12 @@ import {
   type LlmKeywordComment,
   type ScoredKeyword,
 } from "@fomo/core";
+import { callAI, isAiConfigured } from "@fomo/shared";
 
 /**
  * 키워드 카드 코멘트 — LLM 1차, 룰 폴백 강등. KEYWORD_ENGINE_SPEC §4.4 / Phase 3.
  *
- * fomo-comment.ts(기사 코멘트)와 동형: AI_API_URL + 키해소(AI_API_KEY→GITHUB_TOKEN) + 배치 1콜 + 인메모리 캐시.
+ * fomo-comment.ts(기사 코멘트)와 동형: 공용 callAI(@fomo/shared) + 배치 1콜 + 인메모리 캐시.
  * 검증·병합은 @fomo/core 의 순수 함수(applyLlmComment: 금칙어/균형추 가드 + 룰 폴백)에 위임한다.
  *
  * 강등 경로(모두 룰 폴백 = buildKeywordCard 결과 유지):
@@ -21,7 +22,6 @@ import {
  * 정직성(§5): score 를 프롬프트에 넣어, 데이터가 잠잠하면(낮은 점수) LLM 도 과장하지 않게 유도.
  */
 
-const AI_API_URL = process.env["AI_API_URL"] ?? "";
 // 코멘트는 5장 내외라 품질 우선 — 본 모델(AI_MODEL) 사용, 미설정 시 빠른 mini.
 const COMMENT_MODEL = process.env["AI_MODEL"] || "openai/gpt-4.1-mini";
 // 변주(자연스러움) 위해 약간 높게. AI_TEMPERATURE 가 있으면 재활용.
@@ -30,18 +30,6 @@ const TEMPERATURE = Number.parseFloat(process.env["AI_TEMPERATURE"] ?? "") || 0.
 /** keyword|score → 검증 전 LLM 묶음 캐시. 같은 회차 재호출 비용 절감(라우트가 이미 30분 TTL). */
 const cache = new Map<string, LlmKeywordComment>();
 const CACHE_MAX = 500;
-
-function resolveAiKey(): string {
-  const configured = process.env["AI_API_KEY"] ?? "";
-  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
-    return process.env["GITHUB_TOKEN"] ?? "";
-  }
-  return configured;
-}
-
-interface LlmResponse {
-  choices?: Array<{ message?: { content?: string } }>;
-}
 
 const cacheKey = (kw: ScoredKeyword) => `${kw.keyword}|${kw.fomoScore}`;
 
@@ -53,44 +41,31 @@ export async function addKeywordCardComments(
   scored: readonly ScoredKeyword[],
   cards: readonly KeywordCard[]
 ): Promise<KeywordCard[]> {
-  const apiKey = resolveAiKey();
-
-  if (AI_API_URL && apiKey) {
+  if (isAiConfigured()) {
     const uncached = scored.filter((kw) => !cache.has(cacheKey(kw)));
     if (uncached.length > 0) {
-      try {
-        const prompt = buildKeywordCommentPrompt(
-          uncached.map((kw) => ({
-            keyword: kw.keyword,
-            score: kw.fomoScore,
-            titles: kw.articles.map((a) => a.title),
-            related: kw.related,
-          }))
-        );
-        const res = await fetch(AI_API_URL, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-          body: JSON.stringify({
-            model: COMMENT_MODEL,
-            temperature: TEMPERATURE,
-            messages: [{ role: "user", content: prompt }],
-          }),
-          signal: AbortSignal.timeout(25_000),
-        });
-        if (res.ok) {
-          const data = (await res.json()) as LlmResponse;
-          const parsed = parseKeywordComments(data.choices?.[0]?.message?.content ?? "");
-          const byKeyword = new Map(parsed.map((c) => [c.keyword, c]));
-          for (const kw of uncached) {
-            const c = byKeyword.get(kw.keyword);
-            if (c) cache.set(cacheKey(kw), c);
-          }
-          if (cache.size > CACHE_MAX) cache.clear();
-        } else {
-          console.warn("[fomo/keyword-comment] LLM", res.status);
+      const prompt = buildKeywordCommentPrompt(
+        uncached.map((kw) => ({
+          keyword: kw.keyword,
+          score: kw.fomoScore,
+          titles: kw.articles.map((a) => a.title),
+          related: kw.related,
+        }))
+      );
+      const res = await callAI({
+        model: COMMENT_MODEL,
+        temperature: TEMPERATURE,
+        messages: [{ role: "user", content: prompt }],
+        trace: "fomo-keyword-comment",
+      });
+      if (res.ok) {
+        const parsed = parseKeywordComments(res.content);
+        const byKeyword = new Map(parsed.map((c) => [c.keyword, c]));
+        for (const kw of uncached) {
+          const c = byKeyword.get(kw.keyword);
+          if (c) cache.set(cacheKey(kw), c);
         }
-      } catch (err) {
-        console.warn("[fomo/keyword-comment] error", err);
+        if (cache.size > CACHE_MAX) cache.clear();
       }
     }
   }

--- a/apps/web/lib/fomo-translate.ts
+++ b/apps/web/lib/fomo-translate.ts
@@ -5,17 +5,17 @@ import {
   type KoTranslation,
   type ScoredArticle,
 } from "@fomo/core";
+import { callAI, isAiConfigured } from "@fomo/shared";
 
 /**
  * 영문 기사 → 한국어 번역 (LLM). docs/PIVOT_FEED_FIRST.md.
  *
- * AI_API_URL(OpenAI 호환 chat completions) + 키. 키는 AI_API_KEY, 센티넬/공란이면 GITHUB_TOKEN.
+ * 공용 callAI(@fomo/shared, OpenAI 호환) — AI_API_URL/AI_API_KEY/AI_MODEL 체계, 키는 GITHUB_TOKEN 폴백.
  * 미설정/실패/타임아웃 시 원문(영문) 폴백 — localize 가 영문 표기.
  * 속도: 번역 전용 모델(기본 gpt-4.1-mini, 대용량보다 빠름) + 제목/요약만 batch 1콜.
  * 비용/지연: 라우트 엣지 캐시(s-maxage=300) + 아래 인메모리 캐시(id별)로 재번역 최소화.
  */
 
-const AI_API_URL = process.env["AI_API_URL"] ?? "";
 // 번역은 빠른 mini 계열 고정(본문 해석용 AI_MODEL=gpt-4.1은 느려서 타임아웃). AI_TRANSLATE_MODEL 로만 덮어씀.
 const TRANSLATE_MODEL = process.env["AI_TRANSLATE_MODEL"] ?? "openai/gpt-4.1-mini";
 
@@ -26,18 +26,6 @@ const MAX_TRANSLATE = 20;
 const cache = new Map<string, KoTranslation>();
 const CACHE_MAX = 1000;
 
-function resolveAiKey(): string {
-  const configured = process.env["AI_API_KEY"] ?? "";
-  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
-    return process.env["GITHUB_TOKEN"] ?? "";
-  }
-  return configured;
-}
-
-interface LlmResponse {
-  choices?: Array<{ message?: { content?: string } }>;
-}
-
 /**
  * 영문(lang="en") 기사들의 titleKo/summaryKo 를 채워 반환. 한국어 기사는 그대로.
  * 캐시 히트는 즉시 적용하고, 미캐시 영문만 LLM 1콜로 번역. 실패 시 가능한 만큼만(원문 폴백).
@@ -45,8 +33,7 @@ interface LlmResponse {
 export async function translateEnglishToKorean(
   articles: ScoredArticle[]
 ): Promise<ScoredArticle[]> {
-  const apiKey = resolveAiKey();
-  if (!AI_API_URL || !apiKey) return articles;
+  if (!isAiConfigured()) return articles;
 
   // 제목만 번역(요약까지 넣으면 지연이 커져 타임아웃) — 카드 주인공은 헤드라인.
   const english = articles.filter((a) => a.lang === "en");
@@ -56,28 +43,17 @@ export async function translateEnglishToKorean(
     .map((a) => ({ id: a.id, title: a.title }));
 
   if (uncached.length > 0) {
-    try {
-      const res = await fetch(AI_API_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-        body: JSON.stringify({
-          model: TRANSLATE_MODEL,
-          temperature: 0.2,
-          messages: [{ role: "user", content: buildKoTranslationPrompt(uncached) }],
-        }),
-        signal: AbortSignal.timeout(25_000),
-      });
-      if (res.ok) {
-        const data = (await res.json()) as LlmResponse;
-        for (const t of parseKoTranslations(data.choices?.[0]?.message?.content ?? "")) {
-          cache.set(t.id, t);
-        }
-        if (cache.size > CACHE_MAX) cache.clear();
-      } else {
-        console.warn("[fomo/translate] LLM", res.status);
+    const res = await callAI({
+      model: TRANSLATE_MODEL,
+      temperature: 0.2,
+      messages: [{ role: "user", content: buildKoTranslationPrompt(uncached) }],
+      trace: "fomo-translate",
+    });
+    if (res.ok) {
+      for (const t of parseKoTranslations(res.content)) {
+        cache.set(t.id, t);
       }
-    } catch (err) {
-      console.warn("[fomo/translate] error", err);
+      if (cache.size > CACHE_MAX) cache.clear();
     }
   }
 

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -18,6 +18,7 @@ import {
   type WordingVerdict,
   type OfficialFact,
 } from "@fomo/core";
+import { callAI, isAiConfigured } from "@fomo/shared";
 import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
@@ -31,7 +32,6 @@ import { fetchDcStockTitles } from "./dcinside";
  * 정직성: AI 미설정·실패·원문 부족 → emptyThemeInsight(정직한 빈 상태). 가짜 생성 금지.
  */
 
-const AI_API_URL = process.env["AI_API_URL"] ?? "";
 // 한 테마만 깊게 보는 PoC → 품질 우선 본 모델. 충실 추출 위해 온도 낮게.
 const MODEL = process.env["AI_MODEL"] || "openai/gpt-4.1";
 const TEMPERATURE = Number.parseFloat(process.env["AI_TEMPERATURE"] ?? "") || 0.2;
@@ -47,17 +47,6 @@ const THEME_NAVER_CODES: Record<string, { code: string; label: string }[]> = {
   ],
 };
 
-function resolveAiKey(): string {
-  const configured = process.env["AI_API_KEY"] ?? "";
-  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
-    return process.env["GITHUB_TOKEN"] ?? "";
-  }
-  return configured;
-}
-
-interface LlmResponse {
-  choices?: Array<{ message?: { content?: string } }>;
-}
 
 /** 뉴스 + 종토방 원문을 SourceDoc[] 로(제목·본문 보존, S1.. 식별자 부여). */
 export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
@@ -154,8 +143,7 @@ export async function collectThemeDocs(theme: string): Promise<SourceDoc[]> {
  * 애매하면 unsafe(안전 우선). 실패 시 룰 통과분 유지(이미 룰-세이프). 변조 없음 — 통과/탈락만 결정.
  */
 async function judgeWordingsSafety(
-  texts: readonly string[],
-  apiKey: string
+  texts: readonly string[]
 ): Promise<Map<string, { safe: boolean; reason: string }>> {
   const out = new Map<string, { safe: boolean; reason: string }>();
   if (texts.length === 0) return out;
@@ -168,22 +156,18 @@ async function judgeWordingsSafety(
     "",
     JSON.stringify(texts),
   ].join("\n");
+  const res = await callAI({
+    model: MODEL,
+    temperature: 0,
+    messages: [{ role: "user", content: prompt }],
+    trace: "wording-judge",
+  });
+  if (!res.ok) return out; // 룰 통과분 유지(이미 룰-세이프)
+  const content = res.content;
+  const start = content.indexOf("[");
+  const end = content.lastIndexOf("]");
+  if (start === -1 || end <= start) return out;
   try {
-    const res = await fetch(AI_API_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({ model: MODEL, temperature: 0, messages: [{ role: "user", content: prompt }] }),
-      signal: AbortSignal.timeout(25_000),
-    });
-    if (!res.ok) {
-      console.warn("[wording-judge] LLM", res.status, "— 룰 통과분 유지");
-      return out;
-    }
-    const data = (await res.json()) as LlmResponse;
-    const content = data.choices?.[0]?.message?.content ?? "";
-    const start = content.indexOf("[");
-    const end = content.lastIndexOf("]");
-    if (start === -1 || end <= start) return out;
     const arr = JSON.parse(content.slice(start, end + 1)) as unknown;
     if (Array.isArray(arr)) {
       for (const r of arr) {
@@ -195,7 +179,7 @@ async function judgeWordingsSafety(
       }
     }
   } catch (err) {
-    console.warn("[wording-judge] error — 룰 통과분 유지", err);
+    console.warn("[wording-judge] parse error — 룰 통과분 유지", err);
   }
   return out;
 }
@@ -363,41 +347,36 @@ async function runUnderstanding(
   const withFacts = (insight: ThemeInsight): ThemeInsight =>
     officialFacts.length > 0 ? { ...insight, officialFacts } : insight;
 
-  const apiKey = resolveAiKey();
-  if (!AI_API_URL || !apiKey) {
+  if (!isAiConfigured()) {
     return withFacts(emptyThemeInsight(subject, "AI 미설정 — 이해 레이어 비활성(정직한 빈 상태)"));
   }
 
   try {
-    const res = await fetch(AI_API_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({
-        model: MODEL,
-        temperature: TEMPERATURE,
-        messages: [
-          {
-            role: "user",
-            content:
-              kind === "stock"
-                ? buildStockInsightPrompt(subject, docs)
-                : buildThemeInsightPrompt(subject, docs),
-          },
-        ],
-      }),
-      signal: AbortSignal.timeout(45_000),
+    const res = await callAI({
+      model: MODEL,
+      temperature: TEMPERATURE,
+      timeoutMs: 45_000,
+      trace: kind === "stock" ? "understanding-stock" : "understanding-theme",
+      metadata: { subject, kind, docs: docs.length },
+      messages: [
+        {
+          role: "user",
+          content:
+            kind === "stock"
+              ? buildStockInsightPrompt(subject, docs)
+              : buildThemeInsightPrompt(subject, docs),
+        },
+      ],
     });
     if (!res.ok) {
-      console.warn("[understanding] LLM", res.status);
       return withFacts(emptyThemeInsight(subject, `LLM ${res.status} — 정직한 빈 상태`));
     }
-    const data = (await res.json()) as LlmResponse;
-    const raw = parseThemeInsightResponse(data.choices?.[0]?.message?.content ?? "");
+    const raw = parseThemeInsightResponse(res.content);
     const insight = assembleThemeInsight(subject, docs, raw);
 
     // 2단계: 룰 통과 워딩을 LLM 으로 한 번 더 안전 판정(욕설/단정/혐오/찌라시 — 룰이 못 잡는 뉘앙스).
     if (insight.wordings.length === 0) return withFacts(insight);
-    const judged = await judgeWordingsSafety(insight.wordings.map((w) => w.text), apiKey);
+    const judged = await judgeWordingsSafety(insight.wordings.map((w) => w.text));
     const llmAudit: WordingVerdict[] = insight.wordings.map((w) => {
       const v = judged.get(w.text);
       return {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,6 +7,9 @@ const monorepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 
 const sharedConfig = {
   outputFileTracingRoot: monorepoRoot,
   transpilePackages: ["@fomo/shared", "@fomo/core"],
+  // opik(LLM 관측)는 nunjucks/chokidar/fsevents(네이티브) 의존 → 번들 금지, 런타임 require.
+  // ai-client.ts 가 동적 import("opik") 로만 사용(OPIK_* 설정 시). 미설정 시 fail-open.
+  serverExternalPackages: ["opik"],
   webpack(config) {
     // ESM .js 확장자 → .ts 소스 resolve (@fomo/core 등이 main: "src/index.ts" + .js imports 사용)
     config.resolve.extensionAlias = {

--- a/docs/DATA_ENGINE_STRATEGY.md
+++ b/docs/DATA_ENGINE_STRATEGY.md
@@ -156,3 +156,22 @@
    우리 적용: Phase A~D 단계 플랜과 매핑(이미 정합). 단계별 산출물에 confidence·grounding 부착.
 
 > 코드 복사 X(Python 중량 파이프라인 ≠ 우리 TS). 아키텍처 참고 노트로만 사용.
+
+---
+
+## 9. LLM 관측·평가 (opik — 적용됨) + 지식그래프 메모리 (graphiti — 후보)
+
+### 9.1 opik — 응축 품질 가시화 (🟢 적용, 2026-06)
+제품의 #1 리스크는 grounding 위반(지어내기). 그동안 응축 품질이 **안 보여서** 개선이 정체됐다.
+
+- **단일 seam**: 흩어진 7개 AI 호출 → `packages/shared/src/ai-client.ts`의 `callAI()` 하나로 통합(모델 무관). 제품 런타임 호출(theme-understanding·fomo-comment·fomo-keyword-comment·fomo-translate)은 이관 완료. dev/ops 호출(slack/events·researchPipeline·council-meeting)은 follow-up.
+- **추적**: `callAI`에 opik 내장. `OPIK_*`(.env.example) 설정 시 모든 LLM 호출이 input/output/model 과 함께 기록(미설정 시 fail-open). Claude/Codex/Groq/향후 모델 전부 같은 지점 통과 → 모델 비교·관측 일괄.
+- **평가**: `npm run eval:understanding`(`scripts/eval-understanding.ts`) — LLM-as-judge 로 워딩의 grounded 여부 채점, pass rate < 80% 면 exit 1(CI 게이트화 가능). "User Zero 검수 자동화" 목표의 첫 계단.
+- **다음**: 실제 `runUnderstanding` 출력으로 SAMPLES 교체 → 모델/프롬프트 변경 회귀를 수치로.
+
+### 9.2 graphiti — 시간성 지식그래프 (🟡 후보, 지금은 X)
+getzep/graphiti(Apache-2.0). 엔티티(종목·테마·이벤트)·관계(수급·내러티브)·**시점 변화**(어제 vs 오늘 내러티브)를 그래프로. 이해/재가공 레이어(§4 Track A/B)엔 개념적으로 최강 후보.
+
+- **막는 이유**: Python 전용 + Neo4j/FalkorDB 필수 = 우리 TS 스택에 무거운 신규 인프라. 지금(정체 국면) 붙이면 야크쉐이빙.
+- **채택 조건**: 이해 레이어가 PoC 넘어 "내러티브 변화 추적"이 제품 가치로 확인될 때. 그때 Python 사이드카 서비스로 분리 검토(앱은 API로만 소비).
+- **대안 우선**: 지금은 confidence·grounding 부착 + opik 평가로 품질부터 끌어올린다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,145 @@
         }
       }
     },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.87",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.87.tgz",
+      "integrity": "sha512-4v7uoMblNYZ3X7S5a+manSKKqKVmWXTkJOtZ8ymArHdQbhgzMd+um1qDee8MiJbDhk6wjy8T/F+D1pVhB/7HTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.135",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.135.tgz",
+      "integrity": "sha512-vCptKksGABn0UxepZ92MlqY4wY3PNNPCFz2lYVF5PQ+jRRVfNKCFnxXdxmLDLCd5uoJAHyjZ1hQ0tPf28eYNXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.84",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.84.tgz",
+      "integrity": "sha512-TVLcerZs7D70nHGPhtb5cwwX41CzKSVE00IEHRTRXXBa35g6BJdxi48YPglrrP9gDCAPSrl60/Nh5SBMMTwkwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google-vertex": {
+      "version": "4.0.150",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-4.0.150.tgz",
+      "integrity": "sha512-67hfINiuyXHlo4eiAc6gPH+8EPSrMg9c3t0bmC2Dm6DsjW1l7M5HTt+eKtetdJJh/yBWMeJKi2ujLrP6oXvPaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "3.0.87",
+        "@ai-sdk/google": "3.0.84",
+        "@ai-sdk/openai-compatible": "2.0.52",
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31",
+        "google-auth-library": "^10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.75",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.75.tgz",
+      "integrity": "sha512-xKW+ZSHOdsFIUR6H2uSVjQQmzuHG+onsBZQmsr1OagDK/G55Vhx7Msd/5itoIT/kfGIhOGtCY0DTxbP0RWT7hA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.52.tgz",
+      "integrity": "sha512-WdVesd9VJQv8BLLla+x1AjLa40D3QUfnXH488+ydOcOIX7c4m6RF8Sh3JsAF+5ICa2Vknc9GTBlOvqCKoivE1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.11.tgz",
+      "integrity": "sha512-GKu3RxsfKGWjBiXmEdsKsGR9uVgJ56mzL1w7mLsn5k2TiNtpyS2IYQo3v1NJpK3oyv2OVavlK3g801VSe+gujg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.31.tgz",
+      "integrity": "sha512-x4Q1NxNLw8V1AHKOunukpksbKCqzZdZEgpHgbZznUE3ZcWb2liI5j2321TlOvyfn1iL7NmNMFTD5mZYoChVx0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.11",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -4133,6 +4272,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -5397,7 +5545,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -5807,6 +5954,12 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "license": "MIT"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5859,6 +6012,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.210",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.210.tgz",
+      "integrity": "sha512-a/tUhQILXCLtuitzUJxA7pBAXUUjCxrCnyyFPnqWuz1ijFTH63FHZeyjqWgb3844FCz4FlP5dG44UYKWwd8JcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.135",
+        "@ai-sdk/provider": "3.0.11",
+        "@ai-sdk/provider-utils": "4.0.31",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -5897,6 +6068,15 @@
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
       "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
       "license": "MIT"
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -6413,6 +6593,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6424,6 +6613,143 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/bplist-creator": {
@@ -6537,6 +6863,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6556,7 +6888,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6564,6 +6895,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -6723,6 +7070,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -6997,6 +7356,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -7114,6 +7492,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -7162,7 +7549,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7171,6 +7557,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -7209,6 +7604,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
@@ -7222,7 +7629,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7248,7 +7654,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7380,6 +7785,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -7696,6 +8119,12 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fancy-canvas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
@@ -7866,6 +8295,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7981,6 +8433,36 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
+      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -8042,6 +8524,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8060,11 +8570,22 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8107,7 +8628,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8188,11 +8708,36 @@
         "node": "*"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8220,7 +8765,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8533,6 +9077,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8540,6 +9096,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -8592,6 +9160,21 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
@@ -8826,6 +9409,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
@@ -8861,6 +9459,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kleur": {
@@ -9386,7 +10005,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9973,6 +10591,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -10044,6 +10674,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -10142,6 +10781,44 @@
         }
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -10202,6 +10879,40 @@
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "license": "MIT"
     },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nunjucks/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ob1": {
       "version": "0.83.7",
       "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
@@ -10231,6 +10942,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obliterator": {
@@ -10315,6 +11038,246 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/opik/-/opik-2.1.3.tgz",
+      "integrity": "sha512-q/Gv+BjuXr/5coWuF8gRlbxoT+akn4ieZxfBzE8aOwrt/5XhQQiSYlE9tHvwU2zj6JCF7Fg+9P9XkGFZ2dUd8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.1",
+        "@ai-sdk/google": "^3.0.5",
+        "@ai-sdk/google-vertex": "^4.0.1",
+        "@ai-sdk/openai": "^3.0.7",
+        "ai": "^6.0.13",
+        "ansi-escapes": "^7.0.0",
+        "boxen": "^8.0.1",
+        "chalk": "^5.4.1",
+        "date-fns": "^3.5.0",
+        "dotenv": "^16.5.0",
+        "fast-deep-equal": "^3.1.3",
+        "fast-json-stable-stringify": "^2.1.0",
+        "form-data-encoder": "^4.0.2",
+        "formdata-node": "^6.0.3",
+        "ini": "^5.0.0",
+        "jest-diff": "^29.7.0",
+        "mustache": "^4.2.0",
+        "node-fetch": "^3.3.2",
+        "nunjucks": "^3.2.4",
+        "ora": "^8.2.0",
+        "qs": "^6.13.1",
+        "readable-stream": "^4.7.0",
+        "tslog": "^4.9.3",
+        "url-join": "^5.0.0",
+        "uuid": "^11.0.3",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.55 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/opik/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/opik/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/opik/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/opik/node_modules/ini": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/opik/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/opik/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opik/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/ora": {
@@ -10945,6 +11908,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -11007,6 +11979,22 @@
       "integrity": "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==",
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/query-string": {
@@ -11347,6 +12335,46 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/readdirp": {
@@ -11934,6 +12962,78 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -12123,6 +13223,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stream-buffers": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
@@ -12139,6 +13251,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -12621,6 +13742,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tslog": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
+      "integrity": "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
@@ -12765,6 +13898,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -12840,6 +13982,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {
@@ -13126,6 +14281,15 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
@@ -13185,6 +14349,71 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wonka": {
@@ -13291,6 +14520,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -13405,7 +14640,10 @@
     },
     "packages/shared": {
       "name": "@fomo/shared",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dependencies": {
+        "opik": "^2.1.3"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "supply:collect": "tsx scripts/supply-demand-collect.ts",
     "metrics:fomo": "tsx scripts/fomo-product-metrics.ts",
     "quality:fomo": "tsx scripts/fomo-quality-report.ts",
+    "eval:understanding": "tsx scripts/eval-understanding.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "main": "src/index.ts",
-  "types": "src/index.ts"
+  "types": "src/index.ts",
+  "dependencies": {
+    "opik": "^2.1.3"
+  }
 }

--- a/packages/shared/src/ai-client.ts
+++ b/packages/shared/src/ai-client.ts
@@ -1,0 +1,168 @@
+/**
+ * Provider-agnostic AI 클라이언트 — 모든 제품 LLM 호출의 단일 지점.
+ *
+ * OpenAI 호환 chat-completions(Groq / OpenAI / Anthropic 프록시 / 로컬 등)을
+ * AI_API_URL / AI_API_KEY / AI_MODEL 체계로 호출한다(CLAUDE.md 코드원칙 5).
+ * 모델 무관 단일 seam → 모델 교체·비교·관측·평가를 여기서 일괄한다.
+ * (Claude / Codex / Groq / 향후 모델 전부 이 한 지점을 통과)
+ *
+ * opik 추적 내장 — OPIK_API_KEY(또는 OPIK_URL_OVERRIDE)가 있을 때만 활성.
+ * 미설정·패키지 부재·추적 실패는 모두 fail-open(추적만 생략, 호출은 정상).
+ *
+ * 정직성: URL/키 미설정이면 호출하지 않고 빈 결과(ok=false)를 돌려준다 — 호출부가 폴백.
+ */
+
+export type AiRole = "system" | "user" | "assistant";
+
+export interface AiMessage {
+  role: AiRole;
+  content: string;
+}
+
+export interface CallAiOptions {
+  messages: AiMessage[];
+  /** 미지정 시 AI_MODEL env. 호출별 오버라이드로 모델 비교·라우팅. */
+  model?: string;
+  temperature?: number;
+  /** 기본 25_000ms. */
+  timeoutMs?: number;
+  apiUrl?: string;
+  apiKey?: string;
+  /** opik 추적/평가 그룹 이름(예: "theme-understanding"). */
+  trace?: string;
+  /** opik 메타데이터(태그·실험 비교용). */
+  metadata?: Record<string, unknown>;
+}
+
+export interface CallAiResult {
+  content: string;
+  ok: boolean;
+  status: number;
+  model: string;
+}
+
+interface LlmResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/** AI_API_KEY → (공란/USE_GITHUB_TOKEN) GITHUB_TOKEN 폴백. 7곳 중복이던 키 해소 로직 단일화. */
+export function resolveAiKey(apiKey?: string): string {
+  const configured = apiKey ?? process.env["AI_API_KEY"] ?? "";
+  if (!configured || configured.toUpperCase() === "USE_GITHUB_TOKEN") {
+    return process.env["GITHUB_TOKEN"] ?? "";
+  }
+  return configured;
+}
+
+export function aiApiUrl(apiUrl?: string): string {
+  return apiUrl ?? process.env["AI_API_URL"] ?? "";
+}
+
+export function resolveModel(model?: string): string {
+  return model || process.env["AI_MODEL"] || "openai/gpt-4.1-mini";
+}
+
+/** 호출 가능 여부(URL+키). 미설정이면 호출 생략하고 정직한 빈 결과. */
+export function isAiConfigured(apiUrl?: string, apiKey?: string): boolean {
+  return Boolean(aiApiUrl(apiUrl)) && Boolean(resolveAiKey(apiKey));
+}
+
+/**
+ * 단일 LLM 호출. 성공 시 content(=choices[0].message.content), 실패/미설정 시 ok=false + 빈 content.
+ * 예외를 던지지 않는다 — 호출부는 result.ok 로 분기하고 자체 폴백을 유지한다.
+ */
+export async function callAI(opts: CallAiOptions): Promise<CallAiResult> {
+  const url = aiApiUrl(opts.apiUrl);
+  const key = resolveAiKey(opts.apiKey);
+  const model = resolveModel(opts.model);
+  const result: CallAiResult = { content: "", ok: false, status: 0, model };
+  if (!url || !key) return result;
+
+  const finishTrace = beginTrace(opts.trace, {
+    model,
+    messages: opts.messages,
+    ...(opts.metadata ?? {}),
+  });
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        model,
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        messages: opts.messages,
+      }),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 25_000),
+    });
+    result.status = res.status;
+    if (!res.ok) {
+      console.warn(`[ai-client] ${opts.trace ?? "call"} HTTP ${res.status}`);
+      finishTrace({ ok: false, status: res.status });
+      return result;
+    }
+    const data = (await res.json()) as LlmResponse;
+    result.content = data.choices?.[0]?.message?.content ?? "";
+    result.ok = true;
+    finishTrace({ ok: true, status: res.status, content: result.content });
+    return result;
+  } catch (err) {
+    console.warn(`[ai-client] ${opts.trace ?? "call"} error`, err);
+    finishTrace({ error: String(err) });
+    return result;
+  }
+}
+
+// ---- opik 추적(선택, fail-open) ------------------------------------------------
+
+type TraceFinish = (output: Record<string, unknown>) => void;
+const noopFinish: TraceFinish = () => {};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- opik SDK는 동적 로드(선택 의존성)
+let opikClientPromise: Promise<any> | undefined;
+
+function opikEnabled(): boolean {
+  return Boolean(process.env["OPIK_API_KEY"] || process.env["OPIK_URL_OVERRIDE"]);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getOpikClient(): Promise<any> {
+  if (!opikEnabled()) return null;
+  if (opikClientPromise === undefined) {
+    opikClientPromise = import("opik")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then((m: any) => (m?.Opik ? new m.Opik() : null))
+      .catch((err: unknown) => {
+        console.warn("[ai-client] opik 추적 비활성(패키지/설정 없음)", err);
+        return null;
+      });
+  }
+  return opikClientPromise;
+}
+
+/** opik trace 시작 → 종료 콜백 반환. 메인 호출을 절대 블로킹/실패시키지 않는다. */
+function beginTrace(name: string | undefined, input: Record<string, unknown>): TraceFinish {
+  if (!name || !opikEnabled()) return noopFinish;
+  const tracePromise = getOpikClient()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .then((client: any) => (client ? client.trace({ name, input }) : null))
+    .catch(() => null);
+  return (output: Record<string, unknown>) => {
+    void tracePromise
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then(async (trace: any) => {
+        if (!trace) return;
+        try {
+          const span = trace.span({ name, type: "llm", input, output });
+          span.end();
+          trace.end({ output });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const client: any = await getOpikClient();
+          if (client?.flush) await client.flush();
+        } catch {
+          /* fail-open: 추적 실패는 제품에 영향 없음 */
+        }
+      })
+      .catch(() => {});
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./ai-client.js";
+
 export type BotMode = "paper" | "real";
 export type BotStatus = "RUNNING" | "STOPPED" | "DEGRADED";
 export type StrategyStatus = "ACTIVE" | "PAUSED" | "DISABLED";

--- a/scripts/eval-understanding.ts
+++ b/scripts/eval-understanding.ts
@@ -1,0 +1,112 @@
+/**
+ * 이해 레이어 grounding 평가 — 응축 워딩이 원문에 실제로 근거하는지 LLM-as-judge로 점수화.
+ *
+ * 왜: 제품의 #1 리스크는 "지어내기"(grounding 위반). 이 점수가 안 보이면 응축 품질 개선이 정체된다.
+ * 무엇: (원문 sources, 생성 wordings) 쌍을 모델이 보고 각 워딩의 grounded 여부를 판정 → pass rate.
+ * 어떻게: 공용 callAI(@fomo/shared) 사용 → OPIK_* 설정 시 자동으로 opik 에 추적/평가 기록.
+ *
+ * 실행: npm run eval:understanding   (또는 tsx scripts/eval-understanding.ts)
+ * 회귀: 아래 SAMPLES 를 실제 파이프라인 출력(runUnderstanding 결과)으로 교체하면 모델·프롬프트 변경 회귀 측정.
+ * CI 게이트: pass rate < 80% 이면 exit 1.
+ */
+import { callAI, isAiConfigured } from "@fomo/shared";
+
+interface Sample {
+  subject: string;
+  sources: string[];
+  wordings: string[];
+}
+
+// 내장 샘플(반도체) — 일부러 grounded/비grounded 섞음. 실제 출력으로 교체 가능.
+const SAMPLES: Sample[] = [
+  {
+    subject: "반도체",
+    sources: [
+      "SK하이닉스가 HBM3E 12단 양산을 시작했다고 23일 밝혔다.",
+      "삼성전자 4분기 영업이익이 전분기 대비 둔화됐다는 증권가 전망이 나왔다.",
+      "외국인은 이번 주 코스피 반도체 업종을 3거래일 연속 순매수했다.",
+    ],
+    wordings: [
+      "HBM 양산이 본격화되는 분위기", // grounded (source 1)
+      "외국인 수급이 반도체로 유입", // grounded (source 3)
+      "삼성전자 실적은 무조건 반등한다", // NOT grounded (단정·예측, source 2는 둔화 전망)
+    ],
+  },
+];
+
+function buildJudgePrompt(s: Sample): string {
+  return [
+    "너는 투자정보 응축 엔진의 grounding 심사관이다.",
+    "각 '워딩'이 아래 '원문 출처'에 실제로 근거하는지 판정하라.",
+    "grounded=true: 출처에서 사실로 확인됨. grounded=false: 출처에 없거나, 예측·단정·과장으로 비약.",
+    "출처에 없는 미래 단정('무조건/반드시/반등한다')은 grounded=false.",
+    "",
+    `[원문 출처]\n${s.sources.map((x, i) => `(${i + 1}) ${x}`).join("\n")}`,
+    "",
+    `[워딩]\n${JSON.stringify(s.wordings)}`,
+    "",
+    '출력은 JSON 배열만: [{"wording":"원문그대로","grounded":true,"reason":"짧은 사유"}]',
+  ].join("\n");
+}
+
+interface Verdict {
+  wording: string;
+  grounded: boolean;
+  reason: string;
+}
+
+function parseVerdicts(content: string): Verdict[] {
+  const start = content.indexOf("[");
+  const end = content.lastIndexOf("]");
+  if (start === -1 || end <= start) return [];
+  try {
+    const arr = JSON.parse(content.slice(start, end + 1)) as unknown;
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .filter((r): r is Record<string, unknown> => Boolean(r) && typeof r === "object")
+      .map((o) => ({
+        wording: typeof o["wording"] === "string" ? o["wording"] : "",
+        grounded: o["grounded"] === true,
+        reason: typeof o["reason"] === "string" ? o["reason"] : "",
+      }));
+  } catch {
+    return [];
+  }
+}
+
+async function main(): Promise<void> {
+  if (!isAiConfigured()) {
+    console.error("AI 미설정 — AI_API_URL/AI_API_KEY 필요(.env.example 참조)");
+    process.exit(1);
+  }
+
+  let total = 0;
+  let grounded = 0;
+
+  for (const sample of SAMPLES) {
+    const res = await callAI({
+      messages: [{ role: "user", content: buildJudgePrompt(sample) }],
+      temperature: 0,
+      trace: "eval-understanding",
+      metadata: { subject: sample.subject },
+    });
+    if (!res.ok) {
+      console.warn(`[eval] 판정 실패 (${sample.subject}) status=${res.status}`);
+      continue;
+    }
+    for (const v of parseVerdicts(res.content)) {
+      total += 1;
+      if (v.grounded) grounded += 1;
+      console.log(`${v.grounded ? "✓" : "✗"} [${sample.subject}] ${v.wording} — ${v.reason}`);
+    }
+  }
+
+  const rate = total > 0 ? Math.round((grounded / total) * 100) : 0;
+  console.log(`\nGrounding pass rate: ${grounded}/${total} (${rate}%)  model=${SAMPLES.length ? "see traces" : "-"}`);
+  if (process.env["OPIK_API_KEY"] || process.env["OPIK_URL_OVERRIDE"]) {
+    console.log("→ opik 에 추적 기록됨(프로젝트: " + (process.env["OPIK_PROJECT_NAME"] ?? "fomo-club") + ")");
+  }
+  process.exit(rate >= 80 ? 0 : 1);
+}
+
+void main();


### PR DESCRIPTION
## 판단 (후보 3종)
- **opik** (comet-ml, 19.8k★) → 🟢 **적용**. 제품 심장(응축·이해 레이어)의 품질이 안 보이던 게 정체의 구조적 원인. LLM 호출 관측·평가로 가시화.
- **graphiti** (getzep, 27.9k★) → 🟡 **후보 보류**. 이해 레이어엔 최강이나 Python+Neo4j 무거움 → 정체 국면에 붙이면 야크쉐이빙. `DATA_ENGINE_STRATEGY §9.2`에 채택 조건 기록.
- **agent-skills** → 이미 수확 완료(보안 체크리스트). 새로 적용할 것 없음.

## 핵심 발견
codebase-memory로 훑으니 제품 LLM 호출이 **7곳에 중복**(각자 `AI_API_URL`/키해소/`fetch`) — **관측·평가 지점이 없어서** 응축 품질이 안 보였음. 이게 정체의 구조적 원인.

## 변경
- **`packages/shared/ai-client.ts`** — `callAI()` 단일 seam. `AI_API_URL/AI_API_KEY/AI_MODEL` 체계, **모델 무관**(Claude/Codex/Groq/향후 모델 전부 통과), opik 추적 내장(`OPIK_*` 없으면 fail-open). 키해소(GITHUB_TOKEN 폴백)·타임아웃·에러처리 단일화.
- **제품 런타임 4파일 이관** — `theme-understanding`(runUnderstanding·judgeWordings), `fomo-comment`, `fomo-keyword-comment`, `fomo-translate`. 캐시·폴백·프롬프트는 그대로(동작 동일).
- **`scripts/eval-understanding.ts`** (`npm run eval:understanding`) — LLM-as-judge grounding pass rate 측정, <80% exit 1(CI 게이트화 가능). "User Zero 검수 자동화"의 첫 계단.
- opik 의존성(shared), `.env.example` OPIK_*, `next.config` `serverExternalPackages:["opik"]`(네이티브 의존 번들 제외).
- `DATA_ENGINE_STRATEGY §9` — opik(적용)·graphiti(후보) 기록.

## 멀티 LLM 방향
모든 LLM 호출이 `callAI` 한 지점을 통과 → 모델 교체·비교·관측·평가를 일괄. Claude/Codex/Groq + 향후 추가 모델까지 동일 계측.

## 검증
- typecheck 전체 통과 · test **887/887** · build:web 성공 (rebase 후 재검증 포함)
- 정체성 가드레일 유지(매매신호·예측·점수 진열 신설 없음)

## Follow-up (이 PR 제외)
dev/ops 호출 3곳(`slack/events`·`researchPipeline`·`council-meeting`)은 제품 심장이 아니라 다음 PR에서 `callAI` 이관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)