### PR TITLE
fix(web): prewarm discovery and avoid stuck loading

### DIFF
--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -14,6 +14,7 @@ import {
   fetchVoices,
   fetchFeed,
   fetchNews,
+  warmDiscovery,
   postVote,
   type FeedResponse,
   type NewsResponse,
@@ -66,6 +67,11 @@ export default function Home() {
     startedRef.current = true;
 
     const sid = getSessionId();
+    void warmDiscovery().catch((err) => {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[Home] discovery prewarm failed", err);
+      }
+    });
 
     const load = Promise.allSettled([
       fetchIndex(),

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
-import { fetchDiscovery } from "@/lib/fomoApi";
+import { DISCOVERY_UPDATED_EVENT, fetchDiscovery, type DiscoveryResponse } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import { MIN_DISCOVERY_STOCKS, type DeckStock } from "@/lib/discoveryDeck";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
@@ -31,17 +31,26 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
 
   useEffect(() => {
     let alive = true;
+    const applyDiscovery = (discovery: DiscoveryResponse) => {
+      const stocks = discovery.stocks as DeckStock[];
+      if (stocks.length === 0) {
+        setState({ kind: "error" });
+        return;
+      }
+      setState({ kind: "ready", stocks, fronts: discovery.fronts as Record<string, FrontEntry> });
+    };
+    const onDiscoveryUpdated = (event: Event) => {
+      const discovery = (event as CustomEvent<DiscoveryResponse>).detail;
+      if (!alive || !discovery) return;
+      applyDiscovery(discovery);
+    };
+    window.addEventListener(DISCOVERY_UPDATED_EVENT, onDiscoveryUpdated);
     setState({ kind: "loading" });
     (async () => {
       try {
         const discovery = await fetchDiscovery();
         if (!alive) return;
-        const stocks = discovery.stocks as DeckStock[];
-        if (stocks.length === 0) {
-          setState({ kind: "error" });
-          return;
-        }
-        setState({ kind: "ready", stocks, fronts: discovery.fronts as Record<string, FrontEntry> });
+        applyDiscovery(discovery);
       } catch (err) {
         if (process.env.NODE_ENV !== "production") {
           console.warn("[TodayDiscoveryDeck] fetch failed", err);
@@ -51,6 +60,7 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
     })();
     return () => {
       alive = false;
+      window.removeEventListener(DISCOVERY_UPDATED_EVENT, onDiscoveryUpdated);
     };
   }, []);
 

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -29,6 +29,11 @@ const CACHE_TTL = {
   stockInsight: 6 * HOUR,
 } as const;
 export const KEYWORDS_UPDATED_EVENT = "fomo:keywords-updated";
+export const DISCOVERY_UPDATED_EVENT = "fomo:discovery-updated";
+
+const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 2_500;
+const DISCOVERY_BACKEND_TIMEOUT_MS = 8_000;
+const DISCOVERY_REVALIDATE_TIMEOUT_MS = 12_000;
 
 function kstDateKey(now = new Date()): string {
   return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
@@ -65,10 +70,26 @@ async function get<T>(path: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-async function getSameOrigin<T>(path: string): Promise<T> {
-  const res = await fetch(path, { cache: "no-store", credentials: "same-origin" });
-  if (!res.ok) throw new Error(`GET ${path} ${res.status}`);
-  return res.json() as Promise<T>;
+async function fetchJsonWithTimeout<T>(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  label: string
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    if (!res.ok) throw new Error(`${label} ${res.status}`);
+    return res.json() as Promise<T>;
+  } catch (err) {
+    if ((err as { name?: string }).name === "AbortError") {
+      throw new Error(`${label} timeout`);
+    }
+    throw err;
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
 }
 
 export const fetchIndex = () => get<FomoIndexResponse>("/api/fomo/index");
@@ -252,21 +273,101 @@ export interface DiscoveryResponse {
   source: string;
 }
 
-export const fetchDiscovery = () =>
-  cachedGet(
-    "discovery:today:v2",
-    async () => {
-      try {
-        return await getSameOrigin<DiscoveryResponse>("/api/fomo/discovery");
-      } catch (err) {
-        if (process.env.NODE_ENV !== "production") {
-          console.warn("[fomoApi] same-origin discovery failed; retrying backend", err);
-        }
-        return get<DiscoveryResponse>("/api/fomo/discovery");
-      }
-    },
-    CACHE_TTL.stockFront
-  );
+const discoveryKey = () => `discovery:today:v3:${kstDateKey()}`;
+const discoveryStorageKey = () => `fomo:discovery:${kstDateKey()}`;
+
+function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
+  const candidate = value as Partial<DiscoveryResponse> | null;
+  return !!candidate && Array.isArray(candidate.stocks) && !!candidate.fronts && typeof candidate.fronts === "object";
+}
+
+function readStoredDiscovery(): DiscoveryResponse | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(discoveryStorageKey());
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    return isDiscoveryResponse(parsed) ? parsed : null;
+  } catch (err) {
+    console.warn("[fetchDiscovery] localStorage read failed", err);
+    return null;
+  }
+}
+
+function writeStoredDiscovery(value: DiscoveryResponse): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(discoveryStorageKey(), JSON.stringify(value));
+  } catch (err) {
+    console.warn("[fetchDiscovery] localStorage write failed", err);
+  }
+}
+
+function emitDiscoveryUpdated(value: DiscoveryResponse): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<DiscoveryResponse>(DISCOVERY_UPDATED_EVENT, { detail: value }));
+}
+
+async function fetchDiscoveryNetwork({
+  sameOriginTimeoutMs = DISCOVERY_SAME_ORIGIN_TIMEOUT_MS,
+  backendTimeoutMs = DISCOVERY_BACKEND_TIMEOUT_MS,
+}: {
+  sameOriginTimeoutMs?: number;
+  backendTimeoutMs?: number;
+} = {}): Promise<DiscoveryResponse> {
+  try {
+    return await fetchJsonWithTimeout<DiscoveryResponse>(
+      "/api/fomo/discovery",
+      { cache: "no-store", credentials: "same-origin" },
+      sameOriginTimeoutMs,
+      "GET /api/fomo/discovery"
+    );
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[fomoApi] same-origin discovery failed; retrying backend", err);
+    }
+    return fetchJsonWithTimeout<DiscoveryResponse>(
+      `${API_BASE}/api/fomo/discovery`,
+      { cache: "no-store" },
+      backendTimeoutMs,
+      "GET backend /api/fomo/discovery"
+    );
+  }
+}
+
+export const getCachedDiscovery = () => readCached<DiscoveryResponse>(discoveryKey());
+
+export async function fetchDiscovery(): Promise<DiscoveryResponse> {
+  const key = discoveryKey();
+  const cached = readCached<DiscoveryResponse>(key);
+  if (cached) return cached;
+
+  const stored = readStoredDiscovery();
+  if (stored) {
+    setCached(key, stored, CACHE_TTL.stockFront);
+    void refreshCached(
+      key,
+      () =>
+        fetchDiscoveryNetwork({
+          sameOriginTimeoutMs: DISCOVERY_SAME_ORIGIN_TIMEOUT_MS,
+          backendTimeoutMs: DISCOVERY_REVALIDATE_TIMEOUT_MS,
+        }),
+      CACHE_TTL.stockFront
+    )
+      .then((fresh) => {
+        writeStoredDiscovery(fresh);
+        emitDiscoveryUpdated(fresh);
+      })
+      .catch((err) => console.warn("[fetchDiscovery] revalidate failed", err));
+    return stored;
+  }
+
+  const fresh = await cachedGet(key, () => fetchDiscoveryNetwork(), CACHE_TTL.stockFront);
+  writeStoredDiscovery(fresh);
+  return fresh;
+}
+
+export const warmDiscovery = () => fetchDiscovery();
 
 export interface AxisSnapshotEntry {
   axisSignals: import("@fomo/core").AxisSignal[];


### PR DESCRIPTION
## Summary
- Start discovery prewarm as soon as the home orchestrator mounts so the card deck can reuse the in-flight request while splash/home chrome is showing.
- Add same-day localStorage stale-first discovery cache: previously successful decks render immediately, then revalidate in the background.
- Add discovery fetch timeouts so the 90% loading screen cannot wait forever on a slow/504 same-origin proxy.
- Keep same-origin first but fall back quickly to the backend direct endpoint when the proxy stalls.
- Update TodayDiscoveryDeck to accept background discovery refresh events without requiring a manual page refresh.

## Verification
- npm run typecheck
- npm test -- apps/fomo-web/__tests__/discoveryDeck.test.ts apps/fomo-web/__tests__/apiCache.test.ts
- npm run lint
- npm run build:fomo-web
- npm run build:web

## Production observation
- fomo-web same-origin /api/fomo/discovery returned 504 during verification.
- backend direct /api/fomo/discovery returned 200 with the deck payload, so the fallback path is necessary.
