### PR TITLE
fix(discovery): recover from empty deck responses

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -426,13 +426,21 @@ function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
   return !!candidate && Array.isArray(candidate.stocks) && !!candidate.fronts && typeof candidate.fronts === "object";
 }
 
+function hasDiscoveryCards(value: DiscoveryResponse | null | undefined): value is DiscoveryResponse {
+  return !!value && isDiscoveryResponse(value) && value.stocks.length > 0;
+}
+
 function readStoredDiscovery(): DiscoveryResponse | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(discoveryStorageKey()) ?? window.localStorage.getItem(LAST_DISCOVERY_STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
-    return isDiscoveryResponse(parsed) ? parsed : null;
+    const discovery = isDiscoveryResponse(parsed) ? parsed : null;
+    if (hasDiscoveryCards(discovery)) return discovery;
+    window.localStorage.removeItem(discoveryStorageKey());
+    window.localStorage.removeItem(LAST_DISCOVERY_STORAGE_KEY);
+    return null;
   } catch (err) {
     console.warn("[fetchDiscovery] localStorage read failed", err);
     return null;
@@ -441,6 +449,7 @@ function readStoredDiscovery(): DiscoveryResponse | null {
 
 function writeStoredDiscovery(value: DiscoveryResponse): void {
   if (typeof window === "undefined") return;
+  if (!hasDiscoveryCards(value)) return;
   try {
     window.localStorage.setItem(discoveryStorageKey(), JSON.stringify(value));
     window.localStorage.setItem(LAST_DISCOVERY_STORAGE_KEY, JSON.stringify(value));
@@ -495,7 +504,7 @@ export const getCachedDiscovery = () => readCached<DiscoveryResponse>(discoveryK
 export async function fetchDiscovery(): Promise<DiscoveryResponse> {
   const key = discoveryKey();
   const cached = readCached<DiscoveryResponse>(key);
-  if (cached) return cached;
+  if (hasDiscoveryCards(cached)) return cached;
 
   const stored = readStoredDiscovery();
   if (stored) {
@@ -510,6 +519,7 @@ export async function fetchDiscovery(): Promise<DiscoveryResponse> {
       CACHE_TTL.stockFront
     )
       .then((fresh) => {
+        if (!hasDiscoveryCards(fresh)) return;
         writeStoredDiscovery(fresh);
         emitDiscoveryUpdated(fresh);
       })
@@ -521,7 +531,8 @@ export async function fetchDiscovery(): Promise<DiscoveryResponse> {
     return stored;
   }
 
-  const fresh = await cachedGet(key, () => fetchDiscoveryNetwork(), CACHE_TTL.stockFront);
+  const fresh = await fetchDiscoveryNetwork();
+  if (hasDiscoveryCards(fresh)) setCached(key, fresh, CACHE_TTL.stockFront);
   writeStoredDiscovery(fresh);
   return fresh;
 }

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from "vitest";
+import type { DiscoveryCandidate, DiscoveryEventKind } from "@fomo/core";
 
-import { cleanMaterialTitle } from "../../lib/discovery-supply";
+import { cleanMaterialTitle, recoverDiscoveryCandidates } from "../../lib/discovery-supply";
+
+const asOf = "2026-06-27";
+
+function candidate(
+  ticker: string,
+  kind: DiscoveryEventKind,
+  strength: number,
+  opts: { rank?: number; direction?: "up" | "down" | "flat"; label?: string } = {}
+): DiscoveryCandidate {
+  return {
+    ticker,
+    market: "KOSPI",
+    asOf,
+    ...(typeof opts.rank === "number" ? { marketCapRank: opts.rank } : {}),
+    events: [
+      {
+        kind,
+        firstSeen: true,
+        strength,
+        source: "테스트",
+        asOf,
+        confidence: "M",
+        direction: opts.direction ?? "up",
+        label: opts.label ?? `${ticker} 맥락`,
+      },
+    ],
+  };
+}
 
 describe("discovery material news filter", () => {
   it("keeps concrete catalyst headlines for card hooks", () => {
@@ -19,5 +48,32 @@ describe("discovery material news filter", () => {
   it("does not treat generic stock movement as material news", () => {
     expect(cleanMaterialTitle("특징주 모음, 2차전지주 동반 상승")).toBeUndefined();
     expect(cleanMaterialTitle("장중 시황, 반도체주 차익 실현")).toBeUndefined();
+  });
+});
+
+describe("discovery empty-deck recovery", () => {
+  it("fills an empty material deck with honest contextual candidates instead of returning zero cards", () => {
+    const recovered = recoverDiscoveryCandidates(
+      [],
+      [
+        candidate("대형주", "theme_link", 0.95, { rank: 1, label: "반도체 흐름에서 확인해요." }),
+        candidate("하락주", "price_move", 0.99, { rank: 220, direction: "down", label: "오늘 가격이 -12.00% 움직였어요." }),
+        candidate("발굴A", "theme_link", 0.6, { rank: 180, label: "AI 흐름에서 같이 확인해요." }),
+        candidate("발굴B", "market_context", 0.7, { rank: 260, label: "시총 260위권에서 움직였어요." }),
+      ],
+      3
+    );
+
+    expect(recovered.map((row) => row.ticker)).toEqual(["발굴A", "발굴B", "대형주"]);
+    expect(recovered.map((row) => row.ticker)).not.toContain("하락주");
+    expect(recovered.every((row) => row.reason && row.reason.length > 0)).toBe(true);
+  });
+
+  it("leaves a healthy material deck unchanged", () => {
+    const ranked = Array.from({ length: 12 }, (_, index) =>
+      candidate(`재료${index}`, "news_mention", 0.7, { rank: 170 + index, label: `공급계약 ${index}` })
+    );
+
+    expect(recoverDiscoveryCandidates(ranked, [candidate("보조", "theme_link", 0.9)], 50)).toEqual(ranked);
   });
 });

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -41,6 +41,8 @@ const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 10;
 const SPARKLINE_CONCURRENCY = 8;
 const DISCOVERY_DECK_CARD_COUNT = 50;
+const DISCOVERY_RECOVERY_MIN_CARDS = 12;
+const DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF = 30;
 const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
 const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
 const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED
@@ -496,6 +498,7 @@ function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): Disco
   const why = discoveryWhy(candidate);
   const hasMaterial = hasPublicMaterialEvent(candidate);
   const hasDisplayWhy = hasDisplayWhyEvent(candidate);
+  const fallbackWhy = candidate.reason ?? "큰 가격 움직임은 보였지만, 연결된 공개 재료는 확인 안 됨.";
   return {
     canonical: candidate.ticker,
     market: row.market,
@@ -505,9 +508,68 @@ function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): Disco
     sector: sector ?? inferDiscoverySectorLabel(candidate.ticker, candidate.events, undefined, candidate.asOf),
     whyShown: hasDisplayWhy
       ? why
-      : "큰 가격 움직임은 보였지만, 연결된 공개 재료는 확인 안 됨.",
-    ...(hasDisplayWhy ? { reason: why } : {}),
+      : fallbackWhy,
+    ...(hasDisplayWhy || candidate.reason ? { reason: hasDisplayWhy ? why : fallbackWhy } : {}),
   };
+}
+
+function isSameDayEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): boolean {
+  return event.asOf.slice(0, 10) === candidate.asOf.slice(0, 10);
+}
+
+function fallbackContextEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
+  return candidate.events
+    .filter((event) => isSameDayEvent(event, candidate) && event.direction !== "down")
+    .sort((a, b) => {
+      const aTheme = a.kind === "theme_link" ? 1 : 0;
+      const bTheme = b.kind === "theme_link" ? 1 : 0;
+      return bTheme - aTheme || b.strength - a.strength || a.kind.localeCompare(b.kind);
+    })[0];
+}
+
+function fallbackDiscoveryReason(candidate: DiscoveryCandidate): string {
+  const event = fallbackContextEvent(candidate);
+  if (event?.kind === "theme_link" && event.label) return event.label;
+  if (event?.kind === "market_context" && event.label) return event.label;
+  if (event?.kind === "price_move" && event.label) return `${event.label} 공개 재료는 더 확인 중이에요.`;
+  return "오늘 시장에서 다시 확인할 종목으로 남겨뒀어요.";
+}
+
+export function recoverDiscoveryCandidates(
+  ranked: readonly DiscoveryCandidate[],
+  candidates: readonly DiscoveryCandidate[],
+  maxCandidates = DISCOVERY_DECK_CARD_COUNT
+): DiscoveryCandidate[] {
+  if (ranked.length >= DISCOVERY_RECOVERY_MIN_CARDS) return ranked.slice(0, maxCandidates);
+  const used = new Set(ranked.map((candidate) => candidate.ticker));
+  const fallback = candidates
+    .filter((candidate) => !used.has(candidate.ticker))
+    .filter((candidate) => fallbackContextEvent(candidate) !== undefined)
+    .map((candidate, index) => ({
+      candidate: {
+        ...candidate,
+        reason: candidate.reason ?? fallbackDiscoveryReason(candidate),
+      },
+      index,
+      context: fallbackContextEvent(candidate)!,
+    }))
+    .sort((a, b) => {
+      const aFamous = typeof a.candidate.marketCapRank === "number" && a.candidate.marketCapRank <= DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF ? 1 : 0;
+      const bFamous = typeof b.candidate.marketCapRank === "number" && b.candidate.marketCapRank <= DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF ? 1 : 0;
+      const aTheme = a.context.kind === "theme_link" ? 1 : 0;
+      const bTheme = b.context.kind === "theme_link" ? 1 : 0;
+      return (
+        aFamous - bFamous ||
+        bTheme - aTheme ||
+        b.context.strength - a.context.strength ||
+        (a.candidate.marketCapRank ?? 9999) - (b.candidate.marketCapRank ?? 9999) ||
+        a.index - b.index ||
+        a.candidate.ticker.localeCompare(b.candidate.ticker)
+      );
+    })
+    .map((row) => row.candidate);
+
+  return [...ranked, ...fallback].slice(0, maxCandidates);
 }
 
 function frontSeed(
@@ -676,7 +738,11 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
       marquee: def?.marquee === true,
     };
   });
-  const ranked = rankDiscoveryCandidates(candidates, { maxCandidates: DISCOVERY_DECK_CARD_COUNT });
+  const ranked = recoverDiscoveryCandidates(
+    rankDiscoveryCandidates(candidates, { maxCandidates: DISCOVERY_DECK_CARD_COUNT }),
+    candidates,
+    DISCOVERY_DECK_CARD_COUNT
+  );
   const rowsByTicker = new Map([...byTicker.entries()].map(([ticker, value]) => [ticker, value.row]));
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];


### PR DESCRIPTION
## Summary
- prevent discovery API from returning an empty deck when strict material filters find too few real catalyst cards
- fill under-supplied decks with honest contextual candidates while keeping famous/down-only rows out of the first rescue priority
- ignore and purge stored empty discovery responses on the client so retry does not replay a bad cached empty deck

## Verification
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm run typecheck
- npm run lint
- npm run build:web
- npm run build:fomo-web
- live generation probe returned 50 stocks