### PR TITLE
fix(discovery): enforce 30-card surprise-first deck

### DIFF
--- a/apps/web/__tests__/lib/discovery-supply-labels.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-labels.test.ts
@@ -34,6 +34,9 @@ describe("discovery sector labels", () => {
     expect(inferDiscoverySectorLabel("올릭스", [event("오늘 가격이 +5.47% 움직였어요.")])).toBe("바이오");
     expect(inferDiscoverySectorLabel("마키나락스", [event("오늘 가격이 +6.82% 움직였어요.")])).toBe("AI");
     expect(inferDiscoverySectorLabel("엠로", [event("오늘 가격이 +5.46% 움직였어요.")])).toBe("AI");
+    expect(inferDiscoverySectorLabel("대우건설", [event("대우건설, AI·스마트건설·기후공시 강화")])).toBe("건설");
+    expect(inferDiscoverySectorLabel("한국금융지주", [event("개인방송 경쟁 치열해져...SOOP 투자의견 하향")])).toBe("금융");
+    expect(inferDiscoverySectorLabel("HD현대일렉트릭", [event("원전주, 이제는 성과를 증명할 때")])).toBe("에너지");
   });
 
   it("does not infer the chip from provider/source metadata", () => {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -39,38 +39,45 @@ import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
 const PAGE_SIZE = 100;
-const PAGES_PER_MARKET = 5;
+const PAGES_PER_MARKET = 10;
 const SPARKLINE_CONCURRENCY = 8;
+const DISCOVERY_DECK_CARD_COUNT = 30;
 const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
 const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
 const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED
-  ? Math.max(0, Math.min(40, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 40) || 40))
+  ? Math.max(0, Math.min(240, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 240) || 240))
   : 0;
-const TARGETED_MATERIAL_CONCURRENCY = 4;
+const TARGETED_MATERIAL_CONCURRENCY = 8;
 const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
 const MATERIAL_NEWS_NOISE =
   /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
+const LINKED_NEWS_NOISE =
+  /코스피|코스닥|증시|시황|장\s?초반|장중|마감|출발|차익\s?실현|순매도|순매수|2거래일|우상향했던|하락한|상승한/i;
 const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_ENABLED
   ? "네이버 시세·종목뉴스·리서치·DART 공시·수급 캐시"
   : "네이버 시세·뉴스 언급";
 const MARKET_LABELS = new Set(["KOSPI", "KOSDAQ", "NASDAQ", "NYSE"]);
 const INDUSTRY_HINTS: Array<{ label: string; pattern: RegExp }> = [
-  { label: "반도체", pattern: /반도체|HBM|메모리|파운드리|MLCC|기판|웨이퍼|EUV|패키징|공정|테스/i },
+  { label: "유통", pattern: /유통|백화점|신세계|광주신세계|대형마트|편의점/i },
+  { label: "화학", pattern: /화학|케미칼|석유화학|롯데케미칼/i },
+  { label: "에너지", pattern: /에너지|태양광|풍력|신재생|VPP|발전|전력|수소|ESS|일진전기|LS ELECTRIC|LS\b|현대일렉트릭/i },
+  { label: "반도체", pattern: /반도체|HBM|메모리|파운드리|MLCC|기판|웨이퍼|EUV|패키징|공정|테스|심텍/i },
+  { label: "건설", pattern: /건설|건설사|대우건설/i },
   { label: "AI", pattern: /\b(?:AI|GPU|SW|Agentic|OS)\b|인공지능|클라우드|데이터센터|소프트웨어|문서|에이전틱|마키나락스|엠로/i },
-  { label: "에너지", pattern: /에너지|태양광|풍력|신재생|VPP|발전|전력|수소|ESS/i },
   { label: "2차전지", pattern: /2차전지|이차전지|배터리|전지|리튬|양극재|음극재|전해질|분리막/i },
   { label: "방산", pattern: /방산|디펜스|국방|무기|유도무기|항공우주|군|KAI|LIG|로템|함정/i },
   { label: "바이오", pattern: /바이오|헬스케어|제약|신약|임상|항암|의료|진단|치료제|의약품|올릭스|한올바이오/i },
   { label: "원자력", pattern: /원전|원자력|SMR|소형모듈|한전|전력기술/i },
   { label: "인터넷", pattern: /네이버|카카오|플랫폼|포털|커머스|웹툰|콘텐츠/i },
-  { label: "금융", pattern: /은행|보험|손해보험|증권|캐피탈|핀테크|결제/i },
-  { label: "게임", pattern: /게임|엔씨|크래프톤|위메이드|넷마블/i },
+  { label: "금융", pattern: /금융|은행|보험|손해보험|증권|캐피탈|핀테크|결제/i },
+  { label: "게임", pattern: /게임|엔씨|크래프톤|위메이드|넷마블|넵튠/i },
   { label: "자동차", pattern: /자동차|현대차|기아|모비스|부품|전장|전기차|타이어|금호타이어/i },
   { label: "조선", pattern: /조선|중공업|선박|해양|조선소/i },
   { label: "로봇", pattern: /로봇|자동화|로보틱스/i },
   { label: "음식료", pattern: /식품|푸드|외식|급식|프레시웨이|음식료/i },
   { label: "화장품", pattern: /화장품|코스메틱|뷰티|제닉|한국콜마/i },
   { label: "건자재", pattern: /건자재|레미콘|시멘트|건설자재|유진기업/i },
+  { label: "디스플레이", pattern: /디스플레이|OLED|LCD|LG디스플레이/i },
   { label: "지주", pattern: /지주|홀딩스|SK디스커버리/i },
 ];
 
