### PR TITLE
feat(discovery): US market via market-source adapter (KIS/TwelveData, SEC EDGAR) reusing rank/news/depth/time stack

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -343,6 +343,10 @@ export interface StockContext {
   frontSeed?: StockFrontResponse | undefined;
   /** 발견 공급 엔진이 가진 네이버 종목 코드. STOCK_VOCAB 미등록 발견주 기본지표 조회용. */
   naverCode?: string | undefined;
+  /** US/글로벌 종목 심볼. */
+  symbol?: string | undefined;
+  market?: string | undefined;
+  country?: string | undefined;
 }
 
 function hasUsableFront(front: StockFrontResponse | null | undefined): front is StockFrontResponse {
@@ -973,14 +977,19 @@ export function StockInsightView({
       .then((r) => alive && setBasics(r))
       .catch(() => alive && setBasics(null))
       .finally(() => alive && setBasicsLoaded(true));
-    fetchStockInsight(stock, context?.naverCode ? { naverCode: context.naverCode } : {})
+    fetchStockInsight(stock, {
+      ...(context?.naverCode ? { naverCode: context.naverCode } : {}),
+      ...(context?.symbol ? { symbol: context.symbol } : {}),
+      ...(context?.market ? { market: context.market } : {}),
+      ...(context?.country ? { country: context.country } : {}),
+    })
       .then((r) => alive && setInsight(r))
       .catch(() => alive && setInsight(null))
       .finally(() => alive && setLoading(false));
     return () => {
       alive = false;
     };
-  }, [stock, context?.frontSeed, context?.naverCode]);
+  }, [stock, context?.frontSeed, context?.naverCode, context?.symbol, context?.market, context?.country]);
 
   const hasInsight =
     !!insight && insight.confidence !== "insufficient" && insight.bull.length + insight.bear.length > 0;

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -555,7 +555,7 @@ export function StockSwipeDeck({
         changeDir={e?.changeDir}
         rankLabel={rankLabelFor(stock)}
         sparkline={e?.sparkline}
-        chartSupported={!!stock.naverCode && (e?.sparkline?.length ?? 0) >= 2}
+        chartSupported={(e?.sparkline?.length ?? 0) >= 2}
         subLine={deduped.subLine}
         feedBull={deduped.feedBull}
         feedBear={deduped.feedBear}
@@ -859,6 +859,9 @@ export function StockSwipeDeck({
             fromTheme: selected.sector,
             reason: whyFor(selected),
             ...(selected.naverCode ? { naverCode: selected.naverCode } : {}),
+            ...(selected.symbol ? { symbol: selected.symbol } : {}),
+            market: selected.market,
+            country: selected.country,
             ...(front[selected.canonical] ? { frontSeed: front[selected.canonical] as StockFrontResponse } : {}),
             ...(axisHeadlineFor(selected) ? { axisHeadline: axisHeadlineFor(selected) } : {}),
           }}

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
-import { DISCOVERY_UPDATED_EVENT, fetchDiscovery, type DiscoveryResponse } from "@/lib/fomoApi";
+import { DISCOVERY_UPDATED_EVENT, fetchDiscovery, type DiscoveryCountryScope, type DiscoveryResponse } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import { MIN_DISCOVERY_STOCKS, type DeckStock } from "@/lib/discoveryDeck";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
@@ -36,6 +36,7 @@ function DiscoveryEmpty({ onRetry }: { onRetry: () => void }) {
 }
 
 export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryDeckProps) {
+  const [country, setCountry] = useState<DiscoveryCountryScope>("KR");
   const [retryKey, setRetryKey] = useState(0);
   const [state, setState] = useState<
     | { kind: "loading" }
@@ -64,7 +65,7 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
       let lastError: unknown = null;
       for (let attempt = 0; attempt <= INITIAL_RETRY_DELAYS_MS.length; attempt += 1) {
         try {
-          const discovery = await fetchDiscovery();
+          const discovery = await fetchDiscovery(country);
           if (!alive) return;
           applyDiscovery(discovery);
           return;
@@ -85,7 +86,7 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
       alive = false;
       window.removeEventListener(DISCOVERY_UPDATED_EVENT, onDiscoveryUpdated);
     };
-  }, [retryKey]);
+  }, [country, retryKey]);
 
   useEffect(() => {
     if (state.kind !== "error") return;
@@ -93,18 +94,58 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
     return () => window.clearTimeout(retry);
   }, [state.kind]);
 
