### PR TITLE
fix(discovery): restore specific signal-grounded hooks

### DIFF
--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { DiscoveryCandidate, DiscoveryEventKind } from "@fomo/core";
 
-import { cleanMaterialTitle, recoverDiscoveryCandidates } from "../../lib/discovery-supply";
+import { cleanMaterialTitle, formatSectorMarketContextLabel, formatThemeDiscoveryLabel, recoverDiscoveryCandidates } from "../../lib/discovery-supply";
 
 const asOf = "2026-06-27";
 
@@ -48,6 +48,62 @@ describe("discovery material news filter", () => {
   it("does not treat generic stock movement as material news", () => {
     expect(cleanMaterialTitle("특징주 모음, 2차전지주 동반 상승")).toBeUndefined();
     expect(cleanMaterialTitle("장중 시황, 반도체주 차익 실현")).toBeUndefined();
+  });
+});
+
+describe("discovery specific hook copy", () => {
+  it("keeps same-sector leaders specific instead of collapsing to one generic sentence", () => {
+    const hpsp = formatThemeDiscoveryLabel({
+      sector: "반도체",
+      rank: 1,
+      peerCount: 14,
+      averageChangePct: 1.5,
+      relativeChangePct: 1.83,
+      changePct: 3.33,
+    });
+    const wonik = formatThemeDiscoveryLabel({
+      sector: "반도체",
+      rank: 2,
+      peerCount: 14,
+      averageChangePct: 1.5,
+      relativeChangePct: 4.38,
+      changePct: 5.88,
+    });
+    const outperformer = formatThemeDiscoveryLabel({
+      sector: "반도체",
+      rank: 6,
+      peerCount: 14,
+      averageChangePct: 1.5,
+      relativeChangePct: 1.68,
+      changePct: 3.18,
+    });
+
+    expect(hpsp).toBe("오늘 반도체 14개 종목 중 가장 강했어요(+3.33%).");
+    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 강했어요(+5.88%).");
+    expect(outperformer).toBe("오늘 반도체 평균(+1.50%)보다 1.7포인트 더 강했어요(+3.18%).");
+    expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
+    expect([hpsp, wonik, outperformer].some((text) => /흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
+    expect([hpsp, wonik, outperformer].every((text) => !/^오늘 가격이/.test(text))).toBe(true);
+  });
+
+  it("keeps sector-only movers contextual instead of generic or raw price-only copy", () => {
+    const spike = formatSectorMarketContextLabel({
+      sector: "건설",
+      rankText: "시총 461위권",
+      changePct: 30,
+      change: "+30.00%",
+    });
+    const ordinary = formatSectorMarketContextLabel({
+      sector: "화장품",
+      rankText: "시총 210위권",
+      changePct: 4.2,
+      change: "+4.20%",
+    });
+
+    expect(spike).toBe("건설 안에서도 시총 461위권 종목의 큰 움직임이 새로 잡혔어요(+30.00%).");
+    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목이 같이 움직였어요(+4.20%).");
+    expect([spike, ordinary].some((text) => /흐름에서 (?:먼저|같이|새로) 확인/.test(text))).toBe(false);
+    expect([spike, ordinary].every((text) => !/^오늘 가격이/.test(text))).toBe(true);
   });
 });
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -28,7 +28,6 @@ import {
   type MultiAxisHookSelection,
   type SectorStock,
   type StockCountry,
-  type StockSector,
   type RawArticle,
 } from "@fomo/core";
 import { fetchDartDisclosuresByStock, type DartDisclosureHit } from "./dart-disclosures";
@@ -141,7 +140,7 @@ interface RawNaverStock {
 }
 
 interface ThemeMoveSignal {
-  sector: StockSector;
+  sector: string;
   rank: number;
   peerCount: number;
   averageChangePct: number;
@@ -363,9 +362,9 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
 }
 
 function buildThemeMoveSignals(rows: readonly DiscoveryMarketRow[]): Map<string, ThemeMoveSignal> {
-  const groups = new Map<StockSector, Array<{ ticker: string; changePct: number }>>();
+  const groups = new Map<string, Array<{ ticker: string; changePct: number }>>();
   for (const row of rows) {
-    const sector = sectorOf(row.canonical);
+    const sector = sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
     if (!sector || typeof row.changePct !== "number") continue;
     const current = groups.get(sector) ?? [];
     current.push({ ticker: row.canonical, changePct: row.changePct });
@@ -392,6 +391,32 @@ function buildThemeMoveSignals(rows: readonly DiscoveryMarketRow[]): Map<string,
   return out;
 }
 
+export function formatThemeDiscoveryLabel(input: {
+  sector: string;
+  rank: number;
+  peerCount: number;
+  averageChangePct: number;
+  relativeChangePct: number;
+  changePct: number;
+}): string {
+  return input.rank <= 3
+    ? `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${ordinalText(input.rank)} 강했어요(${pctText(input.changePct)}).`
+    : `오늘 ${input.sector} 평균(${pctText(input.averageChangePct)})보다 ${pointText(input.relativeChangePct)}포인트 더 강했어요(${pctText(input.changePct)}).`;
+}
+
+export function formatSectorMarketContextLabel(input: {
+  sector: string;
+  rankText: string;
+  changePct: number;
+  change: string;
+}): string {
+  const positive = input.changePct > 0;
+  const largeMove = Math.abs(input.changePct) >= 10;
+  if (positive && largeMove) return `${input.sector} 안에서도 ${input.rankText} 종목의 큰 움직임이 새로 잡혔어요(${input.change}).`;
+  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목이 같이 움직였어요(${input.change}).`;
+  return `${input.sector} 안에서 ${input.rankText} 종목의 약한 흐름도 같이 확인해요(${input.change}).`;
+}
+
 function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
   if (!theme || typeof row.changePct !== "number") return null;
   const strongTheme = theme.averageChangePct >= 1.5 && theme.positiveCount >= 2;
@@ -400,10 +425,7 @@ function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefi
   const positiveStrongTheme = row.changePct >= 3 && strongTheme && theme.relativeChangePct >= 0;
   const positiveSectorSpike = row.changePct >= 7 && theme.relativeChangePct >= 0;
   if (!leadingTheme && !positiveOutperformer && !positiveStrongTheme && !positiveSectorSpike) return null;
-  const label =
-    theme.rank <= 3
-      ? `오늘 ${theme.sector} 흐름에서 먼저 확인된 종목이에요.`
-      : `오늘 ${theme.sector} 흐름에서 같이 확인된 종목이에요.`;
+  const label = formatThemeDiscoveryLabel({ ...theme, changePct: row.changePct });
   return {
     kind: "theme_link",
     firstSeen: true,
@@ -418,6 +440,17 @@ function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefi
 function pctText(value: number): string {
   const sign = value > 0 ? "+" : "";
   return `${sign}${value.toFixed(2)}%`;
+}
+
+function pointText(value: number): string {
+  return Math.abs(value).toFixed(1);
+}
+
+function ordinalText(rank: number): string {
+  if (rank === 1) return "가장";
+  if (rank === 2) return "두 번째로";
+  if (rank === 3) return "세 번째로";
+  return `${rank}번째로`;
 }
 
 function industryHintForTicker(ticker: string): string | undefined {
@@ -436,10 +469,10 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
-        ? `${sector} 흐름에서 먼저 확인된 종목이에요.`
+        ? `${theme.peerCount}개 ${sector} 종목 중 ${ordinalText(theme.rank)} 강하게 움직였어요.`
         : changePct > 0
-          ? `${sector} 흐름에서 같이 확인된 종목이에요.`
-          : `${sector} 흐름에서 약한 쪽도 함께 확인하고 있어요.`;
+          ? `오늘 ${sector} 안에서 같이 오른 쪽이에요(${change}).`
+          : `오늘 ${sector} 안에서 약한 쪽 흐름이에요(${change}).`;
     return {
       kind: "market_context",
       firstSeen: true,
@@ -451,6 +484,17 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
     };
   }
   if (sector) {
+    if (typeof changePct === "number" && change) {
+      return {
+        kind: "market_context",
+        firstSeen: true,
+        strength: Math.min(0.7, 0.44 + Math.abs(changePct) / 50),
+        source,
+        asOf,
+        confidence: "M",
+        label: formatSectorMarketContextLabel({ sector, rankText, changePct, change }),
+      };
+    }
     return {
       kind: "market_context",
       firstSeen: true,


### PR DESCRIPTION
## Summary
- restore specific theme/relative-strength hooks removed by #696 over-deletion
- keep WO-06 intent: no raw price-percent-only headline, but allow grounded relative rank/peer-count/sector average context
- broaden theme grouping from the 7 curated sectors to industry hints, so construction/retail/cosmetics/etc. cards produce peer-comparison hooks instead of market_context fallbacks
- add regression tests for HPSP/Wonik-style same-sector diversity and sector-only movers

## Before / After smoke
- HPSP: 오늘 반도체 15개 종목 중 두 번째로 강했어요(+3.33%).
- 원익IPS: 오늘 반도체 15개 종목 중 가장 강했어요(+5.88%).
- 금호건설: 오늘 건설 14개 종목 중 가장 강했어요(+30.00%).

## Verification
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run guard:discovery
- npm run typecheck:web
- npm run typecheck:fomo-web
- npm run typecheck:fomo-core
- npm run build:web
- npm run build:fomo-web
