### PR TITLE
fix(discovery): surface material reasons before price-only movers

### DIFF
--- a/apps/web/lib/dart-disclosures.ts
+++ b/apps/web/lib/dart-disclosures.ts
@@ -31,7 +31,7 @@ const DART_ROUTINE_REPORT =
   /사업보고서|반기보고서|분기보고서|증권발행실적|투자설명서|첨부정정|정정신고|임원ㆍ주요주주|임원·주요주주|주식등의대량보유|최대주주등소유주식변동/i;
 
 function dartKey(): string | undefined {
-  if (process.env.DISCOVERY_DART_LIVE !== "1") return undefined;
+  if (process.env.DISCOVERY_DART_LIVE === "0") return undefined;
   return process.env.DART_API_KEY || process.env.DART_CRTFC_KEY;
 }
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -22,6 +22,7 @@ import {
   type DiscoveryEvent,
   type DiscoveryMarket,
   type FomoScoreResult,
+  type InvestorFlow,
   type MultiAxisHookSelection,
   type SectorStock,
   type StockCountry,
@@ -32,22 +33,24 @@ import { fetchDartDisclosuresByStock, type DartDisclosureHit } from "./dart-disc
 import { fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
-import { readSupplyDemandHistory } from "./supply-demand-store";
+import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
 const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 5;
 const SPARKLINE_CONCURRENCY = 8;
-const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL === "1";
-const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE === "1";
-const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED ? 12 : 0;
+const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
+const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
+const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED
+  ? Math.max(0, Math.min(40, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 24) || 24))
+  : 0;
 const TARGETED_MATERIAL_CONCURRENCY = 4;
 const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
 const MATERIAL_NEWS_NOISE =
   /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
 const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_ENABLED
-  ? "네이버 시세·종목뉴스·리서치·DART 공시"
+  ? "네이버 시세·종목뉴스·리서치·DART 공시·수급 캐시"
   : "네이버 시세·뉴스 언급";
 
 export interface DiscoveryFrontSeed {
@@ -409,13 +412,11 @@ function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | un
   };
 }
 
