### PR TITLE
fix(discovery): surprise/awakening-first ranking (fame penalty + direction + 무명각성 boost)

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -621,16 +621,27 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
   const candidates = [...byTicker.entries()].map(([ticker, { row, events }]): DiscoveryCandidate => {
     const def = resolveStock(ticker);
     const sector = sectorOf(ticker);
-    const reason = discoveryWhy({ ticker, market: row.market, events, asOf });
+    const direction: NonNullable<DiscoveryEvent["direction"]> =
+      typeof row.changePct !== "number" ? "flat" : row.changePct > 0 ? "up" : row.changePct < 0 ? "down" : "flat";
+    const directedEvents: DiscoveryEvent[] = events.map((event) => event.direction ? event : { ...event, direction });
+    const candidateBase: DiscoveryCandidate = {
+      ticker,
+      market: row.market,
+      events: directedEvents,
+      asOf,
+      ...(typeof row.marketCapRank === "number" ? { marketCapRank: row.marketCapRank } : {}),
+    };
+    const reason = discoveryWhy(candidateBase);
     return {
       ticker,
       market: row.market,
       country: (def?.country ?? "KR") as StockCountry,
       naverCode: row.naverCode,
       ...(sector ? { sector } : {}),
-      events,
+      events: directedEvents,
       asOf,
-      ...(hasDisplayWhyEvent({ ticker, market: row.market, events, asOf }) ? { reason } : {}),
+      ...(typeof row.marketCapRank === "number" ? { marketCapRank: row.marketCapRank } : {}),
+      ...(hasDisplayWhyEvent(candidateBase) ? { reason } : {}),
       marquee: def?.marquee === true,
     };
   });

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -118,4 +118,54 @@ describe("WO-05 discovery supply engine", () => {
 
     expect(ranked).toHaveLength(0);
   });
