### PR TITLE
chore(pipeline): 수집 진단 도구(Phase 0) — 테마 0건 원인 분류

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "guard:product": "npm run guard:discovery",
     "eval:understanding": "tsx scripts/eval-understanding.ts",
     "eval:understanding:live": "tsx scripts/eval-understanding-live.ts",
+    "diag:collection": "tsx scripts/diag-collection.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/scripts/diag-collection.ts
+++ b/scripts/diag-collection.ts
@@ -1,0 +1,84 @@
+/**
+ * 수집 진단(Phase 0) — 테마별 수집 0건의 원인을 (i)구조적/(ii)일시적/(iii)실부재로 분류.
+ *
+ * 순서: 대조군(반도체)→의심(조선·자동차)→대조군(바이오). 앞뒤 대조군이 정상인데
+ * 중간이 0이면 소스 장애가 아니라 테마→소스 매핑 공백(구조적).
+ * LLM 불필요(수집만). 실행: npm run diag:collection  (또는 tsx scripts/diag-collection.ts [테마...])
+ *
+ * 근본 레버: 뉴스 = THEME_DICTIONARY(packages/fomo-core/src/keyword-cards/extract.ts),
+ *           종토방 = THEME_NAVER_CODES(apps/web/lib/theme-understanding.ts).
+ */
+import { extractKeywords, type KeywordSourceItem } from "@fomo/core";
+import { collectThemeDocs } from "../apps/web/lib/theme-understanding";
+import { fetchAllNews } from "../apps/web/lib/fomo-news-sources";
+
+const THEMES = process.argv.slice(2).length > 0 ? process.argv.slice(2) : ["반도체", "조선", "자동차", "바이오"];
+const CONTROLS = new Set(["반도체", "바이오"]); // 소스 건강성 기준선
+
+interface Row {
+  theme: string;
+  total: number;
+  news: number;
+  community: number;
+  official: number;
+}
+
+async function main(): Promise<void> {
+  // 1) 뉴스 소스 건강성 + 매칭 가능한 키워드 버킷(한 번만 호출).
+  console.log("=== 뉴스 소스 건강성 / 키워드 버킷 ===");
+  let bucketKeywords = new Set<string>();
+  try {
+    const news = await fetchAllNews();
+    const items: KeywordSourceItem[] = news.map((a) => ({
+      title: a.title,
+      ...(a.summary ? { summary: a.summary } : {}),
+      publishedAt: a.publishedAt,
+      source: a.source,
+      lang: a.lang,
+    }));
+    const buckets = extractKeywords(items)
+      .map((k) => ({ keyword: k.keyword, n: k.articles.length }))
+      .sort((a, b) => b.n - a.n);
+    bucketKeywords = new Set(buckets.map((b) => b.keyword));
+    console.log(`fetchAllNews: ${news.length}건 (소스 정상)`);
+    console.log(`매칭 키워드 버킷 ${buckets.length}개: ${buckets.map((b) => `${b.keyword}(${b.n})`).join(", ")}`);
+  } catch (err) {
+    console.log(`fetchAllNews REJECTED: ${(err as Error)?.message}`);
+  }
+
+  // 2) 테마별 실제 collectThemeDocs 결과를 kind 로 분해.
+  console.log("\n=== 테마별 collectThemeDocs (kind 분해) ===");
+  const rows: Row[] = [];
+  for (const theme of THEMES) {
+    const docs = await collectThemeDocs(theme);
+    const byKind = new Map<string, number>();
+    for (const d of docs) byKind.set(d.kind, (byKind.get(d.kind) ?? 0) + 1);
+    const row: Row = {
+      theme,
+      total: docs.length,
+      news: byKind.get("news") ?? 0,
+      community: byKind.get("community") ?? 0,
+      official: byKind.get("official") ?? 0,
+    };
+    rows.push(row);
+    console.log(`  ${theme.padEnd(6)} total=${row.total}  news=${row.news}  community=${row.community}  official=${row.official}`);
+  }
+
+  // 3) 분류 판정.
+  console.log("\n=== 판정 ===");
+  const controlsOk = rows.filter((r) => CONTROLS.has(r.theme)).every((r) => r.total > 0);
+  for (const r of rows) {
+    if (r.total > 0) {
+      console.log(`  ${r.theme}: 정상(${r.total}건)`);
+    } else if (controlsOk && !bucketKeywords.has(r.theme)) {
+      console.log(`  ${r.theme}: (i) 구조적 매핑 공백 — 소스 정상인데 테마 버킷/종토방코드 없음`);
+    } else if (!controlsOk) {
+      console.log(`  ${r.theme}: (ii) 일시적 의심 — 대조군도 실패(소스 장애/레이트리밋)`);
+    } else {
+      console.log(`  ${r.theme}: (iii) 실부재 가능 — 소스·버킷 정상이나 오늘 원문 0`);
+    }
+  }
+  process.exit(0);
+}
+
+void main();


### PR DESCRIPTION
## 무엇
테마별 수집 0건의 원인을 **(i)구조적 매핑 공백 / (ii)일시적 / (iii)실부재**로 가르는 진단 스크립트. `npm run diag:collection [테마...]`.

대조군(반도체)→의심(조선·자동차)→대조군(바이오) 순서로 돌려, 앞뒤 대조군이 정상인데 중간만 0이면 소스 장애가 아닌 구조적 공백으로 판정.

## 실측 결과 (2026-06-27)
| 테마 | 뉴스 | 종토방 | 합 | 판정 |
|---|---|---|---|---|
| 반도체(대조) | 12 | 10 | 22 | 정상 |
| 조선 | 0 | 0 | 0 | **(i) 구조적** |
| 자동차 | 0 | 0 | 0 | **(i) 구조적** |
| 바이오(대조) | 8 | 0 | 8 | 정상(뉴스만) |

- 뉴스소스 정상(386건), 대조군 앞뒤 정상 → **레이트리밋 아님.** 뉴스 매칭 버킷 **9개뿐**(반도체·AI·금리·바이오·원자력·방산·2차전지·코인·공급망).
- 근본 레버: 뉴스 = `THEME_DICTIONARY`(packages/fomo-core/src/keyword-cards/extract.ts), 종토방 = `THEME_NAVER_CODES`(apps/web/lib/theme-understanding.ts, 반도체만).

## 범위
**진단 도구만.** 사전 확장(THEME_DICTIONARY/THEME_NAVER_CODES)은 오추출 위험이 큰 큐레이션 작업이라 별도 처리(광혁/Codex). 이 PR은 제품 동작 무변경(스크립트 추가만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)