### PR TITLE
fix(discovery): gate news hooks and diamond labels

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -486,7 +486,12 @@ export function StockSwipeDeck({
       stock.axisHook ??
       e?.axisHook ??
       (e?.axisSignals ? selectMultiAxisHook(e.axisSignals) : undefined);
-    const baseView = fomoCardView(fomo, { sector: stock.sector, ...(stock.reason ? { reason: stock.reason } : {}) });
+    const baseView = fomoCardView(fomo, {
+      sector: stock.sector,
+      ...(stock.reason ? { reason: stock.reason } : {}),
+      ...(typeof e?.signals.changePct === "number" ? { changePct: e.signals.changePct } : {}),
+      ...(typeof e?.signals.marketCapRank?.rank === "number" ? { marketCapRank: e.signals.marketCapRank.rank } : {}),
+    });
     const view = { ...baseView, headline: axisHook?.hookText ?? legacyHook.headline };
     const usedReasonHeadline = !!reasonHeadlineSeed && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
     const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { cleanMaterialTitle } from "../../lib/discovery-supply";
+
+describe("discovery material news filter", () => {
+  it("keeps concrete catalyst headlines for card hooks", () => {
+    expect(cleanMaterialTitle("아이씨티케이, 120억원 규모 공급계약 공시")).toBe("아이씨티케이, 120억원 규모 공급계약 공시");
+    expect(cleanMaterialTitle("코아스템켐온, 신약 임상 2상 승인")).toBe("코아스템켐온, 신약 임상 2상 승인");
+    expect(cleanMaterialTitle("삼현, 방산 부품 수주잔고 확대")).toBe("삼현, 방산 부품 수주잔고 확대");
+  });
+
+  it("rejects non-material human-interest and market-wrap headlines", () => {
+    expect(cleanMaterialTitle("현대차 회장, 어려울 때마다 이순신 장군 찾았다")).toBeUndefined();
+    expect(cleanMaterialTitle("로켓헬스케어 CEO 인터뷰, 창업 철학 공개")).toBeUndefined();
+    expect(cleanMaterialTitle("오늘의 증시, 코스피 장중 약세")).toBeUndefined();
+    expect(cleanMaterialTitle("ESG 캠페인으로 지역사회 봉사 확대")).toBeUndefined();
+  });
+
+  it("does not treat generic stock movement as material news", () => {
+    expect(cleanMaterialTitle("특징주 모음, 2차전지주 동반 상승")).toBeUndefined();
+    expect(cleanMaterialTitle("장중 시황, 반도체주 차익 실현")).toBeUndefined();
+  });
+});

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -16,7 +16,6 @@ import {
   sectorOf,
   selectMultiAxisHook,
   stockMentionRole,
-  stockMatchesText,
   type AxisSignal,
   type CardFrontSignals,
   type DiscoveryCandidate,
@@ -50,9 +49,9 @@ const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED
 const TARGETED_MATERIAL_CONCURRENCY = 8;
 const NON_STOCK_NAME_PATTERN = /ETF|ETN|KODEX|TIGER|ACE|RISE|SOL\s|PLUS|KBSTAR|HANARO|히어로즈|레버리지|인버스|선물/i;
 const MATERIAL_NEWS_NOISE =
-  /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d/i;
-const LINKED_NEWS_NOISE =
-  /코스피|코스닥|증시|시황|장\s?초반|장중|마감|출발|차익\s?실현|순매도|순매수|2거래일|우상향했던|하락한|상승한|반등|장밋빛\s?전망|투자전략|홀딩\s?전략/i;
+  /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d|회장|최고경영자|CEO|고백|회고|소회|인터뷰|기부|ESG|봉사|사회공헌|미담|창업주|오너|가문|고향|강연|도서|출간|어려울\s?때마다|찾았다/i;
+const MATERIAL_NEWS_CATALYST =
+  /공시|계약|공급계약|수주|납품|실적|매출|영업이익|순이익|가이던스|전망치|컨센서스|어닝|흑자|적자|턴어라운드|임상|허가|승인|FDA|품목허가|신약|치료제|기술이전|라이선스|증설|공장|양산|수율|수주잔고|M&A|인수|합병|지분|투자|유상증자|무상증자|자사주|배당|분할|상장|정부|정책|규제|지원|보조금|관세|제재|신제품|출시|개발|특허|공급|독점|선정|채택|수출|수입|국책|프로젝트|수혜/i;
 const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_ENABLED
   ? "네이버 시세·종목뉴스·리서치·DART 공시·수급 캐시"
   : "네이버 시세·뉴스 언급";
@@ -241,20 +240,7 @@ function eventFromPrice(row: NaverMarketRow, asOf: string): DiscoveryEvent | nul
   };
 }
 
-function eventFromNews(attention: StockAttentionSignal | undefined, asOf: string): DiscoveryEvent | null {
-  if (!attention?.newsEventLabel) return null;
-  return {
-    kind: "news_mention",
-    firstSeen: true,
-    strength: Math.min(1, Math.max(0.32, attention.mentionScore / 100)),
-    source: attention.newsEventSource ?? "뉴스",
-    asOf,
-    confidence: attention.newsEventLabel ? "H" : "M",
-    ...(attention.newsEventLabel ? { label: attention.newsEventLabel } : {}),
-  };
-}
-
-function cleanMaterialTitle(title: string): string | undefined {
+export function cleanMaterialTitle(title: string): string | undefined {
   const cleaned = decodeHtmlEntities(title)
     .replace(/^\s*(?:\[[^\]]+\]|【[^】]+】|\([^)]*\))\s*/g, "")
     .replace(/[“”"]/g, "")
@@ -262,13 +248,10 @@ function cleanMaterialTitle(title: string): string | undefined {
     .replace(/[.!?。]+$/g, "")
     .trim();
   if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned)) return undefined;
+  if (!MATERIAL_NEWS_CATALYST.test(cleaned)) return undefined;
   if (/[\[\]{}<>]/.test(cleaned)) return undefined;
   const compact = cleaned.length > 46 ? `${cleaned.slice(0, 44).replace(/\s+\S*$/, "").trim()}…` : cleaned;
   return isFrontHookSafe(`${compact} 소식이 나왔어요.`) ? compact : undefined;
-}
-
-function isStockArticle(canonical: string, article: RawArticle): boolean {
-  return stockMatchesText(canonical, `${article.title} ${article.summary ?? ""}`);
 }
 
 function isPrimaryStockArticle(canonical: string, article: RawArticle): boolean {
@@ -276,12 +259,6 @@ function isPrimaryStockArticle(canonical: string, article: RawArticle): boolean 
     title: article.title,
     ...(article.summary ? { summary: article.summary } : {}),
   }) === "primary";