+
+  it("ranks obscure stocks above famous stocks at the same signal strength", () => {
+    const famous = candidate("대형주", 0.7, "news_mention", "대형주 기사");
+    famous.marketCapRank = 3;
+    const obscure = candidate("무명주", 0.7, "news_mention", "무명주 기사");
+    obscure.marketCapRank = 250;
+
+    expect(rankDiscoveryCandidates([famous, obscure]).map((row) => row.ticker)).toEqual(["무명주", "대형주"]);
+  });
+
+  it("ranks non-material down moves below same-strength up moves", () => {
+    const up = candidate("상승", 0.9, "price_move", "오늘 가격이 +9.00% 움직였어요.");
+    up.events[0]!.direction = "up";
+    const down = candidate("하락", 0.9, "price_move", "오늘 가격이 -9.00% 움직였어요.");
+    down.events[0]!.direction = "down";
+
+    expect(rankDiscoveryCandidates([down, up]).map((row) => row.ticker)).toEqual(["상승", "하락"]);
+  });
+
+  it("boosts obscure first-seen awakening over stale same-strength candidates", () => {
+    const stale = candidate("기존무명", 0.7, "theme_link", "오늘 원자력 평균보다 강했어요.");
+    stale.marketCapRank = 260;
+    stale.events[0]!.firstSeen = false;
+    const awakening = candidate("각성무명", 0.7, "theme_link", "오늘 원자력 평균보다 강했어요.");
+    awakening.marketCapRank = 260;
+
+    expect(rankDiscoveryCandidates([stale, awakening]).map((row) => row.ticker)).toEqual(["각성무명", "기존무명"]);
+  });
+
+  it("keeps legacy candidates without rank or direction safe and deterministic", () => {
+    const rows = [
+      candidate("B", 0.6, "news_mention", "B 기사"),
+      candidate("A", 0.6, "news_mention", "A 기사"),
+    ];
+
+    const first = rankDiscoveryCandidates(rows).map((row) => row.ticker);
+    const second = rankDiscoveryCandidates(rows).map((row) => row.ticker);
+
+    expect(first).toEqual(["B", "A"]);
+    expect(second).toEqual(first);
+  });
+
+  it("keeps first-seen volume awakenings even below the weak strength floor", () => {
+    const ranked = rankDiscoveryCandidates([
+      candidate("거래량각성", 0.4, "volume_spike", "오늘 거래량이 새로 튀었어요."),
+      candidate("가격약함", 0.4, "price_move", "오늘 가격이 +4.00% 움직였어요."),
+    ]);
+
+    expect(ranked.map((row) => row.ticker)).toEqual(["거래량각성"]);
+  });
 });

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -20,6 +20,7 @@ export interface DiscoveryEvent {
   asOf: string;
   confidence: "L" | "M" | "H";
   label?: string;
+  direction?: "up" | "down" | "flat";
 }
 
 export interface DiscoveryCandidate {
@@ -32,6 +33,7 @@ export interface DiscoveryCandidate {
   asOf: string;
   reason?: string;
   marquee?: boolean;
+  marketCapRank?: number;
 }
 
 export interface UniverseStock {
@@ -60,6 +62,12 @@ export const DISCOVERY_LIQUIDITY_MEDIAN_RATIO_CUT = 0.1;
 export const DISCOVERY_SEEN_DECAY_DAYS = 3;
 export const DISCOVERY_TOP_BAND_WHY_REQUIRED = 30;
 export const DISCOVERY_WEAK_MIN_STRENGTH = 0.85;
+export const DISCOVERY_FAME_MAX_PENALTY = 0.5;
+export const DISCOVERY_FAME_RANK_FLOOR = 120;
+export const DISCOVERY_AWAKENING_MAX_BOOST = 0.3;
+export const DISCOVERY_DIR_DOWN_NOISE_PENALTY = 0.5;
+export const DISCOVERY_DIR_DOWN_MATERIAL_PENALTY = 0.15;
+export const DISCOVERY_STRENGTH_WEIGHT = 0.65;
 
 const RISK_FLAG_PATTERN = /관리|투자경고|투자위험|거래정지|단기과열|이상급등/;
 
@@ -155,11 +163,45 @@ function freshnessBoost(candidate: DiscoveryCandidate): number {
   return candidate.events.some((event) => event.firstSeen) ? 0.16 : 0;
 }
 
+export function famePenalty(rank?: number): number {
+  if (typeof rank !== "number" || !Number.isFinite(rank) || rank <= 0) return 0;
+  const fameRatio = clamp01((DISCOVERY_FAME_RANK_FLOOR - Math.min(rank, DISCOVERY_FAME_RANK_FLOOR)) / DISCOVERY_FAME_RANK_FLOOR);
+  return -DISCOVERY_FAME_MAX_PENALTY * fameRatio;
+}
+
+export function awakeningBoost(candidate: DiscoveryCandidate): number {
+  if (!candidate.events.some((event) => event.firstSeen)) return 0;
+  const rank = candidate.marketCapRank;
+  const obscure =
+    typeof rank === "number" && Number.isFinite(rank)
+      ? clamp01((Math.min(rank, 300) - 80) / 220)
+      : 0.4;
+  return DISCOVERY_AWAKENING_MAX_BOOST * obscure;
+}
+
+export function directionPenalty(candidate: DiscoveryCandidate): number {
+  const hasDownShapeEvent = candidate.events.some(
+    (event) =>
+      event.direction === "down" &&
+      (event.kind === "price_move" || event.kind === "volume_spike" || event.kind === "market_context" || event.kind === "theme_link")
+  );
+  if (!hasDownShapeEvent) return 0;
+  return hasPublicMaterialEvent(candidate) ? -DISCOVERY_DIR_DOWN_MATERIAL_PENALTY : -DISCOVERY_DIR_DOWN_NOISE_PENALTY;
+}
+
 function eventScore(candidate: DiscoveryCandidate): number {
   const maxStrength = Math.max(0, ...candidate.events.map((event) => clamp01(event.strength)));
   const diversity = new Set(candidate.events.map((event) => event.kind)).size;
   const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : hasThemeLinkEvent(candidate) ? 0.08 : hasDisplayWhyEvent(candidate) ? -0.03 : -0.25;
-  return maxStrength + freshnessBoost(candidate) + Math.min(0.12, diversity * 0.03) + materialBoost;
+  return (
+    DISCOVERY_STRENGTH_WEIGHT * maxStrength +
+    freshnessBoost(candidate) +
+    Math.min(0.12, diversity * 0.03) +
+    materialBoost +
+    famePenalty(candidate.marketCapRank) +
+    awakeningBoost(candidate) +
+    directionPenalty(candidate)
+  );
 }
 
 function seenPenalty(ticker: string, seen: readonly SeenRecord[], watched: ReadonlySet<string>): number {
@@ -178,7 +220,12 @@ export function rankDiscoveryCandidates(
   const watched = new Set(opts.watched ?? []);
   return candidates
     .filter((candidate) => candidate.events.length > 0)
-    .filter((candidate) => !isWeakDiscoveryCandidate(candidate) || Math.max(0, ...candidate.events.map((event) => event.strength)) >= DISCOVERY_WEAK_MIN_STRENGTH)
+    .filter(
+      (candidate) =>
+        !isWeakDiscoveryCandidate(candidate) ||
+        Math.max(0, ...candidate.events.map((event) => event.strength)) >= DISCOVERY_WEAK_MIN_STRENGTH ||
+        candidate.events.some((event) => event.firstSeen && (event.kind === "volume_spike" || event.kind === "flow_entry"))
+    )
     .map((candidate, index) => ({
       candidate,
       index,


### PR DESCRIPTION
## Summary
- Switch discovery ranking from raw move-size first to surprise/awakening-first.
- Add marketCapRank-aware fame penalty, first-seen obscure awakening boost, and down-move direction penalty.
- Stamp discovery events with direction and candidates with marketCapRank from the web discovery supply path.
- Keep displayed FOMO score untouched; this changes ranking only.

## Invariant tests added
- Same-strength famous rank<=5 stock sorts below obscure stock.
- Non-material down move sorts below same-strength up move.
- Obscure firstSeen awakening sorts above same-strength stale candidate.
- Legacy candidates without marketCapRank/direction remain deterministic and safe.
- First-seen volume awakening bypasses the weak strength floor.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run build:fomo-web
- npm run build:web

## Live sample check
- Discovery count: 70, confidence H
- Top card shifted to a lower-profile stock (저스템, market rank 248)
- SK하이닉스 shifted to #12 in the sample instead of occupying the top slot.