### PR TITLE
fix(discovery): restore narrative hooks in fast deck

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -147,6 +147,12 @@ function FomoMeter({ score, color }: { score: number; color: string }) {
 
 /** 봉인색 — 등락 데이터 전용(DESIGN.md §2). 브랜드(오렌지/네온)와 분리. 상승 적·하락 청(KR 관습). */
 const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
+const PRICE_ONLY_REASON_PATTERN = /^오늘 가격이 [+-]?\d+(?:\.\d+)?% 움직였어요/;
+
+function nonPriceOnlyHeadline(text: string | undefined): string | undefined {
+  if (!text || PRICE_ONLY_REASON_PATTERN.test(text)) return undefined;
+  return text;
+}
 
 function clampStyle(lines: number): CSSProperties {
   return {
@@ -473,9 +479,10 @@ export function StockSwipeDeck({
     }
     const fomo = e?.fomo ?? EMPTY_FOMO;
     const reasonHeadlineSeed = compactReasonHeadlineSeed(stock.reason);
+    const discoveryHeadline = nonPriceOnlyHeadline(reasonHeadlineSeed);
     const signalsForHook: CardFrontSignals = {
       ...(e?.signals ?? {}),
-      ...(!e?.signals.newsEventLabel && reasonHeadlineSeed ? { newsEventLabel: reasonHeadlineSeed } : {}),
+      ...(!e?.signals.newsEventLabel && discoveryHeadline ? { newsEventLabel: discoveryHeadline } : {}),
     };
     const legacyHook = selectFomoHook({
       fomo,
@@ -492,8 +499,14 @@ export function StockSwipeDeck({
       ...(typeof e?.signals.changePct === "number" ? { changePct: e.signals.changePct } : {}),
       ...(typeof e?.signals.marketCapRank?.rank === "number" ? { marketCapRank: e.signals.marketCapRank.rank } : {}),
     });
-    const view = { ...baseView, headline: axisHook?.hookText ?? legacyHook.headline };
-    const usedReasonHeadline = !!reasonHeadlineSeed && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
+    const fallbackHeadline = stock.sector ? `${stock.sector} 흐름에서 새로 확인하는 종목이에요.` : baseView.headline;
+    const headline =
+      discoveryHeadline ??
+      nonPriceOnlyHeadline(axisHook?.hookText) ??
+      nonPriceOnlyHeadline(legacyHook.headline) ??
+      fallbackHeadline;
+    const view = { ...baseView, headline };
+    const usedReasonHeadline = !!discoveryHeadline && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
     const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);
     return {
       view,

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -57,6 +57,7 @@ describe("discovery empty-deck recovery", () => {
       [],
       [
         candidate("대형주", "theme_link", 0.95, { rank: 1, label: "반도체 흐름에서 확인해요." }),
+        candidate("가격상승", "price_move", 0.99, { rank: 210, direction: "up", label: "오늘 가격이 +12.00% 움직였어요." }),
         candidate("하락주", "price_move", 0.99, { rank: 220, direction: "down", label: "오늘 가격이 -12.00% 움직였어요." }),
         candidate("발굴A", "theme_link", 0.6, { rank: 180, label: "AI 흐름에서 같이 확인해요." }),
         candidate("발굴B", "market_context", 0.7, { rank: 260, label: "시총 260위권에서 움직였어요." }),
@@ -65,8 +66,10 @@ describe("discovery empty-deck recovery", () => {
     );
 
     expect(recovered.map((row) => row.ticker)).toEqual(["발굴A", "발굴B", "대형주"]);
+    expect(recovered.map((row) => row.ticker)).not.toContain("가격상승");
     expect(recovered.map((row) => row.ticker)).not.toContain("하락주");
     expect(recovered.every((row) => row.reason && row.reason.length > 0)).toBe(true);
+    expect(recovered.every((row) => !/^오늘 가격이/.test(row.reason ?? ""))).toBe(true);
   });
 
   it("leaves a healthy material deck unchanged", () => {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -374,8 +374,15 @@ function ordinalText(rank: number): string {
   return `${rank}번째로`;
 }
 
+function industryHintForTicker(ticker: string): string | undefined {
+  for (const hint of INDUSTRY_HINTS) {
+    if (hint.pattern.test(ticker)) return hint.label;
+  }
+  return undefined;
+}
+
 function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent {
-  const sector = theme?.sector ?? sectorOf(row.canonical);
+  const sector = theme?.sector ?? sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
   const rankText = row.marketCapRank ? `시총 ${row.marketCapRank}위권` : "시총 상위권";
   const changePct = row.changePct;
   const change = typeof changePct === "number" ? pctText(changePct) : undefined;
@@ -397,6 +404,17 @@ function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | un
       label: relativeLabel,
     };
   }
+  if (sector) {
+    return {
+      kind: "market_context",
+      firstSeen: true,
+      strength: Math.min(0.68, 0.42 + (typeof changePct === "number" ? Math.abs(changePct) / 55 : 0)),
+      source,
+      asOf,
+      confidence: "M",
+      label: `${sector} 흐름에서 새로 확인하는 종목이에요.`,
+    };
+  }
   if (typeof changePct === "number" && change) {
     return {
       kind: "market_context",
@@ -405,7 +423,7 @@ function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | un
       source,
       asOf,
       confidence: "M",
-      label: `${row.market} ${rankText}에서 오늘 ${change} 움직였어요.`,
+      label: `${row.market === "KOSDAQ" ? "코스닥" : "코스피"} ${rankText}에서 새로 확인하는 종목이에요.`,
     };
   }
   return {
@@ -523,7 +541,12 @@ function isSameDayEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): b
 
 function fallbackContextEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
   return candidate.events
-    .filter((event) => isSameDayEvent(event, candidate) && event.direction !== "down")
+    .filter((event) => {
+      if (!isSameDayEvent(event, candidate) || event.direction === "down") return false;
+      if (event.kind === "price_move") return false;
+      if (event.kind !== "market_context") return true;
+      return !!event.label && !/^KOSPI |^KOSDAQ /.test(event.label);
+    })
     .sort((a, b) => {
       const aTheme = a.kind === "theme_link" ? 1 : 0;
       const bTheme = b.kind === "theme_link" ? 1 : 0;
@@ -535,8 +558,13 @@ function fallbackDiscoveryReason(candidate: DiscoveryCandidate): string {
   const event = fallbackContextEvent(candidate);
   if (event?.kind === "theme_link" && event.label) return event.label;
   if (event?.kind === "market_context" && event.label) return event.label;
-  if (event?.kind === "price_move" && event.label) return `${event.label} 공개 재료는 더 확인 중이에요.`;
   return "오늘 시장에서 다시 확인할 종목으로 남겨뒀어요.";
+}
+
+function fallbackContextQuality(event: DiscoveryEvent): number {
+  if (event.kind === "theme_link") return 2;
+  if (event.kind === "market_context" && event.label && !/^코스피 |^코스닥 /.test(event.label)) return 1;
+  return 0;
 }
 
 export function recoverDiscoveryCandidates(
@@ -562,9 +590,12 @@ export function recoverDiscoveryCandidates(
       const bFamous = typeof b.candidate.marketCapRank === "number" && b.candidate.marketCapRank <= DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF ? 1 : 0;
       const aTheme = a.context.kind === "theme_link" ? 1 : 0;
       const bTheme = b.context.kind === "theme_link" ? 1 : 0;
+      const aQuality = fallbackContextQuality(a.context);
+      const bQuality = fallbackContextQuality(b.context);
       return (
         aFamous - bFamous ||
         bTheme - aTheme ||
+        bQuality - aQuality ||
         b.context.strength - a.context.strength ||
         (a.candidate.marketCapRank ?? 9999) - (b.candidate.marketCapRank ?? 9999) ||
         a.index - b.index ||

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -112,24 +112,25 @@ describe("WO-05 discovery supply engine", () => {
     expect(discoveryWhy(row)).toContain("공급계약");
   });
 
-  it("drops standalone theme and market context from the deck", () => {
-    const ranked = rankDiscoveryCandidates([
-      candidate("시장맥락", 0.65, "market_context", "KOSPI 시총 상위권에서 오늘 +1.2% 움직였어요."),
-      candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요."),
-      candidate("수급", 0.5, "flow_entry", "기관이 3일째 사는 중이에요."),
-    ]);
+  it("keeps constructive theme context but drops generic market context from the deck", () => {
+    const market = candidate("시장맥락", 0.65, "market_context", "KOSPI 시총 상위권에서 오늘 +1.2% 움직였어요.");
+    const theme = candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
+    theme.events[0]!.direction = "up";
+    const flow = candidate("수급", 0.5, "flow_entry", "기관이 3일째 사는 중이에요.");
+    const ranked = rankDiscoveryCandidates([market, theme, flow]);
 
-    expect(ranked.map((c) => c.ticker)).toEqual(["수급"]);
+    expect(ranked.map((c) => c.ticker)).toEqual(["수급", "테마"]);
   });
 
-  it("does not treat market or theme context as a real display WHY", () => {
+  it("treats constructive theme context as display WHY but keeps generic market context weak", () => {
     const market = candidate("시장맥락", 0.55, "market_context", "KOSPI 시총 상위권에서 오늘 +1.2% 움직였어요.");
     const theme = candidate("테마", 0.55, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
+    theme.events[0]!.direction = "up";
 
     expect(hasDisplayWhyEvent(market)).toBe(false);
     expect(isWeakDiscoveryCandidate(market)).toBe(true);
-    expect(hasDisplayWhyEvent(theme)).toBe(false);
-    expect(isWeakDiscoveryCandidate(theme)).toBe(true);
+    expect(hasDisplayWhyEvent(theme)).toBe(true);
+    expect(isWeakDiscoveryCandidate(theme)).toBe(false);
   });
 
   it("does not treat flat or bearish theme comparison as a top-band display WHY", () => {
@@ -144,8 +145,8 @@ describe("WO-05 discovery supply engine", () => {
     expect(isWeakDiscoveryCandidate(flatTheme)).toBe(true);
     expect(hasDisplayWhyEvent(downTheme)).toBe(false);
     expect(isWeakDiscoveryCandidate(downTheme)).toBe(true);
-    expect(hasDisplayWhyEvent(upTheme)).toBe(false);
-    expect(rankDiscoveryCandidates([flatTheme, downTheme, upTheme]).map((row) => row.ticker)).toEqual([]);
+    expect(hasDisplayWhyEvent(upTheme)).toBe(true);
+    expect(rankDiscoveryCandidates([flatTheme, downTheme, upTheme]).map((row) => row.ticker)).toEqual(["상승선두"]);
   });
 
   it("drops weak market-context padding instead of filling the deck with price restatements", () => {
@@ -157,13 +158,14 @@ describe("WO-05 discovery supply engine", () => {
     expect(ranked).toHaveLength(0);
   });
 
-  it("drops price-only and theme-only cards even when their raw strength is larger", () => {
+  it("drops price-only cards but keeps constructive theme context", () => {
     const priceOnly = candidate("가격만큰종목", 1, "price_move", "오늘 가격이 +18.00% 움직였어요.");
     priceOnly.events[0]!.direction = "up";
     const themeWhy = candidate("테마이유", 0.45, "theme_link", "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
+    themeWhy.events[0]!.direction = "up";
     const materialWhy = candidate("뉴스이유", 0.4, "news_mention", "종목 지정 기사");
 
-    expect(rankDiscoveryCandidates([priceOnly, themeWhy, materialWhy]).map((row) => row.ticker)).toEqual(["뉴스이유"]);
+    expect(rankDiscoveryCandidates([priceOnly, themeWhy, materialWhy]).map((row) => row.ticker)).toEqual(["뉴스이유", "테마이유"]);
   });
 
   it("ranks obscure stocks above famous stocks at the same signal strength", () => {
@@ -307,7 +309,7 @@ describe("WO-05 discovery supply engine", () => {
     expect(rankDiscoveryCandidates([evergreen])).toEqual([]);
   });
 
-  it("keeps the whole deck free of price-only, theme-only, flat, down, no-event, and market-context rows", () => {
+  it("keeps the whole deck free of price-only, flat, down, no-event, and market-context rows", () => {
     const material = Array.from({ length: 4 }, (_, index) => candidate(`공시${index}`, 0.4 + index / 100, "disclosure", `공시 ${index}`));
     const theme = Array.from({ length: 3 }, (_, index) => {
       const row = candidate(`테마${index}`, 0.55 + index / 100, "theme_link", `오늘 원자력 흐름 ${index}`);
@@ -329,7 +331,7 @@ describe("WO-05 discovery supply engine", () => {
 
     const ranked = rankDiscoveryCandidates([...rejected, ...price, ...theme, ...material], { maxCandidates: 20 });
     expect(ranked.slice(0, 10).every(hasDeckDisplayEvent)).toBe(true);
-    expect(ranked.map((row) => row.ticker)).toEqual(["공시3", "공시2", "공시1", "공시0"]);
+    expect(ranked.map((row) => row.ticker)).toEqual(["공시3", "공시2", "공시1", "공시0", "테마2", "테마1", "테마0"]);
     expect(ranked.map((row) => row.ticker)).not.toContain("보합");
     expect(ranked.map((row) => row.ticker)).not.toContain("하락");
     expect(ranked.map((row) => row.ticker)).not.toContain("시장맥락");

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -144,7 +144,7 @@ function isDisplayVolumeEvent(event: DiscoveryEvent): boolean {
 
 export function isDeckDisplayEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): boolean {
   if (!isCurrentDeckEvent(event, candidate)) return false;
-  return isMaterialEvent(event) || isDisplayVolumeEvent(event);
+  return isMaterialEvent(event) || isConstructiveThemeEvent(event) || isDisplayVolumeEvent(event);
 }
 
 export function hasDeckDisplayEvent(candidate: DiscoveryCandidate): boolean {


### PR DESCRIPTION
## Summary
- Restore constructive theme/context hooks as valid discovery card headlines in the fast deck
- Stop price_move / “오늘 가격이 ... 움직였어요” from becoming card-facing discovery reasons
- Prefer non-price discovery reasons over price axis hooks, with a UI guard against price-only headline regressions
- Keep generic KOSPI/KOSDAQ market context out of the front recovery band

## Verification
- `npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts`
- `npm run lint`
- `npm run build:fomo-web`
- `npm run build:web`
- Fast deck probe: 50 cards, price-only reasons 0, generic front reasons 0

## Guardrail
This makes “오늘 가격이 +30.0% 움직였어요.” unavailable as a card headline even if a future fast-path payload leaks it again.