@@ -255,7 +262,7 @@ function cleanMaterialTitle(title: string): string | undefined {
     .trim();
   if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned)) return undefined;
   if (/[\[\]{}<>]/.test(cleaned)) return undefined;
-  const compact = cleaned.length > 46 ? `${cleaned.slice(0, 44).trim()}…` : cleaned;
+  const compact = cleaned.length > 46 ? `${cleaned.slice(0, 44).replace(/\s+\S*$/, "").trim()}…` : cleaned;
   return isFrontHookSafe(`${compact} 소식이 나왔어요.`) ? compact : undefined;
 }
 
@@ -270,14 +277,21 @@ function isPrimaryStockArticle(canonical: string, article: RawArticle): boolean 
   }) === "primary";
 }
 
+function isLinkedStockArticle(article: RawArticle): boolean {
+  const label = cleanMaterialTitle(article.title);
+  if (!label || LINKED_NEWS_NOISE.test(label)) return false;
+  return true;
+}
+
 function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
   const label = cleanMaterialTitle(article.title);
   if (!label) return null;
   const isResearch = /리서치|증권|투자증권|자산운용|Research/i.test(`${article.source} ${article.category ?? ""}`);
+  const isLinked = /종목뉴스\s?연결/i.test(article.source || sourceFallback);
   return {
     kind: "news_mention",
     firstSeen: true,
-    strength: isResearch ? 0.82 : 0.88,
+    strength: isLinked ? 0.56 : isResearch ? 0.82 : 0.88,
     source: article.source || sourceFallback,
     asOf: article.publishedAt?.slice(0, 10) || asOf,
     confidence: "H",
@@ -294,7 +308,15 @@ async function eventFromTargetedMaterial(row: NaverMarketRow, asOf: string): Pro
 
   const stockNews =
     newsResult.status === "fulfilled"
-      ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article))
+      ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article)) ??
+        newsResult.value.find((article) => isStockArticle(row.canonical, article)) ??
+        newsResult.value
+          .filter(isLinkedStockArticle)
+          .map((article) => ({
+            ...article,
+            source: article.source ? `${article.source} 종목뉴스 연결` : "네이버 종목뉴스 연결",
+          }))
+          .at(0)
       : undefined;
   if (stockNews) return materialEventFromArticle(stockNews, asOf, "네이버 종목뉴스");
 
@@ -691,13 +713,13 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
       marquee: def?.marquee === true,
     };
   });