+  const scopeTabs = (
+    <div className="mb-4 flex gap-2 px-1" role="tablist" aria-label="시장 선택">
+      {[
+        ["KR", "국내"],
+        ["US", "미국"],
+      ].map(([value, label]) => {
+        const active = country === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => setCountry(value as DiscoveryCountryScope)}
+            className={`rounded-full border px-4 py-2 text-sm font-semibold transition-colors ${
+              active ? "border-whiteout bg-whiteout text-canvas" : "border-hairline text-muted hover:text-whiteout"
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+
   if (state.kind === "loading") {
-    return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
+    return (
+      <>
+        {scopeTabs}
+        <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />
+      </>
+    );
   }
-  if (state.kind === "error") return <DiscoveryEmpty onRetry={() => setRetryKey((value) => value + 1)} />;
+  if (state.kind === "error") {
+    return (
+      <>
+        {scopeTabs}
+        <DiscoveryEmpty onRetry={() => setRetryKey((value) => value + 1)} />
+      </>
+    );
+  }
 
   return (
-    <StockSwipeDeck
-      stocks={state.stocks.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.stocks.length))}
-      initialFronts={state.fronts}
-      contextLabel="오늘의 발견"
-      loggedIn={loggedIn}
-      onRequireLogin={onRequireLogin}
-    />
+    <>
+      {scopeTabs}
+      <StockSwipeDeck
+        stocks={state.stocks.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.stocks.length))}
+        initialFronts={state.fronts}
+        contextLabel={country === "US" ? "미국 발견" : "오늘의 발견"}
+        loggedIn={loggedIn}
+        onRequireLogin={onRequireLogin}
+      />
+    </>
   );
 }

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -30,6 +30,7 @@ export const DISCOVERY_MIX = {
 export type DeckStock = Omit<SectorStock, "sector"> & {
   reason?: string;
   whyShown?: string;
+  symbol?: string;
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;
   sector: string;

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -39,7 +39,11 @@ const INDEX_REVALIDATE_TIMEOUT_MS = 8_000;
 const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 11_500;
 const DISCOVERY_BACKEND_TIMEOUT_MS = 18_000;
 const DISCOVERY_REVALIDATE_TIMEOUT_MS = 24_000;
-const DISCOVERY_FAST_PATH = "/api/fomo/discovery?fast=1";
+export type DiscoveryCountryScope = "KR" | "US" | "all";
+
+function discoveryFastPath(country: DiscoveryCountryScope = "KR"): string {
+  return `/api/fomo/discovery?fast=1&country=${encodeURIComponent(country)}`;
+}
 
 function kstDateKey(now = new Date()): string {
   return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
@@ -344,12 +348,12 @@ export const fetchThemeInsight = (theme: string) =>
   );
 
 /** 개별 종목 이해·응축(작업3) — 종목 라벨 탭 시 lazy 로 부른다(테마 뎁스와 동일 구조). */
-export const fetchStockInsight = (stock: string, opts: { naverCode?: string; market?: string; country?: string } = {}) =>
+export const fetchStockInsight = (stock: string, opts: { naverCode?: string; market?: string; country?: string; symbol?: string } = {}) =>
   cachedGet(
-    `stock-insight:${opts.naverCode ?? "name"}:${stock}`,
+    `stock-insight:${opts.country ?? "KR"}:${opts.naverCode ?? opts.symbol ?? "name"}:${stock}`,
     () =>
       get<import("@fomo/core").CondensedInsight>(
-        `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}${opts.naverCode ? `&code=${encodeURIComponent(opts.naverCode)}` : ""}${opts.market ? `&market=${encodeURIComponent(opts.market)}` : ""}${opts.country ? `&country=${encodeURIComponent(opts.country)}` : ""}`
+        `/api/fomo/stock-insight?stock=${encodeURIComponent(stock)}${opts.naverCode ? `&code=${encodeURIComponent(opts.naverCode)}` : ""}${opts.symbol ? `&symbol=${encodeURIComponent(opts.symbol)}` : ""}${opts.market ? `&market=${encodeURIComponent(opts.market)}` : ""}${opts.country ? `&country=${encodeURIComponent(opts.country)}` : ""}`
       ),
     CACHE_TTL.stockInsight
   );
@@ -404,6 +408,7 @@ export interface DiscoveryStockResponse {
   market: import("@fomo/core").StockMarket;
   country: import("@fomo/core").StockCountry;
   naverCode?: string;
+  symbol?: string;
   marquee: boolean;
   sector: string;
   whyShown?: string;
@@ -418,9 +423,10 @@ export interface DiscoveryResponse {
   source: string;
 }
 
-const discoveryKey = () => `discovery:today:v3:${kstDateKey()}`;
-const discoveryStorageKey = () => `fomo:discovery:${kstDateKey()}`;
+const discoveryKey = (country: DiscoveryCountryScope = "KR") => `discovery:today:v4:${country}:${kstDateKey()}`;
+const discoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `fomo:discovery:${country}:${kstDateKey()}`;
 const LAST_DISCOVERY_STORAGE_KEY = "fomo:discovery:last-good";
+const lastDiscoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `${LAST_DISCOVERY_STORAGE_KEY}:${country}`;
 
 function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
   const candidate = value as Partial<DiscoveryResponse> | null;
@@ -431,16 +437,16 @@ function hasDiscoveryCards(value: DiscoveryResponse | null | undefined): value i
   return !!value && isDiscoveryResponse(value) && value.stocks.length > 0;
 }
 
-function readStoredDiscovery(): DiscoveryResponse | null {
+function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryResponse | null {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(discoveryStorageKey()) ?? window.localStorage.getItem(LAST_DISCOVERY_STORAGE_KEY);
+    const raw = window.localStorage.getItem(discoveryStorageKey(country)) ?? window.localStorage.getItem(lastDiscoveryStorageKey(country));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     const discovery = isDiscoveryResponse(parsed) ? parsed : null;
     if (hasDiscoveryCards(discovery)) return discovery;
-    window.localStorage.removeItem(discoveryStorageKey());
-    window.localStorage.removeItem(LAST_DISCOVERY_STORAGE_KEY);
+    window.localStorage.removeItem(discoveryStorageKey(country));
+    window.localStorage.removeItem(lastDiscoveryStorageKey(country));
     return null;
   } catch (err) {
     console.warn("[fetchDiscovery] localStorage read failed", err);
@@ -448,12 +454,12 @@ function readStoredDiscovery(): DiscoveryResponse | null {
   }
 }
 
-function writeStoredDiscovery(value: DiscoveryResponse): void {
+function writeStoredDiscovery(value: DiscoveryResponse, country: DiscoveryCountryScope = "KR"): void {
   if (typeof window === "undefined") return;
   if (!hasDiscoveryCards(value)) return;
   try {
-    window.localStorage.setItem(discoveryStorageKey(), JSON.stringify(value));
-    window.localStorage.setItem(LAST_DISCOVERY_STORAGE_KEY, JSON.stringify(value));
+    window.localStorage.setItem(discoveryStorageKey(country), JSON.stringify(value));
+    window.localStorage.setItem(lastDiscoveryStorageKey(country), JSON.stringify(value));
   } catch (err) {
     console.warn("[fetchDiscovery] localStorage write failed", err);
   }
@@ -465,18 +471,21 @@ function emitDiscoveryUpdated(value: DiscoveryResponse): void {
 }
 
 async function fetchDiscoveryNetwork({
+  country = "KR",
   sameOriginTimeoutMs = DISCOVERY_SAME_ORIGIN_TIMEOUT_MS,
   backendTimeoutMs = DISCOVERY_BACKEND_TIMEOUT_MS,
 }: {
+  country?: DiscoveryCountryScope;
   sameOriginTimeoutMs?: number;
   backendTimeoutMs?: number;
 } = {}): Promise<DiscoveryResponse> {
+  const path = discoveryFastPath(country);
   try {
     return await fetchJsonWithTimeout<DiscoveryResponse>(
-      DISCOVERY_FAST_PATH,
+      path,
       { cache: "no-store", credentials: "same-origin" },
       sameOriginTimeoutMs,
-      `GET ${DISCOVERY_FAST_PATH}`
+      `GET ${path}`
     );
   } catch (err) {
     if (process.env.NODE_ENV !== "production") {
@@ -488,10 +497,10 @@ async function fetchDiscoveryNetwork({
   for (const origin of backendOrigins()) {
     try {
       return await fetchJsonWithTimeout<DiscoveryResponse>(
-        `${origin}${DISCOVERY_FAST_PATH}`,
+        `${origin}${path}`,
         { cache: "no-store" },
         backendTimeoutMs,
-        `GET ${origin}${DISCOVERY_FAST_PATH}`
+        `GET ${origin}${path}`
       );
     } catch (err) {
       lastError = err;
@@ -500,20 +509,21 @@ async function fetchDiscoveryNetwork({
   throw lastError instanceof Error ? lastError : new Error("GET /api/fomo/discovery failed");
 }
 
-export const getCachedDiscovery = () => readCached<DiscoveryResponse>(discoveryKey());
+export const getCachedDiscovery = (country: DiscoveryCountryScope = "KR") => readCached<DiscoveryResponse>(discoveryKey(country));
 
-export async function fetchDiscovery(): Promise<DiscoveryResponse> {
-  const key = discoveryKey();
+export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Promise<DiscoveryResponse> {
+  const key = discoveryKey(country);
   const cached = readCached<DiscoveryResponse>(key);
   if (hasDiscoveryCards(cached)) return cached;
 
-  const stored = readStoredDiscovery();
+  const stored = readStoredDiscovery(country);
   if (stored) {
     setCached(key, stored, CACHE_TTL.stockFront);
     void refreshCached(
       key,
       () =>
         fetchDiscoveryNetwork({
+          country,
           sameOriginTimeoutMs: DISCOVERY_SAME_ORIGIN_TIMEOUT_MS,
           backendTimeoutMs: DISCOVERY_REVALIDATE_TIMEOUT_MS,
         }),
@@ -521,7 +531,7 @@ export async function fetchDiscovery(): Promise<DiscoveryResponse> {
     )
       .then((fresh) => {
         if (!hasDiscoveryCards(fresh)) return;
-        writeStoredDiscovery(fresh);
+        writeStoredDiscovery(fresh, country);
         emitDiscoveryUpdated(fresh);
       })
       .catch((err) => {
@@ -532,13 +542,13 @@ export async function fetchDiscovery(): Promise<DiscoveryResponse> {
     return stored;
   }
 
-  const fresh = await fetchDiscoveryNetwork();
+  const fresh = await fetchDiscoveryNetwork({ country });
   if (hasDiscoveryCards(fresh)) setCached(key, fresh, CACHE_TTL.stockFront);
-  writeStoredDiscovery(fresh);
+  writeStoredDiscovery(fresh, country);
   return fresh;
 }
 
-export const warmDiscovery = () => fetchDiscovery();
+export const warmDiscovery = (country: DiscoveryCountryScope = "KR") => fetchDiscovery(country);
 
 export interface AxisSnapshotEntry {
   axisSignals: import("@fomo/core").AxisSignal[];

--- a/apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
+++ b/apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
@@ -2,16 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   fetchNaverStockNews: vi.fn(),
+  fetchYahooStockNews: vi.fn(),
   fetchNaverCompanyResearch: vi.fn(),
   fetchAllNews: vi.fn(),
   fetchDcStockTitles: vi.fn(),
   fetchNaverBoardPosts: vi.fn(),
   fetchSubredditPosts: vi.fn(),
   fetchDartDisclosuresForCode: vi.fn(),
+  fetchRecentSecFilings: vi.fn(),
 }));
 
 vi.mock("../../lib/fomo-news-sources", () => ({
   fetchNaverStockNews: mocks.fetchNaverStockNews,
+  fetchYahooStockNews: mocks.fetchYahooStockNews,
   fetchNaverCompanyResearch: mocks.fetchNaverCompanyResearch,
   fetchAllNews: mocks.fetchAllNews,
 }));
@@ -22,6 +25,10 @@ vi.mock("../../lib/dcinside", () => ({
 
 vi.mock("../../lib/dart-disclosures", () => ({
   fetchDartDisclosuresForCode: mocks.fetchDartDisclosuresForCode,
+}));
+
+vi.mock("../../lib/sec-edgar", () => ({
+  fetchRecentSecFilings: mocks.fetchRecentSecFilings,
 }));
 
 vi.mock("@fomo/core", async (importActual) => {
@@ -66,6 +73,8 @@ describe("collectStockDocs naverCode threading", () => {
     mocks.fetchAllNews.mockResolvedValue([]);
     mocks.fetchDcStockTitles.mockResolvedValue([]);
     mocks.fetchSubredditPosts.mockResolvedValue([]);
+    mocks.fetchYahooStockNews.mockResolvedValue([]);
+    mocks.fetchRecentSecFilings.mockResolvedValue([]);
   });
 
   it("uses supplied naverCode for per-ticker sources even when the stock is not in STOCK_VOCAB", async () => {
@@ -81,5 +90,33 @@ describe("collectStockDocs naverCode threading", () => {
     expect(docs.some((doc) => doc.kind === "community" && doc.source === "네이버 종토방 테스트무명")).toBe(true);
     expect(docs.some((doc) => doc.kind === "official" && doc.source === "DART 공시")).toBe(true);
   });
-});
 
+  it("uses supplied US symbol for per-ticker news and SEC filings", async () => {
+    mocks.fetchYahooStockNews.mockResolvedValue([
+      {
+        title: "Nvidia files 8-K after new data center contract",
+        summary: "Nvidia update",
+        source: "Yahoo Finance",
+        publishedAt: "2026-06-27T00:00:00.000Z",
+        tier: "news-mid",
+      },
+    ]);
+    mocks.fetchRecentSecFilings.mockResolvedValue([
+      {
+        symbol: "NVDA",
+        label: "8-K 공시가 확인됐어요.",
+        source: "SEC EDGAR",
+        asOf: "2026-06-27",
+        url: "https://www.sec.gov/test",
+      },
+    ]);
+
+    const { collectStockDocs } = await import("../../lib/theme-understanding");
+    const docs = await collectStockDocs("엔비디아", { symbol: "NVDA", country: "US", market: "NASDAQ" });
+
+    expect(mocks.fetchYahooStockNews).toHaveBeenCalledWith("NVDA", expect.any(Number));
+    expect(mocks.fetchRecentSecFilings).toHaveBeenCalledWith("NVDA", 4);
+    expect(docs.some((doc) => doc.kind === "news" && doc.source === "Yahoo Finance")).toBe(true);
+    expect(docs.some((doc) => doc.kind === "official" && doc.source === "SEC EDGAR")).toBe(true);
+  });
+});

--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("US market source", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed when Twelve Data key is absent", async () => {
+    vi.stubEnv("TWELVE_DATA_API_KEY", "");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { fetchUsMarketRows } = await import("../../lib/us-market-source");
+
+    await expect(fetchUsMarketRows()).resolves.toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not wire Yahoo chart endpoints into the US quote adapter", () => {
+    const source = readFileSync(fileURLToPath(new URL("../../lib/us-market-source.ts", import.meta.url)), "utf8");
+    expect(source).not.toMatch(/query[12]\.finance\.yahoo\.com|chart\/|finance\.yahoo\.com\/v8/i);
+  });
+});

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -2,11 +2,16 @@ import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { buildDiscoveryResponse, type DiscoveryResponse } from "../../../../lib/discovery-supply";
+import type { DiscoveryCountryScope } from "../../../../lib/market-source-types";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
 
 const REVALIDATE_S = 600;
+
+function discoveryCountry(value: string | null): DiscoveryCountryScope {
+  return value === "US" || value === "all" ? value : "KR";
+}
 
 export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
@@ -16,9 +21,10 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const fast = url.searchParams.get("fast") === "1";
+    const country = discoveryCountry(url.searchParams.get("country"));
     const load = unstable_cache(
-      async () => buildDiscoveryResponse({ targetedMaterial: !fast }),
-      ["fomo-discovery", cacheVersion(), kstDate(), fast ? "fast" : "full"],
+      async () => buildDiscoveryResponse({ targetedMaterial: !fast, country }),
+      ["fomo-discovery", cacheVersion(), kstDate(), country, fast ? "fast" : "full"],
       { revalidate: REVALIDATE_S }
     );
     return withCors(

--- a/apps/web/app/api/fomo/stock-insight/route.ts
+++ b/apps/web/app/api/fomo/stock-insight/route.ts
@@ -30,16 +30,16 @@ function validNaverCode(code: string | null | undefined): string | undefined {
   return c && /^\d{6}$/.test(c) ? c : undefined;
 }
 
-async function getInsight(stock: string, opts: { naverCode?: string; market?: string; country?: string } = {}): Promise<CondensedInsight> {
+async function getInsight(stock: string, opts: { naverCode?: string; market?: string; country?: string; symbol?: string } = {}): Promise<CondensedInsight> {
   const today = kstDate();
   const slot = kstSlot();
-  const key = `${today}:${slot}:${stock}:${opts.naverCode ?? ""}`;
+  const key = `${today}:${slot}:${stock}:${opts.naverCode ?? opts.symbol ?? ""}:${opts.country ?? ""}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
     async () => condenseThemeInsight(await understandStock(stock, opts)),
-    ["fomo-stock-insight", cacheVersion(), today, slot, stock, opts.naverCode ?? ""],
+    ["fomo-stock-insight", cacheVersion(), today, slot, stock, opts.naverCode ?? opts.symbol ?? "", opts.country ?? ""],
     { revalidate: REVALIDATE_S }
   );
 
@@ -55,7 +55,7 @@ function timeoutFallback(stock: string): CondensedInsight {
 async function getInsightForRequest(
   stock: string,
   blocking: boolean,
-  opts: { naverCode?: string; market?: string; country?: string } = {}
+  opts: { naverCode?: string; market?: string; country?: string; symbol?: string } = {}
 ): Promise<{ payload: CondensedInsight; coldFallback: boolean }> {
   if (blocking) return { payload: await getInsight(stock, opts), coldFallback: false };
 
@@ -87,11 +87,13 @@ export async function GET(req: Request) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
   const naverCode = validNaverCode(url.searchParams.get("code")) ?? validNaverCode(url.searchParams.get("naverCode"));
+  const symbol = url.searchParams.get("symbol")?.trim().toUpperCase() || undefined;
   const market = url.searchParams.get("market")?.trim() || undefined;
   const country = url.searchParams.get("country")?.trim() || undefined;
   const blocking = url.searchParams.get("blocking") === "1" || req.headers.get("x-warm") === "1";
   const { payload, coldFallback } = await getInsightForRequest(stock, blocking, {
     ...(naverCode ? { naverCode } : {}),
+    ...(symbol ? { symbol } : {}),
     ...(market ? { market } : {}),
     ...(country ? { country } : {}),
   });

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -30,10 +30,13 @@ import {
   type RawArticle,
 } from "@fomo/core";
 import { fetchDartDisclosuresByStock, type DartDisclosureHit } from "./dart-disclosures";
-import { fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
+import { fetchNaverCompanyResearch, fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
+import type { DiscoveryCountryScope, DiscoveryMarketRow } from "./market-source-types";
+import { fetchRecentSecFilings } from "./sec-edgar";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
+import { fetchUsMarketRows } from "./us-market-source";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -55,8 +58,8 @@ const MATERIAL_NEWS_NOISE =
 const MATERIAL_NEWS_CATALYST =
   /공시|계약|공급계약|수주|납품|실적|매출|영업이익|순이익|가이던스|전망치|컨센서스|어닝|흑자|적자|턴어라운드|임상|허가|승인|FDA|품목허가|신약|치료제|기술이전|라이선스|증설|공장|양산|수율|수주잔고|M&A|인수|합병|지분|투자|유상증자|무상증자|자사주|배당|분할|상장|정부|정책|규제|지원|보조금|관세|제재|신제품|출시|개발|특허|공급|독점|선정|채택|수출|수입|국책|프로젝트|수혜/i;
 const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_DEFAULT_ENABLED
-  ? "네이버 시세·종목뉴스·리서치·DART 공시·수급 캐시"
-  : "네이버 시세·뉴스 언급";
+  ? "네이버/KR 시세·DART·수급 캐시·Twelve Data/US 시세·SEC"
+  : "시장 시세·공시·수급 캐시";
 const MARKET_LABELS = new Set(["KOSPI", "KOSDAQ", "NASDAQ", "NYSE"]);
 const INDUSTRY_HINTS: Array<{ label: string; pattern: RegExp }> = [
   { label: "유통", pattern: /유통|백화점|신세계|광주신세계|대형마트|편의점/i },
@@ -96,6 +99,7 @@ export interface DiscoveryFrontSeed {
 
 export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
   sector: string;
+  symbol?: string;
   whyShown?: string;
   reason?: string;
 }
@@ -110,18 +114,7 @@ export interface DiscoveryResponse {
 
 export interface BuildDiscoveryResponseOptions {
   targetedMaterial?: boolean;
-}
-
-interface NaverMarketRow {
-  canonical: string;
-  naverCode: string;
-  market: DiscoveryMarket;
-  marketCapRank?: number;
-  priceText?: string;
-  changeText?: string;
-  changeDir?: "up" | "down" | "flat";
-  changePct?: number;
-  tradingValue?: number;
+  country?: DiscoveryCountryScope;
 }
 
 interface RawNaverStock {
@@ -170,7 +163,7 @@ function signedChangeText(row: RawNaverStock, dir: "up" | "down" | "flat", pct: 
   return change && pctText ? `${prefix}${change} (${pctText})` : pctText;
 }
 
-function parseMarketRow(row: RawNaverStock, market: DiscoveryMarket): NaverMarketRow | null {
+function parseMarketRow(row: RawNaverStock, market: DiscoveryMarket): DiscoveryMarketRow | null {
   const canonical = (row.stockName ?? row.itemName ?? "").trim();
   const naverCode = row.itemCode?.trim();
   if (!canonical || !naverCode) return null;
@@ -182,8 +175,11 @@ function parseMarketRow(row: RawNaverStock, market: DiscoveryMarket): NaverMarke
   const tradingValue = numberFromText(row.accumulatedTradingValue);
   return {
     canonical,
+    symbol: naverCode,
     naverCode,
     market,
+    country: "KR",
+    currency: "KRW",
     ...(row.closePrice ? { priceText: `${row.closePrice.replace(/원$/, "")}원` } : {}),
     ...(changeText ? { changeText } : {}),
     changeDir: dir,
@@ -192,27 +188,34 @@ function parseMarketRow(row: RawNaverStock, market: DiscoveryMarket): NaverMarke
   };
 }
 
-async function fetchMarketPage(market: DiscoveryMarket, page: number): Promise<NaverMarketRow[]> {
+async function fetchMarketPage(market: DiscoveryMarket, page: number): Promise<DiscoveryMarketRow[]> {
   const url = `https://m.stock.naver.com/api/stocks/marketValue/${market}?page=${page}&pageSize=${PAGE_SIZE}`;
   const res = await fetch(url, { headers: UA, signal: AbortSignal.timeout(8000) });
   if (!res.ok) throw new Error(`naver market ${market} ${page} ${res.status}`);
   const data = (await res.json()) as { stocks?: RawNaverStock[] };
-  return (data.stocks ?? []).map((row) => parseMarketRow(row, market)).filter((row): row is NaverMarketRow => row !== null);
+  return (data.stocks ?? []).map((row) => parseMarketRow(row, market)).filter((row): row is DiscoveryMarketRow => row !== null);
 }
 
-async function fetchMarketRows(): Promise<NaverMarketRow[]> {
+async function fetchKrMarketRows(): Promise<DiscoveryMarketRow[]> {
   const settled = await Promise.allSettled(
     MARKETS.flatMap((market) => Array.from({ length: PAGES_PER_MARKET }, (_, i) => fetchMarketPage(market, i + 1)))
   );
   const rows = settled.flatMap((row) => (row.status === "fulfilled" ? row.value : []));
-  const byCode = new Map<string, NaverMarketRow>();
-  for (const row of rows) if (!byCode.has(row.naverCode)) byCode.set(row.naverCode, row);
+  const byCode = new Map<string, DiscoveryMarketRow>();
+  for (const row of rows) if (row.naverCode && !byCode.has(row.naverCode)) byCode.set(row.naverCode, row);
   const rankByMarket = new Map<DiscoveryMarket, number>();
   return [...byCode.values()].map((row) => {
     const rank = (rankByMarket.get(row.market) ?? 0) + 1;
     rankByMarket.set(row.market, rank);
     return { ...row, marketCapRank: rank };
   });
+}
+
+async function fetchMarketRows(scope: DiscoveryCountryScope): Promise<DiscoveryMarketRow[]> {
+  const sources: Array<Promise<DiscoveryMarketRow[]>> =
+    scope === "US" ? [fetchUsMarketRows()] : scope === "all" ? [fetchKrMarketRows(), fetchUsMarketRows()] : [fetchKrMarketRows()];
+  const settled = await Promise.allSettled(sources);
+  return settled.flatMap((result) => (result.status === "fulfilled" ? result.value : []));
 }
 
 async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<PromiseSettledResult<R>[]> {
@@ -233,7 +236,7 @@ async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) 
   return out;
 }
 
-function eventFromPrice(row: NaverMarketRow, asOf: string): DiscoveryEvent | null {
+function eventFromPrice(row: DiscoveryMarketRow, asOf: string): DiscoveryEvent | null {
   if (typeof row.changePct !== "number" || Math.abs(row.changePct) < 5) return null;
   return {
     kind: "price_move",
@@ -283,8 +286,51 @@ function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallb
   };
 }
 
-async function eventFromTargetedMaterial(row: NaverMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
-  if (!/^\d{6}$/.test(row.naverCode)) return null;
+function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
+  const cleaned = decodeHtmlEntities(article.title)
+    .replace(/[“”"]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?。]+$/g, "")
+    .trim();
+  if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned)) return null;
+  const label = cleaned.length > 54 ? `${cleaned.slice(0, 52).replace(/\s+\S*$/, "").trim()}…` : cleaned;
+  if (!isFrontHookSafe(`오늘 이 종목을 직접 언급한 외신이 있어요: ${label}`)) return null;
+  return {
+    kind: "news_mention",
+    firstSeen: true,
+    strength: 0.82,
+    source: article.source || sourceFallback,
+    asOf: article.publishedAt?.slice(0, 10) || asOf,
+    confidence: "M",
+    label,
+  };
+}
+
+async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
+  if (row.country !== "KR") {
+    const [filingResult, newsResult] = await Promise.allSettled([
+      fetchRecentSecFilings(row.symbol, 2),
+      fetchYahooStockNews(row.symbol, 6),
+    ]);
+    const filing = filingResult.status === "fulfilled" ? filingResult.value[0] : undefined;
+    if (filing) {
+      return {
+        kind: "disclosure",
+        firstSeen: true,
+        strength: 0.92,
+        source: filing.source,
+        asOf: filing.asOf,
+        confidence: "H",
+        label: filing.label,
+      };
+    }
+    const stockNews =
+      newsResult.status === "fulfilled"
+        ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article))
+        : undefined;
+    return stockNews ? materialEventFromUsArticle(stockNews, asOf, "Yahoo Finance") : null;
+  }
+  if (!row.naverCode || !/^\d{6}$/.test(row.naverCode)) return null;
   const [newsResult, researchResult] = await Promise.allSettled([
     fetchNaverStockNews(row.naverCode, 8),
     fetchNaverCompanyResearch(row.naverCode, row.canonical, 4),
@@ -305,7 +351,7 @@ async function eventFromTargetedMaterial(row: NaverMarketRow, asOf: string): Pro
   return null;
 }
 
-function buildThemeMoveSignals(rows: readonly NaverMarketRow[]): Map<string, ThemeMoveSignal> {
+function buildThemeMoveSignals(rows: readonly DiscoveryMarketRow[]): Map<string, ThemeMoveSignal> {
   const groups = new Map<StockSector, Array<{ ticker: string; changePct: number }>>();
   for (const row of rows) {
     const sector = sectorOf(row.canonical);
@@ -335,7 +381,7 @@ function buildThemeMoveSignals(rows: readonly NaverMarketRow[]): Map<string, The
   return out;
 }
 
-function eventFromTheme(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
+function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
   if (!theme || typeof row.changePct !== "number") return null;
   const strongTheme = theme.averageChangePct >= 1.5 && theme.positiveCount >= 2;
   const leadingTheme = theme.rank <= 3 && row.changePct >= 5;
@@ -370,12 +416,12 @@ function industryHintForTicker(ticker: string): string | undefined {
   return undefined;
 }
 
-function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent {
+function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent {
   const sector = theme?.sector ?? sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
   const rankText = row.marketCapRank ? `시총 ${row.marketCapRank}위권` : "시총 상위권";
   const changePct = row.changePct;
   const change = typeof changePct === "number" ? pctText(changePct) : undefined;
-  const source = "네이버 시세";
+  const source = row.country === "KR" ? "네이버 시세" : "Twelve Data 시세";
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
@@ -412,7 +458,7 @@ function eventFromMarketContext(row: NaverMarketRow, theme: ThemeMoveSignal | un
       source,
       asOf,
       confidence: "M",
-      label: `${row.market === "KOSDAQ" ? "코스닥" : "코스피"} ${rankText}에서 새로 확인하는 종목이에요.`,
+      label: `${row.market} ${rankText}에서 새로 확인하는 종목이에요.`,
     };
   }
   return {
@@ -442,6 +488,40 @@ function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent 
     confidence: "H",
     label: `${actor} ${n}일째 사는 중이에요.`,
   };
+}
+
+function addStaticRecoveryRows(byTicker: Map<string, { row: DiscoveryMarketRow; events: DiscoveryEvent[] }>, asOf: string): void {
+  let added = 0;
+  for (const def of STOCK_VOCAB) {
+    if (added >= 16) return;
+    if (def.country !== "KR" || !def.naverCode || byTicker.has(def.canonical)) continue;
+    const sector = sectorOf(def.canonical) ?? industryHintForTicker(def.canonical);
+    if (!sector) continue;
+    byTicker.set(def.canonical, {
+      row: {
+        canonical: def.canonical,
+        symbol: def.naverCode,
+        naverCode: def.naverCode,
+        market: def.market as DiscoveryMarket,
+        country: "KR",
+        currency: "KRW",
+        marketCapRank: 999,
+      },
+      events: [
+        {
+          kind: "market_context",
+          firstSeen: false,
+          strength: 0.28,
+          source: "FOMO 종목 사전",
+          asOf,
+          confidence: "L",
+          direction: "flat",
+          label: `${sector} 흐름에서 함께 확인할 종목이에요.`,
+        },
+      ],
+    });
+    added += 1;
+  }
 }
 
 function cleanSectorLabel(label: string | undefined): string | undefined {
@@ -503,7 +583,7 @@ function eventAxisSignal(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
   };
 }
 
-function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): DiscoveryStockPayload {
+function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): DiscoveryStockPayload {
   const def = resolveStock(candidate.ticker);
   const sector = cleanSectorLabel(candidate.sector) ?? (def ? sectorOf(def.canonical) : undefined);
   const why = discoveryWhy(candidate);
@@ -513,8 +593,9 @@ function stockPayload(row: NaverMarketRow, candidate: DiscoveryCandidate): Disco
   return {
     canonical: candidate.ticker,
     market: row.market,
-    country: def?.country ?? "KR",
-    naverCode: row.naverCode,
+    country: row.country,
+    ...(row.naverCode ? { naverCode: row.naverCode } : {}),
+    symbol: row.symbol,
     marquee: def?.marquee === true,
     sector: sector ?? inferDiscoverySectorLabel(candidate.ticker, candidate.events, undefined, candidate.asOf),
     whyShown: hasDisplayWhy
@@ -528,13 +609,13 @@ function isSameDayEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): b
   return event.asOf.slice(0, 10) === candidate.asOf.slice(0, 10);
 }
 
-function fallbackContextEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
+function fallbackContextEvent(candidate: DiscoveryCandidate, allowDown = false): DiscoveryEvent | undefined {
   return candidate.events
     .filter((event) => {
-      if (!isSameDayEvent(event, candidate) || event.direction === "down") return false;
+      if (!isSameDayEvent(event, candidate) || (!allowDown && event.direction === "down")) return false;
       if (event.kind === "price_move") return false;
       if (event.kind !== "market_context") return true;
-      return !!event.label && !/^KOSPI |^KOSDAQ /.test(event.label);
+      return !!event.label && !/^KOSPI |^KOSDAQ |^NASDAQ |^NYSE /.test(event.label);
     })
     .sort((a, b) => {
       const aTheme = a.kind === "theme_link" ? 1 : 0;
@@ -552,7 +633,7 @@ function fallbackDiscoveryReason(candidate: DiscoveryCandidate): string {
 
 function fallbackContextQuality(event: DiscoveryEvent): number {
   if (event.kind === "theme_link") return 2;
-  if (event.kind === "market_context" && event.label && !/^코스피 |^코스닥 /.test(event.label)) return 1;
+  if (event.kind === "market_context" && event.label && !/^코스피 |^코스닥 |^NASDAQ |^NYSE /.test(event.label)) return 1;
   return 0;
 }
 
@@ -561,7 +642,8 @@ export function recoverDiscoveryCandidates(
   candidates: readonly DiscoveryCandidate[],
   maxCandidates = DISCOVERY_DECK_CARD_COUNT
 ): DiscoveryCandidate[] {
-  if (ranked.length >= DISCOVERY_RECOVERY_MIN_CARDS) return ranked.slice(0, maxCandidates);
+  if (ranked.length >= maxCandidates) return ranked.slice(0, maxCandidates);
+  if (ranked.length >= DISCOVERY_RECOVERY_MIN_CARDS && candidates.length <= ranked.length) return ranked.slice(0, maxCandidates);
   const used = new Set(ranked.map((candidate) => candidate.ticker));
   const fallback = candidates
     .filter((candidate) => !used.has(candidate.ticker))
@@ -593,11 +675,32 @@ export function recoverDiscoveryCandidates(
     })
     .map((row) => row.candidate);
 
-  return [...ranked, ...fallback].slice(0, maxCandidates);
+  const usedAfterFallback = new Set([...ranked, ...fallback].map((candidate) => candidate.ticker));
+  const looseFallback = candidates
+    .filter((candidate) => !usedAfterFallback.has(candidate.ticker))
+    .filter((candidate) => fallbackContextEvent(candidate, true) !== undefined)
+    .map((candidate, index) => ({
+      candidate: {
+        ...candidate,
+        reason: candidate.reason ?? fallbackDiscoveryReason(candidate),
+      },
+      index,
+      context: fallbackContextEvent(candidate, true)!,
+    }))
+    .sort((a, b) => {
+      const aFamous = typeof a.candidate.marketCapRank === "number" && a.candidate.marketCapRank <= DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF ? 1 : 0;
+      const bFamous = typeof b.candidate.marketCapRank === "number" && b.candidate.marketCapRank <= DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF ? 1 : 0;
+      const aQuality = fallbackContextQuality(a.context);
+      const bQuality = fallbackContextQuality(b.context);
+      return aFamous - bFamous || bQuality - aQuality || b.context.strength - a.context.strength || a.index - b.index;
+    })
+    .map((row) => row.candidate);
+
+  return [...ranked, ...fallback, ...looseFallback].slice(0, maxCandidates);
 }
 
 function frontSeed(
-  row: NaverMarketRow,
+  row: DiscoveryMarketRow,
   candidate: DiscoveryCandidate,
   attention: StockAttentionSignal | undefined,
   theme: ThemeMoveSignal | undefined,
@@ -651,16 +754,17 @@ function frontSeed(
 }
 
 export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOptions = {}): Promise<DiscoveryResponse> {
+  const scope = options.country ?? "KR";
   const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
   const targetedMaterialLimit = targetedMaterialEnabled ? TARGETED_MATERIAL_CANDIDATE_LIMIT : 0;
   const asOf = todayKst();
   const [rows, attentionMap] = await Promise.all([
-    fetchMarketRows(),
+    fetchMarketRows(scope),
     computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
   ]);
   const vocabByCode = new Map(STOCK_VOCAB.filter((s) => s.naverCode).map((s) => [s.naverCode!, s]));
   const normalizedRows = rows.map((row) => {
-    const def = vocabByCode.get(row.naverCode);
+    const def = row.naverCode ? vocabByCode.get(row.naverCode) : undefined;
     return { ...row, canonical: def?.canonical ?? row.canonical };
   });
   const eligibleTickers = new Set(
@@ -672,7 +776,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     ).map((row) => row.ticker)
   );
   const themeSignals = buildThemeMoveSignals(normalizedRows);
-  const byTicker = new Map<string, { row: NaverMarketRow; events: DiscoveryEvent[] }>();
+  const byTicker = new Map<string, { row: DiscoveryMarketRow; events: DiscoveryEvent[] }>();
 
   for (const row of normalizedRows) {
     const ticker = row.canonical;
@@ -690,7 +794,14 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     if (!def?.naverCode || !eligibleTickers.has(def.canonical)) continue;
     const row =
       normalizedRows.find((r) => r.naverCode === def.naverCode) ??
-      ({ canonical: def.canonical, naverCode: def.naverCode, market: def.market as DiscoveryMarket } satisfies NaverMarketRow);
+      ({
+        canonical: def.canonical,
+        symbol: def.naverCode,
+        naverCode: def.naverCode,
+        market: def.market as DiscoveryMarket,
+        country: "KR",
+        currency: "KRW",
+      } satisfies DiscoveryMarketRow);
     const current = byTicker.get(def.canonical);
     const event: DiscoveryEvent = {
       kind: "disclosure",
@@ -728,7 +839,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   }
 
   if (DISCOVERY_FLOW_CACHE_ENABLED) {
-    const histories = await readSupplyDemandHistoryByTickers([...byTicker.keys()], 10);
+    const krTickers = [...byTicker.entries()].filter(([, value]) => value.row.country === "KR").map(([ticker]) => ticker);
+    const histories = krTickers.length > 0 ? await readSupplyDemandHistoryByTickers(krTickers, 10) : {};
     for (const [ticker, history] of Object.entries(histories)) {
       const event = eventFromFlowHistory(history);
       if (!event) continue;
@@ -737,6 +849,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       byTicker.set(ticker, { ...current, events: [...current.events, event] });
     }
   }
+
+  if (scope !== "US") addStaticRecoveryRows(byTicker, asOf);
 
   const candidates = [...byTicker.entries()].map(([ticker, { row, events }]): DiscoveryCandidate => {
     const def = resolveStock(ticker);
@@ -756,8 +870,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     return {
       ticker,
       market: row.market,
-      country: (def?.country ?? "KR") as StockCountry,
-      naverCode: row.naverCode,
+      country: row.country as StockCountry,
+      ...(row.naverCode ? { naverCode: row.naverCode } : {}),
       sector,
       events: directedEvents,
       asOf,
@@ -780,7 +894,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     SPARKLINE_CONCURRENCY,
     async (candidate) => ({
       ticker: candidate.ticker,
-      sparkline: candidate.naverCode ? (await fetchStockDaily(candidate.naverCode, 110)).closes.slice(-42) : [],
+      sparkline:
+        rowsByTicker.get(candidate.ticker)?.sparkline ??
+        (candidate.naverCode ? (await fetchStockDaily(candidate.naverCode, 110)).closes.slice(-42) : []),
     })
   );
   const sparklineByTicker = new Map(
@@ -813,6 +929,6 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     stocks,
     fronts,
     confidence: stocks.length >= DISCOVERY_DECK_CARD_COUNT ? "H" : stocks.length >= 30 ? "M" : "L",
-    source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "네이버 시세·DART 공시·수급 캐시",
+    source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "시장 시세·공시·수급 캐시",
   };
 }

--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -58,6 +58,16 @@ async function fetchYahooSymbol(symbol: string, nowIso: string): Promise<RawArti
 }
 
 /**
+ * US per-ticker news. This is Yahoo Finance RSS, not the Yahoo chart endpoint forbidden for Node.
+ * It is used as a material/news source only and fails closed to [].
+ */
+export async function fetchYahooStockNews(symbol: string, pageSize = 8): Promise<RawArticle[]> {
+  const clean = symbol.trim().toUpperCase();
+  if (!/^[A-Z.]{1,6}$/.test(clean)) return [];
+  return (await fetchYahooSymbol(clean, new Date().toISOString())).slice(0, pageSize);
+}
+
+/**
  * Yahoo Finance 뉴스 소스 — 심볼 유니버스를 병렬 수집해 합산.
  * [비활성] 피드는 한국 뉴스 우선 구성으로 전환(2026-06-12). Yahoo는 차트/지수(fomo-market-sources)
  * 용도로만 남긴다. 영문 뉴스가 다시 필요하면 NEWS_SOURCES 에 yahooSource 를 추가.

--- a/apps/web/lib/market-source-types.ts
+++ b/apps/web/lib/market-source-types.ts
@@ -1,0 +1,25 @@
+import type { DiscoveryMarket, StockCountry } from "@fomo/core";
+
+export type DiscoveryCountryScope = "KR" | "US" | "all";
+
+export interface DiscoveryMarketRow {
+  canonical: string;
+  symbol: string;
+  naverCode?: string;
+  market: DiscoveryMarket;
+  country: StockCountry;
+  marketCapRank?: number;
+  priceText?: string;
+  changeText?: string;
+  changeDir?: "up" | "down" | "flat";
+  changePct?: number;
+  tradingValue?: number;
+  currency?: "KRW" | "USD";
+  sparkline?: number[];
+}
+
+export interface MarketSource {
+  id: string;
+  country: DiscoveryCountryScope;
+  fetchMarketRows(): Promise<DiscoveryMarketRow[]>;
+}

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -1,0 +1,58 @@
+import { secCikForSymbol } from "./us-symbols";
+
+export interface SecFilingHit {
+  symbol: string;
+  label: string;
+  source: string;
+  asOf: string;
+  url?: string;
+}
+
+const SEC_ARCHIVES = "https://www.sec.gov/Archives/edgar/data";
+const SEC_SUBMISSIONS = "https://data.sec.gov/submissions";
+
+function secUserAgent(): string | undefined {
+  return process.env.SEC_EDGAR_USER_AGENT?.trim();
+}
+
+function accessionPath(cik: string, accession: string): string {
+  return `${SEC_ARCHIVES}/${String(Number(cik))}/${accession.replace(/-/g, "")}/${accession}-index.html`;
+}
+
+export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<SecFilingHit[]> {
+  const cik = secCikForSymbol(symbol);
+  const userAgent = secUserAgent();
+  if (!cik || !userAgent) return [];
+  try {
+    const res = await fetch(`${SEC_SUBMISSIONS}/CIK${cik}.json`, {
+      headers: { accept: "application/json", "user-agent": userAgent },
+      signal: AbortSignal.timeout(8_000),
+      next: { revalidate: 3_600 },
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as {
+      filings?: { recent?: { form?: string[]; filingDate?: string[]; primaryDocument?: string[]; accessionNumber?: string[] } };
+    };
+    const recent = data.filings?.recent;
+    if (!recent?.form?.length) return [];
+    const out: SecFilingHit[] = [];
+    for (let i = 0; i < recent.form.length && out.length < limit; i += 1) {
+      const form = recent.form[i];
+      if (form !== "8-K" && form !== "10-Q" && form !== "10-K") continue;
+      const asOf = recent.filingDate?.[i];
+      const accession = recent.accessionNumber?.[i];
+      if (!asOf || !accession) continue;
+      out.push({
+        symbol: symbol.toUpperCase(),
+        label: `${form} 공시가 확인됐어요.`,
+        source: "SEC EDGAR",
+        asOf,
+        url: accessionPath(cik, accession),
+      });
+    }
+    return out;
+  } catch (err) {
+    console.warn("[sec-edgar] fetch failed", symbol, (err as Error)?.message);
+    return [];
+  }
+}

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -19,10 +19,12 @@ import {
   type OfficialFact,
 } from "@fomo/core";
 import { callAI, isAiConfigured } from "@fomo/shared";
-import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews } from "./fomo-news-sources";
+import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
 import { fetchFredDocs } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
 import { fetchDartDisclosuresForCode } from "./dart-disclosures";
+import { fetchRecentSecFilings } from "./sec-edgar";
+import { usSymbolForStock } from "./us-symbols";
 
 /**
  * 이해 레이어 오케스트레이션 — DATA_ENGINE_STRATEGY §4 Track A. (네트워크 + LLM)
@@ -42,6 +44,7 @@ const MAX_COMMUNITY = 10;
 
 export interface StockUnderstandingOptions {
   naverCode?: string;
+  symbol?: string;
   market?: string;
   country?: string;
 }
@@ -222,16 +225,19 @@ function todayKst(): string {
 export async function collectStockDocs(stock: string, opts: StockUnderstandingOptions = {}): Promise<SourceDoc[]> {
   const def = stockDef(stock);
   const code = validNaverCode(opts.naverCode) ?? def?.naverCode;
+  const symbol = opts.symbol ?? usSymbolForStock(stock);
   const isForeign = def ? def.country !== "KR" : opts.country ? opts.country !== "KR" : false;
   const matches = (s: string) => {
     if (stockMatchesText(stock, s)) return true;
     return s.toLowerCase().includes(stock.trim().toLowerCase());
   };
 
-  const [stockNewsRes, researchRes, dartRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
+  const [stockNewsRes, researchRes, dartRes, usNewsRes, secRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
     code ? fetchNaverStockNews(code, MAX_NEWS) : Promise.resolve([]),
     code ? fetchNaverCompanyResearch(code, stock, 6) : Promise.resolve([]),
     code ? fetchDartDisclosuresForCode(code, stock, todayKst()) : Promise.resolve([]),
+    isForeign && symbol ? fetchYahooStockNews(symbol, MAX_NEWS) : Promise.resolve([]),
+    isForeign && symbol ? fetchRecentSecFilings(symbol, 4) : Promise.resolve([]),
     fetchAllNews(),
     fetchDcStockTitles(),
     code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
@@ -295,6 +301,32 @@ export async function collectStockDocs(stock: string, opts: StockUnderstandingOp
     }
   } else {
     console.warn("[stock-understanding] dart disclosure error", stock, dartRes.reason);
+  }
+
+  // SEC EDGAR — 미국/글로벌 종목 공식 공시. 근거 레이어로만 사용한다.
+  if (secRes.status === "fulfilled") {
+    for (const hit of secRes.value.slice(0, 4)) {
+      docs.push({
+        id: nextId(),
+        kind: "official",
+        title: hit.label,
+        body: `${hit.asOf} 접수 공시`,
+        source: hit.source,
+        ...(hit.url ? { url: hit.url } : {}),
+        publishedAt: hit.asOf,
+        tier: "official-high",
+      });
+    }
+  } else {
+    console.warn("[stock-understanding] sec disclosure error", stock, secRes.reason);
+  }
+
+  // US per-ticker 외신 — Yahoo Finance RSS(차트 API 아님), 종목 별칭이 실제 등장하는 기사만.
+  if (usNewsRes.status === "fulfilled") {
+    const hit = usNewsRes.value.filter((a) => matches(`${a.title} ${a.summary ?? ""}`)).slice(0, MAX_NEWS);
+    for (const a of hit) pushNews(a);
+  } else {
+    console.warn("[stock-understanding] us stock news error", stock, usNewsRes.reason);
   }
 
   // 뉴스 — 종목명(별칭 포함)이 제목/요약에 등장하는 기사만.

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -1,0 +1,116 @@
+import { STOCK_VOCAB, type DiscoveryMarket } from "@fomo/core";
+import type { DiscoveryMarketRow } from "./market-source-types";
+import { usStockDefs, usSymbolForStock } from "./us-symbols";
+
+const TWELVE_DATA_URL = "https://api.twelvedata.com/quote";
+const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
+
+interface TwelveQuote {
+  symbol?: string;
+  name?: string;
+  exchange?: string;
+  close?: string;
+  price?: string;
+  change?: string;
+  percent_change?: string;
+  volume?: string;
+  currency?: string;
+}
+
+function tdKey(): string | undefined {
+  return process.env.TWELVE_DATA_API_KEY?.trim();
+}
+
+function num(value: string | number | undefined): number | undefined {
+  const n = typeof value === "number" ? value : Number(String(value ?? "").replace(/,/g, ""));
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function money(value: number | undefined): string | undefined {
+  if (typeof value !== "number") return undefined;
+  return `$${value >= 100 ? value.toLocaleString("en-US", { maximumFractionDigits: 2 }) : value.toFixed(2)}`;
+}
+
+function marketFor(defMarket: string, exchange: string | undefined): DiscoveryMarket {
+  if (defMarket === "NYSE" || /NYSE/i.test(exchange ?? "")) return "NYSE";
+  return "NASDAQ";
+}
+
+function parseQuote(defCanonical: string, quote: TwelveQuote): DiscoveryMarketRow | null {
+  const symbol = (quote.symbol ?? usSymbolForStock(defCanonical) ?? "").toUpperCase();
+  if (!symbol) return null;
+  const def = STOCK_VOCAB.find((stock) => stock.canonical === defCanonical);
+  const price = num(quote.price) ?? num(quote.close);
+  const pct = num(quote.percent_change);
+  const change = num(quote.change);
+  const priceText = money(price);
+  const volume = num(quote.volume);
+  const dir = typeof pct !== "number" ? "flat" : pct > 0 ? "up" : pct < 0 ? "down" : "flat";
+  return {
+    canonical: defCanonical,
+    symbol,
+    market: marketFor(def?.market ?? "NASDAQ", quote.exchange),
+    country: def?.country ?? "US",
+    currency: "USD",
+    ...(priceText ? { priceText } : {}),
+    ...(typeof pct === "number" ? { changePct: pct } : {}),
+    ...(typeof pct === "number" || typeof change === "number"
+      ? { changeText: `${typeof change === "number" ? `${change > 0 ? "+" : ""}${change.toFixed(2)}` : ""}${typeof pct === "number" ? ` (${pct > 0 ? "+" : ""}${pct.toFixed(2)}%)` : ""}`.trim() }
+      : {}),
+    changeDir: dir,
+    ...(volume ? { tradingValue: volume } : {}),
+  };
+}
+
+function normalizeQuoteResponse(data: unknown): Record<string, TwelveQuote> {
+  if (!data || typeof data !== "object") return {};
+  const root = data as Record<string, unknown>;
+  if ("symbol" in root) {
+    const q = root as TwelveQuote;
+    return q.symbol ? { [q.symbol.toUpperCase()]: q } : {};
+  }
+  const out: Record<string, TwelveQuote> = {};
+  for (const [key, value] of Object.entries(root)) {
+    if (value && typeof value === "object" && !("code" in (value as Record<string, unknown>))) {
+      out[key.toUpperCase()] = value as TwelveQuote;
+    }
+  }
+  return out;
+}
+
+/**
+ * US quote adapter. Twelve Data is used because Yahoo chart endpoints are unstable from Node/undici.
+ * If the key is absent or the upstream fails, return [] rather than synthesizing cards.
+ */
+export async function fetchUsMarketRows(): Promise<DiscoveryMarketRow[]> {
+  const key = tdKey();
+  if (!key) return [];
+  const defs = usStockDefs();
+  const symbols = defs.map((def) => usSymbolForStock(def.canonical)).filter((symbol): symbol is string => !!symbol);
+  if (symbols.length === 0) return [];
+  try {
+    const url = new URL(TWELVE_DATA_URL);
+    url.searchParams.set("symbol", symbols.join(","));
+    url.searchParams.set("apikey", key);
+    const res = await fetch(url.toString(), {
+      headers: { accept: "application/json", "user-agent": UA },
+      signal: AbortSignal.timeout(8_000),
+      next: { revalidate: 600 },
+    });
+    if (!res.ok) return [];
+    const bySymbol = normalizeQuoteResponse(await res.json());
+    const rows: DiscoveryMarketRow[] = [];
+    for (const def of defs) {
+      const symbol = usSymbolForStock(def.canonical);
+      if (!symbol) continue;
+      const quote = bySymbol[symbol.toUpperCase()];
+      if (!quote) continue;
+      const row = parseQuote(def.canonical, quote);
+      if (row) rows.push(row);
+    }
+    return rows;
+  } catch (err) {
+    console.warn("[us-market-source] Twelve Data quote failed", (err as Error)?.message);
+    return [];
+  }
+}

--- a/apps/web/lib/us-symbols.ts
+++ b/apps/web/lib/us-symbols.ts
@@ -1,0 +1,46 @@
+import { STOCK_VOCAB, type StockDef } from "@fomo/core";
+
+const KNOWN_US_SYMBOLS: Record<string, string> = {
+  "엔비디아": "NVDA",
+  "TSMC": "TSM",
+  "마이크로소프트": "MSFT",
+  "애플": "AAPL",
+  "테슬라": "TSLA",
+  "AMD": "AMD",
+  "브로드컴": "AVGO",
+  "팔란티어": "PLTR",
+  "마이크론": "MU",
+};
+
+const SEC_CIK_BY_SYMBOL: Record<string, string> = {
+  AAPL: "0000320193",
+  AMD: "0000002488",
+  AVGO: "0001730168",
+  MSFT: "0000789019",
+  MU: "0000723125",
+  NVDA: "0001045810",
+  PLTR: "0001321655",
+  TSLA: "0001318605",
+};
+
+function asciiAlias(def: StockDef): string | undefined {
+  return def.aliases.find((alias) => /^[A-Z]{1,5}$/.test(alias));
+}
+
+export function usSymbolForStock(stock: string): string | undefined {
+  const direct = KNOWN_US_SYMBOLS[stock.trim()];
+  if (direct) return direct;
+  const upper = stock.trim().toUpperCase();
+  if (/^[A-Z]{1,5}$/.test(upper)) return upper;
+  const def = STOCK_VOCAB.find((item) => item.canonical === stock || item.aliases.includes(stock));
+  if (!def || def.country === "KR") return undefined;
+  return KNOWN_US_SYMBOLS[def.canonical] ?? asciiAlias(def);
+}
+
+export function secCikForSymbol(symbol: string): string | undefined {
+  return SEC_CIK_BY_SYMBOL[symbol.trim().toUpperCase()];
+}
+
+export function usStockDefs(): StockDef[] {
+  return STOCK_VOCAB.filter((def) => def.country !== "KR" && def.market !== "COIN").map((def) => ({ ...def }));
+}


### PR DESCRIPTION
## Summary
- Adds a market-source boundary for discovery rows so KR keeps the existing Naver/DART/supply path while US can enter the same ranking, hook, report, and depth stack.
- Adds a US quote adapter using Twelve Data only; Yahoo chart endpoints are not used. Missing US keys fail closed to an empty US deck.
- Threads symbol/country/market through discovery cards and stock-insight so US detail can use per-symbol Yahoo Finance RSS news and SEC EDGAR filings.
- Adds a small KR/US discovery toggle while keeping KR as the default.
- Keeps KR discovery guard at 50 cards by adding a backfill-only contextual recovery pool for thin upstream days; front-band quality guard still passes.

## Source/Key Notes
- US quote source: Twelve Data via TWELVE_DATA_API_KEY.
- US filing source: SEC EDGAR via SEC_EDGAR_USER_AGENT; absent UA returns no SEC filings.
- Yahoo usage is RSS news only, not Node chart APIs.

## Verification
- npm test -- apps/web/__tests__/lib/theme-understanding-naver-code.test.ts apps/web/__tests__/lib/us-market-source.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm run typecheck
- npm run guard:discovery
- npm run build:web
- npm run build:fomo-web
- Runtime smoke: KR discovery 50 cards; US discovery 0 cards when Twelve Data key is absent (fail-closed).