-async function eventFromFlow(ticker: string): Promise<DiscoveryEvent | null> {
-  if (!process.env.DATABASE_URL) return null;
-  const history = await readSupplyDemandHistory(ticker, 10);
+function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent | null {
   if (history.length === 0) return null;
   const streak = investorNetStreak(history);
-  const useForeign = Math.abs(streak.foreign) >= Math.abs(streak.institution);
-  const n = useForeign ? streak.foreign : streak.institution;
+  const useForeign = streak.foreign >= streak.institution;
+  const n = Math.max(streak.foreign, streak.institution);
   if (n < 2) return null;
   const actor = useForeign ? "외국인이" : "기관이";
   return {
@@ -609,12 +610,13 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
   }
 
   if (DISCOVERY_FLOW_CACHE_ENABLED) {
-    const flowRows = await mapLimit([...byTicker.keys()], 8, async (ticker) => ({ ticker, event: await eventFromFlow(ticker) }));
-    for (const result of flowRows) {
-      if (result.status !== "fulfilled" || !result.value.event) continue;
-      const current = byTicker.get(result.value.ticker);
+    const histories = await readSupplyDemandHistoryByTickers([...byTicker.keys()], 10);
+    for (const [ticker, history] of Object.entries(histories)) {
+      const event = eventFromFlowHistory(history);
+      if (!event) continue;
+      const current = byTicker.get(ticker);
       if (!current) continue;
-      byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
+      byTicker.set(ticker, { ...current, events: [...current.events, event] });
     }
   }
 

--- a/apps/web/lib/supply-demand-store.ts
+++ b/apps/web/lib/supply-demand-store.ts
@@ -114,3 +114,38 @@ export async function readSupplyDemandHistory(
     return [];
   }
 }
+
+/** 여러 종목의 최근 N거래일 수급을 한 번에 조회. 발견 덱에서 카드별 DB 왕복을 막기 위한 배치 경로. */
+export async function readSupplyDemandHistoryByTickers(
+  tickers: readonly string[],
+  days = 10
+): Promise<Record<string, InvestorFlow[]>> {
+  if (!process.env.DATABASE_URL) return {};
+  const unique = Array.from(new Set(tickers.filter(Boolean)));
+  if (unique.length === 0) return {};
+  const take = Math.max(1, Math.min(days, 60));
+
+  try {
+    const rows = await prisma.supplyDemandDaily.findMany({
+      where: { ticker: { in: unique } },
+      orderBy: [{ ticker: "asc" }, { date: "desc" }],
+    });
+
+    const out: Record<string, InvestorFlow[]> = {};
+    for (const row of rows) {
+      const current = out[row.ticker] ?? [];
+      if (current.length >= take) continue;
+      current.push({
+        date: row.date,
+        foreignNet: row.foreignNet,
+        institutionNet: row.institutionNet,
+        ...(row.individualNet != null ? { individualNet: row.individualNet } : {}),
+      });
+      out[row.ticker] = current;
+    }
+    return out;
+  } catch (err) {
+    console.warn("[supply-demand-store] batch history read skipped (table missing?)", (err as Error)?.message);
+    return {};
+  }
+}

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -119,6 +119,18 @@ describe("WO-05 discovery supply engine", () => {
     expect(ranked).toHaveLength(0);
   });
 
+  it("keeps real WHY cards above price-only cards even when price-only strength is larger", () => {
+    const priceOnly = candidate("가격만큰종목", 1, "price_move", "오늘 가격이 +18.00% 움직였어요.");
+    const themeWhy = candidate("테마이유", 0.45, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
+    const materialWhy = candidate("뉴스이유", 0.4, "news_mention", "종목 지정 기사");
+
+    expect(rankDiscoveryCandidates([priceOnly, themeWhy, materialWhy]).map((row) => row.ticker)).toEqual([
+      "뉴스이유",
+      "테마이유",
+      "가격만큰종목",
+    ]);
+  });
+
   it("ranks obscure stocks above famous stocks at the same signal strength", () => {
     const famous = candidate("대형주", 0.7, "news_mention", "대형주 기사");
     famous.marketCapRank = 3;

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -110,7 +110,10 @@ export function hasThemeLinkEvent(candidate: DiscoveryCandidate): boolean {
 }
 
 export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
-  return hasPublicMaterialEvent(candidate) || candidate.events.some((event) => event.kind === "theme_link");
+  return (
+    hasPublicMaterialEvent(candidate) ||
+    candidate.events.some((event) => event.kind === "theme_link" || (event.kind === "volume_spike" && event.firstSeen))
+  );
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
@@ -233,6 +236,7 @@ export function rankDiscoveryCandidates(
     }))
     .sort(
       (a, b) =>
+        Number(hasDisplayWhyEvent(b.candidate)) - Number(hasDisplayWhyEvent(a.candidate)) ||
         b.score - a.score ||
         Number(hasPublicMaterialEvent(b.candidate)) - Number(hasPublicMaterialEvent(a.candidate)) ||
         a.index - b.index ||


### PR DESCRIPTION
## Summary
- Enable targeted stock news/research material lookup by default, with a capped candidate limit and opt-out env.
- Enable DART disclosure lookup when a key exists instead of requiring a separate live flag.
- Restore flow_entry supply evidence from cached DB history using one batch read, not per-card live lookups.
- Rank real WHY cards above price-only movers so top-band cards do not feel like simple price restatements.

## Why
The previous surprise-first ranking changed ordering, but production still lacked visible catalyst supply because targeted material, DART, and flow cache paths were effectively off. This makes the deck feel like only card order changed. This PR turns on the existing material paths safely and keeps price-only cards behind real WHY cards.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run build:fomo-web
- npm run build:web
- local live discovery sample: count=70, confidence=H, noWhyTop30=[]
- local top cards now include stock-specific news/research reasons for 저스템, 솔트룩스, 일진파워, 코스모신소재, 한글과컴퓨터, 천보, 네패스, etc.

## Notes
- No buy/sell/target-price wording added.
- DART remains fail-closed without DART_API_KEY/DART_CRTFC_KEY.
- Flow evidence remains cache-only and fail-closed without DATABASE_URL/table data.