### PR TITLE
Improve discovery WHY quality

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -14,6 +14,7 @@ import {
   resolveStock,
   sectorOf,
   selectMultiAxisHook,
+  stockMentionRole,
   stockMatchesText,
   type AxisSignal,
   type CardFrontSignals,
@@ -38,8 +39,8 @@ const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
 const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 5;
 const SPARKLINE_CONCURRENCY = 8;
-const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL === "1";
-const DISCOVERY_FLOW_ENABLED = process.env.DISCOVERY_FLOW_LIVE === "1";
+const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
+const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
 const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED ? 12 : 0;
 const TARGETED_MATERIAL_CONCURRENCY = 4;
 const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
@@ -209,7 +210,7 @@ function eventFromPrice(row: NaverMarketRow, asOf: string): DiscoveryEvent | nul
 }
 
 function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string): DiscoveryEvent | null {
-  if (!attention || attention.mentionCount <= 0) return null;
+  if (!attention?.newsEventLabel || attention.mentionCount <= 0) return null;
   return {
     kind: "news_mention",
     firstSeen: true,
@@ -238,6 +239,13 @@ function isStockArticle(canonical: string, article: RawArticle): boolean {
   return stockMatchesText(canonical, `${article.title} ${article.summary ?? ""}`);
 }
 
+function isPrimaryStockArticle(canonical: string, article: RawArticle): boolean {
+  return stockMentionRole(canonical, {
+    title: article.title,
+    ...(article.summary ? { summary: article.summary } : {}),
+  }) === "primary";
+}
+
 function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
   const label = cleanMaterialTitle(article.title);
   if (!label) return null;
@@ -262,7 +270,7 @@ async function eventFromTargetedMaterial(row: NaverMarketRow, asOf: string): Pro
 
   const stockNews =
     newsResult.status === "fulfilled"
-      ? newsResult.value.find((article) => isStockArticle(row.canonical, article))
+      ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article))
       : undefined;
   if (stockNews) return materialEventFromArticle(stockNews, asOf, "네이버 종목뉴스");
 
@@ -306,18 +314,31 @@ function buildThemeMoveSignals(rows: readonly NaverMarketRow[]): Map<string, The
 }
 
 function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
-  if (!theme || typeof row.changePct !== "number" || row.changePct <= 0) return null;
+  if (!theme || typeof row.changePct !== "number") return null;
   const strongTheme = theme.averageChangePct >= 1.5 && theme.positiveCount >= 2;
+  const weakTheme = theme.averageChangePct <= -1.5 && theme.positiveCount <= Math.max(1, Math.floor(theme.peerCount / 3));
   const leadingTheme = theme.rank <= 3 && row.changePct >= 5;
-  if (!strongTheme && !leadingTheme) return null;
+  const laggingTheme = theme.rank >= Math.max(3, theme.peerCount - 2) && row.changePct <= -5;
+  const bigSectorMove = Math.abs(row.changePct) >= 7 && Math.abs(theme.relativeChangePct) >= 2;
+  const sectorSpike = Math.abs(row.changePct) >= 5;
+  if (!strongTheme && !weakTheme && !leadingTheme && !laggingTheme && !bigSectorMove && !sectorSpike) return null;
+  const weakRank = theme.peerCount - theme.rank + 1;
   const label =
