### PR TITLE
fix(discovery): demote flat and bearish theme filler

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -319,27 +319,15 @@ function buildThemeMoveSignals(rows: readonly NaverMarketRow[]): Map<string, The
 function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
   if (!theme || typeof row.changePct !== "number") return null;
   const strongTheme = theme.averageChangePct >= 1.5 && theme.positiveCount >= 2;
-  const weakTheme = theme.averageChangePct <= -1.5 && theme.positiveCount <= Math.max(1, Math.floor(theme.peerCount / 3));
   const leadingTheme = theme.rank <= 3 && row.changePct >= 5;
-  const laggingTheme = theme.rank >= Math.max(3, theme.peerCount - 2) && row.changePct <= -5;
-  const bigSectorMove = Math.abs(row.changePct) >= 7 && Math.abs(theme.relativeChangePct) >= 2;
-  const sectorSpike = Math.abs(row.changePct) >= 5;
-  if (!strongTheme && !weakTheme && !leadingTheme && !laggingTheme && !bigSectorMove && !sectorSpike) return null;
-  const weakRank = theme.peerCount - theme.rank + 1;
+  const positiveOutperformer = row.changePct >= 1.5 && theme.relativeChangePct >= 2;
+  const positiveStrongTheme = row.changePct >= 3 && strongTheme && theme.relativeChangePct >= 0;
+  const positiveSectorSpike = row.changePct >= 7 && theme.relativeChangePct >= 0;
+  if (!leadingTheme && !positiveOutperformer && !positiveStrongTheme && !positiveSectorSpike) return null;
   const label =
