### PR TITLE
fix(discovery): serve fast first-load deck

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -36,9 +36,10 @@ export const FOMO_INDEX_UPDATED_EVENT = "fomo:index-updated";
 const INDEX_SAME_ORIGIN_TIMEOUT_MS = 1_800;
 const INDEX_BACKEND_TIMEOUT_MS = 4_000;
 const INDEX_REVALIDATE_TIMEOUT_MS = 8_000;
-const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 1_800;
+const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 9_000;
 const DISCOVERY_BACKEND_TIMEOUT_MS = 18_000;
 const DISCOVERY_REVALIDATE_TIMEOUT_MS = 24_000;
+const DISCOVERY_FAST_PATH = "/api/fomo/discovery?fast=1";
 
 function kstDateKey(now = new Date()): string {
   return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
@@ -472,10 +473,10 @@ async function fetchDiscoveryNetwork({
 } = {}): Promise<DiscoveryResponse> {
   try {
     return await fetchJsonWithTimeout<DiscoveryResponse>(
-      "/api/fomo/discovery",
+      DISCOVERY_FAST_PATH,
       { cache: "no-store", credentials: "same-origin" },
       sameOriginTimeoutMs,
-      "GET /api/fomo/discovery"
+      `GET ${DISCOVERY_FAST_PATH}`
     );
   } catch (err) {
     if (process.env.NODE_ENV !== "production") {
@@ -487,10 +488,10 @@ async function fetchDiscoveryNetwork({
   for (const origin of backendOrigins()) {
     try {
       return await fetchJsonWithTimeout<DiscoveryResponse>(
-        `${origin}/api/fomo/discovery`,
+        `${origin}${DISCOVERY_FAST_PATH}`,
         { cache: "no-store" },
         backendTimeoutMs,
-        `GET ${origin}/api/fomo/discovery`
+        `GET ${origin}${DISCOVERY_FAST_PATH}`
       );
     } catch (err) {
       lastError = err;

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -12,11 +12,13 @@ export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const url = new URL(request.url);
+    const fast = url.searchParams.get("fast") === "1";
     const load = unstable_cache(
-      async () => buildDiscoveryResponse(),
-      ["fomo-discovery", cacheVersion(), kstDate()],
+      async () => buildDiscoveryResponse({ targetedMaterial: !fast }),
+      ["fomo-discovery", cacheVersion(), kstDate(), fast ? "fast" : "full"],
       { revalidate: REVALIDATE_S }
     );
     return withCors(

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -43,9 +43,9 @@ const SPARKLINE_CONCURRENCY = 8;
 const DISCOVERY_DECK_CARD_COUNT = 50;
 const DISCOVERY_RECOVERY_MIN_CARDS = 12;
 const DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF = 30;
-const TARGETED_MATERIAL_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
+const TARGETED_MATERIAL_DEFAULT_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
 const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
-const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_ENABLED
+const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_DEFAULT_ENABLED
   ? Math.max(0, Math.min(720, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 720) || 720))
   : 0;
 const TARGETED_MATERIAL_CONCURRENCY = 8;
@@ -54,7 +54,7 @@ const MATERIAL_NEWS_NOISE =
   /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d|회장|최고경영자|CEO|고백|회고|소회|인터뷰|기부|ESG|봉사|사회공헌|미담|창업주|오너|가문|고향|강연|도서|출간|어려울\s?때마다|찾았다/i;
 const MATERIAL_NEWS_CATALYST =
   /공시|계약|공급계약|수주|납품|실적|매출|영업이익|순이익|가이던스|전망치|컨센서스|어닝|흑자|적자|턴어라운드|임상|허가|승인|FDA|품목허가|신약|치료제|기술이전|라이선스|증설|공장|양산|수율|수주잔고|M&A|인수|합병|지분|투자|유상증자|무상증자|자사주|배당|분할|상장|정부|정책|규제|지원|보조금|관세|제재|신제품|출시|개발|특허|공급|독점|선정|채택|수출|수입|국책|프로젝트|수혜/i;
-const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_ENABLED
+const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_DEFAULT_ENABLED
   ? "네이버 시세·종목뉴스·리서치·DART 공시·수급 캐시"
   : "네이버 시세·뉴스 언급";
 const MARKET_LABELS = new Set(["KOSPI", "KOSDAQ", "NASDAQ", "NYSE"]);
@@ -106,6 +106,10 @@ export interface DiscoveryResponse {
   fronts: Record<string, DiscoveryFrontSeed>;
   confidence: "L" | "M" | "H";
   source: string;
+}
+
+export interface BuildDiscoveryResponseOptions {
+  targetedMaterial?: boolean;
 }
 
 interface NaverMarketRow {
@@ -626,7 +630,9 @@ function frontSeed(
   };
 }
 
-export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
+export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOptions = {}): Promise<DiscoveryResponse> {
+  const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
+  const targetedMaterialLimit = targetedMaterialEnabled ? TARGETED_MATERIAL_CANDIDATE_LIMIT : 0;
   const asOf = todayKst();
   const [rows, attentionMap] = await Promise.all([
     fetchMarketRows(),
@@ -687,16 +693,18 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
       const bHasTheme = Number(b[1].events.some((event) => event.kind === "theme_link"));
       return bHasTheme - aHasTheme || bPct - aPct || a[0].localeCompare(b[0]);
     })
-    .slice(0, TARGETED_MATERIAL_CANDIDATE_LIMIT);
-  const targetedMaterial = await mapLimit(targetedRows, TARGETED_MATERIAL_CONCURRENCY, async ([ticker, value]) => ({
-    ticker,
-    event: await eventFromTargetedMaterial(value.row, asOf),
-  }));
-  for (const result of targetedMaterial) {
-    if (result.status !== "fulfilled" || !result.value.event) continue;
-    const current = byTicker.get(result.value.ticker);
-    if (!current) continue;
-    byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
+    .slice(0, targetedMaterialLimit);
+  if (targetedMaterialLimit > 0) {
+    const targetedMaterial = await mapLimit(targetedRows, TARGETED_MATERIAL_CONCURRENCY, async ([ticker, value]) => ({
+      ticker,
+      event: await eventFromTargetedMaterial(value.row, asOf),
+    }));
+    for (const result of targetedMaterial) {
+      if (result.status !== "fulfilled" || !result.value.event) continue;
+      const current = byTicker.get(result.value.ticker);
+      if (!current) continue;
+      byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
+    }
   }
 
   if (DISCOVERY_FLOW_CACHE_ENABLED) {
@@ -785,6 +793,6 @@ export async function buildDiscoveryResponse(): Promise<DiscoveryResponse> {
     stocks,
     fronts,
     confidence: stocks.length >= DISCOVERY_DECK_CARD_COUNT ? "H" : stocks.length >= 30 ? "M" : "L",
-    source: DISCOVERY_SOURCE_LABEL,
+    source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "네이버 시세·DART 공시·수급 캐시",
   };
 }


### PR DESCRIPTION
## Summary
- add a fast discovery API mode that skips targeted news/research matching on first load
- route the FOMO web first-load discovery fetch through 
- raise same-origin discovery timeout so mobile/serverless cold starts can actually complete

## Verification
-  -> 50 cards in ~0.7s locally
- 
> test
> vitest run apps/web/__tests__/lib/discovery-supply-material.test.ts


 RUN  v4.1.9 /Users/cocteau/Documents/Fomo Club/taro-stock-app


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  17:15:48
   Duration  232ms (transform 133ms, setup 0ms, import 174ms, tests 3ms, environment 0ms)
- 
> typecheck
> npm run typecheck --workspaces --if-present


> @fomo/legacy-paper-api@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> fomo-club@0.1.0 typecheck
> tsc --noEmit


> @fomo/web@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> @fomo/backend@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> @fomo/core@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> @fomo/shared@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit
- 
> lint
> npm run lint --workspaces --if-present


> @fomo/legacy-paper-api@0.1.0 lint
> npm run typecheck


> @fomo/legacy-paper-api@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> fomo-club@0.1.0 lint
> tsc --noEmit


> @fomo/web@0.1.0 lint
> npm run typecheck


> @fomo/web@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> @fomo/backend@0.1.0 lint
> npm run typecheck


> @fomo/backend@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> @fomo/core@0.1.0 lint
> npm run typecheck


> @fomo/core@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit


> @fomo/shared@0.1.0 lint
> npm run typecheck


> @fomo/shared@0.1.0 typecheck
> tsc -p tsconfig.json --noEmit
- 
> build:web
> npm --workspace @fomo/backend run build


> @fomo/backend@0.1.0 build
> next build --webpack

▲ Next.js 16.2.9 (webpack)

  Creating an optimized production build ...
✓ Compiled successfully in 952ms
  Running TypeScript ...
  Finished TypeScript in 2.2s ...
  Collecting page data using 9 workers ...
  Generating static pages using 9 workers (0/13) ...
  Generating static pages using 9 workers (3/13) 
  Generating static pages using 9 workers (6/13) 
  Generating static pages using 9 workers (9/13) 
✓ Generating static pages using 9 workers (13/13) in 91ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /api/auth/forgot-password
├ ƒ /api/auth/reset-password
├ ƒ /api/control/kill-switch
├ ƒ /api/dashboard/summary
├ ƒ /api/exchange/settings
├ ƒ /api/fomo/account
├ ƒ /api/fomo/auth/login
├ ƒ /api/fomo/auth/register
├ ƒ /api/fomo/axis-snapshot
├ ƒ /api/fomo/banner
├ ƒ /api/fomo/challenges
├ ƒ /api/fomo/discovery
├ ƒ /api/fomo/emotions/calendar
├ ƒ /api/fomo/emotions/link
├ ƒ /api/fomo/emotions/today
├ ƒ /api/fomo/emotions/vote
├ ƒ /api/fomo/feed
├ ƒ /api/fomo/index
├ ƒ /api/fomo/keywords
├ ƒ /api/fomo/news
├ ƒ /api/fomo/pulse
├ ƒ /api/fomo/sector-stocks
├ ƒ /api/fomo/stock-basics
├ ƒ /api/fomo/stock-front
├ ƒ /api/fomo/stock-insight
├ ƒ /api/fomo/taste
├ ƒ /api/fomo/taste/link
├ ƒ /api/fomo/theme-insight
├ ƒ /api/fomo/voices
├ ƒ /api/fomo/whale
├ ƒ /api/market/overview
├ ƒ /api/newsletter/daily
├ ƒ /api/paper/logs
├ ƒ /api/research/behavior
├ ƒ /api/research/briefing
├ ƒ /api/research/pipeline
├ ƒ /api/research/ticker
├ ƒ /api/research/ticker-search
├ ƒ /api/risk/settings
├ ƒ /api/runtime/state
├ ƒ /api/slack/commands
├ ƒ /api/slack/events
├ ƒ /api/strategies/[id]/toggle
├ ƒ /api/strategies/control
├ ƒ /api/strategies/execution
├ ƒ /login
├ ƒ /sector/[sector]
└ ƒ /ticker/[ticker]


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
- 
> build:fomo-web
> npm --workspace @fomo/web run build


> @fomo/web@0.1.0 build
> next build --webpack

▲ Next.js 16.2.9 (webpack)

  Creating an optimized production build ...
✓ Compiled successfully in 588ms
  Running TypeScript ...
  Finished TypeScript in 1246ms ...
  Collecting page data using 8 workers ...
  Generating static pages using 8 workers (0/5) ...
  Generating static pages using 8 workers (1/5) 
  Generating static pages using 8 workers (2/5) 
  Generating static pages using 8 workers (3/5) 
✓ Generating static pages using 8 workers (5/5) in 190ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /api/fomo/[...path]
├ ƒ /insight/[id]
├ ○ /privacy
└ ○ /terms


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
