### PR TITLE
fix(discovery): mix marquee cards and explain fomo index

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -48,6 +48,7 @@ export function HomeView({
   const [authOpen, setAuthOpen] = useState(false);
   const [noticeOpen, setNoticeOpen] = useState(false);
   const [noticeChecked, setNoticeChecked] = useState(true);
+  const [indexHelpOpen, setIndexHelpOpen] = useState(false);
   const color = index ? scoreToColor(index.score) : undefined;
 
   useEffect(() => {
@@ -88,7 +89,12 @@ export function HomeView({
 
         {/* 시장 온도(FOMO Index) */}
         {index ? (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+          <button
+            type="button"
+            onClick={() => setIndexHelpOpen(true)}
+            className="mt-3 flex w-full items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5 text-left transition-colors hover:border-whiteout/20"
+            aria-label="오늘의 시장 온도 계산 방식 보기"
+          >
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <div className="flex items-baseline gap-2">
               <span className="font-number text-xl font-bold leading-none" style={{ color }}>
@@ -103,12 +109,17 @@ export function HomeView({
                 </span>
               )}
             </div>
-          </div>
+          </button>
         ) : (
-          <div className="mt-3 flex items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5">
+          <button
+            type="button"
+            onClick={() => setIndexHelpOpen(true)}
+            className="mt-3 flex w-full items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5 text-left transition-colors hover:border-whiteout/20"
+            aria-label="오늘의 시장 온도 계산 방식 보기"
+          >
             <span className="text-xs text-muted">오늘의 시장 온도</span>
             <span className="font-pixel text-[11px] text-muted">데이터 수집 중…</span>
-          </div>
+          </button>
         )}
 
         <div className={`mt-3 flex flex-1 flex-col ${tab === "card" ? "justify-center" : ""}`}>
@@ -132,6 +143,8 @@ export function HomeView({
         <LoginPage loggedIn={loggedIn} onClose={() => setAuthOpen(false)} onAuthed={onLoggedIn} />
       )}
 
+      {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
+
       {noticeOpen && (
         <FirstVisitNoticeSheet
           checked={noticeChecked}
@@ -148,6 +161,74 @@ export function HomeView({
         />
       )}
     </>
+  );
+}
+
+function FomoIndexInfoSheet({
+  index,
+  onClose,
+}: {
+  index: FomoIndexResponse | null;
+  onClose: () => void;
+}) {
+  const rows = [
+    { label: "시장 움직임", points: "30점", desc: "국내외 주요 지수와 자산 흐름을 봅니다." },
+    { label: "언급·커뮤니티", points: "30점", desc: "뉴스와 공개 글에서 관심이 늘었는지 봅니다." },
+    { label: "감정 투표", points: "30점", desc: "사용자가 남긴 오늘의 감정 분포를 더합니다." },
+    { label: "고래·크립토", points: "10점", desc: "큰 자금 흐름과 코인 시장 분위기를 보조로 봅니다." },
+  ];
+  const components = index?.components;
+  const valueOf = (key: keyof FomoIndexResponse["components"]) => components?.[key];
+  const values = [valueOf("market"), valueOf("community"), valueOf("emotion"), valueOf("whale")];
+
+  return (
+    <div className="fixed inset-0 z-[85]" role="dialog" aria-modal="true" aria-labelledby="fomo-index-info-title">
+      <button className="absolute inset-0 bg-black/72 backdrop-blur-md" onClick={onClose} aria-label="닫기" type="button" />
+      <div className="absolute inset-x-0 bottom-0 mx-auto max-w-md">
+        <section className="fomo-sheet-rise rounded-t-[28px] border border-hairline bg-[#1A1A1A] px-6 pb-[calc(24px+env(safe-area-inset-bottom))] pt-5">
+          <div className="mx-auto h-1 w-14 rounded-full bg-white/20" />
+          <div className="mt-6 flex items-start justify-between gap-4">
+            <div>
+              <p className="font-pixel text-[11px] text-muted">FOMO INDEX</p>
+              <h1 id="fomo-index-info-title" className="mt-2 text-2xl font-semibold text-whiteout">
+                시장 온도는 이렇게 계산해요
+              </h1>
+            </div>
+            <button
+              className="rounded-full border border-hairline px-3 py-1.5 text-sm text-muted transition-colors hover:text-whiteout"
+              onClick={onClose}
+              type="button"
+            >
+              닫기
+            </button>
+          </div>
+
+          <p className="mt-5 text-sm leading-6 text-muted">
+            오늘의 시장 온도는 0~100점 체감 지표예요. 여러 공개 신호를 같은 저울에 올려 시장이 얼마나 뜨겁거나
+            차분한지 보여줍니다.
+          </p>
+
+          <div className="mt-6 space-y-3">
+            {rows.map((row, index) => (
+              <div key={row.label} className="rounded-2xl border border-hairline bg-white/[0.035] px-4 py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-semibold text-whiteout">{row.label}</span>
+                  <span className="font-number text-sm font-semibold" style={{ color: NEON }}>
+                    {values[index] ?? "—"} / {row.points}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-muted">{row.desc}</p>
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-5 text-xs leading-5 text-muted">
+            데이터가 부족한 항목은 중립값으로 낮게 반영돼요. 이 점수는 시장 분위기를 읽기 위한 정보이며,
+            투자 자문·매수·매도 신호가 아닙니다.
+          </p>
+        </section>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -551,9 +551,19 @@ function frontSeed(
   const currentNewsEvent = candidate.events.find(
     (event) => isDeckDisplayEvent(event, candidate) && (event.kind === "news_mention" || event.kind === "disclosure")
   );
+  const materialMentionScore =
+    currentNewsEvent?.kind === "news_mention" || currentNewsEvent?.kind === "disclosure"
+      ? Math.round(Math.max(0, Math.min(1, currentNewsEvent.strength)) * 100)
+      : undefined;
+  const mentionSignals =
+    attention
+      ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore }
+      : typeof materialMentionScore === "number"
+        ? { mentionCount: 1, mentionScore: materialMentionScore }
+        : undefined;
   const signals: CardFrontSignals = {
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
-    ...(attention ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore } : {}),
+    ...(mentionSignals ? mentionSignals : {}),
     ...(currentNewsEvent?.label ? { newsEventLabel: currentNewsEvent.label } : {}),
     ...(currentNewsEvent?.source ? { newsEventSource: currentNewsEvent.source } : {}),
     ...(row.marketCapRank ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -209,13 +209,22 @@ describe("WO-05 discovery supply engine", () => {
     });
 
     const ranked = rankDiscoveryCandidates([...famousRows, ...obscureRows], { maxCandidates: 50 });
-    const firstTen = ranked.slice(0, 10).map((row) => row.ticker);
+    const firstBand = ranked.slice(0, 16).map((row) => row.ticker);
+    const tickers = ranked.map((row) => row.ticker);
 
     expect(ranked).toHaveLength(50);
-    expect(firstTen).not.toContain("삼성전자");
-    expect(firstTen).not.toContain("SK하이닉스");
-    expect(firstTen).not.toContain("NAVER");
-    expect(firstTen).not.toContain("카카오");
+    expect(firstBand).not.toContain("삼성전자");
+    expect(firstBand).not.toContain("SK하이닉스");
+    expect(firstBand).not.toContain("NAVER");
+    expect(firstBand).not.toContain("카카오");
+    expect(tickers).toContain("삼성전자");
+    expect(tickers).toContain("SK하이닉스");
+    expect(tickers).toContain("NAVER");
+    expect(tickers).toContain("카카오");
+    expect(tickers.indexOf("삼성전자")).toBeGreaterThanOrEqual(16);
+    expect(tickers.indexOf("SK하이닉스")).toBeGreaterThanOrEqual(16);
+    expect(tickers.indexOf("NAVER")).toBeGreaterThanOrEqual(16);
+    expect(tickers.indexOf("카카오")).toBeGreaterThanOrEqual(16);
     expect(ranked.every(hasDeckDisplayEvent)).toBe(true);
   });
 

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -70,6 +70,8 @@ export const DISCOVERY_DIR_DOWN_NOISE_PENALTY = 0.5;
 export const DISCOVERY_DIR_DOWN_MATERIAL_PENALTY = 0.15;
 export const DISCOVERY_STRENGTH_WEIGHT = 0.65;
 export const DISCOVERY_FAMOUS_FRONT_RANK_CUTOFF = 30;
+export const DISCOVERY_FAMOUS_FRONT_BAND_SIZE = 16;
+export const DISCOVERY_FAMOUS_DECK_MIX_COUNT = 4;
 
 const RISK_FLAG_PATTERN = /관리|투자경고|투자위험|거래정지|단기과열|이상급등/;
 
@@ -278,13 +280,52 @@ function seenPenalty(ticker: string, seen: readonly SeenRecord[], watched: Reado
   return (left / DISCOVERY_SEEN_DECAY_DAYS) * 0.3;
 }
 
+interface RankedDiscoveryRow {
+  candidate: DiscoveryCandidate;
+  index: number;
+  score: number;
+  tier: number;
+  fameTier: number;
+}
+
+function mixFamousRowsIntoDeck(sorted: readonly RankedDiscoveryRow[], max: number): RankedDiscoveryRow[] {
+  const deck = sorted.slice(0, max);
+  const frontBand = Math.min(DISCOVERY_FAMOUS_FRONT_BAND_SIZE, max);
+  const used = new Set(deck.map((row) => row.candidate.ticker));
+  const famousRows = sorted
+    .filter((row) => row.fameTier === 1 && !used.has(row.candidate.ticker))
+    .slice(0, DISCOVERY_FAMOUS_DECK_MIX_COUNT);
+
+  for (const famous of famousRows) {
+    for (let i = deck.length - 1; i >= frontBand; i -= 1) {
+      const current = deck[i];
+      if (!current || current.fameTier === 1) continue;
+      used.delete(current.candidate.ticker);
+      deck[i] = famous;
+      used.add(famous.candidate.ticker);
+      break;
+    }
+  }
+
+  for (let i = 0; i < Math.min(frontBand, deck.length); i += 1) {
+    if (deck[i]?.fameTier !== 1) continue;
+    const replacement = deck.findIndex((row, index) => index >= frontBand && row.fameTier !== 1);
+    if (replacement < 0) break;
+    const current = deck[i]!;
+    deck[i] = deck[replacement]!;
+    deck[replacement] = current;
+  }
+
+  return deck;
+}
+
 export function rankDiscoveryCandidates(
   candidates: readonly DiscoveryCandidate[],
   opts: RankDiscoveryOptions = {}
 ): DiscoveryCandidate[] {
   const max = opts.maxCandidates ?? DISCOVERY_MAX_CANDIDATES;
   const watched = new Set(opts.watched ?? []);
-  return candidates
+  const sorted = candidates
     .filter(hasDeckDisplayEvent)
     .map((candidate, index) => ({
       candidate,
@@ -296,13 +337,12 @@ export function rankDiscoveryCandidates(
     .sort(
       (a, b) =>
         a.tier - b.tier ||
-        a.fameTier - b.fameTier ||
         Number(hasDisplayWhyEvent(b.candidate)) - Number(hasDisplayWhyEvent(a.candidate)) ||
         b.score - a.score ||
         Number(hasPublicMaterialEvent(b.candidate)) - Number(hasPublicMaterialEvent(a.candidate)) ||
         a.index - b.index ||
         a.candidate.ticker.localeCompare(b.candidate.ticker)
-    )
-    .slice(0, max)
+    );
+  return mixFamousRowsIntoDeck(sorted, max)
     .map((row) => row.candidate);
 }


### PR DESCRIPTION
## Summary
- Keep famous/marquee stocks out of the first 16 discovery cards, but preserve a small number later in the 50-card deck when they have real display evidence.
- Reflect card-level news/disclosure material as the attention axis for FOMO score calculation, so material-backed cards no longer all look artificially low.
- Add a tappable FOMO Index bottom sheet explaining the market-temperature formula and the non-advice guardrail.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-labels.test.ts apps/fomo-web/__tests__/discoveryDeck.test.ts
- npm run typecheck
- npm run lint
- npm run build:fomo-web
- npm run build:web

## Live sample check
- discovery count: 50
- score buckets: low 20 / mid 23 / high 7
- famous in first 16: none
- famous/marquee later in deck: 한화오션 #47, 한미반도체 #48, POSCO홀딩스 #49