-}
-
-function isLinkedStockArticle(article: RawArticle): boolean {
-  const label = cleanMaterialTitle(article.title);
-  if (!label || LINKED_NEWS_NOISE.test(label)) return false;
-  return true;
 }
 
 function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
@@ -309,21 +286,13 @@ async function eventFromTargetedMaterial(row: NaverMarketRow, asOf: string): Pro
 
   const stockNews =
     newsResult.status === "fulfilled"
-      ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article)) ??
-        newsResult.value.find((article) => isStockArticle(row.canonical, article)) ??
-        newsResult.value
-          .filter(isLinkedStockArticle)
-          .map((article) => ({
-            ...article,
-            source: article.source ? `${article.source} 종목뉴스 연결` : "네이버 종목뉴스 연결",
-          }))
-          .at(0)
+      ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article))
       : undefined;
   if (stockNews) return materialEventFromArticle(stockNews, asOf, "네이버 종목뉴스");
 
   const research =
     researchResult.status === "fulfilled"
-      ? researchResult.value.find((article) => isStockArticle(row.canonical, article))
+      ? researchResult.value.find((article) => isPrimaryStockArticle(row.canonical, article))
       : undefined;
   if (research) return materialEventFromArticle(research, asOf, "네이버 증권 리서치");
 
@@ -625,23 +594,6 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
       (event): event is DiscoveryEvent => event !== null
     );
     if (events.length > 0) byTicker.set(ticker, { row: { ...row, canonical: ticker }, events });
