### PR TITLE
feat(depth): thread discovery naverCode + verified-data report floor for long-tail tickers

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -973,7 +973,7 @@ export function StockInsightView({
       .then((r) => alive && setBasics(r))
       .catch(() => alive && setBasics(null))
       .finally(() => alive && setBasicsLoaded(true));
-    fetchStockInsight(stock)
+    fetchStockInsight(stock, context?.naverCode ? { naverCode: context.naverCode } : {})
       .then((r) => alive && setInsight(r))
       .catch(() => alive && setInsight(null))
       .finally(() => alive && setLoading(false));
@@ -989,6 +989,14 @@ export function StockInsightView({
     context?.reason && !copyRestates(context.reason, context.axisHeadline)
       ? context.reason
       : undefined;
+  const hasVerifiedFloor = !!(
+    basics?.marketCap ||
+    (basics?.metrics?.length ?? 0) > 0 ||
+    front?.priceText ||
+    (front?.sparkline?.length ?? 0) >= 2
+  );
+  const showThinSourceFootnote =
+    !hasInsight && !insight?.officialFacts?.length && auditWordings(insight).length === 0;
 
   return (
     <div className="fixed inset-0 z-[70] bg-black">
@@ -1076,15 +1084,17 @@ export function StockInsightView({
           <OfficialFactsBlock facts={insight?.officialFacts} />
           <CommunityWordingBlock insight={insight} />
 
-          {!hasInsight && !insight?.officialFacts?.length && auditWordings(insight).length === 0 && (
-            <p className="mt-6 text-sm leading-6 text-muted">
-              이 종목으로 모인 원문은 아직 적어요. 그래서 위에는 가격·차트·수급처럼 확인된 재료만 정리했어요.
-            </p>
-          )}
-
           <div className="mt-7">
             <StockFundamentalsBlock basics={basics} front={front} />
           </div>
+
+          {showThinSourceFootnote && (
+            <p className="mt-5 text-[12px] leading-5 text-muted">
+              {hasVerifiedFloor
+                ? "원문 기반 요약은 아직 얇아요. 위에는 가격·차트·수급·기본 지표처럼 확인된 자료만 먼저 정리했어요."
+                : "이 종목으로 모인 원문은 아직 적어요. 확인된 자료가 들어오면 이 화면에 붙어요."}
+            </p>
+          )}
 
           {/* 회사가 뭐 하는 곳 — 맨 아래 한 줄로 강등(긴 blurb 폐기). */}
           {basics?.summary && (

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -344,12 +344,12 @@ export const fetchThemeInsight = (theme: string) =>
   );
 
 /** 개별 종목 이해·응축(작업3) — 종목 라벨 탭 시 lazy 로 부른다(테마 뎁스와 동일 구조). */
-export const fetchStockInsight = (stock: string) =>
+export const fetchStockInsight = (stock: string, opts: { naverCode?: string; market?: string; country?: string } = {}) =>
   cachedGet(
-    `stock-insight:${stock}`,
+    `stock-insight:${opts.naverCode ?? "name"}:${stock}`,
     () =>
       get<import("@fomo/core").CondensedInsight>(
-        `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}`
+        `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}${opts.naverCode ? `&code=${encodeURIComponent(opts.naverCode)}` : ""}${opts.market ? `&market=${encodeURIComponent(opts.market)}` : ""}${opts.country ? `&country=${encodeURIComponent(opts.country)}` : ""}`
       ),
     CACHE_TTL.stockInsight
   );

--- a/apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
+++ b/apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchNaverStockNews: vi.fn(),
+  fetchNaverCompanyResearch: vi.fn(),
+  fetchAllNews: vi.fn(),
+  fetchDcStockTitles: vi.fn(),
+  fetchNaverBoardPosts: vi.fn(),
+  fetchSubredditPosts: vi.fn(),
+  fetchDartDisclosuresForCode: vi.fn(),
+}));
+
+vi.mock("../../lib/fomo-news-sources", () => ({
+  fetchNaverStockNews: mocks.fetchNaverStockNews,
+  fetchNaverCompanyResearch: mocks.fetchNaverCompanyResearch,
+  fetchAllNews: mocks.fetchAllNews,
+}));
+
+vi.mock("../../lib/dcinside", () => ({
+  fetchDcStockTitles: mocks.fetchDcStockTitles,
+}));
+
+vi.mock("../../lib/dart-disclosures", () => ({
+  fetchDartDisclosuresForCode: mocks.fetchDartDisclosuresForCode,
+}));
+
+vi.mock("@fomo/core", async (importActual) => {
+  const actual = await importActual<typeof import("@fomo/core")>();
+  return {
+    ...actual,
+    fetchNaverBoardPosts: mocks.fetchNaverBoardPosts,
+    fetchSubredditPosts: mocks.fetchSubredditPosts,
+  };
+});
+
+describe("collectStockDocs naverCode threading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchNaverStockNews.mockResolvedValue([
+      {
+        title: "테스트무명 공급계약 공시가 나왔어요",
+        summary: "테스트무명 관련 계약 소식",
+        source: "테스트뉴스",
+        publishedAt: "2026-06-27T00:00:00.000Z",
+        tier: "news-mid",
+      },
+    ]);
+    mocks.fetchNaverCompanyResearch.mockResolvedValue([
+      {
+        title: "테스트무명 리서치 코멘트",
+        summary: "테스트무명 종목 리포트",
+        source: "테스트증권 리서치",
+        publishedAt: "2026-06-27T00:00:00.000Z",
+        tier: "news-mid",
+      },
+    ]);
+    mocks.fetchDartDisclosuresForCode.mockResolvedValue([
+      {
+        ticker: "테스트무명",
+        label: "단일판매ㆍ공급계약체결",
+        source: "DART 공시",
+        asOf: "2026-06-27",
+      },
+    ]);
+    mocks.fetchNaverBoardPosts.mockResolvedValue([{ title: "테스트무명 오늘 거래량 보네", tsMs: 1_782_486_000_000 }]);
+    mocks.fetchAllNews.mockResolvedValue([]);
+    mocks.fetchDcStockTitles.mockResolvedValue([]);
+    mocks.fetchSubredditPosts.mockResolvedValue([]);
+  });
+
+  it("uses supplied naverCode for per-ticker sources even when the stock is not in STOCK_VOCAB", async () => {
+    const { collectStockDocs } = await import("../../lib/theme-understanding");
+
+    const docs = await collectStockDocs("테스트무명", { naverCode: "123456", country: "KR" });
+
+    expect(mocks.fetchNaverStockNews).toHaveBeenCalledWith("123456", expect.any(Number));
+    expect(mocks.fetchNaverCompanyResearch).toHaveBeenCalledWith("123456", "테스트무명", 6);
+    expect(mocks.fetchNaverBoardPosts).toHaveBeenCalledWith("123456");
+    expect(mocks.fetchDartDisclosuresForCode).toHaveBeenCalledWith("123456", "테스트무명", expect.any(String));
+    expect(docs.some((doc) => doc.kind === "news" && doc.title.includes("공급계약"))).toBe(true);
+    expect(docs.some((doc) => doc.kind === "community" && doc.source === "네이버 종토방 테스트무명")).toBe(true);
+    expect(docs.some((doc) => doc.kind === "official" && doc.source === "DART 공시")).toBe(true);
+  });
+});
+

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -25,16 +25,21 @@ const REVALIDATE_S = 21_600; // 6h
 const USER_WAIT_MS = 4_500;
 const inflight = new Map<string, Promise<CondensedInsight>>();
 
