### PR TITLE
fix(depth): resolve basics with discovery naver code

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -341,6 +341,8 @@ export interface StockContext {
   axisHeadline?: string | undefined;
   /** 발견 덱이 이미 가진 가격·포모·차트 seed. 상세 fetch 실패 시 비어 보이지 않게 한다. */
   frontSeed?: StockFrontResponse | undefined;
+  /** 발견 공급 엔진이 가진 네이버 종목 코드. STOCK_VOCAB 미등록 발견주 기본지표 조회용. */
+  naverCode?: string | undefined;
 }
 
 function hasUsableFront(front: StockFrontResponse | null | undefined): front is StockFrontResponse {
@@ -967,7 +969,7 @@ export function StockInsightView({
       .then((r) => alive && setFront(mergeFrontSeed(seed, r)))
       .catch(() => alive && setFront(seed))
       .finally(() => alive && setFrontLoaded(true));
-    fetchStockBasics(stock)
+    fetchStockBasics(stock, context?.naverCode ? { naverCode: context.naverCode } : {})
       .then((r) => alive && setBasics(r))
       .catch(() => alive && setBasics(null))
       .finally(() => alive && setBasicsLoaded(true));
@@ -978,7 +980,7 @@ export function StockInsightView({
     return () => {
       alive = false;
     };
-  }, [stock, context?.frontSeed]);
+  }, [stock, context?.frontSeed, context?.naverCode]);
 
   const hasInsight =
     !!insight && insight.confidence !== "insufficient" && insight.bull.length + insight.bear.length > 0;

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -838,6 +838,7 @@ export function StockSwipeDeck({
           context={{
             fromTheme: selected.sector,
             reason: whyFor(selected),
+            ...(selected.naverCode ? { naverCode: selected.naverCode } : {}),
             ...(front[selected.canonical] ? { frontSeed: front[selected.canonical] as StockFrontResponse } : {}),
             ...(axisHeadlineFor(selected) ? { axisHeadline: axisHeadlineFor(selected) } : {}),
           }}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -190,12 +190,12 @@ export const fetchStockInsight = (stock: string) =>
 
 /** 종목 기본 정보(바닥 — 주가·개요·시총·지표·재무). 항상 깔린다(원문 무관). */
 export type { StockBasics } from "@fomo/core";
-export const fetchStockBasics = (stock: string) =>
+export const fetchStockBasics = (stock: string, opts: { naverCode?: string } = {}) =>
   cachedGet(
-    `stock-basics:${stock}`,
+    `stock-basics:${opts.naverCode ?? "name"}:${stock}`,
     () =>
       get<import("@fomo/core").StockBasics>(
-        `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}`
+        `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}${opts.naverCode ? `&code=${encodeURIComponent(opts.naverCode)}` : ""}`
       ),
     CACHE_TTL.stockBasics
   );

--- a/apps/web/app/api/fomo/stock-basics/route.ts
+++ b/apps/web/app/api/fomo/stock-basics/route.ts
@@ -19,15 +19,20 @@ export function OPTIONS() {
 const REVALIDATE_S = 21_600; // 6h (가격은 약간 지연 허용 — 바닥 정보 안정성 우선, SWR)
 const inflight = new Map<string, Promise<StockBasics>>();
 
-async function getBasics(stock: string): Promise<StockBasics> {
+function validNaverCode(code: string | null): string | undefined {
+  const c = code?.trim();
+  return c && /^\d{6}$/.test(c) ? c : undefined;
+}
+
+async function getBasics(stock: string, naverCode?: string): Promise<StockBasics> {
   const today = kstDate();
-  const key = `${today}:${stock}`;
+  const key = `${today}:${stock}:${naverCode ?? ""}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
-    async () => fetchStockBasics(stock),
-    ["fomo-stock-basics", cacheVersion(), today, stock],
+    async () => fetchStockBasics(stock, naverCode),
+    ["fomo-stock-basics", cacheVersion(), today, stock, naverCode ?? ""],
     { revalidate: REVALIDATE_S }
   );
   const p = load().finally(() => inflight.delete(key));
@@ -36,11 +41,12 @@ async function getBasics(stock: string): Promise<StockBasics> {
 }
 
 export async function GET(req: Request) {
-  const stock = new URL(req.url).searchParams.get("stock")?.trim();
+  const url = new URL(req.url);
+  const stock = url.searchParams.get("stock")?.trim();
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
-  const payload = await getBasics(stock);
+  const payload = await getBasics(stock, validNaverCode(url.searchParams.get("code")));
   return withCors(
     NextResponse.json(payload, {
       headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=1800" },

--- a/apps/web/lib/stock-basics.ts
+++ b/apps/web/lib/stock-basics.ts
@@ -30,10 +30,15 @@ async function getJson(url: string, timeoutMs = 8000): Promise<unknown> {
   }
 }
 
+function validNaverCode(code: string | undefined | null): string | undefined {
+  const c = code?.trim();
+  return c && /^\d{6}$/.test(c) ? c : undefined;
+}
+
 /** 카드 앞면 lite용 — 주가·등락만 짧게 가져온다. 상세 지표/재무/개요는 depth API가 맡는다. */
-export async function fetchStockBasicsLite(stock: string, timeoutMs = 3500): Promise<StockBasics> {
+export async function fetchStockBasicsLite(stock: string, timeoutMs = 3500, naverCode?: string): Promise<StockBasics> {
   const def = resolveStock(stock);
-  const code = def?.naverCode;
+  const code = validNaverCode(naverCode) ?? def?.naverCode;
   if (!code) return { name: def?.canonical ?? stock, metrics: [] };
 
   const base = `https://m.stock.naver.com/api/stock/${encodeURIComponent(code)}`;
@@ -49,10 +54,10 @@ export async function fetchStockBasicsLite(stock: string, timeoutMs = 3500): Pro
   };
 }
 
-/** 종목명으로 기본 정보. 코드 해석 실패(미등록/미국주) → name 만(빈 화면 대신 최소 보장). */
-export async function fetchStockBasics(stock: string): Promise<StockBasics> {
+/** 종목명으로 기본 정보. discovery row 의 naverCode 가 있으면 vocab 미등록 종목도 조회한다. */
+export async function fetchStockBasics(stock: string, naverCode?: string): Promise<StockBasics> {
   const def = resolveStock(stock);
-  const code = def?.naverCode;
+  const code = validNaverCode(naverCode) ?? def?.naverCode;
   if (!code) {
     // 국내 코드 없음 → 네이버 종목 API 경로 없음. 정직하게 이름만(상위에서 수급/해석으로 보완).
     return { name: def?.canonical ?? stock, metrics: [] };


### PR DESCRIPTION
## Summary
- pass discovery naverCode into stock depth context
- let stock-basics API accept a trusted 6-digit code override
- use code override before STOCK_VOCAB lookup so newly discovered stocks can load real PER/EPS/PBR/52w/financial basics

## Root Cause
Discovery supply already had naverCode for long-tail stocks, but depth basics only resolved codes through STOCK_VOCAB. New discovery names like 대명에너지/SK오션플랜트/해성산업 were not in vocab, so stock-basics returned name-only payloads.

## Verification
- npm run typecheck:fomo-web
- npm run typecheck
- npm run build:fomo-web
- direct check: fetchStockBasics("대명에너지", "389260") returns marketCap, PER/EPS/PBR, 52w metrics, financials, summary