### PR TITLE
feat(login): 메인 디자인 싱크 — 네온옐로우·취향투자 카피

### DIFF
--- a/apps/fomo-club/app/login/index.tsx
+++ b/apps/fomo-club/app/login/index.tsx
@@ -1,27 +1,101 @@
 import { View, Text, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Link } from "expo-router";
-import { FomoColors, Spacing } from "../../constants/fomoTheme";
+import { FomoColors, Spacing, Radius } from "../../constants/fomoTheme";
+
+const NEON = "#D8FF3A";
 
 export default function Login() {
   return (
     <SafeAreaView style={styles.safe}>
-      <View style={styles.header}>
-        <Text style={styles.title}>로그인</Text>
-        <Link href="/settings" style={styles.link}>닫기</Link>
+      <View style={styles.nav}>
+        <Link href="/settings" style={styles.close}>닫기</Link>
       </View>
-      <Text style={styles.body}>
-        로그인은 선택입니다. 가입 없이도 감정 선택과 FOMO Index 확인이 가능합니다.
-        {"\n"}소셜 로그인 실연동은 Phase 5에서 추가됩니다.
-      </Text>
+
+      <View style={styles.hero}>
+        <Text style={styles.eyebrow}>FOMO CLUB</Text>
+        <Text style={styles.headline}>
+          당신을 위한{"\n"}
+          <Text style={styles.accent}>취향투자</Text> 클럽
+        </Text>
+        <Text style={styles.sub}>
+          분석보다 발견.{"\n"}멈춰 보게 되는 종목이 당신의 기준이다.
+        </Text>
+      </View>
+
+      <View style={styles.bottom}>
+        <View style={styles.cta}>
+          <Text style={styles.ctaText}>소셜 로그인 준비 중</Text>
+        </View>
+        <Text style={styles.hint}>
+          가입 없이도 카드를 스와이프하고{"\n"}FOMO 지수를 확인할 수 있어요.
+        </Text>
+      </View>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: FomoColors.ink, paddingHorizontal: Spacing.s24, paddingTop: Spacing.s16 },
-  header: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: Spacing.s32 },
-  title: { color: FomoColors.whiteout, fontSize: 18, fontWeight: "600" },
-  link: { color: FomoColors.muted, fontSize: 14 },
-  body: { color: FomoColors.muted, fontSize: 14, lineHeight: 24 },
+  safe: {
+    flex: 1,
+    backgroundColor: FomoColors.ink,
+    paddingHorizontal: Spacing.s24,
+  },
+  nav: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingTop: Spacing.s8,
+    marginBottom: Spacing.s32,
+  },
+  close: {
+    color: FomoColors.muted,
+    fontSize: 14,
+  },
+  hero: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  eyebrow: {
+    color: NEON,
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 3,
+    marginBottom: Spacing.s16,
+  },
+  headline: {
+    color: FomoColors.whiteout,
+    fontSize: 40,
+    fontWeight: "700",
+    lineHeight: 48,
+    marginBottom: Spacing.s24,
+  },
+  accent: {
+    color: NEON,
+  },
+  sub: {
+    color: FomoColors.muted,
+    fontSize: 16,
+    lineHeight: 26,
+  },
+  bottom: {
+    paddingBottom: Spacing.s32,
+    gap: Spacing.s16,
+  },
+  cta: {
+    backgroundColor: NEON,
+    borderRadius: Radius.pill,
+    paddingVertical: Spacing.s16,
+    alignItems: "center",
+  },
+  ctaText: {
+    color: FomoColors.ink,
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  hint: {
+    color: FomoColors.muted,
+    fontSize: 13,
+    lineHeight: 20,
+    textAlign: "center",
+  },
 });


### PR DESCRIPTION
## Summary
- 배경/텍스트 색상 메인 피드와 완전 통일 (`FomoColors.ink/whiteout/muted`)
- 브랜드 액센트 `#D8FF3A`(neon500) 적용 — eyebrow "FOMO CLUB" + "취향투자" 단어 강조
- 헤드라인 `fontSize: 40 / fontWeight: 700` — 카드 value 스타일 맞춤
- CTA 버튼: 네온 pill 배경 + 검정 텍스트
- 카피 전면 교체: "다시 왔다" 류 → "당신을 위한 취향투자 클럽 / 멈춰 보게 되는 종목이 기준"

## Test plan
- [ ] iOS 시뮬레이터에서 로그인 화면 렌더링 확인
- [ ] 네온 옐로우 eyebrow + accent 표시 확인
- [ ] CTA 버튼 레이아웃 확인
- [ ] `닫기` 링크 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)