### PR TITLE
에이전트 툴링 후보를 하루 1개 중심으로 재설계

### DIFF
--- a/.github/workflows/agent-tooling-scout.yml
+++ b/.github/workflows/agent-tooling-scout.yml
@@ -6,14 +6,18 @@ name: Agent Tooling Scout
 on:
   workflow_dispatch:
     inputs:
-      repos:
-        description: "Comma-separated repos to scan"
+      seed_repos:
+        description: "Comma-separated curated repos to inspect"
         required: false
-        default: "mlender-ai/simulo,openai/codex,anthropics/claude-code,modelcontextprotocol/servers,github/github-mcp-server,microsoft/playwright-mcp"
-      days:
-        description: "Lookback window in days"
+        default: "NVIDIA/SkillSpector,openai/codex,anthropics/claude-code,github/github-mcp-server,modelcontextprotocol/servers,microsoft/playwright-mcp"
+      search_queries:
+        description: "Pipe-separated GitHub search queries"
         required: false
-        default: "21"
+        default: "agent skills security scanner|claude code skills|codex agent tooling|mcp agent workflow|ai agent security"
+      updated_days:
+        description: "Require repos to be updated within this many days"
+        required: false
+        default: "60"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -40,15 +44,17 @@ jobs:
       - name: Run tooling scout
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TOOLING_SCOUT_REPOS: ${{ github.event.inputs.repos || 'mlender-ai/simulo,openai/codex,anthropics/claude-code,modelcontextprotocol/servers,github/github-mcp-server,microsoft/playwright-mcp' }}
-          TOOLING_SCOUT_DAYS: ${{ github.event.inputs.days || '21' }}
+          TOOLING_SCOUT_SEED_REPOS: ${{ github.event.inputs.seed_repos || 'NVIDIA/SkillSpector,openai/codex,anthropics/claude-code,github/github-mcp-server,modelcontextprotocol/servers,microsoft/playwright-mcp' }}
+          TOOLING_SCOUT_SEARCH_QUERIES: ${{ github.event.inputs.search_queries || 'agent skills security scanner|claude code skills|codex agent tooling|mcp agent workflow|ai agent security' }}
+          TOOLING_SCOUT_UPDATED_DAYS: ${{ github.event.inputs.updated_days || '60' }}
+          TOOLING_SCOUT_MIN_STARS: "1000"
         run: npm run agent:tooling-scout
 
       - name: Upload scout report
         uses: actions/upload-artifact@v4
         with:
           name: agent-tooling-scout
