### PR TITLE
fix(web): harden discovery first load

### DIFF
--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -12,6 +12,10 @@ interface TodayDiscoveryDeckProps {
   onRequireLogin?: (() => void) | undefined;
 }
 
+const INITIAL_RETRY_DELAYS_MS = [1_200, 2_400] as const;
+
+const wait = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
 function DiscoveryEmpty({ onRetry }: { onRetry: () => void }) {
   return (
     <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout" role="status">
@@ -57,16 +61,25 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
     window.addEventListener(DISCOVERY_UPDATED_EVENT, onDiscoveryUpdated);
     setState({ kind: "loading" });
     (async () => {
-      try {
-        const discovery = await fetchDiscovery();
-        if (!alive) return;
-        applyDiscovery(discovery);
-      } catch (err) {
-        if (process.env.NODE_ENV !== "production") {
-          console.warn("[TodayDiscoveryDeck] fetch failed", err);
+      let lastError: unknown = null;
+      for (let attempt = 0; attempt <= INITIAL_RETRY_DELAYS_MS.length; attempt += 1) {
+        try {
+          const discovery = await fetchDiscovery();
+          if (!alive) return;
+          applyDiscovery(discovery);
+          return;
+        } catch (err) {
+          lastError = err;
+          if (attempt < INITIAL_RETRY_DELAYS_MS.length) {
+            await wait(INITIAL_RETRY_DELAYS_MS[attempt] ?? 0);
+            if (!alive) return;
+          }
         }
-        if (alive) setState({ kind: "error" });
       }
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[TodayDiscoveryDeck] fetch failed", lastError);
+      }
+      if (alive) setState({ kind: "error" });
     })();
     return () => {
       alive = false;

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -36,9 +36,9 @@ export const FOMO_INDEX_UPDATED_EVENT = "fomo:index-updated";
 const INDEX_SAME_ORIGIN_TIMEOUT_MS = 1_800;
 const INDEX_BACKEND_TIMEOUT_MS = 4_000;
 const INDEX_REVALIDATE_TIMEOUT_MS = 8_000;
-const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 2_500;
-const DISCOVERY_BACKEND_TIMEOUT_MS = 8_000;
-const DISCOVERY_REVALIDATE_TIMEOUT_MS = 12_000;
+const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 1_800;
+const DISCOVERY_BACKEND_TIMEOUT_MS = 18_000;
+const DISCOVERY_REVALIDATE_TIMEOUT_MS = 24_000;
 
 function kstDateKey(now = new Date()): string {
   return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
@@ -419,6 +419,7 @@ export interface DiscoveryResponse {
 
 const discoveryKey = () => `discovery:today:v3:${kstDateKey()}`;
 const discoveryStorageKey = () => `fomo:discovery:${kstDateKey()}`;
+const LAST_DISCOVERY_STORAGE_KEY = "fomo:discovery:last-good";
 
 function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
   const candidate = value as Partial<DiscoveryResponse> | null;
@@ -428,7 +429,7 @@ function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
 function readStoredDiscovery(): DiscoveryResponse | null {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(discoveryStorageKey());
+    const raw = window.localStorage.getItem(discoveryStorageKey()) ?? window.localStorage.getItem(LAST_DISCOVERY_STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     return isDiscoveryResponse(parsed) ? parsed : null;
@@ -442,6 +443,7 @@ function writeStoredDiscovery(value: DiscoveryResponse): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(discoveryStorageKey(), JSON.stringify(value));
+    window.localStorage.setItem(LAST_DISCOVERY_STORAGE_KEY, JSON.stringify(value));
   } catch (err) {
     console.warn("[fetchDiscovery] localStorage write failed", err);
   }
@@ -470,13 +472,22 @@ async function fetchDiscoveryNetwork({
     if (process.env.NODE_ENV !== "production") {
       console.warn("[fomoApi] same-origin discovery failed; retrying backend", err);
     }
-    return fetchJsonWithTimeout<DiscoveryResponse>(
-      `${API_BASE}/api/fomo/discovery`,
-      { cache: "no-store" },
-      backendTimeoutMs,
-      "GET backend /api/fomo/discovery"
-    );
   }
+
+  let lastError: unknown = null;
+  for (const origin of backendOrigins()) {
+    try {
+      return await fetchJsonWithTimeout<DiscoveryResponse>(
+        `${origin}/api/fomo/discovery`,
+        { cache: "no-store" },
+        backendTimeoutMs,
+        `GET ${origin}/api/fomo/discovery`
+      );
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("GET /api/fomo/discovery failed");
 }
 
 export const getCachedDiscovery = () => readCached<DiscoveryResponse>(discoveryKey());
@@ -502,7 +513,11 @@ export async function fetchDiscovery(): Promise<DiscoveryResponse> {
         writeStoredDiscovery(fresh);
         emitDiscoveryUpdated(fresh);
       })
-      .catch((err) => console.warn("[fetchDiscovery] revalidate failed", err));
+      .catch((err) => {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[fetchDiscovery] revalidate failed", err);
+        }
+      });
     return stored;
   }
 


### PR DESCRIPTION
## Summary
- keep first discovery load in loading/retry instead of flashing the failure state immediately
- store a date-scoped discovery cache plus a last-good fallback for cold starts
- retry discovery against all backend origins, matching the fomo index fallback behavior
- extend discovery cold-start timeout for backend fetches and silence production revalidate warnings

## Verification
- npm run typecheck:fomo-web
- npm run typecheck
- npm run build:fomo-web
- npm run build:web
- npm test -- apps/fomo-web/__tests__/discoveryDeck.test.ts
- npm test -- apps/fomo-web/__tests__/browser-auth-security.test.ts

HANDOFF
- 목표: 최초 입장 시 discovery 카드가 실패 화면에 먼저 떨어지는 문제 해결
- 한 일: apps/fomo-web/lib/fomoApi.ts discovery fallback/cache/timeout 보강, apps/fomo-web/components/TodayDiscoveryDeck.tsx 초기 silent retry 추가
- 안 한 일/막힌 곳: 없음
- 다음 액션: CI 확인 후 main 머지
- 검증: typecheck/build/focused tests 통과
- SSOT 변경: 없음