-    theme.rank <= 3
-      ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 ${ordinalText(theme.rank)} 강하게 움직였어요.`
-      : `오늘 ${theme.sector} 흐름이 강했고, 이 종목도 같이 움직였어요.`;
+    row.changePct < 0
+      ? laggingTheme
+        ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 아래에서 ${ordinalText(weakRank)} 약했어요(${pctText(row.changePct)}).`
+        : theme.relativeChangePct >= 0
+          ? `가격은 빠졌지만 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다는 ${pointText(theme.relativeChangePct)}포인트 덜 약했어요(${pctText(row.changePct)}).`
+          : `오늘 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다 ${pointText(theme.relativeChangePct)}포인트 더 약했어요(${pctText(row.changePct)}).`
+      : theme.rank <= 3
+        ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 ${ordinalText(theme.rank)} 강했어요(${pctText(row.changePct)}).`
+        : theme.relativeChangePct >= 0
+          ? `오늘 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다 ${pointText(theme.relativeChangePct)}포인트 더 강했어요(${pctText(row.changePct)}).`
+          : `가격은 올랐지만 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다는 ${pointText(theme.relativeChangePct)}포인트 덜 강했어요(${pctText(row.changePct)}).`;
   return {
     kind: "theme_link",
     firstSeen: true,
-    strength: Math.min(0.92, 0.48 + Math.max(0, theme.averageChangePct) / 10 + Math.max(0, row.changePct) / 40),
+    strength: Math.min(0.92, 0.48 + Math.abs(theme.averageChangePct) / 10 + Math.abs(row.changePct) / 40),
     source: "FOMO 섹터맵·네이버 시세",
     asOf,
     confidence: "M",
@@ -328,6 +349,10 @@ function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined,
 function pctText(value: number): string {
   const sign = value > 0 ? "+" : "";
   return `${sign}${value.toFixed(2)}%`;
+}
+
+function pointText(value: number): string {
+  return Math.abs(value).toFixed(1);
 }
 
 function ordinalText(rank: number): string {
@@ -383,7 +408,6 @@ function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | un
 }
 
 async function eventFromFlow(ticker: string): Promise<DiscoveryEvent | null> {
-  if (!DISCOVERY_FLOW_ENABLED) return null;
   if (!process.env.DATABASE_URL) return null;
   const history = await readSupplyDemandHistory(ticker, 10);
   if (history.length === 0) return null;
@@ -408,13 +432,12 @@ function eventAxisSignal(event: DiscoveryEvent): AxisSignal | null {
     event.kind !== "theme_link" &&
     event.kind !== "flow_entry" &&
     event.kind !== "disclosure" &&
-    event.kind !== "news_mention" &&
-    event.kind !== "market_context"
+    event.kind !== "news_mention"
   ) return null;
   const axis =
-    event.kind === "theme_link" || event.kind === "market_context" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
+    event.kind === "theme_link" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
   const sourceKind =
-    event.kind === "theme_link" || event.kind === "market_context"
+    event.kind === "theme_link"
       ? "market"
       : event.kind === "news_mention"
         ? "news"
@@ -425,9 +448,7 @@ function eventAxisSignal(event: DiscoveryEvent): AxisSignal | null {
     axis,
     fired: true,
     strength:
-      event.kind === "market_context"
-        ? event.strength
-        : event.kind === "theme_link"
+      event.kind === "theme_link"
           ? Math.max(0.91, event.strength)
           : event.kind === "news_mention"
             ? Math.max(0.94, event.strength)
@@ -585,7 +606,7 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
   }
 
-  if (DISCOVERY_FLOW_ENABLED) {
+  if (DISCOVERY_FLOW_CACHE_ENABLED) {
     const flowRows = await mapLimit([...byTicker.keys()], 8, async (ticker) => ({ ticker, event: await eventFromFlow(ticker) }));
     for (const result of flowRows) {
       if (result.status !== "fulfilled" || !result.value.event) continue;

--- a/apps/web/lib/stock-signal-coverage.ts
+++ b/apps/web/lib/stock-signal-coverage.ts
@@ -4,7 +4,7 @@ import {
   fetchCommunity,
   isFrontHookSafe,
   signalsFromBasics,
-  stockMatchesText,
+  stockMentionRole,
   stocksBySector,
   type StockSector,
   type KeywordSourceItem,
@@ -86,7 +86,7 @@ function buildNewsEventMap(newsItems: readonly KeywordSourceItem[], canonicals: 
   const out = new Map<string, { label: string; source?: string }>();
   for (const canonical of canonicals) {
     for (const item of newsItems) {
-      if (!stockMatchesText(canonical, item.title)) continue;
+      if (stockMentionRole(canonical, item) !== "primary") continue;
       const label = cleanNewsEventTitle(item.title);
       if (!label) continue;
       out.set(canonical, {

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   discoveryWhy,
   eligibleUniverse,
+  hasDisplayWhyEvent,
+  isWeakDiscoveryCandidate,
   rankDiscoveryCandidates,
   type DiscoveryEventKind,
   type DiscoveryCandidate,
@@ -88,23 +90,32 @@ describe("WO-05 discovery supply engine", () => {
     expect(discoveryWhy(row)).toContain("공급계약");
   });
 
-  it("ranks contextual theme links above market context but below material events", () => {
+  it("keeps contextual theme links and drops weak market context", () => {
     const ranked = rankDiscoveryCandidates([
       candidate("시장맥락", 0.65, "market_context", "KOSPI 시총 상위권에서 오늘 +1.2% 움직였어요."),
       candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요."),
       candidate("수급", 0.5, "flow_entry", "기관이 3일째 사는 중이에요."),
     ]);
 
-    expect(ranked.map((c) => c.ticker)).toEqual(["수급", "테마", "시장맥락"]);
+    expect(ranked.map((c) => c.ticker)).toEqual(["수급", "테마"]);
   });
 
-  it("keeps the deck full when market context gives every card a real reason", () => {
+  it("does not treat market context as a real display WHY", () => {
+    const market = candidate("시장맥락", 0.55, "market_context", "KOSPI 시총 상위권에서 오늘 +1.2% 움직였어요.");
+    const theme = candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
+
+    expect(hasDisplayWhyEvent(market)).toBe(false);
+    expect(isWeakDiscoveryCandidate(market)).toBe(true);
+    expect(hasDisplayWhyEvent(theme)).toBe(true);
+    expect(isWeakDiscoveryCandidate(theme)).toBe(false);
+  });
+
+  it("drops weak market-context padding instead of filling the deck with price restatements", () => {
     const rows = Array.from({ length: 100 }, (_, index) =>
       candidate(`시장${index}`, 0.35 + (index % 10) / 100, "market_context", `KOSPI 시총 ${index + 1}위권에서 오늘 시장 흐름과 같이 확인해요.`)
     );
     const ranked = rankDiscoveryCandidates(rows, { maxCandidates: 100 });
 
-    expect(ranked).toHaveLength(100);
-    expect(ranked.every((row) => discoveryWhy(row).length > 0)).toBe(true);
+    expect(ranked).toHaveLength(0);
   });
 });

--- a/packages/fomo-core/__tests__/stock-extraction.test.ts
+++ b/packages/fomo-core/__tests__/stock-extraction.test.ts
@@ -3,6 +3,7 @@ import {
   extractStocks,
   isLikelyStock,
   pickSurpriseStock,
+  stockMentionRole,
   stockMatchesText,
   stockDef,
   resolveStock,
@@ -78,6 +79,29 @@ describe("stockMatchesText — 별칭/티커 grounding", () => {
   it("stockDef 로 정의 조회", () => {
     expect(stockDef("엔비디아")?.country).toBe("US");
     expect(stockDef("없는종목")).toBeUndefined();
+  });
+});
+
+describe("stockMentionRole — 뉴스 WHY 주어/부차 언급 분리", () => {
+  it("제목에서 먼저 등장한 종목만 primary 로 본다", () => {
+    const item = {
+      title: "하이닉스, 나스닥100 연내편입 유력…삼성전자도 ADR 상장설",
+      summary: "메모리 업종 주요 종목이 함께 언급됐어요.",
+    };
+
+    expect(stockMentionRole("SK하이닉스", item)).toBe("primary");
+    expect(stockMentionRole("삼성전자", item)).toBe("secondary");
+  });
+
+  it("본문에만 등장한 종목은 WHY 헤드라인 후보에서 내린다", () => {
+    const item = {
+      title: "SK하이닉스, AI 메모리 투자 확대",
+      summary: "삼성전자와 마이크론도 업황 비교 대상으로 언급됐어요.",
+    };
+
+    expect(stockMentionRole("SK하이닉스", item)).toBe("primary");
+    expect(stockMentionRole("삼성전자", item)).toBe("secondary");
+    expect(stockMentionRole("엔비디아", item)).toBe("none");
   });
 });
 

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -102,11 +102,11 @@ export function hasThemeLinkEvent(candidate: DiscoveryCandidate): boolean {
 }
 
 export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
-  return hasPublicMaterialEvent(candidate) || candidate.events.some((event) => event.kind === "theme_link" || event.kind === "market_context");
+  return hasPublicMaterialEvent(candidate) || candidate.events.some((event) => event.kind === "theme_link");
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
-  return !hasDisplayWhyEvent(candidate) && candidate.events.every((event) => event.kind === "price_move" || event.kind === "volume_spike");
+  return !hasDisplayWhyEvent(candidate) && candidate.events.every((event) => event.kind === "price_move" || event.kind === "volume_spike" || event.kind === "market_context");
 }
 
 const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {

--- a/packages/fomo-core/src/keyword-cards/stocks.ts
+++ b/packages/fomo-core/src/keyword-cards/stocks.ts
@@ -199,6 +199,50 @@ export interface ExtractStocksOptions {
   minMentions?: number;
 }
 
+export type StockMentionRole = "primary" | "secondary" | "none";
+
+function aliasMatchIndex(def: StockDef, text: string): number {
+  const blob = text.toLowerCase();
+  let best = Number.POSITIVE_INFINITY;
+  for (const alias of def.aliases) {
+    const low = alias.toLowerCase();
+    if (isAsciiAlias(alias)) {
+      const re = new RegExp(`(^|[^a-z0-9])${escapeRegex(low)}([^a-z0-9]|$)`, "i");
+      const match = re.exec(blob);
+      if (match) best = Math.min(best, match.index + (match[1]?.length ?? 0));
+    } else {
+      const index = blob.indexOf(low);
+      if (index >= 0) best = Math.min(best, index);
+    }
+  }
+  return best;
+}
+
+/**
+ * 기사/원문이 특정 종목을 어느 정도로 다루는지.
+ * - primary: 제목에서 해당 종목이 가장 먼저 등장하거나 제목이 그 종목명으로 시작.
+ * - secondary: 본문/제목에 등장하지만 다른 종목이 먼저 나온 부차 언급.
+ * WHY 헤드라인은 primary 에만 붙인다. 부차 동시언급을 그대로 쓰면 삼성=하이닉스 같은 중복 이유가 된다.
+ */
+export function stockMentionRole(canonical: string, item: Pick<KeywordSourceItem, "title" | "summary">): StockMentionRole {
+  const def = resolveStock(canonical);
+  if (!def) return "none";
+  const title = item.title ?? "";
+  const summary = item.summary ?? "";
+  if (!stockMatchesText(canonical, `${title} ${summary}`)) return "none";
+
+  const titleIndex = aliasMatchIndex(def, title);
+  if (Number.isFinite(titleIndex)) {
+    const titleHits = STOCK_VOCAB
+      .map((stock) => ({ stock, index: aliasMatchIndex(stock, title) }))
+      .filter((hit) => Number.isFinite(hit.index))
+      .sort((a, b) => a.index - b.index || a.stock.canonical.localeCompare(b.stock.canonical));
+    return titleHits[0]?.stock.canonical === def.canonical ? "primary" : "secondary";
+  }
+
+  return stockMatchesText(canonical, summary) ? "secondary" : "none";
+}
+
 /**
  * 그날 원문 글 → 등장 종목 추출(빈도 임계 컷). §1 "원문이 곧 필터".
  * - 글 1건에 같은 종목이 여러 별칭으로 나와도 그 글은 1회로 센다(글 수 기준).


### PR DESCRIPTION
## Summary
- Treat market-context and bare mention-count signals as weak/backstop signals instead of real card WHY.
- Add primary-vs-secondary stock mention detection so a headline led by one stock is not reused as another stock's WHY.
- Re-enable capped targeted stock news/research material lookup by default, with primary-title guard for stock news.
- Broaden theme-link WHY to down/relative sector moves, so movers get sector-position context instead of price restatement.

## Monitoring sample (local live discovery, 2026-06-25 KST)
- Count: 70 cards, confidence H
- Top 30 weak/price-only WHY: 0
- Top 30 no-WHY: 0
- Duplicate WHY: 23 -> 14
- Axis mix: time 20 / herd 35 / price 15
- Default response time sample: ~938ms

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts packages/fomo-core/__tests__/stock-extraction.test.ts
- npm run typecheck
- npm run build:web