### PR TITLE
fix(discovery): drop no-event/evergreen-blurb cards from deck and top-band

### DIFF
--- a/apps/fomo-web/__tests__/discoveryDeck.test.ts
+++ b/apps/fomo-web/__tests__/discoveryDeck.test.ts
@@ -104,6 +104,41 @@ describe("buildTodayDiscoveryStocks", () => {
     expect(first20).not.toContain("테스트1");
   });
 
+  it("downranks sectors that the user recently dismissed", () => {
+    installLocalStorage();
+    const now = Date.now();
+    storage.set("fomo_stock_interest", JSON.stringify([{ stock: "삼성전자", signal: "less", ts: now }]));
+
+    const cards = [
+      {
+        keyword: "반도체",
+        surpriseStock: {
+          canonical: "한미반도체",
+          market: "KOSDAQ",
+          country: "KR",
+          mentions: 2,
+          surprise: 0.8,
+          reason: "반도체 사건 근거",
+        },
+      } as KeywordCard,
+      {
+        keyword: "AI",
+        surpriseStock: {
+          canonical: "SK바이오팜",
+          market: "KOSPI",
+          country: "KR",
+          mentions: 2,
+          surprise: 0.8,
+          reason: "AI 사건 근거",
+        },
+      } as KeywordCard,
+    ];
+
+    const result = buildTodayDiscoveryStocks([], cards, ["반도체", "AI"]);
+
+    expect(result.map((s) => s.canonical)).toEqual(["SK바이오팜", "한미반도체"]);
+  });
+
   it("applies axis snapshot order while avoiding three identical hook axes in a row", () => {
     installLocalStorage();
     const stocks = Array.from({ length: 7 }, (_, i) => stock(i, i < 3 ? "AI" : i < 5 ? "반도체" : "방산"));

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -166,6 +166,8 @@ function compactEvidenceLine(text: string | undefined): string | undefined {
 function compactReasonHeadlineSeed(text: string | undefined): string | undefined {
   const clean = (text ?? "").replace(/\s+/g, " ").trim();
   if (!clean) return undefined;
+  if (!/오늘|최근|공시|뉴스|리서치|수급|외국인|기관|거래량|가격|테마|흐름|순매수|신고가/.test(clean)) return undefined;
+  if (/전문\s?기업|플랫폼\s?리더|도약\s?중|안정화\s?예상|사업\s?영역|서비스\s?제공/.test(clean)) return undefined;
   return clean.length > 38 ? `${clean.slice(0, 37)}…` : clean;
 }
 

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -216,11 +216,30 @@ function todayDiscoveryRank(stock: DeckStock, recentRank: ReadonlyMap<string, nu
     (stock.reason ? 90 : 0) +
     (stock.marquee ? 35 : 0) +
     (isTasteSimilarStock(stock) ? 40 : 0) +
+    sectorTasteScore(stock, nowMs) +
     interest * 0.25 -
     recentPenalty * 10 -
     lessPenalty -
     positiveRevisitPenalty
   );
+}
+
+function sectorTasteScore(stock: DeckStock, nowMs = Date.now()): number {
+  if (!isKnownStockSector(stock.sector)) return 0;
+  const dayMs = 86_400_000;
+  const peers = stocksBySector(stock.sector).map((s) => s.canonical).filter((peer) => peer !== stock.canonical);
+  const watch = new Set(getWatchlist().map((w) => w.stock));
+  let score = 0;
+  for (const peer of peers) {
+    if (watch.has(peer)) score += 10;
+    const summary = stockInteractionSummary(peer);
+    const fresh = typeof summary.lastTs === "number" && nowMs - summary.lastTs < dayMs;
+    if (fresh && summary.lastSignal === "less") score -= 22;
+    if (fresh && (summary.lastSignal === "more" || summary.lastSignal === "view_depth")) score += 16;
+    score += Math.min(12, summary.moreCount * 4 + summary.depthCount * 3);
+    score -= Math.min(18, summary.lessCount * 5);
+  }
+  return Math.max(-80, Math.min(80, score));
 }
 
 function isTasteSimilarStock(stock: DeckStock): boolean {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -8,6 +8,7 @@ import {
   eligibleUniverse,
   hasDisplayWhyEvent,
   hasPublicMaterialEvent,
+  isDeckDisplayEvent,
   isFrontHookSafe,
   investorNetStreak,
   rankDiscoveryCandidates,
@@ -213,7 +214,7 @@ function eventFromPrice(row: NaverMarketRow, asOf: string): DiscoveryEvent | nul
 }
 
 function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string): DiscoveryEvent | null {
-  if (!attention?.newsEventLabel || attention.mentionCount <= 0) return null;
+  if (!attention?.newsEventLabel) return null;
   return {
     kind: "news_mention",
     firstSeen: true,
@@ -418,7 +419,8 @@ function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent 
   };
 }
 
-function eventAxisSignal(event: DiscoveryEvent): AxisSignal | null {
+function eventAxisSignal(event: DiscoveryEvent, candidate: DiscoveryCandidate): AxisSignal | null {
+  if (!isDeckDisplayEvent(event, candidate)) return null;
   if (
     event.kind !== "theme_link" &&
     event.kind !== "flow_entry" &&
@@ -477,11 +479,14 @@ function frontSeed(
   theme: ThemeMoveSignal | undefined,
   sparkline: number[]
 ): DiscoveryFrontSeed {
+  const currentNewsEvent = candidate.events.find(
+    (event) => isDeckDisplayEvent(event, candidate) && (event.kind === "news_mention" || event.kind === "disclosure")
+  );
   const signals: CardFrontSignals = {
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
     ...(attention ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore } : {}),
-    ...(attention?.newsEventLabel ? { newsEventLabel: attention.newsEventLabel } : {}),
-    ...(attention?.newsEventSource ? { newsEventSource: attention.newsEventSource } : {}),
+    ...(currentNewsEvent?.label ? { newsEventLabel: currentNewsEvent.label } : {}),
+    ...(currentNewsEvent?.source ? { newsEventSource: currentNewsEvent.source } : {}),
     ...(row.marketCapRank ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),
     ...(theme ? {
       themeLabel: theme.sector,
@@ -496,7 +501,7 @@ function frontSeed(
     ...(typeof signals.changePct === "number" ? { changePct: signals.changePct } : {}),
     ...(typeof signals.mentionScore === "number" ? { mentionScore: signals.mentionScore } : {}),
   });
-  const eventSignals = candidate.events.map(eventAxisSignal).filter((signal): signal is AxisSignal => signal !== null);
+  const eventSignals = candidate.events.map((event) => eventAxisSignal(event, candidate)).filter((signal): signal is AxisSignal => signal !== null);
   const axisSignals = [...buildAxisSignals({ signals }), ...eventSignals];
   const axisHook = selectMultiAxisHook(axisSignals);
   return {
@@ -545,15 +550,19 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
 
   for (const [ticker, attention] of Object.entries(attentionMap)) {
     const def = resolveStock(ticker);
-    if (!def?.naverCode) continue;
-    if (!eligibleTickers.has(def.canonical)) continue;
+    const canonical = def?.canonical ?? ticker;
+    if (!eligibleTickers.has(canonical)) continue;
     const row =
-      normalizedRows.find((r) => r.naverCode === def.naverCode) ??
-      ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow);
+      normalizedRows.find((r) => r.canonical === canonical) ??
+      (def?.naverCode ? normalizedRows.find((r) => r.naverCode === def.naverCode) : undefined) ??
+      (def?.naverCode
+        ? ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow)
+        : undefined);
+    if (!row) continue;
     const event = eventFromNews(attention, asOf);
     if (!event) continue;
-    const current = byTicker.get(def.canonical);
-    byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
+    const current = byTicker.get(canonical);
+    byTicker.set(canonical, { row: { ...row, canonical }, events: [...(current?.events ?? []), event] });
   }
 
   const disclosureMap = await fetchDartDisclosuresByStock(asOf).catch((): Record<string, DartDisclosureHit> => ({}));

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   discoveryWhy,
   eligibleUniverse,
+  hasDeckDisplayEvent,
   hasDisplayWhyEvent,
   isWeakDiscoveryCandidate,
   rankDiscoveryCandidates,
@@ -60,8 +61,10 @@ describe("WO-05 discovery supply engine", () => {
     expect(rankDiscoveryCandidates(rows, { seen: [{ ticker: "최근봄", daysAgo: 0 }], watched: ["최근봄"] })[0]?.ticker).toBe("최근봄");
   });
 
-  it("labels weak price-only material honestly instead of inventing a catalyst", () => {
-    expect(discoveryWhy(candidate("가격만", 0.8))).toContain("뚜렷한 공개 재료는 확인 안 됨");
+  it("labels positive price-only events as price movement instead of inventing a catalyst", () => {
+    const priceUp = candidate("가격만", 0.8, "price_move", "오늘 가격이 +8.00% 움직였어요.");
+    priceUp.events[0]!.direction = "up";
+    expect(discoveryWhy(priceUp)).toBe("오늘 가격이 +8.00% 움직였어요.");
     expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
   });
 
@@ -135,14 +138,16 @@ describe("WO-05 discovery supply engine", () => {
     expect(ranked).toHaveLength(0);
   });
 
-  it("keeps real WHY cards and drops price-only cards even when price-only strength is larger", () => {
+  it("keeps real WHY cards above positive price-only cards even when price-only strength is larger", () => {
     const priceOnly = candidate("가격만큰종목", 1, "price_move", "오늘 가격이 +18.00% 움직였어요.");
+    priceOnly.events[0]!.direction = "up";
     const themeWhy = candidate("테마이유", 0.45, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
     const materialWhy = candidate("뉴스이유", 0.4, "news_mention", "종목 지정 기사");
 
     expect(rankDiscoveryCandidates([priceOnly, themeWhy, materialWhy]).map((row) => row.ticker)).toEqual([
       "뉴스이유",
       "테마이유",
+      "가격만큰종목",
     ]);
   });
 
@@ -155,13 +160,15 @@ describe("WO-05 discovery supply engine", () => {
     expect(rankDiscoveryCandidates([famous, obscure]).map((row) => row.ticker)).toEqual(["무명주", "대형주"]);
   });
 
-  it("drops non-material direction-only price moves instead of ranking them as discovery", () => {
+  it("allows positive price moves only after stronger event tiers and drops down-only moves", () => {
     const up = candidate("상승", 0.9, "price_move", "오늘 가격이 +9.00% 움직였어요.");
     up.events[0]!.direction = "up";
     const down = candidate("하락", 0.9, "price_move", "오늘 가격이 -9.00% 움직였어요.");
     down.events[0]!.direction = "down";
 
-    expect(rankDiscoveryCandidates([down, up]).map((row) => row.ticker)).toEqual([]);
+    expect(hasDeckDisplayEvent(up)).toBe(true);
+    expect(hasDeckDisplayEvent(down)).toBe(false);
+    expect(rankDiscoveryCandidates([down, up]).map((row) => row.ticker)).toEqual(["상승"]);
   });
 
   it("boosts obscure first-seen awakening over stale same-strength candidates", () => {
@@ -188,11 +195,53 @@ describe("WO-05 discovery supply engine", () => {
   });
 
   it("keeps first-seen volume awakenings even below the weak strength floor", () => {
-    const ranked = rankDiscoveryCandidates([
-      candidate("거래량각성", 0.4, "volume_spike", "오늘 거래량이 새로 튀었어요."),
-      candidate("가격약함", 0.4, "price_move", "오늘 가격이 +4.00% 움직였어요."),
-    ]);
+    const volume = candidate("거래량각성", 0.4, "volume_spike", "오늘 거래량이 새로 튀었어요.");
+    volume.events[0]!.direction = "up";
+    const weakPrice = candidate("가격약함", 0.4, "price_move", "오늘 가격이 +4.00% 움직였어요.");
+    weakPrice.events[0]!.direction = "up";
+    const ranked = rankDiscoveryCandidates([volume, weakPrice]);
 
-    expect(ranked.map((row) => row.ticker)).toEqual(["거래량각성"]);
+    expect(ranked.map((row) => row.ticker)).toEqual(["거래량각성", "가격약함"]);
+  });
+
+  it("excludes evergreen company blurb-only rows from display and ranking", () => {
+    const evergreen: DiscoveryCandidate = {
+      ticker: "회사소개",
+      market: "KOSPI",
+      asOf,
+      reason: "새로운 시장을 여는 플랫폼 리더로 도약 중",
+      events: [],
+    };
+
+    expect(hasDeckDisplayEvent(evergreen)).toBe(false);
+    expect(hasDisplayWhyEvent(evergreen)).toBe(false);
+    expect(rankDiscoveryCandidates([evergreen])).toEqual([]);
+  });
+
+  it("keeps the top band free of flat, down, no-event, and market-context rows", () => {
+    const material = Array.from({ length: 4 }, (_, index) => candidate(`공시${index}`, 0.4 + index / 100, "disclosure", `공시 ${index}`));
+    const theme = Array.from({ length: 3 }, (_, index) => {
+      const row = candidate(`테마${index}`, 0.55 + index / 100, "theme_link", `오늘 원자력 흐름 ${index}`);
+      row.events[0]!.direction = "up";
+      return row;
+    });
+    const price = Array.from({ length: 5 }, (_, index) => {
+      const row = candidate(`가격상승${index}`, 0.9 - index / 100, "price_move", `오늘 가격이 +${8 + index}.00% 움직였어요.`);
+      row.events[0]!.direction = "up";
+      return row;
+    });
+    const rejected = [
+      candidate("보합", 0.9, "price_move", "오늘 가격이 0.00% 움직였어요."),
+      candidate("하락", 0.9, "price_move", "오늘 가격이 -9.00% 움직였어요."),
+      candidate("시장맥락", 0.9, "market_context", "KOSPI 시총 상위권에서 오늘 시장 흐름과 같이 확인해요."),
+    ];
+    rejected[0]!.events[0]!.direction = "flat";
+    rejected[1]!.events[0]!.direction = "down";
+
+    const ranked = rankDiscoveryCandidates([...rejected, ...price, ...theme, ...material], { maxCandidates: 20 });
+    expect(ranked.slice(0, 10).every(hasDeckDisplayEvent)).toBe(true);
+    expect(ranked.map((row) => row.ticker)).not.toContain("보합");
+    expect(ranked.map((row) => row.ticker)).not.toContain("하락");
+    expect(ranked.map((row) => row.ticker)).not.toContain("시장맥락");
   });
 });

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -60,7 +60,8 @@ export interface RankDiscoveryOptions {
 export const DISCOVERY_MAX_CANDIDATES = 100;
 export const DISCOVERY_LIQUIDITY_MEDIAN_RATIO_CUT = 0.1;
 export const DISCOVERY_SEEN_DECAY_DAYS = 3;
-export const DISCOVERY_TOP_BAND_WHY_REQUIRED = 30;
+export const DISCOVERY_TOP_BAND_EVENT_REQUIRED = 10;
+export const DISCOVERY_TOP_BAND_WHY_REQUIRED = DISCOVERY_TOP_BAND_EVENT_REQUIRED;
 export const DISCOVERY_WEAK_MIN_STRENGTH = 0.85;
 export const DISCOVERY_FAME_MAX_PENALTY = 0.5;
 export const DISCOVERY_FAME_RANK_FLOOR = 120;
@@ -100,9 +101,7 @@ export function eligibleUniverse(
 }
 
 export function hasPublicMaterialEvent(candidate: DiscoveryCandidate): boolean {
-  return candidate.events.some((event) =>
-    event.kind === "disclosure" || event.kind === "news_mention" || event.kind === "flow_entry" || event.kind === "new_high"
-  );
+  return candidate.events.some((event) => isCurrentDeckEvent(event, candidate) && isMaterialEvent(event));
 }
 
 function isConstructiveThemeEvent(event: DiscoveryEvent): boolean {
@@ -110,23 +109,50 @@ function isConstructiveThemeEvent(event: DiscoveryEvent): boolean {
 }
 
 export function hasThemeLinkEvent(candidate: DiscoveryCandidate): boolean {
-  return candidate.events.some(isConstructiveThemeEvent);
+  return candidate.events.some((event) => isCurrentDeckEvent(event, candidate) && isConstructiveThemeEvent(event));
+}
+
+function sameDay(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  return a.slice(0, 10) === b.slice(0, 10);
+}
+
+function isCurrentDeckEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): boolean {
+  return sameDay(event.asOf, candidate.asOf);
+}
+
+function isMaterialEvent(event: DiscoveryEvent): boolean {
+  return (
+    event.kind === "disclosure" ||
+    event.kind === "news_mention" ||
+    event.kind === "flow_entry" ||
+    event.kind === "new_high"
+  );
+}
+
+function isDisplayVolumeEvent(event: DiscoveryEvent): boolean {
+  return event.kind === "volume_spike" && event.firstSeen && event.direction !== "down" && event.direction !== "flat";
+}
+
+function isPositivePriceMoveEvent(event: DiscoveryEvent): boolean {
+  return event.kind === "price_move" && event.direction === "up";
+}
+
+export function isDeckDisplayEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): boolean {
+  if (!isCurrentDeckEvent(event, candidate)) return false;
+  return isMaterialEvent(event) || isConstructiveThemeEvent(event) || isDisplayVolumeEvent(event) || isPositivePriceMoveEvent(event);
+}
+
+export function hasDeckDisplayEvent(candidate: DiscoveryCandidate): boolean {
+  return candidate.events.some((event) => isDeckDisplayEvent(event, candidate));
 }
 
 export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
-  return (
-    hasPublicMaterialEvent(candidate) ||
-    candidate.events.some((event) => isConstructiveThemeEvent(event) || (event.kind === "volume_spike" && event.firstSeen))
-  );
+  return hasDeckDisplayEvent(candidate);
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {
-  return !hasDisplayWhyEvent(candidate) && candidate.events.every((event) =>
-    event.kind === "price_move" ||
-    event.kind === "volume_spike" ||
-    event.kind === "market_context" ||
-    (event.kind === "theme_link" && !isConstructiveThemeEvent(event))
-  );
+  return !hasDeckDisplayEvent(candidate);
 }
 
 const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
@@ -134,10 +160,10 @@ const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
   news_mention: 1,
   flow_entry: 2,
   theme_link: 3,
-  market_context: 4,
-  new_high: 5,
-  volume_spike: 6,
-  price_move: 7,
+  new_high: 4,
+  volume_spike: 5,
+  price_move: 6,
+  market_context: 99,
 };
 
 function eventTimePrefix(event: DiscoveryEvent, candidate: DiscoveryCandidate): "오늘" | "최근" {
@@ -145,7 +171,8 @@ function eventTimePrefix(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
 }
 
 export function discoveryWhy(candidate: DiscoveryCandidate): string {
-  const strongest = [...candidate.events].sort(
+  const displayEvents = candidate.events.filter((event) => isDeckDisplayEvent(event, candidate));
+  const strongest = displayEvents.sort(
     (a, b) => WHY_KIND_PRIORITY[a.kind] - WHY_KIND_PRIORITY[b.kind] || b.strength - a.strength || a.kind.localeCompare(b.kind)
   )[0];
   if (!strongest) return "오늘 확인된 사건이 아직 없어요.";
@@ -169,10 +196,9 @@ export function discoveryWhy(candidate: DiscoveryCandidate): string {
   }
   if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";
   if (strongest.kind === "theme_link") return strongest.label ?? "오늘 강한 테마 흐름에 같이 묶여 있어요.";
-  if (strongest.kind === "market_context") return strongest.label ?? "오늘 시장 흐름 안에서 확인하는 종목이에요.";
   if (strongest.kind === "new_high") return strongest.label ?? "새로운 가격 위치가 확인된 종목이에요.";
   if (strongest.kind === "volume_spike") {
-    return strongest.label ?? "오늘 거래량 급증, 뚜렷한 공개 재료는 확인 안 됨.";
+    return strongest.label ?? "오늘 거래량이 새로 늘었어요.";
   }
   return strongest.label ?? "오늘 가격 움직임이 커졌고, 뚜렷한 공개 재료는 확인 안 됨.";
 }
@@ -208,8 +234,10 @@ export function directionPenalty(candidate: DiscoveryCandidate): number {
 }
 
 function eventScore(candidate: DiscoveryCandidate): number {
-  const maxStrength = Math.max(0, ...candidate.events.map((event) => clamp01(event.strength)));
-  const diversity = new Set(candidate.events.map((event) => event.kind)).size;
+  const displayEvents = candidate.events.filter((event) => isDeckDisplayEvent(event, candidate));
+  const scoreEvents = displayEvents.length > 0 ? displayEvents : candidate.events;
+  const maxStrength = Math.max(0, ...scoreEvents.map((event) => clamp01(event.strength)));
+  const diversity = new Set(scoreEvents.map((event) => event.kind)).size;
   const materialBoost = hasPublicMaterialEvent(candidate) ? 0.22 : hasThemeLinkEvent(candidate) ? 0.08 : hasDisplayWhyEvent(candidate) ? -0.03 : -0.25;
   return (
     DISCOVERY_STRENGTH_WEIGHT * maxStrength +
@@ -220,6 +248,14 @@ function eventScore(candidate: DiscoveryCandidate): number {
     awakeningBoost(candidate) +
     directionPenalty(candidate)
   );
+}
+
+function eventTier(candidate: DiscoveryCandidate): number {
+  const displayEvents = candidate.events.filter((event) => isDeckDisplayEvent(event, candidate));
+  if (displayEvents.some(isMaterialEvent)) return 0;
+  if (displayEvents.some((event) => event.kind === "theme_link" || event.kind === "new_high" || event.kind === "volume_spike")) return 1;
+  if (displayEvents.some((event) => event.kind === "price_move")) return 2;
+  return 9;
 }
 
 function seenPenalty(ticker: string, seen: readonly SeenRecord[], watched: ReadonlySet<string>): number {
@@ -237,19 +273,16 @@ export function rankDiscoveryCandidates(
   const max = opts.maxCandidates ?? DISCOVERY_MAX_CANDIDATES;
   const watched = new Set(opts.watched ?? []);
   return candidates
-    .filter((candidate) => candidate.events.length > 0)
-    .filter(
-      (candidate) =>
-        !isWeakDiscoveryCandidate(candidate) ||
-        candidate.events.some((event) => event.firstSeen && (event.kind === "volume_spike" || event.kind === "flow_entry"))
-    )
+    .filter(hasDeckDisplayEvent)
     .map((candidate, index) => ({
       candidate,
       index,
       score: eventScore(candidate) - seenPenalty(candidate.ticker, opts.seen ?? [], watched),
+      tier: eventTier(candidate),
     }))
     .sort(
       (a, b) =>
+        a.tier - b.tier ||
         Number(hasDisplayWhyEvent(b.candidate)) - Number(hasDisplayWhyEvent(a.candidate)) ||
         b.score - a.score ||
         Number(hasPublicMaterialEvent(b.candidate)) - Number(hasPublicMaterialEvent(a.candidate)) ||


### PR DESCRIPTION
## What changed
- Added a hard discovery display-event gate: current-day material/news/flow/new-high, constructive theme/volume awakening, or positive price move only.
- Removed market_context/flat/down/no-event/company-blurb-only rows from discovery ranking eligibility.
- Made discoveryWhy choose only gated display events, so market context and stale evergreen blurbs cannot become the card WHY.
- Aligned front seed axis signals with the same event gate, preventing stale research/company-style headlines from overriding the actual discovery reason.
- Let long-tail attention news attach to existing market rows even when the stock is not in STOCK_VOCAB.
- Added local sector taste adjustment: recently dismissed sectors are downranked, watched/positive peer sectors are boosted.

## Root cause
- Backend ranking filtered only weak shape rows, but the frontend still promoted stock.reason into newsEventLabel and stock-front axis signals could surface stale research/company-style labels. Also eventAxisSignal did not share discoveryWhy's current-day gate, causing reason/headline mismatches.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/fomo-web/__tests__/discoveryDeck.test.ts
- npm run typecheck
- npm run build:fomo-web
- npm run build:web
- npm run lint

## Manual first-10 check
Local live discovery sample returned 16 current-event cards. First 10 had no no-event/company-blurb-only rows; reason/headline were aligned for current material/theme/price events. No E1/CJ프레시웨이/DXVX-style 0.00/company-intro cards appeared in the first band.