-          path: agent-tooling-reports/latest.md
+          path: agent-tooling-reports/*
 
       - name: Create or update review issue
         uses: actions/github-script@v7
@@ -56,6 +62,12 @@ jobs:
           script: |
             const fs = require("fs");
             const body = fs.readFileSync("agent-tooling-reports/latest.md", "utf8");
+            const summary = JSON.parse(fs.readFileSync("agent-tooling-reports/latest.json", "utf8"));
+            if (!summary.candidateCount) {
+              core.info("오늘 후보 없음");
+              return;
+            }
+
             const labels = [
               { name: "agent-ops", color: "1d76db", description: "Agent operations and tooling" },
               { name: "tooling-scout", color: "5319e7", description: "Automated agent/tooling update scout" },
@@ -81,8 +93,8 @@ jobs:
               const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
               return `${values.year}-${values.month}-${values.day}`;
             };
-            const date = kstDate();
-            const title = `에이전트 툴링 업데이트 후보 - ${date}`;
+            const date = summary.generatedDateKst || kstDate();
+            const title = `오늘의 에이전트 툴링 후보 - ${date}`;
             const marker = "<!-- agent-tooling-scout -->";
             const issueBody = `${marker}\n\n${body}`;
             const { data: openIssues } = await github.rest.issues.listForRepo({
@@ -92,7 +104,8 @@ jobs:
               labels: "tooling-scout",
               per_page: 30
             });
-            const existing = openIssues.find((issue) => issue.title === title);
+            const existing = openIssues.find((issue) => issue.title === title)
+              || openIssues.find((issue) => issue.title.includes(date) && issue.body?.includes(marker));
 
             if (existing) {
               await github.rest.issues.update({

--- a/scripts/agent-tooling-scout.ts
+++ b/scripts/agent-tooling-scout.ts
@@ -2,88 +2,109 @@ import { execFileSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
-type CandidateRisk = "low" | "medium" | "high";
+type ApplicationIdea = "검토만" | "PoC 후보" | "바로 도입 후보";
+type CandidateSource = "seed" | "search";
 
-interface GitHubCommitSummary {
-  sha: string;
+interface GitHubRepo {
+  full_name: string;
   html_url: string;
-  commit: {
-    message: string;
-    author?: { date?: string };
-  };
+  description: string | null;
+  stargazers_count: number;
+  updated_at: string;
+  pushed_at?: string;
+  archived: boolean;
+  topics?: string[];
 }
 
-interface GitHubCommitDetail extends GitHubCommitSummary {
-  files?: Array<{
-    filename: string;
-    status?: string;
-    additions?: number;
-    deletions?: number;
-  }>;
+interface GitHubSearchResponse {
+  items: GitHubRepo[];
+}
+
+interface ScoreBreakdown {
+  trust: number;
+  fit: number;
+  directness: number;
+  recency: number;
 }
 
 interface ToolingCandidate {
-  repo: string;
-  title: string;
+  fullName: string;
   url: string;
-  sha: string;
-  date: string;
+  description: string;
+  stars: number;
+  updatedAt: string;
+  topics: string[];
+  source: CandidateSource;
+  sourceLabel: string;
   score: number;
-  risk: CandidateRisk;
-  matchedKeywords: string[];
-  paths: string[];
-  whyItMatters: string[];
-  suggestedIssue: string;
+  scoreBreakdown: ScoreBreakdown;
+  matchedSignals: string[];
+  whyItMatters: string;
+  applicationIdea: ApplicationIdea;
+  risk: string;
 }
 
-const DEFAULT_REPOS = [
-  "mlender-ai/simulo",
+interface ScoutSummary {
+  generatedAt: string;
+  generatedDateKst: string;
+  candidateCount: number;
+  primary?: Pick<ToolingCandidate, "fullName" | "url" | "stars" | "score">;
+  runnerUp?: Pick<ToolingCandidate, "fullName" | "url" | "stars" | "score">;
+  errors: string[];
+}
+
+const DEFAULT_SEED_REPOS = [
+  "NVIDIA/SkillSpector",
   "openai/codex",
   "anthropics/claude-code",
-  "modelcontextprotocol/servers",
   "github/github-mcp-server",
-  "microsoft/playwright-mcp",
+  "modelcontextprotocol/servers",
+  "microsoft/playwright-mcp"
 ];
-const DEFAULT_DAYS = 21;
-const MAX_COMMITS_PER_REPO = 30;
-const MAX_CANDIDATES = 8;
+
+const DEFAULT_SEARCH_QUERIES = [
+  "agent skills security scanner",
+  "claude code skills",
+  "codex agent tooling",
+  "mcp agent workflow",
+  "ai agent security"
+];
+
+const DEFAULT_UPDATED_DAYS = 60;
+const DEFAULT_MIN_STARS = 1000;
+const MAX_SEARCH_ITEMS_PER_QUERY = 10;
+const STRONG_SEED_MIN_SCORE = 65;
+const RUNNER_UP_MAX_SCORE_GAP = 8;
 const REPORT_DIR = "agent-tooling-reports";
 
-const KEYWORD_WEIGHTS: Array<{ keyword: string; weight: number; reason: string }> = [
-  { keyword: "agent", weight: 4, reason: "에이전트 운영 패턴 후보" },
-  { keyword: "codex", weight: 5, reason: "Codex 작업 방식 업데이트 후보" },
-  { keyword: "claude", weight: 3, reason: "멀티 LLM 핸드오프 비교 후보" },
-  { keyword: "mcp", weight: 6, reason: "MCP 도구 확장 후보" },
-  { keyword: "codebase_memory", weight: 6, reason: "코드베이스 탐색 비용 절감 후보" },
-  { keyword: "headroom", weight: 6, reason: "컨텍스트/토큰 예산 관리 후보" },
-  { keyword: "handoff", weight: 5, reason: "에이전트 핸드오프 규약 후보" },
-  { keyword: "workflow", weight: 3, reason: "GitHub Actions 자동화 후보" },
-  { keyword: "github", weight: 2, reason: "GitHub 이슈/PR 운영 후보" },
-  { keyword: "issue", weight: 2, reason: "이슈 생성/정리 자동화 후보" },
-  { keyword: "qa", weight: 3, reason: "품질 검수 자동화 후보" },
-  { keyword: "security", weight: 5, reason: "보안/grounding 가드 후보" },
-  { keyword: "grounding", weight: 5, reason: "근거 기반 출력 가드 후보" },
-  { keyword: "ci", weight: 3, reason: "CI 안정화 후보" },
-  { keyword: "tooling", weight: 4, reason: "개발 도구 개선 후보" }
+const FIT_SIGNALS: Array<{ pattern: RegExp; points: number; label: string }> = [
+  { pattern: /\bagents?\b/i, points: 18, label: "agent" },
+  { pattern: /\bskills?\b/i, points: 18, label: "skill" },
+  { pattern: /\bmcp\b|modelcontextprotocol/i, points: 18, label: "mcp" },
+  { pattern: /\bcodex\b/i, points: 15, label: "codex" },
+  { pattern: /\bclaude\b/i, points: 12, label: "claude" },
+  { pattern: /\btool(?:ing)?s?\b/i, points: 10, label: "tooling" },
+  { pattern: /\bworkflow\b|\bautomation\b/i, points: 10, label: "workflow" },
+  { pattern: /\bcontext\b|\bmemory\b/i, points: 8, label: "context" },
+  { pattern: /\beval(?:uation)?s?\b|\bbench(?:mark)?s?\b/i, points: 8, label: "evaluation" }
 ];
 
-const PATH_WEIGHTS: Array<{ pattern: RegExp; weight: number; reason: string }> = [
-  { pattern: /^\.github\/workflows\//, weight: 5, reason: "워크플로 자동화 변경" },
-  { pattern: /^scripts\/agents?\//, weight: 5, reason: "에이전트 스크립트 변경" },
-  { pattern: /^scripts\//, weight: 3, reason: "운영 스크립트 변경" },
-  { pattern: /AGENTS\.md$/, weight: 5, reason: "에이전트 규칙 변경" },
-  { pattern: /CLAUDE\.md$/, weight: 3, reason: "LLM 핸드오프 규칙 변경" },
-  { pattern: /SECURITY/i, weight: 5, reason: "보안 체크리스트 변경" },
-  { pattern: /package\.json$/, weight: 2, reason: "도구 의존성 또는 명령 변경" }
+const DIRECT_SIGNALS: Array<{ pattern: RegExp; points: number; label: string }> = [
+  { pattern: /\bsecurity\b|\bvulnerabilit(?:y|ies)\b|\bmalicious\b/i, points: 26, label: "security" },
+  { pattern: /\bscanner\b|\bscan\b|\baudit\b/i, points: 22, label: "scanner" },
+  { pattern: /\bmonitor(?:ing)?\b|\bobservability\b/i, points: 16, label: "monitoring" },
+  { pattern: /\bissue\b|\bgithub\b|\bpull request\b|\bpr\b/i, points: 14, label: "github-ops" },
+  { pattern: /\bworkflow\b|\bautomation\b|\bci\b/i, points: 12, label: "workflow-automation" },
+  { pattern: /\bskills?\b|\bmcp\b/i, points: 18, label: "skill-management" }
 ];
 
-const EXCLUDED_CHANGE_PATTERNS = [
-  /자동\s*이슈\s*생성\s*중단/i,
-  /schedule\s*트리거\s*제거/i,
-  /\bdisable[ds]?\b.*\b(workflow|cron|schedule|issue|agent)s?\b/i,
-  /\bremove[sd]?\b.*\b(workflow|cron|schedule|issue|agent)s?\b/i,
-  /\bdelete[sd]?\b.*\b(workflow|cron|schedule|issue|agent)s?\b/i,
-  /\bstop(?:ped|ping)?\b.*\b(workflow|cron|schedule|issue|agent)s?\b/i,
+const EXCLUDED_REPO_PATTERNS = [
+  /\b(product|startup|business)\s+ideas?\b/i,
+  /\bidea\s+generator\b/i,
+  /\btrading\b|\bstocks?\b|\bcrypto\b|\bforex\b|\bprediction\b|\bprice\s+target\b/i,
+  /\bbuy\b.*\bsell\b|\bsell\b.*\bbuy\b/i,
+  /\bschedule\b.*\b(disable|remove|stop)\b/i,
+  /\b(disable|remove|stop)\b.*\b(schedule|automation|workflow)\b/i
 ];
 
 function env(name: string): string | undefined {
@@ -91,25 +112,37 @@ function env(name: string): string | undefined {
   return value && value.length > 0 ? value : undefined;
 }
 
-function parseRepos(value: string | undefined): string[] {
-  const repos = (value ?? DEFAULT_REPOS.join(","))
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-
-  return repos.filter((repo) => /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo));
+function parseList(value: string | undefined, fallback: string[]): string[] {
+  return unique(
+    (value ?? fallback.join(","))
+      .split(/[,|\n]/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+  );
 }
 
-function parseDays(value: string | undefined): number {
+function parsePositiveInt(value: string | undefined, fallback: number, max: number): number {
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 1 || parsed > 90) {
-    return DEFAULT_DAYS;
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > max) {
+    return fallback;
   }
   return Math.floor(parsed);
 }
 
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function kstDate(now = new Date()): string {
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
 function git(args: string[]): string {
-  return execFileSync("git", args, { encoding: "utf8" }).trim();
+  try {
+    return execFileSync("git", args, { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
 }
 
 async function githubRequest<T>(apiPath: string): Promise<T> {
@@ -132,203 +165,281 @@ async function githubRequest<T>(apiPath: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-function unique(values: string[]): string[] {
-  return [...new Set(values.filter(Boolean))];
-}
+async function fetchSeedRepos(seedRepos: string[], errors: string[]): Promise<Array<{ repo: GitHubRepo; sourceLabel: string }>> {
+  const repos: Array<{ repo: GitHubRepo; sourceLabel: string }> = [];
 
-function cleanSubject(message: string): string {
-  return message.split("\n")[0]?.replace(/\s+/g, " ").trim() || "제목 없는 변경";
-}
+  for (const fullName of seedRepos) {
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(fullName)) {
+      errors.push(`${fullName}: 잘못된 seed repo 형식`);
+      continue;
+    }
 
-function scoreCommit(detail: GitHubCommitDetail): ToolingCandidate | null {
-  const files = detail.files ?? [];
-  const paths = files.map((file) => file.filename);
-  const searchable = `${detail.commit.message}\n${paths.join("\n")}`.toLowerCase();
-  if (EXCLUDED_CHANGE_PATTERNS.some((pattern) => pattern.test(searchable))) {
-    return null;
-  }
-
-  const matchedKeywords: string[] = [];
-  const whyItMatters: string[] = [];
-  let score = 0;
-
-  for (const item of KEYWORD_WEIGHTS) {
-    if (searchable.includes(item.keyword.toLowerCase())) {
-      matchedKeywords.push(item.keyword);
-      whyItMatters.push(item.reason);
-      score += item.weight;
+    try {
+      const repo = await githubRequest<GitHubRepo>(`/repos/${fullName}`);
+      repos.push({ repo, sourceLabel: "curated seed" });
+    } catch (error) {
+      errors.push(`${fullName}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
-  for (const item of PATH_WEIGHTS) {
-    if (paths.some((candidatePath) => item.pattern.test(candidatePath))) {
-      score += item.weight;
-      whyItMatters.push(item.reason);
+  return repos;
+}
+
+async function searchRepos(queries: string[], minStars: number, errors: string[]): Promise<Array<{ repo: GitHubRepo; sourceLabel: string }>> {
+  const repos: Array<{ repo: GitHubRepo; sourceLabel: string }> = [];
+
+  for (const query of queries) {
+    const q = `${query} stars:>=${minStars} archived:false`;
+    try {
+      const response = await githubRequest<GitHubSearchResponse>(
+        `/search/repositories?q=${encodeURIComponent(q)}&sort=stars&order=desc&per_page=${MAX_SEARCH_ITEMS_PER_QUERY}`
+      );
+      repos.push(...response.items.map((repo) => ({ repo, sourceLabel: `search: ${query}` })));
+    } catch (error) {
+      errors.push(`${query}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
-  if (score < 7) {
+  return repos;
+}
+
+function isFresh(updatedAt: string, updatedDays: number): boolean {
+  const updated = new Date(updatedAt).getTime();
+  if (!Number.isFinite(updated)) return false;
+  return Date.now() - updated <= updatedDays * 24 * 60 * 60 * 1000;
+}
+
+function normalizedText(repo: GitHubRepo): string {
+  return [repo.full_name, repo.description ?? "", ...(repo.topics ?? [])].join(" ");
+}
+
+function shouldExclude(repo: GitHubRepo): boolean {
+  const text = normalizedText(repo);
+  return EXCLUDED_REPO_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function scoreRepo(repo: GitHubRepo, source: CandidateSource, sourceLabel: string): ToolingCandidate | null {
+  const text = normalizedText(repo);
+  const matchedSignals: string[] = [];
+
+  const trust = Math.min(100, Math.round((Math.log10(repo.stargazers_count + 1) / 5) * 100));
+  const fit = Math.min(100, FIT_SIGNALS.reduce((sum, signal) => {
+    if (!signal.pattern.test(text)) return sum;
+    matchedSignals.push(signal.label);
+    return sum + signal.points;
+  }, source === "seed" ? 10 : 0));
+  const directness = Math.min(100, DIRECT_SIGNALS.reduce((sum, signal) => {
+    if (!signal.pattern.test(text)) return sum;
+    matchedSignals.push(signal.label);
+    return sum + signal.points;
+  }, 0));
+  const recency = recencyScore(repo.updated_at);
+  const score = Math.round(trust * 0.35 + fit * 0.35 + directness * 0.2 + recency * 0.1);
+
+  if (fit < 25 || directness < 12 || score < 45) {
     return null;
   }
-
-  const risk = assessRisk(detail);
-  const subject = cleanSubject(detail.commit.message);
-  const repo = env("CURRENT_SCOUT_REPO") ?? "unknown";
 
   return {
-    repo,
-    title: subject,
-    url: detail.html_url,
-    sha: detail.sha.slice(0, 12),
-    date: detail.commit.author?.date ?? "unknown",
+    fullName: repo.full_name,
+    url: repo.html_url,
+    description: repo.description?.replace(/\s+/g, " ").trim() || "설명 없음",
+    stars: repo.stargazers_count,
+    updatedAt: repo.updated_at,
+    topics: repo.topics ?? [],
+    source,
+    sourceLabel,
     score,
-    risk,
-    matchedKeywords: unique(matchedKeywords),
-    paths: paths.slice(0, 8),
-    whyItMatters: unique(whyItMatters).slice(0, 5),
-    suggestedIssue: buildSuggestedIssue(subject, risk)
+    scoreBreakdown: { trust, fit, directness, recency },
+    matchedSignals: unique(matchedSignals).slice(0, 8),
+    whyItMatters: buildWhyItMatters(repo),
+    applicationIdea: applicationIdea(score, directness),
+    risk: assessRisk(repo)
   };
 }
 
-function assessRisk(detail: GitHubCommitDetail): CandidateRisk {
-  const text = `${detail.commit.message}\n${(detail.files ?? []).map((file) => file.filename).join("\n")}`.toLowerCase();
-  if (/(secret|token|auth|permission|deploy|production|billing|payment)/.test(text)) {
-    return "high";
-  }
-  if (/(package\.json|lock|dependency|workflow|mcp|api)/.test(text)) {
-    return "medium";
-  }
-  return "low";
+function recencyScore(updatedAt: string): number {
+  const updated = new Date(updatedAt).getTime();
+  if (!Number.isFinite(updated)) return 0;
+  const ageDays = (Date.now() - updated) / (24 * 60 * 60 * 1000);
+  if (ageDays <= 7) return 100;
+  if (ageDays <= 30) return 80;
+  if (ageDays <= 60) return 60;
+  return 0;
 }
 
-function buildSuggestedIssue(subject: string, risk: CandidateRisk): string {
-  const approval = risk === "high" ? "보안/권한 리스크를 먼저 확인한 뒤" : "작은 PR로";
-  return `${approval} '${subject}' 변경에서 FOMO Club 에이전트 운영에 재사용할 수 있는 부분만 검토한다. 제품 아이디어 자동 생성이나 투자 판단 로직은 범위에서 제외한다.`;
-}
+function buildWhyItMatters(repo: GitHubRepo): string {
+  const text = normalizedText(repo).toLowerCase();
 
-async function collectRepoCandidates(repo: string, days: number): Promise<ToolingCandidate[]> {
-  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-  const commits = await githubRequest<GitHubCommitSummary[]>(
-    `/repos/${repo}/commits?per_page=${MAX_COMMITS_PER_REPO}&since=${encodeURIComponent(since)}`
-  );
-  const candidates: ToolingCandidate[] = [];
-
-  for (const commit of commits) {
-    process.env.CURRENT_SCOUT_REPO = repo;
-    const detail = await githubRequest<GitHubCommitDetail>(`/repos/${repo}/commits/${commit.sha}`);
-    const candidate = scoreCommit(detail);
-    if (candidate) {
-      candidates.push(candidate);
-    }
+  if (/\bsecurity\b|\bscanner\b|\bvulnerabilit/.test(text)) {
+    return "에이전트 스킬과 외부 도구를 도입하기 전에 악성 패턴과 권한 리스크를 먼저 걸러낼 수 있다.";
   }
-
-  delete process.env.CURRENT_SCOUT_REPO;
-  return candidates;
+  if (/\bmcp\b|modelcontextprotocol/.test(text)) {
+    return "에이전트가 실제로 호출하는 도구 표준과 서버 운영 방식을 정리하는 데 바로 참고할 수 있다.";
+  }
+  if (/\bcodex\b|\bclaude\b|\bskills?\b/.test(text)) {
+    return "Codex/Claude 기반 작업 규칙, 스킬 관리, 핸드오프 품질을 개선할 후보로 검토할 가치가 있다.";
+  }
+  return "FOMO Club 에이전트 운영 자동화와 툴링 검토 기준을 높이는 데 참고할 수 있다.";
 }
 
-function sortCandidates(candidates: ToolingCandidate[]): ToolingCandidate[] {
-  return [...candidates].sort((a, b) => {
+function applicationIdea(score: number, directness: number): ApplicationIdea {
+  if (score >= 78 && directness >= 55) return "바로 도입 후보";
+  if (score >= 62) return "PoC 후보";
+  return "검토만";
+}
+
+function assessRisk(repo: GitHubRepo): string {
+  const text = normalizedText(repo).toLowerCase();
+  if (/\bsecurity\b|\bscanner\b|\baudit\b|\bmcp\b/.test(text)) {
+    return "외부 코드 실행, 권한 범위, 스캔 대상 파일 노출 여부를 먼저 확인해야 한다.";
+  }
+  if (/\bgithub\b|\bworkflow\b|\bautomation\b/.test(text)) {
+    return "GitHub 토큰 권한과 이슈/PR 자동 변경 범위를 제한해야 한다.";
+  }
+  return "도입 가치 대비 유지보수 비용과 의존성 지속성을 확인해야 한다.";
+}
+
+function collectSelectedCandidates(candidates: ToolingCandidate[]): ToolingCandidate[] {
+  const sorted = [...candidates].sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;
-    if (a.risk !== b.risk) return riskRank(a.risk) - riskRank(b.risk);
-    return `${a.repo}:${a.sha}`.localeCompare(`${b.repo}:${b.sha}`);
+    if (b.stars !== a.stars) return b.stars - a.stars;
+    return a.fullName.localeCompare(b.fullName);
   });
-}
+  const strongSeed = sorted.find((candidate) => candidate.source === "seed" && candidate.score >= STRONG_SEED_MIN_SCORE);
+  const primary = strongSeed ?? sorted[0];
+  if (!primary) return [];
 
-function riskRank(risk: CandidateRisk): number {
-  return risk === "low" ? 0 : risk === "medium" ? 1 : 2;
-}
+  const runnerUp = sorted.find((candidate) => candidate.fullName !== primary.fullName);
+  if (!runnerUp) return [primary];
 
-function kstDate(now = new Date()): string {
-  return new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const scoreGap = Math.abs(primary.score - runnerUp.score);
+  const isStrongSeed = runnerUp.source === "seed" && runnerUp.score >= 70;
+  return scoreGap <= RUNNER_UP_MAX_SCORE_GAP || isStrongSeed ? [primary, runnerUp] : [primary];
 }
 
 function renderReport(params: {
-  repos: string[];
-  days: number;
-  candidates: ToolingCandidate[];
+  seedRepos: string[];
+  searchQueries: string[];
+  updatedDays: number;
+  minStars: number;
+  selectedCandidates: ToolingCandidate[];
   errors: string[];
   generatedAt: string;
 }): string {
-  const localHead = git(["rev-parse", "--short", "HEAD"]);
-  const localBranch = git(["branch", "--show-current"]);
-  const recentLocal = git(["log", "--oneline", "-5"]);
-  const topCandidates = sortCandidates(params.candidates).slice(0, MAX_CANDIDATES);
   const generatedDateKst = kstDate(new Date(params.generatedAt));
+  const [primary, runnerUp] = params.selectedCandidates;
 
   return [
-    "# Agent Tooling Scout Report",
+    "# 오늘의 에이전트 툴링 후보",
     "",
-    `- Generated At: ${params.generatedAt}`,
-    `- Generated Date (KST): ${generatedDateKst}`,
-    `- Local Branch: ${localBranch}`,
-    `- Local Head: ${localHead}`,
-    `- Lookback: ${params.days} days`,
-    `- Source Repos: ${params.repos.join(", ")}`,
+    `- 생성일(KST): ${generatedDateKst}`,
+    `- 기준: stars ${params.minStars.toLocaleString("en-US")}개 이상, 최근 ${params.updatedDays}일 내 업데이트, archived 제외`,
+    `- 로컬 기준: ${git(["branch", "--show-current"])}@${git(["rev-parse", "--short", "HEAD"])}`,
     "",
-    "## Guardrails",
-    "- 이 리포트는 에이전트/툴링 업데이트 후보만 다룬다.",
-    "- 제품 아이디어 자동 생성, 종목 추천, 매수/매도/목표가/예측 로직은 범위 밖이다.",
-    "- 자동 구현은 하지 않는다. 후보는 이슈로 남기고, 광혁 리뷰 후 별도 PR로 진행한다.",
-    "- 외부 코드 도입 전 AGENTS.md, SECURITY_CHECKLIST, DATA_ENGINE_STRATEGY §8을 다시 확인한다.",
+    "## 오늘의 1순위",
+    primary ? renderCandidate(primary) : "오늘 기준을 넘긴 후보가 없습니다.",
     "",
-    "## Local Context",
-    "```text",
-    recentLocal || "(recent git log unavailable)",
-    "```",
+    ...(runnerUp ? ["## 보조 후보", renderCandidate(runnerUp), ""] : []),
+    "## 다음 액션",
+    "- 채택: 별도 구현 이슈/PR로 넘긴다.",
+    "- 보류: 다음 스카우트에서 더 강한 후보가 나올 때까지 기다린다.",
+    "- 제외: 권한/보안/유지보수 리스크가 크면 같은 후보를 다시 뽑지 않도록 제외 기준에 반영한다.",
     "",
-    "## Candidates",
-    topCandidates.length === 0 ? "최근 기간 안에 기준을 넘긴 툴링 후보가 없어요." : "",
-    ...topCandidates.flatMap((candidate, index) => renderCandidate(candidate, index + 1)),
+    "## 운영 가드레일",
+    "- 자동 구현은 하지 않고 후보 발굴과 검토 이슈 생성까지만 한다.",
+    "- 제품 아이디어 생성, 투자 판단, 매매, 예측 도구는 제외한다.",
+    "- 후보가 없으면 이슈를 만들지 않고 Actions 로그에만 남긴다.",
     "",
-    "## Collection Errors",
-    params.errors.length === 0 ? "- 없음" : params.errors.map((error) => `- ${error}`).join("\n"),
-    "",
-    "## Next Step",
-    "- `needs-ceo-review` 라벨이 붙은 이슈에서 채택 여부를 결정한다.",
-    "- 채택된 항목만 별도 구현 이슈/PR로 넘긴다.",
-    "- MCP/권한/외부 네트워크가 필요한 변경은 먼저 보안 체크리스트를 통과한다."
+    "## 수집 정보",
+    `- Seed: ${params.seedRepos.join(", ")}`,
+    `- Search: ${params.searchQueries.join(" / ")}`,
+    `- 오류: ${params.errors.length === 0 ? "없음" : params.errors.join(" | ")}`
   ].join("\n");
 }
 
-function renderCandidate(candidate: ToolingCandidate, index: number): string[] {
+function renderCandidate(candidate: ToolingCandidate): string {
   return [
-    `### ${index}. ${candidate.title}`,
-    `- Source: [${candidate.repo}@${candidate.sha}](${candidate.url})`,
-    `- Date: ${candidate.date}`,
-    `- Score: ${candidate.score}`,
-    `- Risk: ${candidate.risk}`,
-    `- Matched: ${candidate.matchedKeywords.join(", ") || "n/a"}`,
-    `- Why: ${candidate.whyItMatters.join(" / ") || "n/a"}`,
-    `- Suggested Issue: ${candidate.suggestedIssue}`,
-    "- Paths:",
-    ...(candidate.paths.length > 0 ? candidate.paths.map((item) => `  - ${item}`) : ["  - n/a"]),
-    ""
-  ];
+    `- 레포: [${candidate.fullName}](${candidate.url})`,
+    `- stars: ${candidate.stars.toLocaleString("en-US")}`,
+    `- 설명: ${candidate.description}`,
+    `- 왜 필요한가: ${candidate.whyItMatters}`,
+    `- 적용 아이디어: ${candidate.applicationIdea}`,
+    `- 리스크: ${candidate.risk}`,
+    `- 점수: ${candidate.score} (신뢰 ${candidate.scoreBreakdown.trust}, 적합도 ${candidate.scoreBreakdown.fit}, 직접성 ${candidate.scoreBreakdown.directness}, 최근성 ${candidate.scoreBreakdown.recency})`,
+    `- 근거: ${candidate.sourceLabel}; ${candidate.matchedSignals.join(", ") || "n/a"}; updated ${candidate.updatedAt.slice(0, 10)}`
+  ].join("\n");
+}
+
+function buildSummary(generatedAt: string, selectedCandidates: ToolingCandidate[], errors: string[]): ScoutSummary {
+  const [primary, runnerUp] = selectedCandidates;
+  return {
+    generatedAt,
+    generatedDateKst: kstDate(new Date(generatedAt)),
+    candidateCount: selectedCandidates.length,
+    primary: primary ? pickSummary(primary) : undefined,
+    runnerUp: runnerUp ? pickSummary(runnerUp) : undefined,
+    errors
+  };
+}
+
+function pickSummary(candidate: ToolingCandidate): Pick<ToolingCandidate, "fullName" | "url" | "stars" | "score"> {
+  return {
+    fullName: candidate.fullName,
+    url: candidate.url,
+    stars: candidate.stars,
+    score: candidate.score
+  };
 }
 
 async function main(): Promise<void> {
-  const repos = parseRepos(env("TOOLING_SCOUT_REPOS"));
-  const days = parseDays(env("TOOLING_SCOUT_DAYS"));
+  const seedRepos = parseList(env("TOOLING_SCOUT_SEED_REPOS") ?? env("TOOLING_SCOUT_REPOS"), DEFAULT_SEED_REPOS);
+  const searchQueries = parseList(env("TOOLING_SCOUT_SEARCH_QUERIES"), DEFAULT_SEARCH_QUERIES);
+  const updatedDays = parsePositiveInt(env("TOOLING_SCOUT_UPDATED_DAYS") ?? env("TOOLING_SCOUT_DAYS"), DEFAULT_UPDATED_DAYS, 120);
+  const minStars = parsePositiveInt(env("TOOLING_SCOUT_MIN_STARS"), DEFAULT_MIN_STARS, 1_000_000);
   const generatedAt = new Date().toISOString();
-  const candidates: ToolingCandidate[] = [];
   const errors: string[] = [];
 
-  for (const repo of repos) {
-    try {
-      candidates.push(...(await collectRepoCandidates(repo, days)));
-    } catch (error) {
-      errors.push(`${repo}: ${error instanceof Error ? error.message : String(error)}`);
+  const seedResults = await fetchSeedRepos(seedRepos, errors);
+  const searchResults = await searchRepos(searchQueries, minStars, errors);
+  const byRepo = new Map<string, { repo: GitHubRepo; source: CandidateSource; sourceLabel: string }>();
+
+  for (const item of seedResults) {
+    byRepo.set(item.repo.full_name.toLowerCase(), { repo: item.repo, source: "seed", sourceLabel: item.sourceLabel });
+  }
+
+  for (const item of searchResults) {
+    const key = item.repo.full_name.toLowerCase();
+    if (!byRepo.has(key)) {
+      byRepo.set(key, { repo: item.repo, source: "search", sourceLabel: item.sourceLabel });
     }
   }
 
-  const report = renderReport({ repos, days, candidates, errors, generatedAt });
+  const candidates = [...byRepo.values()]
+    .filter(({ repo }) => !repo.archived)
+    .filter(({ repo }) => repo.stargazers_count >= minStars)
+    .filter(({ repo }) => isFresh(repo.updated_at, updatedDays))
+    .filter(({ repo }) => !shouldExclude(repo))
+    .map(({ repo, source, sourceLabel }) => scoreRepo(repo, source, sourceLabel))
+    .filter((candidate): candidate is ToolingCandidate => Boolean(candidate));
+
+  const selectedCandidates = collectSelectedCandidates(candidates);
+  const report = renderReport({ seedRepos, searchQueries, updatedDays, minStars, selectedCandidates, errors, generatedAt });
+  const summary = buildSummary(generatedAt, selectedCandidates, errors);
   const date = kstDate(new Date(generatedAt));
   const outputDir = path.resolve(process.cwd(), REPORT_DIR);
+
   await fs.mkdir(outputDir, { recursive: true });
   await fs.writeFile(path.join(outputDir, `tooling-scout-${date}.md`), report);
   await fs.writeFile(path.join(outputDir, "latest.md"), report);
+  await fs.writeFile(path.join(outputDir, `tooling-scout-${date}.json`), `${JSON.stringify(summary, null, 2)}\n`);
+  await fs.writeFile(path.join(outputDir, "latest.json"), `${JSON.stringify(summary, null, 2)}\n`);
 
-  console.log(`Agent tooling scout wrote ${sortCandidates(candidates).slice(0, MAX_CANDIDATES).length} candidate(s).`);
+  if (selectedCandidates.length === 0) {
+    console.log("오늘 후보 없음");
+  } else {
+    console.log(`Agent tooling scout wrote ${selectedCandidates.length} candidate(s): ${selectedCandidates.map((item) => item.fullName).join(", ")}`);
+  }
   console.log(path.join(REPORT_DIR, "latest.md"));
 }
 


### PR DESCRIPTION
## 요약
- 에이전트 툴링 스카우트를 커밋 단위가 아니라 레포/툴 단위 후보 발굴로 바꿨습니다.
- 기본은 오늘의 1순위 1개만 이슈에 쓰고, 정말 점수 차이가 가까운 경우에만 보조 후보 1개를 붙입니다.
- NVIDIA/SkillSpector를 포함한 curated seed와 GitHub repo search를 함께 사용합니다.
- 후보가 없으면 이슈를 만들지 않고 Actions 로그에만 남기도록 latest.json 기반 스킵 로직을 추가했습니다.

## 확인
- npm run agent:tooling-scout
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- GitHub Actions 수동 실행 성공: https://github.com/mlender-ai/fomo-club/actions/runs/28178204286
- #664 새 포맷 업데이트 확인
- #654 closed 확인

## 참고
- 프로덕션 제품 코드, UI, 데이터는 변경하지 않았고 자동 후보 발굴 스크립트와 워크플로만 수정했습니다.