### PR TITLE
feat(splash): 최초 진입 스플래시 화면 — 취향투자 클럽 브랜딩

### DIFF
--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { FEATURE_EMOTION_VOTE, type EmotionType } from "@fomo/core";
 import { EmotionGate } from "@/components/EmotionGate";
 import { HomeView } from "@/components/HomeView";
+import { SplashScreen } from "@/components/SplashScreen";
 import { getSessionId } from "@/lib/session";
 import { hasSession } from "@/lib/auth";
 import {
@@ -25,15 +26,26 @@ import {
   type MarketScore,
 } from "@/lib/fomoApi";
 
-type Phase = "gate" | "home";
+type Phase = "splash" | "splashLeaving" | "gate" | "home";
 
 /**
  * 진입 여정 오케스트레이터 — 진입 시 바로 home(스플래시 제거). 데이터는 백그라운드 로드.
  * (감정 투표 flag 가 켜져 오늘 미선택이면 gate 로, 현재는 OFF 라 항상 home.)
  */
 export default function Home() {
-  const [phase, setPhase] = useState<Phase>("home");
+  const [phase, setPhase] = useState<Phase>(() => {
+    if (typeof window !== "undefined" && !localStorage.getItem("fomo_splash_seen")) {
+      return "splash";
+    }
+    return "home";
+  });
   const [gateReopen, setGateReopen] = useState(false);
+
+  const dismissSplash = useCallback(() => {
+    localStorage.setItem("fomo_splash_seen", "1");
+    setPhase("splashLeaving");
+    setTimeout(() => setPhase("home"), 500);
+  }, []);
 
   const [index, setIndex] = useState<FomoIndexResponse | null>(null);
   const [tally, setTally] = useState<TallyResponse | null>(null);
@@ -150,6 +162,10 @@ export default function Home() {
         /* 조회 실패해도 게이트는 통과 — 다음 진입에 다시 시도 */
       });
   }, []);
+
+  if (phase === "splash" || phase === "splashLeaving") {
+    return <SplashScreen leaving={phase === "splashLeaving"} onDone={dismissSplash} />;
+  }
 
   if (phase === "gate") {
     return (

--- a/apps/fomo-web/components/SplashScreen.tsx
+++ b/apps/fomo-web/components/SplashScreen.tsx
@@ -1,23 +1,36 @@
 "use client";
 
-import { FomoFace } from "@/components/FomoFace";
-
 /**
- * 스플래시 — 진입 여정의 첫 호흡. 검정 배경에 포모가 떠오르고 로고/태그라인이 뜬다.
- * 타이밍은 오케스트레이터(app/page.tsx)가 관리. 여기는 표시만.
- * leaving=true면 부드럽게 사라진다(다음 phase로 양보).
+ * 스플래시 — 최초 진입 시 1회만 노출. 브랜드 정체성 각인.
+ * leaving=true 면 fade-out 후 onDone() 호출.
  */
-export function SplashScreen({ leaving = false }: { leaving?: boolean }) {
+export function SplashScreen({ leaving = false, onDone }: { leaving?: boolean; onDone: () => void }) {
   return (
     <main
-      className={`flex min-h-screen flex-col items-center justify-center bg-ink px-6 ${
-        leaving ? "fomo-fade-out" : ""
+      className={`fixed inset-0 z-50 flex flex-col bg-canvas px-6 transition-opacity duration-500 ${
+        leaving ? "opacity-0 pointer-events-none" : "opacity-100"
       }`}
     >
-      <div className="fomo-splash-in flex flex-col items-center">
-        <FomoFace face="calm" size={76} />
-        <p className="mt-7 font-pixel text-lg tracking-wide text-whiteout">FOMO CLUB</p>
-        <p className="mt-2 text-sm text-muted">나만 그런 게 아니구나.</p>
+      {/* 상단 여백 */}
+      <div className="flex flex-1 flex-col justify-center">
+        <p className="font-pixel text-xs font-bold tracking-widest text-neon">FOMO CLUB</p>
+        <h1 className="mt-4 text-[2.5rem] font-bold leading-tight text-whiteout">
+          당신을 위한<br />
+          <span className="text-neon">취향투자</span> 클럽
+        </h1>
+        <p className="mt-4 text-[15px] leading-6 text-muted">
+          멈춰 보게 되는 종목이<br />당신의 기준이다.
+        </p>
+      </div>
+
+      {/* CTA */}
+      <div className="pb-14">
+        <button
+          onClick={onDone}
+          className="w-full rounded-full bg-neon py-4 text-[15px] font-bold text-black"
+        >
+          발견 시작
+        </button>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- 최초 방문 시 1회만 노출 (localStorage `fomo_splash_seen`)
- 헤드라인: "당신을 위한 **취향투자** 클럽" — text-neon 강조
- 서브: "멈춰 보게 되는 종목이 당신의 기준이다."
- CTA: "발견 시작" — bg-neon rounded-full
- 500ms fade-out 후 홈으로 전환
- 구 마스코트·"나만 그런 게 아니구나" 카피 제거

## Test plan
- [ ] 최초 방문 시 스플래시 노출 확인
- [ ] "발견 시작" 탭 후 홈 전환 확인
- [ ] 재방문 시 스플래시 미노출 확인 (localStorage 세팅됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)