### PR TITLE
fix(web): restore splash session flow and retry discovery

### DIFF
--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -28,22 +28,35 @@ import {
 } from "@/lib/fomoApi";
 
 type Phase = "splash" | "splashLeaving" | "gate" | "home";
+const SPLASH_SESSION_KEY = "fomo_splash_seen_session";
+
+function shouldShowSplash(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(SPLASH_SESSION_KEY) !== "1";
+  } catch {
+    return true;
+  }
+}
+
+function markSplashSeen(): void {
+  try {
+    window.sessionStorage.setItem(SPLASH_SESSION_KEY, "1");
+  } catch {
+    /* 세션 저장이 막혀도 스플래시 종료 흐름은 유지한다. */
+  }
+}
 
 /**
- * 진입 여정 오케스트레이터 — 진입 시 바로 home(스플래시 제거). 데이터는 백그라운드 로드.
- * (감정 투표 flag 가 켜져 오늘 미선택이면 gate 로, 현재는 OFF 라 항상 home.)
+ * 진입 여정 오케스트레이터 — 스플래시가 떠 있는 동안 발견 덱 데이터를 먼저 당긴다.
+ * (감정 투표 flag 가 켜져 오늘 미선택이면 gate 로, 현재는 OFF 라 대부분 home.)
  */
 export default function Home() {
-  const [phase, setPhase] = useState<Phase>(() => {
-    if (typeof window !== "undefined" && !localStorage.getItem("fomo_splash_seen")) {
-      return "splash";
-    }
-    return "home";
-  });
+  const [phase, setPhase] = useState<Phase>("splash");
   const [gateReopen, setGateReopen] = useState(false);
 
   const dismissSplash = useCallback(() => {
-    localStorage.setItem("fomo_splash_seen", "1");
+    markSplashSeen();
     setPhase("splashLeaving");
     setTimeout(() => setPhase("home"), 500);
   }, []);
@@ -58,6 +71,10 @@ export default function Home() {
   const [news, setNews] = useState<NewsResponse | null>(null);
   const [mine, setMine] = useState<EmotionType | null>(null);
   const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if (!shouldShowSplash()) setPhase("home");
+  }, []);
 
   // 로그인 상태는 클라에서만 확정(SSR 불일치 방지).
   useEffect(() => {

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -12,17 +12,27 @@ interface TodayDiscoveryDeckProps {
   onRequireLogin?: (() => void) | undefined;
 }
 
-function DiscoveryEmpty() {
+function DiscoveryEmpty({ onRetry }: { onRetry: () => void }) {
   return (
-    <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout">
-      오늘 발견 풀을 불러오지 못했어요.
-      <br />
-      잠깐 뒤 다시 들어와 주세요.
+    <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout" role="status">
+      <p>
+        오늘 발견 풀을 불러오지 못했어요.
+        <br />
+        다시 불러오는 중이에요.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-5 rounded-full border border-hairline bg-surface px-5 py-2 text-xs font-semibold text-whiteout transition-colors hover:border-whiteout/30"
+      >
+        지금 다시 불러오기
+      </button>
     </div>
   );
 }
 
 export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryDeckProps) {
+  const [retryKey, setRetryKey] = useState(0);
   const [state, setState] = useState<
     | { kind: "loading" }
     | { kind: "error" }
@@ -62,12 +72,18 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
       alive = false;
       window.removeEventListener(DISCOVERY_UPDATED_EVENT, onDiscoveryUpdated);
     };
-  }, []);
+  }, [retryKey]);
+
+  useEffect(() => {
+    if (state.kind !== "error") return;
+    const retry = window.setTimeout(() => setRetryKey((value) => value + 1), 3_500);
+    return () => window.clearTimeout(retry);
+  }, [state.kind]);
 
   if (state.kind === "loading") {
     return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
   }
-  if (state.kind === "error") return <DiscoveryEmpty />;
+  if (state.kind === "error") return <DiscoveryEmpty onRetry={() => setRetryKey((value) => value + 1)} />;
 
   return (
     <StockSwipeDeck


### PR DESCRIPTION
## Summary
- Restore the splash flow so it is not permanently hidden by the old localStorage flag; it now uses sessionStorage and renders splash first.
- Keep discovery prewarm active while the splash is visible.
- Add automatic retry and a manual retry button when the discovery deck falls into the error state, so users do not need to refresh the browser.

## Verification
- npm run typecheck
- npm test -- apps/fomo-web/__tests__/discoveryDeck.test.ts apps/fomo-web/__tests__/apiCache.test.ts
- npm run build:fomo-web
- npm run lint
- npm run build:web