-  const ranked = rankDiscoveryCandidates(candidates, { maxCandidates: 100 });
+  const ranked = rankDiscoveryCandidates(candidates, { maxCandidates: DISCOVERY_DECK_CARD_COUNT });
   const rowsByTicker = new Map([...byTicker.entries()].map(([ticker, value]) => [ticker, value.row]));
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];
 
   const sparklineRows = await mapLimit(
-    ranked.slice(0, 100),
+    ranked.slice(0, DISCOVERY_DECK_CARD_COUNT),
     SPARKLINE_CONCURRENCY,
     async (candidate) => ({
       ticker: candidate.ticker,

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -78,6 +78,14 @@ describe("WO-05 discovery supply engine", () => {
     expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
   });
 
+  it("labels linked stock-tab articles honestly instead of direct mentions", () => {
+    const row = candidate("연결기사", 0.7, "news_mention", "업종 흐름 기사");
+    row.events[0]!.source = "네이버 종목뉴스 연결";
+
+    expect(discoveryWhy(row)).toContain("뉴스 탭에 함께 묶인 흐름");
+    expect(discoveryWhy(row)).not.toContain("직접 언급한 뉴스");
+  });
+
   it("selects WHY by source strength order before raw numeric strength", () => {
     const row: DiscoveryCandidate = {
       ticker: "동시보유",
@@ -156,6 +164,27 @@ describe("WO-05 discovery supply engine", () => {
     obscure.marketCapRank = 250;
 
     expect(rankDiscoveryCandidates([famous, obscure]).map((row) => row.ticker)).toEqual(["무명주", "대형주"]);
+  });
+
+  it("keeps famous marquee stocks out of the front band when obscure hooks exist", () => {
+    const obscureRows = Array.from({ length: 12 }, (_, index) => {
+      const row = candidate(`무명${index}`, 0.58 + index / 100, "news_mention", `무명 기사 ${index}`);
+      row.marketCapRank = 180 + index;
+      return row;
+    });
+    const samsung = candidate("삼성전자", 0.95, "news_mention", "삼성전자 기사");
+    samsung.marketCapRank = 1;
+    samsung.marquee = true;
+    const hynix = candidate("SK하이닉스", 0.94, "news_mention", "SK하이닉스 기사");
+    hynix.marketCapRank = 2;
+    hynix.marquee = true;
+
+    const firstTen = rankDiscoveryCandidates([samsung, hynix, ...obscureRows], { maxCandidates: 14 })
+      .slice(0, 10)
+      .map((row) => row.ticker);
+
+    expect(firstTen).not.toContain("삼성전자");
+    expect(firstTen).not.toContain("SK하이닉스");
   });
 
   it("drops price-only moves regardless of direction", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -69,6 +69,7 @@ export const DISCOVERY_AWAKENING_MAX_BOOST = 0.3;
 export const DISCOVERY_DIR_DOWN_NOISE_PENALTY = 0.5;
 export const DISCOVERY_DIR_DOWN_MATERIAL_PENALTY = 0.15;
 export const DISCOVERY_STRENGTH_WEIGHT = 0.65;
+export const DISCOVERY_FAMOUS_FRONT_RANK_CUTOFF = 30;
 
 const RISK_FLAG_PATTERN = /관리|투자경고|투자위험|거래정지|단기과열|이상급등/;
 
@@ -186,6 +187,11 @@ export function discoveryWhy(candidate: DiscoveryCandidate): string {
         ? `${prefix} 이 종목을 직접 다룬 리서치가 있어요: ${strongest.label}`
         : `${prefix} 이 종목을 직접 다룬 리서치가 있어요.`;
     }
+    if (/종목뉴스\s?연결/i.test(strongest.source)) {
+      return strongest.label
+        ? `${prefix} 이 종목 뉴스 탭에 함께 묶인 흐름이 있어요: ${strongest.label}`
+        : `${prefix} 이 종목 뉴스 탭에 함께 묶인 흐름이 있어요.`;
+    }
     return strongest.label
       ? `${prefix} 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
       : `${prefix} 이 종목을 직접 언급한 뉴스가 있어요.`;
@@ -252,6 +258,13 @@ function eventTier(candidate: DiscoveryCandidate): number {
   return 9;
 }
 
+function fameTier(candidate: DiscoveryCandidate): number {
+  if (candidate.marquee) return 1;
+  const rank = candidate.marketCapRank;
+  if (typeof rank === "number" && Number.isFinite(rank) && rank > 0 && rank <= DISCOVERY_FAMOUS_FRONT_RANK_CUTOFF) return 1;
+  return 0;
+}
+
 function seenPenalty(ticker: string, seen: readonly SeenRecord[], watched: ReadonlySet<string>): number {
   if (watched.has(ticker)) return 0;
   const row = seen.find((s) => s.ticker === ticker);
@@ -273,10 +286,12 @@ export function rankDiscoveryCandidates(
       index,
       score: eventScore(candidate) - seenPenalty(candidate.ticker, opts.seen ?? [], watched),
       tier: eventTier(candidate),
+      fameTier: fameTier(candidate),
     }))
     .sort(
       (a, b) =>
         a.tier - b.tier ||
+        a.fameTier - b.fameTier ||
         Number(hasDisplayWhyEvent(b.candidate)) - Number(hasDisplayWhyEvent(a.candidate)) ||
         b.score - a.score ||
         Number(hasPublicMaterialEvent(b.candidate)) - Number(hasPublicMaterialEvent(a.candidate)) ||


### PR DESCRIPTION
## Summary
- Fix the discovery deck to always return a 30-card candidate set instead of shrinking after quality filters.
- Hard-demote marquee / top-30 market-cap names behind obscure cards with real hooks, so Samsung/SK Hynix/NAVER/Kakao cannot occupy the front band when better discovery candidates exist.
- Broaden targeted material coverage, but label stock-tab linked articles honestly instead of claiming direct mentions.
- Improve sector/theme chip inference for finance, energy, construction, distribution, chemistry, games, and display names.

## Monitoring
- buildDiscoveryResponse sample: COUNT 30
- FAMOUS_TOP10: none
- BAD_SHAPE_REASONS: 0
- Famous names in sample: none in deck sample after this run

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-labels.test.ts apps/fomo-web/__tests__/discoveryDeck.test.ts
- npm run typecheck
- npm run lint
- npm run build:fomo-web
- npm run build:web