-    row.changePct <= 0
-      ? laggingTheme
-        ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 아래에서 ${ordinalText(weakRank)} 약했어요(${pctText(row.changePct)}).`
-        : row.changePct === 0
-          ? `${theme.sector} 평균(${pctText(theme.averageChangePct)})이 약한 날, 이 종목은 보합으로 버텼어요.`
-          : theme.relativeChangePct >= 0
-            ? `가격은 빠졌지만 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다는 ${pointText(theme.relativeChangePct)}포인트 덜 약했어요(${pctText(row.changePct)}).`
-          : `오늘 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다 ${pointText(theme.relativeChangePct)}포인트 더 약했어요(${pctText(row.changePct)}).`
-      : theme.rank <= 3
-        ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 ${ordinalText(theme.rank)} 강했어요(${pctText(row.changePct)}).`
-        : theme.relativeChangePct >= 0
-          ? `오늘 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다 ${pointText(theme.relativeChangePct)}포인트 더 강했어요(${pctText(row.changePct)}).`
-          : `가격은 올랐지만 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다는 ${pointText(theme.relativeChangePct)}포인트 덜 강했어요(${pctText(row.changePct)}).`;
+    theme.rank <= 3
+      ? `오늘 ${theme.sector} ${theme.peerCount}개 종목 중 ${ordinalText(theme.rank)} 강했어요(${pctText(row.changePct)}).`
+      : `오늘 ${theme.sector} 평균(${pctText(theme.averageChangePct)})보다 ${pointText(theme.relativeChangePct)}포인트 더 강했어요(${pctText(row.changePct)}).`;
   return {
     kind: "theme_link",
     firstSeen: true,

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -43,14 +43,14 @@ describe("WO-05 discovery supply engine", () => {
     expect(result.map((s) => s.ticker)).toEqual(["정상A", "정상B"]);
   });
 
-  it("keeps candidates with real events and ranks public material above weak shape-only cards", () => {
+  it("keeps candidates with real events and drops weak shape-only cards", () => {
     const ranked = rankDiscoveryCandidates([
       { ticker: "조용", market: "KOSPI", events: [], asOf },
       candidate("가격만", 0.9, "price_move"),
       candidate("뉴스", 0.55, "news_mention"),
     ]);
 
-    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스", "가격만"]);
+    expect(ranked.map((c) => c.ticker)).toEqual(["뉴스"]);
   });
 
   it("applies seen decay but keeps watched stocks exempt", () => {
@@ -110,6 +110,22 @@ describe("WO-05 discovery supply engine", () => {
     expect(isWeakDiscoveryCandidate(theme)).toBe(false);
   });
 
+  it("does not treat flat or bearish theme comparison as a top-band display WHY", () => {
+    const flatTheme = candidate("보합방어", 0.72, "theme_link", "AI 평균(-3.00%)이 약한 날, 이 종목은 보합으로 버텼어요.");
+    flatTheme.events[0]!.direction = "flat";
+    const downTheme = candidate("약세비교", 0.72, "theme_link", "오늘 AI 평균(-3.00%)보다 1.8포인트 더 약했어요(-4.81%).");
+    downTheme.events[0]!.direction = "down";
+    const upTheme = candidate("상승선두", 0.45, "theme_link", "오늘 원자력 7개 종목 중 가장 강했어요(+6.20%).");
+    upTheme.events[0]!.direction = "up";
+
+    expect(hasDisplayWhyEvent(flatTheme)).toBe(false);
+    expect(isWeakDiscoveryCandidate(flatTheme)).toBe(true);
+    expect(hasDisplayWhyEvent(downTheme)).toBe(false);
+    expect(isWeakDiscoveryCandidate(downTheme)).toBe(true);
+    expect(hasDisplayWhyEvent(upTheme)).toBe(true);
+    expect(rankDiscoveryCandidates([flatTheme, downTheme, upTheme]).map((row) => row.ticker)).toEqual(["상승선두"]);
+  });
+
   it("drops weak market-context padding instead of filling the deck with price restatements", () => {
     const rows = Array.from({ length: 100 }, (_, index) =>
       candidate(`시장${index}`, 0.35 + (index % 10) / 100, "market_context", `KOSPI 시총 ${index + 1}위권에서 오늘 시장 흐름과 같이 확인해요.`)
@@ -119,7 +135,7 @@ describe("WO-05 discovery supply engine", () => {
     expect(ranked).toHaveLength(0);
   });
 
-  it("keeps real WHY cards above price-only cards even when price-only strength is larger", () => {
+  it("keeps real WHY cards and drops price-only cards even when price-only strength is larger", () => {
     const priceOnly = candidate("가격만큰종목", 1, "price_move", "오늘 가격이 +18.00% 움직였어요.");
     const themeWhy = candidate("테마이유", 0.45, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
     const materialWhy = candidate("뉴스이유", 0.4, "news_mention", "종목 지정 기사");
@@ -127,7 +143,6 @@ describe("WO-05 discovery supply engine", () => {
     expect(rankDiscoveryCandidates([priceOnly, themeWhy, materialWhy]).map((row) => row.ticker)).toEqual([
       "뉴스이유",
       "테마이유",
-      "가격만큰종목",
     ]);
   });
 
@@ -140,13 +155,13 @@ describe("WO-05 discovery supply engine", () => {
     expect(rankDiscoveryCandidates([famous, obscure]).map((row) => row.ticker)).toEqual(["무명주", "대형주"]);
   });
 
-  it("ranks non-material down moves below same-strength up moves", () => {
+  it("drops non-material direction-only price moves instead of ranking them as discovery", () => {
     const up = candidate("상승", 0.9, "price_move", "오늘 가격이 +9.00% 움직였어요.");
     up.events[0]!.direction = "up";
     const down = candidate("하락", 0.9, "price_move", "오늘 가격이 -9.00% 움직였어요.");
     down.events[0]!.direction = "down";
 
-    expect(rankDiscoveryCandidates([down, up]).map((row) => row.ticker)).toEqual(["상승", "하락"]);
+    expect(rankDiscoveryCandidates([down, up]).map((row) => row.ticker)).toEqual([]);
   });
 
   it("boosts obscure first-seen awakening over stale same-strength candidates", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -105,19 +105,28 @@ export function hasPublicMaterialEvent(candidate: DiscoveryCandidate): boolean {
   );
 }
 
+function isConstructiveThemeEvent(event: DiscoveryEvent): boolean {
+  return event.kind === "theme_link" && event.direction !== "down" && event.direction !== "flat";
+}
+
 export function hasThemeLinkEvent(candidate: DiscoveryCandidate): boolean {
-  return candidate.events.some((event) => event.kind === "theme_link");
+  return candidate.events.some(isConstructiveThemeEvent);
 }
 
 export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
   return (
     hasPublicMaterialEvent(candidate) ||
-    candidate.events.some((event) => event.kind === "theme_link" || (event.kind === "volume_spike" && event.firstSeen))
+    candidate.events.some((event) => isConstructiveThemeEvent(event) || (event.kind === "volume_spike" && event.firstSeen))
   );
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
-  return !hasDisplayWhyEvent(candidate) && candidate.events.every((event) => event.kind === "price_move" || event.kind === "volume_spike" || event.kind === "market_context");
+  return !hasDisplayWhyEvent(candidate) && candidate.events.every((event) =>
+    event.kind === "price_move" ||
+    event.kind === "volume_spike" ||
+    event.kind === "market_context" ||
+    (event.kind === "theme_link" && !isConstructiveThemeEvent(event))
+  );
 }
 
 const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
@@ -131,26 +140,32 @@ const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
   price_move: 7,
 };
 
+function eventTimePrefix(event: DiscoveryEvent, candidate: DiscoveryCandidate): "오늘" | "최근" {
+  return event.asOf.slice(0, 10) === candidate.asOf.slice(0, 10) ? "오늘" : "최근";
+}
+
 export function discoveryWhy(candidate: DiscoveryCandidate): string {
   const strongest = [...candidate.events].sort(
     (a, b) => WHY_KIND_PRIORITY[a.kind] - WHY_KIND_PRIORITY[b.kind] || b.strength - a.strength || a.kind.localeCompare(b.kind)
   )[0];
   if (!strongest) return "오늘 확인된 사건이 아직 없어요.";
   if (strongest.kind === "disclosure") {
+    const prefix = eventTimePrefix(strongest, candidate);
     return strongest.label
-      ? `오늘 공시가 확인됐어요: ${strongest.label}`
-      : "오늘 이 종목의 공시가 확인됐어요.";
+      ? `${prefix} 공시가 확인됐어요: ${strongest.label}`
+      : `${prefix} 이 종목의 공시가 확인됐어요.`;
   }
   if (strongest.kind === "news_mention") {
+    const prefix = eventTimePrefix(strongest, candidate);
     const isResearch = /리서치|증권|투자증권|자산운용|Research/i.test(strongest.source);
     if (isResearch) {
       return strongest.label
-        ? `오늘 이 종목을 직접 다룬 리서치가 있어요: ${strongest.label}`
-        : "오늘 이 종목을 직접 다룬 리서치가 있어요.";
+        ? `${prefix} 이 종목을 직접 다룬 리서치가 있어요: ${strongest.label}`
+        : `${prefix} 이 종목을 직접 다룬 리서치가 있어요.`;
     }
     return strongest.label
-      ? `오늘 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
-      : "오늘 이 종목을 직접 언급한 뉴스가 있어요.";
+      ? `${prefix} 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
+      : `${prefix} 이 종목을 직접 언급한 뉴스가 있어요.`;
   }
   if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";
   if (strongest.kind === "theme_link") return strongest.label ?? "오늘 강한 테마 흐름에 같이 묶여 있어요.";
@@ -226,7 +241,6 @@ export function rankDiscoveryCandidates(
     .filter(
       (candidate) =>
         !isWeakDiscoveryCandidate(candidate) ||
-        Math.max(0, ...candidate.events.map((event) => event.strength)) >= DISCOVERY_WEAK_MIN_STRENGTH ||
         candidate.events.some((event) => event.firstSeen && (event.kind === "volume_spike" || event.kind === "flow_entry"))
     )
     .map((candidate, index) => ({


### PR DESCRIPTION
## Summary
- Stop treating flat/bearish sector comparison as a top-band discovery WHY.
- Only create theme_link events for constructive positive theme leaders/outperformers.
- Drop price-only / direction-only movers instead of keeping them as discovery cards.
- Use 오늘/최근 prefix based on evidence date instead of always saying 오늘.

## Why
Production still showed cards like 금양/더존비즈온 with FOMO 0 and copy such as 'weak sector, this stock held flat'. That is not a discovery hook. This PR removes those filler cards from the top deck and keeps only cards with actual material, constructive theme leadership, flow, disclosure, news/research, or first-seen volume evidence.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run build:fomo-web
- npm run build:web
- local live discovery sample: count=28, noWhy=[], bad=[] for 보합/덜 강함/덜 약함/재료 없음 patterns.