-async function getInsight(stock: string): Promise<CondensedInsight> {
+function validNaverCode(code: string | null | undefined): string | undefined {
+  const c = code?.trim();
+  return c && /^\d{6}$/.test(c) ? c : undefined;
+}
+
+async function getInsight(stock: string, opts: { naverCode?: string; market?: string; country?: string } = {}): Promise<CondensedInsight> {
   const today = kstDate();
   const slot = kstSlot();
-  const key = `${today}:${slot}:${stock}`;
+  const key = `${today}:${slot}:${stock}:${opts.naverCode ?? ""}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
-    async () => condenseThemeInsight(await understandStock(stock)),
-    ["fomo-stock-insight", cacheVersion(), today, slot, stock],
+    async () => condenseThemeInsight(await understandStock(stock, opts)),
+    ["fomo-stock-insight", cacheVersion(), today, slot, stock, opts.naverCode ?? ""],
     { revalidate: REVALIDATE_S }
   );
 
@@ -47,8 +52,12 @@ function timeoutFallback(stock: string): CondensedInsight {
   return condenseThemeInsight(emptyThemeInsight(stock, "인사이트 캐시 준비 중 — 원문 근거가 아직 충분히 모이지 않았어요."));
 }
 
-async function getInsightForRequest(stock: string, blocking: boolean): Promise<{ payload: CondensedInsight; coldFallback: boolean }> {
-  if (blocking) return { payload: await getInsight(stock), coldFallback: false };
+async function getInsightForRequest(
+  stock: string,
+  blocking: boolean,
+  opts: { naverCode?: string; market?: string; country?: string } = {}
+): Promise<{ payload: CondensedInsight; coldFallback: boolean }> {
+  if (blocking) return { payload: await getInsight(stock, opts), coldFallback: false };
 
   let timedOut = false;
   const timeout = new Promise<CondensedInsight>((resolve) => {
@@ -58,7 +67,7 @@ async function getInsightForRequest(stock: string, blocking: boolean): Promise<{
     }, USER_WAIT_MS);
   });
   const payload = await Promise.race([
-    getInsight(stock).catch((err) => {
+    getInsight(stock, opts).catch((err) => {
       console.warn("[stock-insight] getInsight failed", stock, (err as Error)?.message);
       return timeoutFallback(stock);
     }),
@@ -77,12 +86,19 @@ export async function GET(req: Request) {
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
+  const naverCode = validNaverCode(url.searchParams.get("code")) ?? validNaverCode(url.searchParams.get("naverCode"));
+  const market = url.searchParams.get("market")?.trim() || undefined;
+  const country = url.searchParams.get("country")?.trim() || undefined;
   const blocking = url.searchParams.get("blocking") === "1" || req.headers.get("x-warm") === "1";
-  const { payload, coldFallback } = await getInsightForRequest(stock, blocking);
+  const { payload, coldFallback } = await getInsightForRequest(stock, blocking, {
+    ...(naverCode ? { naverCode } : {}),
+    ...(market ? { market } : {}),
+    ...(country ? { country } : {}),
+  });
 
   // 수급(외인·기관 장마감 확정) — 공식 지표 섹션에 객관 사실로 동봉(§4). 데이터 없으면 미표시(정직).
   // 캐시 밖에서 1회 조회(일별이라 가벼움). 테이블 전/미수집이면 null → 기존 응답 그대로.
-  const code = stockDef(stock)?.naverCode;
+  const code = naverCode ?? stockDef(stock)?.naverCode;
   const flow = code ? await readLatestSupplyDemand(code) : null;
   const out = flow
     ? { ...payload, officialFacts: [supplyDemandFact(flow), ...(payload.officialFacts ?? [])] }

--- a/apps/web/lib/dart-disclosures.ts
+++ b/apps/web/lib/dart-disclosures.ts
@@ -12,6 +12,7 @@ interface DartListItem {
   corp_name?: string;
   report_nm?: string;
   rcept_dt?: string;
+  rcept_no?: string;
 }
 
 interface DartListResponse {
@@ -97,5 +98,34 @@ export async function fetchDartDisclosuresByStock(asOf: string): Promise<Record<
     if (typeof data.total_page === "number" && page >= data.total_page) break;
   }
 
+  return out;
+}
+
+export async function fetchDartDisclosuresForCode(
+  code: string,
+  stock: string,
+  asOf: string
+): Promise<DartDisclosureHit[]> {
+  const key = dartKey();
+  const normalized = code.trim();
+  if (!key || !/^\d{6}$/.test(normalized)) return [];
+
+  const out: DartDisclosureHit[] = [];
+  for (let page = 1; page <= DART_MAX_PAGES; page += 1) {
+    const data = await fetchDartPage(key, asOf, page).catch(() => null);
+    if (!data?.list?.length || (data.status && data.status !== "000")) break;
+    for (const item of data.list) {
+      if (item.stock_code?.trim() !== normalized) continue;
+      const label = cleanReportName(item.report_nm);
+      if (!label) continue;
+      out.push({
+        ticker: stock,
+        label,
+        source: "DART 공시",
+        asOf: isoFromDartDate(item.rcept_dt, asOf),
+      });
+    }
+    if (typeof data.total_page === "number" && page >= data.total_page) break;
+  }
   return out;
 }

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -22,6 +22,7 @@ import { callAI, isAiConfigured } from "@fomo/shared";
 import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
+import { fetchDartDisclosuresForCode } from "./dart-disclosures";
 
 /**
  * 이해 레이어 오케스트레이션 — DATA_ENGINE_STRATEGY §4 Track A. (네트워크 + LLM)
@@ -38,6 +39,12 @@ const TEMPERATURE = Number.parseFloat(process.env["AI_TEMPERATURE"] ?? "") || 0.
 
 const MAX_NEWS = 12;
 const MAX_COMMUNITY = 10;
+
+export interface StockUnderstandingOptions {
+  naverCode?: string;
+  market?: string;
+  country?: string;
+}
 
 /** 테마 → 종토방 종목코드(원문 커뮤니티 수집 대상). 지금은 반도체만(PoC). */
 const THEME_NAVER_CODES: Record<string, { code: string; label: string }[]> = {
@@ -197,21 +204,34 @@ function officialFactsFrom(docs: readonly SourceDoc[]): OfficialFact[] {
     }));
 }
 
+function validNaverCode(code: string | undefined | null): string | undefined {
+  const c = code?.trim();
+  return c && /^\d{6}$/.test(c) ? c : undefined;
+}
+
+function todayKst(): string {
+  return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
 /**
  * 개별 종목 원문 수집(B 트랙 §1) — 종목 *국적*에 맞는 소스를 연결한다.
  * - 한국 종목(종토방 코드 보유): 한국뉴스(종목명 필터) + 네이버 종토방 + 디시.
  * - 미국/글로벌 종목(엔비디아 등): 뉴스(종목명 필터) + **레딧 글 제목**(외신/해외 커뮤니티) + 디시.
  * grounding 가드 그대로 — 별칭(엔비디아=Nvidia=NVDA)이 원문에 실제 substring/단어경계로 존재하는 글만.
  */
-export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
+export async function collectStockDocs(stock: string, opts: StockUnderstandingOptions = {}): Promise<SourceDoc[]> {
   const def = stockDef(stock);
-  const code = def?.naverCode;
-  const isForeign = def ? def.country !== "KR" : false;
-  const matches = (s: string) => stockMatchesText(stock, s);
+  const code = validNaverCode(opts.naverCode) ?? def?.naverCode;
+  const isForeign = def ? def.country !== "KR" : opts.country ? opts.country !== "KR" : false;
+  const matches = (s: string) => {
+    if (stockMatchesText(stock, s)) return true;
+    return s.toLowerCase().includes(stock.trim().toLowerCase());
+  };
 
-  const [stockNewsRes, researchRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
+  const [stockNewsRes, researchRes, dartRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
     code ? fetchNaverStockNews(code, MAX_NEWS) : Promise.resolve([]),
     code ? fetchNaverCompanyResearch(code, stock, 6) : Promise.resolve([]),
+    code ? fetchDartDisclosuresForCode(code, stock, todayKst()) : Promise.resolve([]),
     fetchAllNews(),
     fetchDcStockTitles(),
     code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
@@ -258,6 +278,23 @@ export async function collectStockDocs(stock: string): Promise<SourceDoc[]> {
     for (const a of researchRes.value.slice(0, 6)) pushNews(a);
   } else {
     console.warn("[stock-understanding] naver research error", stock, researchRes.reason);
+  }
+
+  // DART 공시 — 발견 이벤트에만 쓰지 않고 depth 공식 사실에도 합류시킨다.
+  if (dartRes.status === "fulfilled") {
+    for (const hit of dartRes.value.slice(0, 4)) {
+      docs.push({
+        id: nextId(),
+        kind: "official",
+        title: hit.label,
+        body: `${hit.asOf} 접수 공시`,
+        source: hit.source,
+        publishedAt: hit.asOf,
+        tier: "official-high",
+      });
+    }
+  } else {
+    console.warn("[stock-understanding] dart disclosure error", stock, dartRes.reason);
   }
 
   // 뉴스 — 종목명(별칭 포함)이 제목/요약에 등장하는 기사만.
@@ -327,8 +364,8 @@ export async function collectThemeStocks(
 }
 
 /** 개별 종목 이해·구조화(작업3, BM 심장) — 테마와 동일 구조/가드. 자료 적으면 정직한 빈 상태. */
-export async function understandStock(stock: string): Promise<ThemeInsight> {
-  return runUnderstanding(stock, await collectStockDocs(stock), "stock");
+export async function understandStock(stock: string, opts: StockUnderstandingOptions = {}): Promise<ThemeInsight> {
+  return runUnderstanding(stock, await collectStockDocs(stock, opts), "stock");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Thread discovery-provided naverCode into stock insight collection so long-tail discovered stocks can use per-ticker Naver news, research, board posts, and supply facts even when they are not in STOCK_VOCAB.
- Add per-ticker DART disclosure fetches into stock understanding docs as official facts.
- Keep thin-source copy as a footnote and let verified price/chart/basics/supply floor remain visible instead of replacing the depth page with an apology.

## Root Cause Confirmed
- apps/web/lib/theme-understanding.ts only used stockDef(stock)?.naverCode.
- New discovery names often are not in STOCK_VOCAB, so code was undefined and per-ticker sources were skipped.
- apps/web/app/api/fomo/stock-insight/route.ts called understandStock(stock) with only the name, dropping naverCode from the discovery card context.

## Manual Verification
Ran a live discovery sample and then collectStockDocs with discovery naverCode for long-tail names:
- 광주신세계 / 037710 / rank 356: 19 docs (news 9, community 10)
- 금호건설 / 002990 / rank 461: 21 docs (news 11, community 10)
- 제닉 / 123330 / rank 411: 11 docs (news 11)

## Verification
- npm run lint
- npm run typecheck:web
- npm run typecheck:fomo-web
- npm run build:web
- npm run build:fomo-web
- npm test -- apps/web/__tests__/lib/theme-understanding-naver-code.test.ts scripts/__tests__/discovery-regression-gate.test.ts
- npm run guard:discovery (cards: 50, front band: 16, passed)

## Notes
- Schedule/D-day remains data-gated; this PR does not create fake schedule catalysts.