-  }
-
-  for (const [ticker, attention] of Object.entries(attentionMap)) {
-    const def = resolveStock(ticker);
-    const canonical = def?.canonical ?? ticker;
-    if (!eligibleTickers.has(canonical)) continue;
-    const row =
-      normalizedRows.find((r) => r.canonical === canonical) ??
-      (def?.naverCode ? normalizedRows.find((r) => r.naverCode === def.naverCode) : undefined) ??
-      (def?.naverCode
-        ? ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow)
-        : undefined);
-    if (!row) continue;
-    const event = eventFromNews(attention, asOf);
-    if (!event) continue;
-    const current = byTicker.get(canonical);
-    byTicker.set(canonical, { row: { ...row, canonical }, events: [...(current?.events ?? []), event] });
   }
 
   const disclosureMap = await fetchDartDisclosuresByStock(asOf).catch((): Record<string, DartDisclosureHit> => ({}));

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -5,6 +5,7 @@ import {
   hasDeckDisplayEvent,
   hasDisplayWhyEvent,
   isWeakDiscoveryCandidate,
+  isDiscoveryAwakening,
   rankDiscoveryCandidates,
   type DiscoveryEventKind,
   type DiscoveryCandidate,
@@ -270,6 +271,26 @@ describe("WO-05 discovery supply engine", () => {
     const ranked = rankDiscoveryCandidates([volume, weakPrice]);
 
     expect(ranked.map((row) => row.ticker)).toEqual(["거래량각성"]);
+  });
+
+  it("allows 💎 awakening only for obscure non-down first-seen flow/disclosure/volume signals", () => {
+    const obscureFlow = candidate("무명수급", 0.65, "flow_entry", "외국인이 오늘 새로 담기 시작했어요.");
+    obscureFlow.marketCapRank = 220;
+    obscureFlow.events[0]!.direction = "up";
+    const famousFlow = candidate("대형수급", 0.65, "flow_entry", "외국인이 오늘 새로 담기 시작했어요.");
+    famousFlow.marketCapRank = 5;
+    famousFlow.events[0]!.direction = "up";
+    const downFlow = candidate("하락수급", 0.65, "flow_entry", "외국인이 오늘 새로 담기 시작했어요.");
+    downFlow.marketCapRank = 220;
+    downFlow.events[0]!.direction = "down";
+    const newsOnly = candidate("뉴스만", 0.65, "news_mention", "공급계약 뉴스");
+    newsOnly.marketCapRank = 220;
+    newsOnly.events[0]!.direction = "up";
+
+    expect(isDiscoveryAwakening(obscureFlow)).toBe(true);
+    expect(isDiscoveryAwakening(famousFlow)).toBe(false);
+    expect(isDiscoveryAwakening(downFlow)).toBe(false);
+    expect(isDiscoveryAwakening(newsOnly)).toBe(false);
   });
 
   it("excludes evergreen company blurb-only rows from display and ranking", () => {

--- a/packages/fomo-core/__tests__/fomo-score.test.ts
+++ b/packages/fomo-core/__tests__/fomo-score.test.ts
@@ -243,6 +243,27 @@ describe("fomoCardView — 엔진 출력 → 카드(척추 ②, 단일 출처)",
     expect(v.headline).not.toMatch(/오를|될 것|상승할/);
   });
 
+  it("💎 incoming 표면 배지는 하락 당일이나 시총 상위 종목에는 붙이지 않는다", () => {
+    const s = computeFomoScore({
+      volumeRatio: 1.1,
+      foreignNetStreak: 5,
+      foreignNetRatio: 0.01,
+      institutionNetStreak: 5,
+      institutionNetRatio: 0.01,
+    });
+    expect(s.label).toBe("incoming");
+
+    const down = fomoCardView(s, { changePct: -2.5, marketCapRank: 220 });
+    const famous = fomoCardView(s, { changePct: 0.2, marketCapRank: 5 });
+
+    expect(down.isLeading).toBe(false);
+    expect(down.emoji).toBe("");
+    expect(down.badge).toBe("조용");
+    expect(famous.isLeading).toBe(false);
+    expect(famous.emoji).toBe("");
+    expect(famous.badge).toBe("조용");
+  });
+
   it("강도 비례 톤 — 핫 세게(hot)·조용 차분(calm)·식는 중(cooling)", () => {
     expect(fomoCardView(computeFomoScore({ volumeRatio: 3.5, changePct: 7, mentionScore: 90 })).tone).toBe("hot");
     expect(fomoCardView(computeFomoScore({ mentionScore: 10 })).tone).toBe("calm");

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -72,6 +72,7 @@ export const DISCOVERY_STRENGTH_WEIGHT = 0.65;
 export const DISCOVERY_FAMOUS_FRONT_RANK_CUTOFF = 30;
 export const DISCOVERY_FAMOUS_FRONT_BAND_SIZE = 16;
 export const DISCOVERY_FAMOUS_DECK_MIX_COUNT = 4;
+export const DISCOVERY_AWAKENING_RANK_MIN = 150;
 
 const RISK_FLAG_PATTERN = /관리|투자경고|투자위험|거래정지|단기과열|이상급등/;
 
@@ -152,6 +153,20 @@ export function hasDeckDisplayEvent(candidate: DiscoveryCandidate): boolean {
 
 export function hasDisplayWhyEvent(candidate: DiscoveryCandidate): boolean {
   return hasDeckDisplayEvent(candidate);
+}
+
+export function isDiscoveryAwakening(candidate: DiscoveryCandidate): boolean {
+  const rank = candidate.marketCapRank;
+  if (typeof rank === "number" && Number.isFinite(rank) && rank > 0 && rank < DISCOVERY_AWAKENING_RANK_MIN) {
+    return false;
+  }
+  return candidate.events.some(
+    (event) =>
+      isCurrentDeckEvent(event, candidate) &&
+      event.firstSeen &&
+      event.direction !== "down" &&
+      (event.kind === "volume_spike" || event.kind === "flow_entry" || event.kind === "disclosure")
+  );
 }
 
 export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean {

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -315,8 +315,29 @@ export function computeFomoScore(input: FomoScoreInputs = {}, tuning: FomoScoreT
   return out;
 }
 
+export interface LeadingSetupContext {
+  /** 하락 당일에는 조기 발견(💎)으로 과장하지 않는다. */
+  changePct?: number;
+  /** 시총 상위 대형주는 "조기 발견" 표면 배지에서 제외한다. */
+  marketCapRank?: number;
+  /** discovery 엔진이 firstSeen 수급/공시/거래량 각성을 별도 판정한 경우. */
+  awakening?: boolean;
+}
+
+export const LEADING_SETUP_OBSCURE_RANK_MIN = 150;
+
 /** 💎 "오기 직전" — 현재는 조용한데 수급이 먼저 들어오는 자리. */
-export function isLeadingSetup(score: FomoScoreResult): boolean {
+export function isLeadingSetup(score: FomoScoreResult, context: LeadingSetupContext = {}): boolean {
+  if (typeof context.changePct === "number" && context.changePct < 0) return false;
+  if (
+    typeof context.marketCapRank === "number" &&
+    Number.isFinite(context.marketCapRank) &&
+    context.marketCapRank > 0 &&
+    context.marketCapRank < LEADING_SETUP_OBSCURE_RANK_MIN
+  ) {
+    return false;
+  }
+  if (typeof context.awakening === "boolean") return context.awakening && score.label === "incoming";
   return score.label === "incoming";
 }
 
@@ -401,14 +422,19 @@ const TONE: Record<FomoLabel, FomoTone> = {
  * 포모 점수 → 카드 앞면 표현(점수·라벨·헤드라인·톤). 순수·결정적. 단일 출처.
  * 헤드라인은 상태 메시지 함수만 사용한다. 근거(reason)는 보조 재료로만 남겨 모순을 막는다.
  */
-export function fomoCardView(score: FomoScoreResult, _opts: { sector?: string; reason?: string } = {}): FomoCardView {
+export function fomoCardView(
+  score: FomoScoreResult,
+  opts: { sector?: string; reason?: string } & LeadingSetupContext = {}
+): FomoCardView {
   const { label } = score;
-  const isLeading = label === "incoming";
+  const isLeading = isLeadingSetup(score, opts);
+  const emoji = isLeading ? EMOJI[label] : label === "incoming" ? "" : EMOJI[label];
+  const badge = !isLeading && label === "incoming" ? STATE_MESSAGE.quiet.badge : BADGE[label];
 
   return {
     scoreText: score.confidence > 0 ? `포모 ${score.fomoScore}` : "",
-    emoji: EMOJI[label],
-    badge: BADGE[label],
+    emoji,
+    badge,
     headline: fomoHeadline(score),
     tone: TONE[label],
     isLeading,


### PR DESCRIPTION
## Summary
- keep attention/news mentions out of discovery material hooks unless the article is a primary stock article
- require material catalyst terms and reject human-interest/market-wrap/news-noise titles before a news headline can become a card hook
- suppress 💎/incoming surface treatment for down-day or market-cap-front stocks

## Tests
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts packages/fomo-core/__tests__/fomo-score.test.ts
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm run typecheck
- npm run lint
- npm run build:web
- npm run build:fomo-web