### PR TITLE
feat(discovery): grounded relation graph + event-driven theme bundle cards

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -16,6 +16,7 @@ import type { FeedSignalPoint, StockFrontResponse } from "@/lib/fomoApi";
 import { recordStockInterest } from "@/lib/stockInterest";
 import { upsertWatch } from "@/lib/watchlist";
 import type { DeckStock } from "@/lib/discoveryDeck";
+import { isThemeBundleCard, type DiscoveryDeckCard, type DeckThemeBundle } from "@/lib/discoveryDeck";
 import { whyShown } from "@/lib/whyShown";
 import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
@@ -53,7 +54,7 @@ export type FrontEntry = {
 type UndoEntry = {
   idx: number;
   dir: "left" | "right";
-  stock: DeckStock;
+  stock: DiscoveryDeckCard;
 };
 
 function prefersReducedMotion(): boolean {
@@ -202,6 +203,80 @@ function FeedSignalStrip({
           <span className="shrink-0 text-[10px] text-muted/80">{row.point.source}</span>
         </div>
       ))}
+    </div>
+  );
+}
+
+function cardKey(card: DiscoveryDeckCard): string {
+  return isThemeBundleCard(card) ? card.id : card.canonical;
+}
+
+function cardLabel(card: DiscoveryDeckCard): string {
+  return isThemeBundleCard(card) ? card.title : card.canonical;
+}
+
+function isStockCard(card: DiscoveryDeckCard): card is DeckStock {
+  return !isThemeBundleCard(card);
+}
+
+function relationLabel(relation: DeckThemeBundle["items"][number]["relation"]): string {
+  switch (relation) {
+    case "customer":
+      return "수요처";
+    case "supplier":
+      return "공급사";
+    case "material":
+      return "원재료";
+    case "beneficiary":
+      return "확산 수혜";
+    case "peer":
+    default:
+      return "비교군";
+  }
+}
+
+function BundleCardFace({ bundle, progress }: { bundle: DeckThemeBundle; progress?: string | undefined }) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0">
+        <span className="font-pixel text-[10px] uppercase tracking-wide text-muted">THEME BUNDLE</span>
+        <h3 className="mt-3 text-2xl font-bold leading-8 text-whiteout" style={clampStyle(2)}>
+          {bundle.title}
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-muted" style={clampStyle(2)}>
+          {bundle.subtitle}
+        </p>
+      </div>
+
+      <div className="mt-5 grid min-h-0 gap-2 overflow-hidden">
+        {bundle.items.slice(0, 4).map((item) => (
+          <div key={`${bundle.id}:${item.ticker}`} className="rounded-xl border border-hairline bg-white/[0.035] px-3 py-2.5">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <span className="min-w-0 truncate text-base font-bold text-whiteout">{item.label}</span>
+              <span className="shrink-0 rounded-full border border-hairline-soft px-2 py-0.5 text-[10px] text-muted">
+                {relationLabel(item.relation)}
+              </span>
+            </div>
+            <p className="mt-1 text-xs leading-5 text-muted" style={clampStyle(2)}>
+              {item.reason}
+            </p>
+            <div className="mt-1 flex items-center justify-between gap-2 text-[10px] text-muted/80">
+              <span>{item.source}</span>
+              {typeof item.changePct === "number" && (
+                <span style={{ color: item.changePct > 0 ? DIR_COLOR.up : item.changePct < 0 ? DIR_COLOR.down : DIR_COLOR.flat }}>
+                  {item.changePct > 0 ? "+" : ""}
+                  {item.changePct.toFixed(2)}%
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-auto flex shrink-0 items-center justify-between pt-2">
+        <span className="font-pixel text-[11px] text-muted">관계 근거 · {bundle.confidence}</span>
+        {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
+      </div>
     </div>
   );
 }
@@ -384,7 +459,7 @@ function StockCardLoadingFace({
 }
 
 interface StockSwipeDeckProps {
-  stocks: DeckStock[];
+  stocks: DiscoveryDeckCard[];
   initialFronts?: Record<string, FrontEntry>;
   contextLabel?: string | undefined;
   loggedIn?: boolean | undefined;
@@ -426,7 +501,8 @@ export function StockSwipeDeck({
   const at = (i: number) => stocks[((i % stocks.length) + stocks.length) % stocks.length]!;
 
   const ensureFront = useCallback(
-    (stock: DeckStock) => {
+    (stock: DiscoveryDeckCard) => {
+      if (isThemeBundleCard(stock)) return;
       const key = stock.canonical;
       if (front[key] || inflight.current.has(key)) return;
       if (!stock.naverCode) {
@@ -531,7 +607,8 @@ export function StockSwipeDeck({
   const saveDiscovery = (stock: DeckStock) => {
     upsertWatch(stock.canonical, Date.now(), { sector: stock.sector, reason: whyFor(stock) });
   };
-  const renderFace = (stock: DeckStock, progress?: string) => {
+  const renderFace = (stock: DiscoveryDeckCard, progress?: string) => {
+    if (isThemeBundleCard(stock)) return <BundleCardFace bundle={stock} progress={progress} />;
     const e = front[stock.canonical];
     if (!e) {
       return <StockCardLoadingFace stock={stock} themeLabel={stock.sector} progress={progress} />;
@@ -592,6 +669,12 @@ export function StockSwipeDeck({
   const advance = useCallback(
     (dir: "left" | "right") => {
       const stock = at(idx);
+      if (isThemeBundleCard(stock)) {
+        setUndoEntry({ idx, dir, stock });
+        recordDiscoveryEvent("swipe", { direction: dir, hydrated: true });
+        flingNext(dir);
+        return;
+      }
       setUndoEntry({ idx, dir, stock });
       if (dir === "right") saveDiscovery(stock);
       recordDiscoveryEvent("swipe", { direction: dir, hydrated: !!front[stock.canonical] });
@@ -628,6 +711,11 @@ export function StockSwipeDeck({
   // 비로그인은 로그인 유도 후 스냅백(저장·매칭 없음). kind는 매칭 모먼트 표현만 다름(하트/별).
   const interest = useCallback((kind: "like" | "super") => {
     const stock = at(idx);
+    if (isThemeBundleCard(stock)) {
+      recordDiscoveryEvent("swipe", { direction: "right", hydrated: true });
+      flingNext("right");
+      return;
+    }
     if (!loggedIn && onRequireLogin) {
       onRequireLogin();
       setDx(0);
@@ -678,7 +766,8 @@ export function StockSwipeDeck({
 
   const onPointerDown = (e: React.PointerEvent) => {
     if (exiting || restoring) return;
-    if (!front[at(idx).canonical]) return;
+    const current = at(idx);
+    if (isStockCard(current) && !front[current.canonical]) return;
     dragging.current = true;
     moved.current = false;
     startX.current = e.clientX;
@@ -721,7 +810,8 @@ export function StockSwipeDeck({
   }, [stocks]);
 
   useEffect(() => {
-    const stock = at(idx).canonical;
+    const card = at(idx);
+    const stock = isStockCard(card) ? card.canonical : card.id;
     if (!firstCardRecorded.current) {
       firstCardRecorded.current = true;
       recordDiscoveryEvent("first_card_display");
@@ -732,7 +822,9 @@ export function StockSwipeDeck({
   }, [idx, stocks]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const stock = at(idx).canonical;
+    const card = at(idx);
+    if (!isStockCard(card)) return;
+    const stock = card.canonical;
     if (!front[stock] || hydratedRecorded.current.has(stock)) return;
     hydratedRecorded.current.add(stock);
     recordDiscoveryEvent("card_hydrate");
@@ -749,7 +841,7 @@ export function StockSwipeDeck({
         : flingTransform(exiting)
       : `translate(${dx}px, ${dy}px) rotate(${dx * 0.04}deg)`;
   const topTransition = dragging.current || restorePrimed ? "none" : `transform ${EXIT_MS}ms cubic-bezier(0.22,1,0.36,1)`;
-  const topReady = !!front[top.canonical];
+  const topReady = isThemeBundleCard(top) ? true : !!front[top.canonical];
 
   return (
     <div className="w-full">
@@ -772,7 +864,7 @@ export function StockSwipeDeck({
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onClick={() => {
-            if (topReady && !moved.current && !exiting && !restoring) openDepth(top, "card");
+            if (topReady && isStockCard(top) && !moved.current && !exiting && !restoring) openDepth(top, "card");
           }}
           className="absolute inset-0 z-10 cursor-pointer overflow-hidden rounded-2xl border border-hairline-soft bg-surface-raised px-6 py-7"
           style={{ transform: topTransform, transition: topTransition }}
@@ -817,8 +909,8 @@ export function StockSwipeDeck({
         <button
           onClick={undoLast}
           disabled={!!exiting || restoring || !undoEntry}
-          aria-label={undoEntry ? `${undoEntry.stock.canonical} 카드로 돌아가기` : "이전 카드 없음"}
-          title={undoEntry ? `${undoEntry.stock.canonical} 다시 보기` : "이전 카드 없음"}
+          aria-label={undoEntry ? `${cardLabel(undoEntry.stock)} 카드로 돌아가기` : "이전 카드 없음"}
+          title={undoEntry ? `${cardLabel(undoEntry.stock)} 다시 보기` : "이전 카드 없음"}
           className="flex h-14 w-14 items-center justify-center rounded-full border border-hairline-soft bg-surface-raised text-muted transition-colors hover:text-whiteout disabled:opacity-30"
         >
           <UndoIcon size={24} />

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
 import { DISCOVERY_UPDATED_EVENT, fetchDiscovery, type DiscoveryCountryScope, type DiscoveryResponse } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
-import { MIN_DISCOVERY_STOCKS, type DeckStock } from "@/lib/discoveryDeck";
+import { MIN_DISCOVERY_STOCKS, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
 
 interface TodayDiscoveryDeckProps {
@@ -41,18 +41,18 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
   const [state, setState] = useState<
     | { kind: "loading" }
     | { kind: "error" }
-    | { kind: "ready"; stocks: DeckStock[]; fronts: Record<string, FrontEntry> }
+    | { kind: "ready"; cards: DiscoveryDeckCard[]; fronts: Record<string, FrontEntry> }
   >({ kind: "loading" });
 
   useEffect(() => {
     let alive = true;
     const applyDiscovery = (discovery: DiscoveryResponse) => {
-      const stocks = discovery.stocks as DeckStock[];
-      if (stocks.length === 0) {
+      const cards = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
+      if (cards.length === 0) {
         setState({ kind: "error" });
         return;
       }
-      setState({ kind: "ready", stocks, fronts: discovery.fronts as Record<string, FrontEntry> });
+      setState({ kind: "ready", cards, fronts: discovery.fronts as Record<string, FrontEntry> });
     };
     const onDiscoveryUpdated = (event: Event) => {
       const discovery = (event as CustomEvent<DiscoveryResponse>).detail;
@@ -140,7 +140,7 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
     <>
       {scopeTabs}
       <StockSwipeDeck
-        stocks={state.stocks.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.stocks.length))}
+        stocks={state.cards.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.cards.length))}
         initialFronts={state.fronts}
         contextLabel={country === "US" ? "미국 발견" : "오늘의 발견"}
         loggedIn={loggedIn}

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -28,6 +28,7 @@ export const DISCOVERY_MIX = {
 
 /** 덱 카드 — 섹터 풀 종목 + 발굴 근거(있으면 "주목 종목"으로 노출). */
 export type DeckStock = Omit<SectorStock, "sector"> & {
+  kind?: "stock";
   reason?: string;
   whyShown?: string;
   symbol?: string;
@@ -37,6 +38,42 @@ export type DeckStock = Omit<SectorStock, "sector"> & {
   market: StockMarket;
   country: StockCountry;
 };
+
+export type DeckRelationKind = "customer" | "supplier" | "material" | "peer" | "beneficiary";
+
+export interface DeckThemeBundleItem {
+  ticker: string;
+  label: string;
+  market: StockMarket;
+  country?: StockCountry;
+  sector?: string;
+  relation: DeckRelationKind;
+  reason: string;
+  source: string;
+  confidence: "L" | "M" | "H";
+  changePct?: number;
+  naverCode?: string;
+  symbol?: string;
+}
+
+export interface DeckThemeBundle {
+  kind: "theme_bundle";
+  id: string;
+  title: string;
+  subtitle: string;
+  source: string;
+  asOf: string;
+  confidence: "L" | "M" | "H";
+  anchorTicker: string;
+  relation: "event_bundle";
+  items: DeckThemeBundleItem[];
+}
+
+export type DiscoveryDeckCard = DeckStock | DeckThemeBundle;
+
+export function isThemeBundleCard(card: DiscoveryDeckCard): card is DeckThemeBundle {
+  return card.kind === "theme_bundle";
+}
 
 export interface AxisSnapshotLike {
   axisSignals: AxisSignal[];

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -404,6 +404,7 @@ export const fetchStockFront = (stock: string, opts: { lite?: boolean } = {}) =>
   );
 
 export interface DiscoveryStockResponse {
+  kind?: "stock";
   canonical: string;
   market: import("@fomo/core").StockMarket;
   country: import("@fomo/core").StockCountry;
@@ -415,9 +416,40 @@ export interface DiscoveryStockResponse {
   reason?: string;
 }
 
+export interface DiscoveryThemeBundleItemResponse {
+  ticker: string;
+  label: string;
+  market: import("@fomo/core").StockMarket;
+  country?: import("@fomo/core").StockCountry;
+  sector?: string;
+  relation: "customer" | "supplier" | "material" | "peer" | "beneficiary";
+  reason: string;
+  source: string;
+  confidence: "L" | "M" | "H";
+  changePct?: number;
+  naverCode?: string;
+  symbol?: string;
+}
+
+export interface DiscoveryThemeBundleResponse {
+  kind: "theme_bundle";
+  id: string;
+  title: string;
+  subtitle: string;
+  source: string;
+  asOf: string;
+  confidence: "L" | "M" | "H";
+  anchorTicker: string;
+  relation: "event_bundle";
+  items: DiscoveryThemeBundleItemResponse[];
+}
+
+export type DiscoveryCardResponse = DiscoveryStockResponse | DiscoveryThemeBundleResponse;
+
 export interface DiscoveryResponse {
   asOf: string;
   stocks: DiscoveryStockResponse[];
+  cards?: DiscoveryCardResponse[];
   fronts: Record<string, StockFrontResponse>;
   confidence: "L" | "M" | "H";
   source: string;
@@ -434,7 +466,7 @@ function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
 }
 
 function hasDiscoveryCards(value: DiscoveryResponse | null | undefined): value is DiscoveryResponse {
-  return !!value && isDiscoveryResponse(value) && value.stocks.length > 0;
+  return !!value && isDiscoveryResponse(value) && (value.stocks.length > 0 || (value.cards?.length ?? 0) > 0);
 }
 
 function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryResponse | null {

--- a/apps/web/__tests__/lib/relation-graph-theme-bundle.test.ts
+++ b/apps/web/__tests__/lib/relation-graph-theme-bundle.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { DiscoveryCandidate } from "@fomo/core";
+import { buildThemeBundleCards } from "../../lib/discovery-supply";
+import type { DiscoveryMarketRow } from "../../lib/market-source-types";
+import { relatedTo } from "../../lib/relation-graph";
+
+describe("relation graph", () => {
+  it("returns only grounded curated relations with source and confidence", () => {
+    const nodes = relatedTo({ kind: "ticker", ticker: "005930.KS" });
+
+    expect(nodes.length).toBeGreaterThan(0);
+    expect(nodes.every((node) => node.source && node.confidence)).toBe(true);
+    expect(nodes.every((node) => node.relation !== undefined)).toBe(true);
+  });
+
+  it("maps app themes to curated relation seeds without using same-sector as standalone evidence", () => {
+    const nodes = relatedTo({ kind: "theme", theme: "반도체" });
+
+    expect(nodes.length).toBeGreaterThan(0);
+    expect(nodes.every((node) => node.source === "FOMO curated relation map")).toBe(true);
+  });
+});
+
+describe("theme bundle cards", () => {
+  it("does not create a bundle without a real current event", () => {
+    const candidate: DiscoveryCandidate = {
+      ticker: "삼성전자",
+      market: "KOSPI",
+      country: "KR",
+      sector: "반도체",
+      asOf: "2026-06-27",
+      events: [
+        {
+          kind: "market_context",
+          firstSeen: true,
+          strength: 0.5,
+          source: "FOMO 섹터맵",
+          asOf: "2026-06-27",
+          confidence: "M",
+          label: "반도체 흐름에서 확인하는 종목이에요.",
+          direction: "up",
+        },
+      ],
+    };
+
+    const cards = buildThemeBundleCards([candidate], new Map());
+
+    expect(cards).toEqual([]);
+  });
+
+  it("does not create a bundle from same-sector theme movement alone", () => {
+    const candidate: DiscoveryCandidate = {
+      ticker: "삼성전자",
+      market: "KOSPI",
+      country: "KR",
+      sector: "반도체",
+      asOf: "2026-06-27",
+      events: [
+        {
+          kind: "theme_link",
+          firstSeen: true,
+          strength: 0.92,
+          source: "FOMO 섹터맵·네이버 시세",
+          asOf: "2026-06-27",
+          confidence: "M",
+          label: "오늘 반도체 흐름에서 먼저 확인된 종목이에요.",
+          direction: "up",
+        },
+      ],
+    };
+    const rows = new Map<string, DiscoveryMarketRow>([
+      ["SK하이닉스", row("SK하이닉스", "000660", 3.2)],
+      ["엔비디아", { canonical: "엔비디아", symbol: "NVDA", market: "NASDAQ", country: "US", currency: "USD", changePct: 1.1 }],
+    ]);
+
+    const cards = buildThemeBundleCards([candidate], rows);
+
+    expect(cards).toEqual([]);
+  });
+
+  it("creates an event-driven bundle only when related stocks have current market rows", () => {
+    const candidate: DiscoveryCandidate = {
+      ticker: "삼성전자",
+      market: "KOSPI",
+      country: "KR",
+      sector: "반도체",
+      asOf: "2026-06-27",
+      events: [
+        {
+          kind: "disclosure",
+          firstSeen: true,
+          strength: 0.96,
+          source: "DART",
+          asOf: "2026-06-27",
+          confidence: "H",
+          label: "신규 공급계약 공시가 확인됐어요.",
+          direction: "up",
+        },
+      ],
+    };
+    const rows = new Map<string, DiscoveryMarketRow>([
+      ["SK하이닉스", row("SK하이닉스", "000660", 3.2)],
+      ["엔비디아", { canonical: "엔비디아", symbol: "NVDA", market: "NASDAQ", country: "US", currency: "USD", changePct: 1.1 }],
+    ]);
+
+    const cards = buildThemeBundleCards([candidate], rows);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.items).toHaveLength(2);
+    expect(cards[0]?.items.every((item) => item.source && item.confidence)).toBe(true);
+  });
+});
+
+function row(canonical: string, naverCode: string, changePct: number): DiscoveryMarketRow {
+  return {
+    canonical,
+    symbol: naverCode,
+    naverCode,
+    market: "KOSPI",
+    country: "KR",
+    currency: "KRW",
+    changePct,
+  };
+}

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -39,6 +39,7 @@ export async function GET(request: Request) {
         {
           asOf: kstDate(),
           stocks: [],
+          cards: [],
           fronts: {},
           confidence: "L",
           source: "데이터 없음",

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -19,6 +19,8 @@ import {
   type AxisSignal,
   type CardFrontSignals,
   type DiscoveryCandidate,
+  type DiscoveryThemeBundleCard,
+  type DiscoveryThemeBundleItem,
   type DiscoveryEvent,
   type DiscoveryMarket,
   type FomoScoreResult,
@@ -32,6 +34,7 @@ import {
 import { fetchDartDisclosuresByStock, type DartDisclosureHit } from "./dart-disclosures";
 import { fetchNaverCompanyResearch, fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
 import type { DiscoveryCountryScope, DiscoveryMarketRow } from "./market-source-types";
+import { relatedTo, type RelatedNode } from "./relation-graph";
 import { fetchRecentSecFilings } from "./sec-edgar";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
@@ -48,6 +51,9 @@ const DISCOVERY_RECOVERY_MIN_CARDS = 12;
 const DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF = 30;
 const TARGETED_MATERIAL_DEFAULT_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
 const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
+const THEME_BUNDLE_MAX_CARDS = 2;
+const THEME_BUNDLE_MIN_ITEMS = 2;
+const THEME_BUNDLE_MAX_ITEMS = 4;
 const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_DEFAULT_ENABLED
   ? Math.max(0, Math.min(720, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 720) || 720))
   : 0;
@@ -104,9 +110,14 @@ export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
   reason?: string;
 }
 
+export type DiscoveryDeckCardPayload =
+  | ({ kind: "stock" } & DiscoveryStockPayload)
+  | DiscoveryThemeBundleCard;
+
 export interface DiscoveryResponse {
   asOf: string;
   stocks: DiscoveryStockPayload[];
+  cards?: DiscoveryDeckCardPayload[];
   fronts: Record<string, DiscoveryFrontSeed>;
   confidence: "L" | "M" | "H";
   source: string;
@@ -753,6 +764,116 @@ function frontSeed(
   };
 }
 
+function relationCopy(relation: RelatedNode["relation"]): string {
+  switch (relation) {
+    case "customer":
+      return "수요처";
+    case "supplier":
+      return "공급사";
+    case "material":
+      return "원재료";
+    case "beneficiary":
+      return "확산 수혜";
+    case "peer":
+    default:
+      return "비교군";
+  }
+}
+
+function bundleAnchorEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
+  return candidate.events
+    .filter((event) => isDeckDisplayEvent(event, candidate))
+    .filter((event) => event.kind === "disclosure" || event.kind === "news_mention" || event.kind === "flow_entry")
+    .sort((a, b) => {
+      const priority = (event: DiscoveryEvent) =>
+        event.kind === "disclosure" ? 0 : event.kind === "news_mention" ? 1 : 2;
+      return priority(a) - priority(b) || b.strength - a.strength || a.kind.localeCompare(b.kind);
+    })[0];
+}
+
+function relationItemFromNode(
+  node: RelatedNode,
+  row: DiscoveryMarketRow,
+): DiscoveryThemeBundleItem {
+  return {
+    ticker: node.ticker,
+    label: node.label,
+    market: row.market,
+    country: row.country,
+    relation: node.relation,
+    reason: node.reason,
+    source: node.source,
+    confidence: node.confidence,
+    ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
+    ...(node.sector ? { sector: node.sector } : {}),
+    ...(row.naverCode ?? node.naverCode ? { naverCode: row.naverCode ?? node.naverCode } : {}),
+    ...(row.symbol ?? node.symbol ? { symbol: row.symbol ?? node.symbol } : {}),
+  };
+}
+
+export function buildThemeBundleCards(
+  ranked: readonly DiscoveryCandidate[],
+  rowsByTicker: ReadonlyMap<string, DiscoveryMarketRow>,
+): DiscoveryThemeBundleCard[] {
+  const cards: DiscoveryThemeBundleCard[] = [];
+  const usedAnchors = new Set<string>();
+  for (const candidate of ranked) {
+    if (cards.length >= THEME_BUNDLE_MAX_CARDS) break;
+    if (usedAnchors.has(candidate.ticker)) continue;
+    const event = bundleAnchorEvent(candidate);
+    if (!event?.label) continue;
+    const relations = relatedTo({
+      kind: "event",
+      ticker: candidate.ticker,
+      ...(candidate.sector ? { theme: candidate.sector } : {}),
+    });
+    const items = relations
+      .filter((node) => node.ticker !== candidate.ticker)
+      .map((node) => {
+        const row = rowsByTicker.get(node.ticker);
+        return row ? relationItemFromNode(node, row) : null;
+      })
+      .filter((item): item is DiscoveryThemeBundleItem => item !== null)
+      .sort((a, b) => {
+        const aRank = rowsByTicker.get(a.ticker)?.marketCapRank ?? 9999;
+        const bRank = rowsByTicker.get(b.ticker)?.marketCapRank ?? 9999;
+        return aRank - bRank || a.ticker.localeCompare(b.ticker);
+      })
+      .slice(0, THEME_BUNDLE_MAX_ITEMS);
+    if (items.length < THEME_BUNDLE_MIN_ITEMS) continue;
+    const theme = candidate.sector ?? "관련 흐름";
+    const title = `${theme} 사건으로 같이 볼 종목 ${items.length}개`;
+    cards.push({
+      kind: "theme_bundle",
+      id: `bundle:${candidate.ticker}:${event.kind}:${candidate.asOf.slice(0, 10)}`,
+      title,
+      subtitle: event.label,
+      source: event.source,
+      asOf: event.asOf,
+      confidence: event.confidence,
+      anchorTicker: candidate.ticker,
+      relation: "event_bundle",
+      items,
+    });
+    usedAnchors.add(candidate.ticker);
+  }
+  return cards;
+}
+
+function interleaveThemeBundles(
+  stocks: readonly DiscoveryStockPayload[],
+  bundles: readonly DiscoveryThemeBundleCard[],
+): DiscoveryDeckCardPayload[] {
+  const cards: DiscoveryDeckCardPayload[] = stocks.map((stock) => ({ kind: "stock", ...stock }));
+  if (bundles.length === 0 || cards.length < 8) return cards;
+  const out = [...cards];
+  bundles.forEach((bundle, index) => {
+    const insertAt = Math.min(out.length, 6 + index * 10);
+    out.splice(insertAt, 0, bundle);
+  });
+  return out;
+}
+
 export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOptions = {}): Promise<DiscoveryResponse> {
   const scope = options.country ?? "KR";
   const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
@@ -923,10 +1044,12 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       axisHook: selectMultiAxisHook(axisSignals),
     };
   });
+  const bundleCards = buildThemeBundleCards(ranked, rowsByTicker);
 
   return {
     asOf,
     stocks,
+    cards: interleaveThemeBundles(stocks, bundleCards),
     fronts,
     confidence: stocks.length >= DISCOVERY_DECK_CARD_COUNT ? "H" : stocks.length >= 30 ? "M" : "L",
     source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "시장 시세·공시·수급 캐시",

--- a/apps/web/lib/relation-graph.ts
+++ b/apps/web/lib/relation-graph.ts
@@ -1,0 +1,237 @@
+import {
+  STOCK_VOCAB,
+  sectorOf,
+  type DiscoveryRelationKind,
+  type StockCountry,
+  type StockMarket,
+} from "@fomo/core";
+import { usSymbolForStock } from "./us-symbols";
+
+export interface RelatedNode {
+  ticker: string;
+  label: string;
+  market: StockMarket;
+  country: StockCountry;
+  relation: DiscoveryRelationKind;
+  reason: string;
+  source: string;
+  confidence: "L" | "M" | "H";
+  sector?: string;
+  symbol?: string;
+  naverCode?: string;
+}
+
+export type RelationQuery =
+  | { kind: "ticker"; ticker: string }
+  | { kind: "theme"; theme: string }
+  | { kind: "event"; ticker?: string; theme?: string };
+
+interface CuratedRelationSeed {
+  from: { kind: "sector"; id: string } | { kind: "ticker"; ticker: string };
+  ticker: string;
+  reason: string;
+  relation: DiscoveryRelationKind;
+  source: "FOMO curated relation map";
+  confidence: "M";
+}
+
+const RELATION_LIMIT = 8;
+const THEME_TO_RESEARCH_SECTOR: Record<string, string> = {
+  반도체: "semiconductors",
+  AI: "ai-infra",
+  "2차전지": "battery-chain",
+  자동차: "ev-mobility",
+  에너지: "energy-oil",
+};
+
+const CURATED_RELATION_SEEDS: readonly CuratedRelationSeed[] = [
+  {
+    from: { kind: "sector", id: "semiconductors" },
+    ticker: "005930.KS",
+    reason: "국장 메모리·파운드리 체인으로 미국 리더십의 국내 확산을 읽을 수 있습니다.",
+    relation: "supplier",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "semiconductors" },
+    ticker: "000660.KS",
+    reason: "HBM/메모리 업황의 국내 수혜 강도를 확인하는 대표 축입니다.",
+    relation: "beneficiary",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "semiconductors" },
+    ticker: "NVDA",
+    reason: "AI 수요 확산의 최전선이라 업종 심리의 선행 지표 역할을 합니다.",
+    relation: "peer",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "ai-infra" },
+    ticker: "VRT",
+    reason: "실제 데이터센터 전력·냉각 투자가 열리는지 보여줍니다.",
+    relation: "beneficiary",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "ai-infra" },
+    ticker: "ETN",
+    reason: "전력 장비 발주가 장기화되는지 확인하기 좋습니다.",
+    relation: "beneficiary",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "battery-chain" },
+    ticker: "373220.KS",
+    reason: "국내 셀 리더로 완성차 수요와 셀 단가 개선을 동시에 반영합니다.",
+    relation: "peer",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "battery-chain" },
+    ticker: "006400.KS",
+    reason: "고부가 배터리 수요가 열릴 때 먼저 확인할 수 있는 축입니다.",
+    relation: "peer",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "sector", id: "battery-chain" },
+    ticker: "ALB",
+    reason: "리튬 가격과 원재료 스프레드가 공급망 전체에 미치는 영향을 대표합니다.",
+    relation: "material",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "ticker", ticker: "005930.KS" },
+    ticker: "NVDA",
+    reason: "AI 서버 수요가 메모리 업황을 끌고 가는 핵심 수요처입니다.",
+    relation: "customer",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "ticker", ticker: "005930.KS" },
+    ticker: "000660.KS",
+    reason: "국내 메모리 업황 강도를 비교하는 직접 동행주입니다.",
+    relation: "peer",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "ticker", ticker: "NVDA" },
+    ticker: "VRT",
+    reason: "GPU 수요가 실제 데이터센터 증설로 번지는지 확인하는 후행 수혜주입니다.",
+    relation: "beneficiary",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+  {
+    from: { kind: "ticker", ticker: "NVDA" },
+    ticker: "005930.KS",
+    reason: "메모리/HBM 수요가 국장으로 확산되는 대표 수혜 축입니다.",
+    relation: "supplier",
+    source: "FOMO curated relation map",
+    confidence: "M",
+  },
+];
+
+function normalizeKey(value: string): string {
+  return value.trim().toUpperCase().replace(/\s+/g, "");
+}
+
+function canonicalFromRelationTicker(ticker: string): string | undefined {
+  const clean = ticker.trim();
+  if (!clean) return undefined;
+  const upper = clean.toUpperCase();
+  const krCode = upper.match(/^(\d{6})\.K[QS]$/)?.[1] ?? (/^\d{6}$/.test(upper) ? upper : undefined);
+  if (krCode) {
+    return STOCK_VOCAB.find((stock) => stock.naverCode === krCode)?.canonical;
+  }
+  const usSymbol = usSymbolForStock(upper);
+  if (usSymbol) {
+    return STOCK_VOCAB.find((stock) => stock.country !== "KR" && stock.aliases.some((alias) => normalizeKey(alias) === usSymbol))?.canonical ?? upper;
+  }
+  return STOCK_VOCAB.find((stock) => normalizeKey(stock.canonical) === normalizeKey(clean))?.canonical ?? clean;
+}
+
+function relationTickerKeys(ticker: string): Set<string> {
+  const keys = new Set<string>();
+  const clean = ticker.trim();
+  const canonical = canonicalFromRelationTicker(clean) ?? clean;
+  keys.add(normalizeKey(clean));
+  keys.add(normalizeKey(canonical));
+  const def = STOCK_VOCAB.find((stock) => stock.canonical === canonical);
+  if (def?.naverCode) {
+    keys.add(normalizeKey(def.naverCode));
+    keys.add(normalizeKey(`${def.naverCode}.KS`));
+  }
+  const symbol = usSymbolForStock(clean) ?? usSymbolForStock(canonical);
+  if (symbol) keys.add(normalizeKey(symbol));
+  for (const alias of def?.aliases ?? []) keys.add(normalizeKey(alias));
+  return keys;
+}
+
+function nodeFromSeed(seed: CuratedRelationSeed): RelatedNode | null {
+  const canonical = canonicalFromRelationTicker(seed.ticker);
+  if (!canonical) return null;
+  const def = STOCK_VOCAB.find((stock) => stock.canonical === canonical);
+  const symbol = usSymbolForStock(seed.ticker) ?? usSymbolForStock(canonical);
+  const market = def?.market ?? (symbol ? "NASDAQ" : undefined);
+  const country = def?.country ?? (symbol ? "US" : undefined);
+  if (!market || !country) return null;
+  const sector = sectorOf(canonical);
+  return {
+    ticker: canonical,
+    label: canonical,
+    market,
+    country,
+    relation: seed.relation,
+    reason: seed.reason,
+    source: seed.source,
+    confidence: seed.confidence,
+    ...(sector ? { sector } : {}),
+    ...(def?.naverCode ? { naverCode: def.naverCode } : {}),
+    ...(symbol ? { symbol } : {}),
+  };
+}
+
+function uniqueNodes(nodes: RelatedNode[]): RelatedNode[] {
+  const seen = new Set<string>();
+  const out: RelatedNode[] = [];
+  for (const node of nodes) {
+    if (!node.source || !node.confidence || seen.has(node.ticker)) continue;
+    seen.add(node.ticker);
+    out.push(node);
+  }
+  return out;
+}
+
+export function relatedTo(query: RelationQuery): RelatedNode[] {
+  const seeds = CURATED_RELATION_SEEDS;
+  const themeId =
+    query.kind === "theme"
+      ? (THEME_TO_RESEARCH_SECTOR[query.theme] ?? query.theme)
+      : query.kind === "event" && query.theme
+        ? (THEME_TO_RESEARCH_SECTOR[query.theme] ?? query.theme)
+        : undefined;
+  const matched =
+    query.kind === "ticker"
+      ? seeds.filter((seed) => seed.from.kind === "ticker" && relationTickerKeys(query.ticker).has(normalizeKey(seed.from.ticker)))
+      : query.kind === "theme"
+        ? seeds.filter((seed) => seed.from.kind === "sector" && seed.from.id === themeId)
+        : seeds.filter((seed) => {
+            const tickerMatch =
+              query.ticker && seed.from.kind === "ticker" && relationTickerKeys(query.ticker).has(normalizeKey(seed.from.ticker));
+            const themeMatch = themeId && seed.from.kind === "sector" && seed.from.id === themeId;
+            return tickerMatch || themeMatch;
+          });
+  return uniqueNodes(matched.map(nodeFromSeed).filter((node): node is RelatedNode => node !== null)).slice(0, RELATION_LIMIT);
+}

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -36,6 +36,36 @@ export interface DiscoveryCandidate {
   marketCapRank?: number;
 }
 
+export type DiscoveryRelationKind = "customer" | "supplier" | "material" | "peer" | "beneficiary";
+
+export interface DiscoveryThemeBundleItem {
+  ticker: string;
+  label: string;
+  market: DiscoveryMarket;
+  country?: StockCountry;
+  sector?: string;
+  relation: DiscoveryRelationKind;
+  reason: string;
+  source: string;
+  confidence: "L" | "M" | "H";
+  changePct?: number;
+  naverCode?: string;
+  symbol?: string;
+}
+
+export interface DiscoveryThemeBundleCard {
+  kind: "theme_bundle";
+  id: string;
+  title: string;
+  subtitle: string;
+  source: string;
+  asOf: string;
+  confidence: "L" | "M" | "H";
+  anchorTicker: string;
+  relation: "event_bundle";
+  items: DiscoveryThemeBundleItem[];
+}
+
 export interface UniverseStock {
   ticker: string;
   riskFlags?: readonly string[];


### PR DESCRIPTION
## Summary
- Add a grounded relation graph seed layer for typed `customer/supplier/material/peer/beneficiary` relationships.
- Extend discovery responses with optional mixed `cards` while keeping legacy `stocks` unchanged for guard/cache compatibility.
- Render event-driven theme bundle cards in the swipe deck without hydrating stock-front or writing fake watchlist items.
- Gate bundle creation to real current events only: disclosure/news/flow. Same-sector theme movement alone does not create a bundle.

## Notes
- Current KR runtime smoke produced 50 stock cards and 0 bundle cards because no current event anchor with 2+ related market rows was available.
- This is intentional fail-closed behavior: no event, no bundle.
- Existing discovery stock quality is preserved: `stocks` remains 50 and regression guard passes.

## Verification
- `npm test -- apps/web/__tests__/lib/relation-graph-theme-bundle.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts`
- `npm run typecheck`
- `npm run guard:discovery`
- `npm run build:web`
- `npm run build:fomo-web`
- `npm run lint`

## Runtime Smoke
- KR discovery: 50 stocks / 50 cards / 0 bundles under current live data.
- Bundle creation is verified with fixture disclosure event + related rows.
