### PR TITLE
fix(ui): 스플래시·로그인 서브타이틀 제거

### DIFF
--- a/apps/fomo-web/components/LoginPage.tsx
+++ b/apps/fomo-web/components/LoginPage.tsx
@@ -94,9 +94,6 @@ export function LoginPage({
                   당신을 위한<br />
                   <span className="text-neon">취향투자</span> 클럽
                 </h1>
-                <p className="mt-3 text-[13px] leading-5 text-muted">
-                  멈춰 보게 되는 종목이 당신의 기준이다.
-                </p>
               </div>
 
               <input

--- a/apps/fomo-web/components/SplashScreen.tsx
+++ b/apps/fomo-web/components/SplashScreen.tsx
@@ -18,9 +18,6 @@ export function SplashScreen({ leaving = false, onDone }: { leaving?: boolean; o
           당신을 위한<br />
           <span className="text-neon">취향투자</span> 클럽
         </h1>
-        <p className="mt-4 text-[15px] leading-6 text-muted">
-          멈춰 보게 되는 종목이<br />당신의 기준이다.
-        </p>
       </div>
 
       {/* CTA */}


### PR DESCRIPTION
스플래시·로그인 화면의 '멈춰 보게 되는 종목이 당신의 기준이다.' 서브타이틀 삭제. 그 외 변경 없음.