### PR TITLE
feat(us): real discovery universe + chart/session hooks

### DIFF
--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -14,10 +14,44 @@ describe("US market source", () => {
     const { fetchUsMarketRows } = await import("../../lib/us-market-source");
 
     const rows = await fetchUsMarketRows();
-    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeGreaterThan(30);
     expect(rows.every((row) => row.country !== "KR" && row.symbol && row.currency === "USD")).toBe(true);
     expect(rows.every((row) => row.priceText === undefined && row.changePct === undefined && row.changeText === undefined)).toBe(true);
+    expect(rows.some((row) => row.symbol === "SMCI")).toBe(true);
+    expect(rows.some((row) => row.sectorHint === "양자")).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("hydrates US quotes and sparklines without Yahoo chart endpoints", async () => {
+    vi.stubEnv("TWELVE_DATA_API_KEY", "td-test");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("market_movers")) {
+        return Response.json({ values: [{ symbol: "SMCI" }, { symbol: "IONQ" }] });
+      }
+      if (url.includes("quote")) {
+        return Response.json({
+          SMCI: { symbol: "SMCI", price: "49.20", change: "3.10", percent_change: "6.72", volume: "23000000", exchange: "NASDAQ" },
+          IONQ: { symbol: "IONQ", price: "38.10", change: "1.20", percent_change: "3.25", volume: "18000000", exchange: "NYSE" },
+          NVDA: { symbol: "NVDA", price: "150.00", change: "1.00", percent_change: "0.67", volume: "100000000", exchange: "NASDAQ" },
+        });
+      }
+      if (url.includes("time_series")) {
+        return Response.json({
+          SMCI: { values: [{ datetime: "2026-06-27", close: "49.2" }, { datetime: "2026-06-26", close: "46.1" }] },
+          IONQ: { values: [{ datetime: "2026-06-27", close: "38.1" }, { datetime: "2026-06-26", close: "36.9" }] },
+        });
+      }
+      return Response.json({});
+    });
+    const { fetchUsMarketRows } = await import("../../lib/us-market-source");
+
+    const rows = await fetchUsMarketRows();
+    const smci = rows.find((row) => row.symbol === "SMCI");
+    expect(smci?.priceText).toBe("$49.20");
+    expect(smci?.changePct).toBe(6.72);
+    expect(smci?.sparkline).toEqual([46.1, 49.2]);
+    expect(smci?.sectorHint).toBe("AI");
   });
 
   it("does not wire Yahoo chart endpoints into the US quote adapter", () => {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -38,7 +38,7 @@ import { fetchRecentSecFilings } from "./sec-edgar";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
-import { fetchUsMarketRows } from "./us-market-source";
+import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -62,6 +62,10 @@ const MATERIAL_NEWS_NOISE =
   /인기검색|검색\s?순위|주요\s?뉴스|오늘의\s?증시|마감\s?시황|장중\s?시황|특징주\s?모음|주식\s?초고수|초고수|단타|ETF|ETN|상장지수|레버리지|인버스|TOP\s?\d|상위\s?\d|회장|최고경영자|CEO|고백|회고|소회|인터뷰|기부|ESG|봉사|사회공헌|미담|창업주|오너|가문|고향|강연|도서|출간|어려울\s?때마다|찾았다/i;
 const MATERIAL_NEWS_CATALYST =
   /공시|계약|공급계약|수주|납품|실적|매출|영업이익|순이익|가이던스|전망치|컨센서스|어닝|흑자|적자|턴어라운드|임상|허가|승인|FDA|품목허가|신약|치료제|기술이전|라이선스|증설|공장|양산|수율|수주잔고|M&A|인수|합병|지분|투자|유상증자|무상증자|자사주|배당|분할|상장|정부|정책|규제|지원|보조금|관세|제재|신제품|출시|개발|특허|공급|독점|선정|채택|수출|수입|국책|프로젝트|수혜/i;
+const US_MATERIAL_NEWS_NOISE =
+  /price\s?target|target price|analyst|rating|upgrade|downgrade|initiates?|maintains?|reiterates?|buybacks?\s+explained|history of|should you buy|stock to buy|motley fool|zacks|benzinga|investorplace|why .* stock (?:is )?(?:up|down|rising|falling)|shares? (?:rise|fall|slip|jump) after hours/i;
+const US_MATERIAL_NEWS_CATALYST =
+  /earnings|results|revenue|profit|margin|guidance|forecast|quarter|q[1-4]|contract|deal|order|supply|supplier|customer|partnership|launch|unveil|product|chip|gpu|ai|data center|approval|fda|trial|drug|sec|8-k|10-q|filing|acquisition|merger|stake|investment|buyback authorization|dividend/i;
 const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_DEFAULT_ENABLED
   ? "네이버/KR 시세·DART·수급 캐시·Twelve Data/US 시세·SEC"
   : "시장 시세·공시·수급 캐시";
@@ -150,6 +154,10 @@ interface ThemeMoveSignal {
 
 function todayKst(): string {
   return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function discoveryAsOf(scope: DiscoveryCountryScope): string {
+  return scope === "US" ? latestUsSessionAsOf().date : todayKst();
 }
 
 function numberFromText(value: string | undefined): number | undefined {
@@ -252,7 +260,7 @@ function eventFromPrice(row: DiscoveryMarketRow, asOf: string): DiscoveryEvent |
     kind: "price_move",
     firstSeen: true,
     strength: Math.min(1, Math.abs(row.changePct) / 15),
-    source: "네이버 시세",
+    source: row.country === "US" ? row.sessionLabel ?? "Twelve Data 시세" : "네이버 시세",
     asOf,
     confidence: "H",
     label: `오늘 가격이 ${row.changePct > 0 ? "+" : ""}${row.changePct.toFixed(2)}% 움직였어요.`,
@@ -302,9 +310,10 @@ function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFal
     .replace(/\s+/g, " ")
     .replace(/[.!?。]+$/g, "")
     .trim();
-  if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned)) return null;
-  const label = cleaned.length > 54 ? `${cleaned.slice(0, 52).replace(/\s+\S*$/, "").trim()}…` : cleaned;
-  if (!isFrontHookSafe(`오늘 이 종목을 직접 언급한 외신이 있어요: ${label}`)) return null;
+  if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned) || US_MATERIAL_NEWS_NOISE.test(cleaned)) return null;
+  if (!US_MATERIAL_NEWS_CATALYST.test(cleaned)) return null;
+  const label = usMaterialLabel(cleaned);
+  if (!isFrontHookSafe(label)) return null;
   return {
     kind: "news_mention",
     firstSeen: true,
@@ -314,6 +323,24 @@ function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFal
     confidence: "M",
     label,
   };
+}
+
+function usMaterialLabel(title: string): string {
+  if (/8-k|10-q|filing|sec/i.test(title)) return "SEC 공시로 확인된 재료가 있어요.";
+  if (/earnings|results|revenue|profit|margin|guidance|forecast|quarter|q[1-4]/i.test(title)) {
+    return "실적·가이던스 이슈를 직접 다룬 외신이 나왔어요.";
+  }
+  if (/contract|deal|order|supply|supplier|customer|partnership/i.test(title)) {
+    return "계약·공급망 이슈를 직접 다룬 외신이 나왔어요.";
+  }
+  if (/launch|unveil|product|chip|gpu|ai|data center/i.test(title)) {
+    return "제품·AI 인프라 이슈를 직접 다룬 외신이 나왔어요.";
+  }
+  if (/approval|fda|trial|drug/i.test(title)) return "임상·허가 이슈를 직접 다룬 외신이 나왔어요.";
+  if (/acquisition|merger|stake|investment|buyback authorization|dividend/i.test(title)) {
+    return "투자·자본정책 이슈를 직접 다룬 외신이 나왔어요.";
+  }
+  return "이 종목을 직접 다룬 외신 재료가 나왔어요.";
 }
 
 async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
@@ -336,7 +363,7 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
     }
     const stockNews =
       newsResult.status === "fulfilled"
-        ? newsResult.value.find((article) => isPrimaryStockArticle(row.canonical, article))
+        ? newsResult.value.find((article) => materialEventFromUsArticle(article, asOf, "Yahoo Finance") !== null)
         : undefined;
     return stockNews ? materialEventFromUsArticle(stockNews, asOf, "Yahoo Finance") : null;
   }
@@ -364,7 +391,7 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
 function buildThemeMoveSignals(rows: readonly DiscoveryMarketRow[]): Map<string, ThemeMoveSignal> {
   const groups = new Map<string, Array<{ ticker: string; changePct: number }>>();
   for (const row of rows) {
-    const sector = sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
+    const sector = row.sectorHint ?? sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
     if (!sector || typeof row.changePct !== "number") continue;
     const current = groups.get(sector) ?? [];
     current.push({ ticker: row.canonical, changePct: row.changePct });
@@ -461,11 +488,11 @@ function industryHintForTicker(ticker: string): string | undefined {
 }
 
 function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent {
-  const sector = theme?.sector ?? sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
+  const sector = theme?.sector ?? row.sectorHint ?? sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
   const rankText = row.marketCapRank ? `시총 ${row.marketCapRank}위권` : "시총 상위권";
   const changePct = row.changePct;
   const change = typeof changePct === "number" ? pctText(changePct) : undefined;
-  const source = row.country === "KR" ? "네이버 시세" : typeof row.changePct === "number" || row.priceText ? "Twelve Data 시세" : "FOMO US 종목 사전";
+  const source = row.country === "KR" ? "네이버 시세" : row.sessionLabel ?? (typeof row.changePct === "number" || row.priceText ? "Twelve Data 시세" : "FOMO US 종목 사전");
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
@@ -779,7 +806,7 @@ function frontSeed(
     ...(mentionSignals ? mentionSignals : {}),
     ...(currentNewsEvent?.label ? { newsEventLabel: currentNewsEvent.label } : {}),
     ...(currentNewsEvent?.source ? { newsEventSource: currentNewsEvent.source } : {}),
-    ...(row.marketCapRank ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),
+    ...(row.marketCapRank && row.marketCapRankSource !== "curated" ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),
     ...(theme ? {
       themeLabel: theme.sector,
       themeRelativeRank: theme.rank,
@@ -922,7 +949,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   const scope = options.country ?? "KR";
   const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
   const targetedMaterialLimit = targetedMaterialEnabled ? TARGETED_MATERIAL_CANDIDATE_LIMIT : 0;
-  const asOf = todayKst();
+  const asOf = discoveryAsOf(scope);
   const [rows, attentionMap] = await Promise.all([
     fetchMarketRows(scope),
     computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
@@ -1022,7 +1049,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     const direction: NonNullable<DiscoveryEvent["direction"]> =
       typeof row.changePct !== "number" ? "flat" : row.changePct > 0 ? "up" : row.changePct < 0 ? "down" : "flat";
     const directedEvents: DiscoveryEvent[] = events.map((event) => event.direction ? event : { ...event, direction });
-    const sector = inferDiscoverySectorLabel(ticker, directedEvents, themeSignals.get(ticker), asOf);
+    const sector = row.sectorHint ?? inferDiscoverySectorLabel(ticker, directedEvents, themeSignals.get(ticker), asOf);
     const candidateBase: DiscoveryCandidate = {
       ticker,
       market: row.market,

--- a/apps/web/lib/market-source-types.ts
+++ b/apps/web/lib/market-source-types.ts
@@ -9,6 +9,7 @@ export interface DiscoveryMarketRow {
   market: DiscoveryMarket;
   country: StockCountry;
   marketCapRank?: number;
+  marketCapRankSource?: "live" | "curated";
   priceText?: string;
   changeText?: string;
   changeDir?: "up" | "down" | "flat";
@@ -16,6 +17,8 @@ export interface DiscoveryMarketRow {
   tradingValue?: number;
   currency?: "KRW" | "USD";
   sparkline?: number[];
+  sectorHint?: string;
+  sessionLabel?: string;
 }
 
 export interface MarketSource {

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -1,21 +1,13 @@
-import { STOCK_VOCAB, type DiscoveryMarket } from "@fomo/core";
+import type { DiscoveryMarket } from "@fomo/core";
 import type { DiscoveryMarketRow } from "./market-source-types";
-import { usStockDefs, usSymbolForStock } from "./us-symbols";
+import { usDiscoveryUniverse, type UsDiscoverySymbol } from "./us-symbols";
 
 const TWELVE_DATA_URL = "https://api.twelvedata.com/quote";
+const TWELVE_TIME_SERIES_URL = "https://api.twelvedata.com/time_series";
+const TWELVE_MARKET_MOVERS_URL = "https://api.twelvedata.com/market_movers/stocks";
 const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
-
-const US_MARKET_CAP_RANK: Record<string, number> = {
-  AAPL: 1,
-  MSFT: 2,
-  NVDA: 3,
-  AVGO: 8,
-  TSLA: 9,
-  TSM: 10,
-  AMD: 32,
-  PLTR: 55,
-  MU: 96,
-};
+const US_QUOTE_LIMIT = 80;
+const US_SPARKLINE_LIMIT = 60;
 
 interface TwelveQuote {
   symbol?: string;
@@ -27,6 +19,16 @@ interface TwelveQuote {
   percent_change?: string;
   volume?: string;
   currency?: string;
+}
+
+interface TwelveTimeSeriesValue {
+  datetime?: string;
+  close?: string;
+}
+
+interface TwelveTimeSeries {
+  symbol?: string;
+  values?: TwelveTimeSeriesValue[];
 }
 
 function tdKey(): string | undefined {
@@ -48,23 +50,62 @@ function marketFor(defMarket: string, exchange: string | undefined): DiscoveryMa
   return "NASDAQ";
 }
 
-function parseQuote(defCanonical: string, quote: TwelveQuote): DiscoveryMarketRow | null {
-  const symbol = (quote.symbol ?? usSymbolForStock(defCanonical) ?? "").toUpperCase();
+function latestUsSessionDate(now = new Date()): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "short",
+  }).formatToParts(now);
+  const value = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  const ymd = `${value("year")}-${value("month")}-${value("day")}`;
+  const day = value("weekday");
+  const current = new Date(`${ymd}T12:00:00-05:00`);
+  while (current.getUTCDay() === 0 || current.getUTCDay() === 6 || isSimpleUsMarketHoliday(current)) {
+    current.setUTCDate(current.getUTCDate() - 1);
+  }
+  return current.toISOString().slice(0, 10);
+}
+
+function isSimpleUsMarketHoliday(date: Date): boolean {
+  const yyyy = date.getUTCFullYear();
+  const mmdd = date.toISOString().slice(5, 10);
+  const holidays = new Set([
+    `${yyyy}-01-01`.slice(5),
+    `${yyyy}-06-19`.slice(5),
+    `${yyyy}-07-04`.slice(5),
+    `${yyyy}-12-25`.slice(5),
+  ]);
+  return holidays.has(mmdd);
+}
+
+export function latestUsSessionAsOf(now = new Date()): { date: string; label: string } {
+  const date = latestUsSessionDate(now);
+  const [, month, day] = date.match(/^\d{4}-(\d{2})-(\d{2})$/) ?? [];
+  return {
+    date,
+    label: month && day ? `${Number(month)}월 ${Number(day)}일(ET) 종가 기준` : `${date}(ET) 기준`,
+  };
+}
+
+function parseQuote(seed: UsDiscoverySymbol, quote: TwelveQuote | undefined, sparkline?: number[]): DiscoveryMarketRow | null {
+  const symbol = (quote?.symbol ?? seed.symbol).toUpperCase();
   if (!symbol) return null;
-  const def = STOCK_VOCAB.find((stock) => stock.canonical === defCanonical);
-  const price = num(quote.price) ?? num(quote.close);
-  const pct = num(quote.percent_change);
-  const change = num(quote.change);
+  const session = latestUsSessionAsOf();
+  const price = num(quote?.price) ?? num(quote?.close);
+  const pct = num(quote?.percent_change);
+  const change = num(quote?.change);
   const priceText = money(price);
-  const volume = num(quote.volume);
+  const volume = num(quote?.volume);
   const dir = typeof pct !== "number" ? "flat" : pct > 0 ? "up" : pct < 0 ? "down" : "flat";
   return {
-    canonical: defCanonical,
+    canonical: seed.canonical,
     symbol,
-    market: marketFor(def?.market ?? "NASDAQ", quote.exchange),
-    country: def?.country ?? "US",
+    market: marketFor(seed.market, quote?.exchange),
+    country: "US",
     currency: "USD",
-    ...(US_MARKET_CAP_RANK[symbol] ? { marketCapRank: US_MARKET_CAP_RANK[symbol] } : {}),
+    ...(seed.fameRank ? { marketCapRank: seed.fameRank, marketCapRankSource: "curated" as const } : {}),
     ...(priceText ? { priceText } : {}),
     ...(typeof pct === "number" ? { changePct: pct } : {}),
     ...(typeof pct === "number" || typeof change === "number"
@@ -72,24 +113,24 @@ function parseQuote(defCanonical: string, quote: TwelveQuote): DiscoveryMarketRo
       : {}),
     changeDir: dir,
     ...(volume ? { tradingValue: volume } : {}),
+    ...(sparkline && sparkline.length >= 2 ? { sparkline } : {}),
+    sectorHint: seed.sector,
+    sessionLabel: session.label,
   };
 }
 
 function seedRows(): DiscoveryMarketRow[] {
-  return usStockDefs()
-    .map((def, index): DiscoveryMarketRow | null => {
-      const symbol = usSymbolForStock(def.canonical)?.toUpperCase();
-      if (!symbol) return null;
-      return {
-        canonical: def.canonical,
-        symbol,
-        market: marketFor(def.market, undefined),
-        country: def.country === "KR" ? "US" : def.country,
-        currency: "USD",
-        marketCapRank: US_MARKET_CAP_RANK[symbol] ?? index + 200,
-      };
-    })
-    .filter((row): row is DiscoveryMarketRow => row !== null);
+  const session = latestUsSessionAsOf();
+  return usDiscoveryUniverse().map((seed) => ({
+    canonical: seed.canonical,
+    symbol: seed.symbol,
+    market: marketFor(seed.market, undefined),
+    country: "US",
+    currency: "USD",
+    ...(seed.fameRank ? { marketCapRank: seed.fameRank, marketCapRankSource: "curated" as const } : {}),
+    sectorHint: seed.sector,
+    sessionLabel: session.label,
+  }));
 }
 
 function normalizeQuoteResponse(data: unknown): Record<string, TwelveQuote> {
@@ -108,6 +149,95 @@ function normalizeQuoteResponse(data: unknown): Record<string, TwelveQuote> {
   return out;
 }
 
+function normalizeTimeSeriesResponse(data: unknown): Record<string, number[]> {
+  if (!data || typeof data !== "object") return {};
+  const root = data as Record<string, unknown>;
+  const parseOne = (series: TwelveTimeSeries): number[] =>
+    (series.values ?? [])
+      .map((row) => num(row.close))
+      .filter((value): value is number => typeof value === "number")
+      .reverse();
+  if ("values" in root) {
+    const series = root as TwelveTimeSeries;
+    return series.symbol ? { [series.symbol.toUpperCase()]: parseOne(series) } : {};
+  }
+  const out: Record<string, number[]> = {};
+  for (const [key, value] of Object.entries(root)) {
+    if (value && typeof value === "object" && !("code" in (value as Record<string, unknown>))) {
+      const parsed = parseOne(value as TwelveTimeSeries);
+      if (parsed.length > 0) out[key.toUpperCase()] = parsed;
+    }
+  }
+  return out;
+}
+
+function normalizeMoverSymbols(data: unknown): string[] {
+  if (!data || typeof data !== "object") return [];
+  const root = data as Record<string, unknown>;
+  const arrays = [root.values, root.data, root.gainers, root.losers, root.most_active].filter(Array.isArray) as unknown[][];
+  const symbols = new Set<string>();
+  for (const arr of arrays) {
+    for (const item of arr) {
+      if (!item || typeof item !== "object") continue;
+      const symbol = String((item as Record<string, unknown>).symbol ?? "").toUpperCase();
+      if (/^[A-Z.]{1,6}$/.test(symbol)) symbols.add(symbol);
+    }
+  }
+  return [...symbols];
+}
+
+async function fetchMoverSymbols(key: string): Promise<string[]> {
+  const out = new Set<string>();
+  for (const type of ["gainers", "most_active"] as const) {
+    try {
+      const url = new URL(TWELVE_MARKET_MOVERS_URL);
+      url.searchParams.set("apikey", key);
+      url.searchParams.set("country", "United States");
+      url.searchParams.set("type", type);
+      const res = await fetch(url.toString(), {
+        headers: { accept: "application/json", "user-agent": UA },
+        signal: AbortSignal.timeout(5_000),
+        next: { revalidate: 900 },
+      });
+      if (!res.ok) continue;
+      for (const symbol of normalizeMoverSymbols(await res.json())) out.add(symbol);
+    } catch {
+      // Market movers is opportunistic. The curated universe + quote batch is the fail-closed path.
+    }
+  }
+  return [...out];
+}
+
+async function fetchQuotes(symbols: readonly string[], key: string): Promise<Record<string, TwelveQuote>> {
+  if (symbols.length === 0) return {};
+  const url = new URL(TWELVE_DATA_URL);
+  url.searchParams.set("symbol", symbols.join(","));
+  url.searchParams.set("apikey", key);
+  const res = await fetch(url.toString(), {
+    headers: { accept: "application/json", "user-agent": UA },
+    signal: AbortSignal.timeout(8_000),
+    next: { revalidate: 600 },
+  });
+  if (!res.ok) return {};
+  return normalizeQuoteResponse(await res.json());
+}
+
+async function fetchSparklines(symbols: readonly string[], key: string): Promise<Record<string, number[]>> {
+  if (symbols.length === 0) return {};
+  const url = new URL(TWELVE_TIME_SERIES_URL);
+  url.searchParams.set("symbol", symbols.join(","));
+  url.searchParams.set("interval", "1day");
+  url.searchParams.set("outputsize", "42");
+  url.searchParams.set("apikey", key);
+  const res = await fetch(url.toString(), {
+    headers: { accept: "application/json", "user-agent": UA },
+    signal: AbortSignal.timeout(8_000),
+    next: { revalidate: 1_800 },
+  });
+  if (!res.ok) return {};
+  return normalizeTimeSeriesResponse(await res.json());
+}
+
 /**
  * US quote adapter. Twelve Data is used because Yahoo chart endpoints are unstable from Node/undici.
  * If the key is absent or the upstream fails, return a verified seed universe without price data.
@@ -116,27 +246,29 @@ function normalizeQuoteResponse(data: unknown): Record<string, TwelveQuote> {
 export async function fetchUsMarketRows(): Promise<DiscoveryMarketRow[]> {
   const key = tdKey();
   if (!key) return seedRows();
-  const defs = usStockDefs();
-  const symbols = defs.map((def) => usSymbolForStock(def.canonical)).filter((symbol): symbol is string => !!symbol);
-  if (symbols.length === 0) return seedRows();
+  const seeds = usDiscoveryUniverse();
+  const bySymbol = new Map(seeds.map((seed) => [seed.symbol.toUpperCase(), seed]));
   try {
-    const url = new URL(TWELVE_DATA_URL);
-    url.searchParams.set("symbol", symbols.join(","));
-    url.searchParams.set("apikey", key);
-    const res = await fetch(url.toString(), {
-      headers: { accept: "application/json", "user-agent": UA },
-      signal: AbortSignal.timeout(8_000),
-      next: { revalidate: 600 },
-    });
-    if (!res.ok) return seedRows();
-    const bySymbol = normalizeQuoteResponse(await res.json());
+    const moverSymbols = await fetchMoverSymbols(key);
+    const symbols = [...new Set([...moverSymbols, ...seeds.map((seed) => seed.symbol)])]
+      .filter((symbol) => /^[A-Z.]{1,6}$/.test(symbol))
+      .slice(0, US_QUOTE_LIMIT);
+    if (symbols.length === 0) return seedRows();
+    const [quotes, sparklines] = await Promise.all([
+      fetchQuotes(symbols, key),
+      fetchSparklines(symbols.slice(0, US_SPARKLINE_LIMIT), key).catch((): Record<string, number[]> => ({})),
+    ]);
     const rows: DiscoveryMarketRow[] = [];
-    for (const def of defs) {
-      const symbol = usSymbolForStock(def.canonical);
-      if (!symbol) continue;
-      const quote = bySymbol[symbol.toUpperCase()];
-      if (!quote) continue;
-      const row = parseQuote(def.canonical, quote);
+    for (const symbol of symbols) {
+      const upper = symbol.toUpperCase();
+      const quote = quotes[upper];
+      const seed = bySymbol.get(upper) ?? {
+        canonical: quote?.name?.trim() || upper,
+        symbol: upper,
+        market: /NYSE/i.test(quote?.exchange ?? "") ? "NYSE" : "NASDAQ",
+        sector: "미국주식",
+      };
+      const row = parseQuote(seed, quote, sparklines[upper]);
       if (row) rows.push(row);
     }
     return rows.length > 0 ? rows : seedRows();

--- a/apps/web/lib/us-symbols.ts
+++ b/apps/web/lib/us-symbols.ts
@@ -1,16 +1,87 @@
 import { STOCK_VOCAB, type StockDef } from "@fomo/core";
 
-const KNOWN_US_SYMBOLS: Record<string, string> = {
-  "엔비디아": "NVDA",
-  "TSMC": "TSM",
-  "마이크로소프트": "MSFT",
-  "애플": "AAPL",
-  "테슬라": "TSLA",
-  "AMD": "AMD",
-  "브로드컴": "AVGO",
-  "팔란티어": "PLTR",
-  "마이크론": "MU",
-};
+export interface UsDiscoverySymbol {
+  canonical: string;
+  symbol: string;
+  market: "NASDAQ" | "NYSE";
+  sector: string;
+  /**
+   * Fame rank is a coarse, curated ordering used only for deck sorting when
+   * live market-cap rank is unavailable. It must not be displayed as 시총 순위.
+   */
+  fameRank?: number;
+}
+
+export const US_DISCOVERY_SYMBOLS: UsDiscoverySymbol[] = [
+  { canonical: "엔비디아", symbol: "NVDA", market: "NASDAQ", sector: "AI", fameRank: 3 },
+  { canonical: "TSMC", symbol: "TSM", market: "NYSE", sector: "반도체", fameRank: 10 },
+  { canonical: "마이크로소프트", symbol: "MSFT", market: "NASDAQ", sector: "AI", fameRank: 2 },
+  { canonical: "애플", symbol: "AAPL", market: "NASDAQ", sector: "빅테크", fameRank: 1 },
+  { canonical: "테슬라", symbol: "TSLA", market: "NASDAQ", sector: "전기차", fameRank: 9 },
+  { canonical: "AMD", symbol: "AMD", market: "NASDAQ", sector: "반도체", fameRank: 32 },
+  { canonical: "브로드컴", symbol: "AVGO", market: "NASDAQ", sector: "반도체", fameRank: 8 },
+  { canonical: "팔란티어", symbol: "PLTR", market: "NASDAQ", sector: "AI", fameRank: 55 },
+  { canonical: "마이크론", symbol: "MU", market: "NASDAQ", sector: "반도체", fameRank: 96 },
+  { canonical: "슈퍼마이크로", symbol: "SMCI", market: "NASDAQ", sector: "AI", fameRank: 170 },
+  { canonical: "앱러빈", symbol: "APP", market: "NASDAQ", sector: "AI", fameRank: 120 },
+  { canonical: "로빈후드", symbol: "HOOD", market: "NASDAQ", sector: "핀테크", fameRank: 190 },
+  { canonical: "코인베이스", symbol: "COIN", market: "NASDAQ", sector: "핀테크", fameRank: 160 },
+  { canonical: "크라우드스트라이크", symbol: "CRWD", market: "NASDAQ", sector: "보안", fameRank: 150 },
+  { canonical: "스노우플레이크", symbol: "SNOW", market: "NYSE", sector: "클라우드", fameRank: 220 },
+  { canonical: "데이터독", symbol: "DDOG", market: "NASDAQ", sector: "클라우드", fameRank: 210 },
+  { canonical: "몽고DB", symbol: "MDB", market: "NASDAQ", sector: "클라우드", fameRank: 260 },
+  { canonical: "아이온큐", symbol: "IONQ", market: "NYSE", sector: "양자", fameRank: 360 },
+  { canonical: "리게티", symbol: "RGTI", market: "NASDAQ", sector: "양자", fameRank: 620 },
+  { canonical: "디웨이브퀀텀", symbol: "QBTS", market: "NYSE", sector: "양자", fameRank: 650 },
+  { canonical: "사운드하운드AI", symbol: "SOUN", market: "NASDAQ", sector: "AI", fameRank: 540 },
+  { canonical: "빅베어AI", symbol: "BBAI", market: "NYSE", sector: "AI", fameRank: 690 },
+  { canonical: "세레브라스", symbol: "CRWV", market: "NASDAQ", sector: "AI", fameRank: 430 },
+  { canonical: "아스테라랩스", symbol: "ALAB", market: "NASDAQ", sector: "반도체", fameRank: 310 },
+  { canonical: "램리서치", symbol: "LRCX", market: "NASDAQ", sector: "반도체", fameRank: 80 },
+  { canonical: "어플라이드머티어리얼즈", symbol: "AMAT", market: "NASDAQ", sector: "반도체", fameRank: 75 },
+  { canonical: "마벨테크놀로지", symbol: "MRVL", market: "NASDAQ", sector: "반도체", fameRank: 130 },
+  { canonical: "ARM", symbol: "ARM", market: "NASDAQ", sector: "반도체", fameRank: 60 },
+  { canonical: "웨스턴디지털", symbol: "WDC", market: "NASDAQ", sector: "반도체", fameRank: 230 },
+  { canonical: "시게이트", symbol: "STX", market: "NASDAQ", sector: "반도체", fameRank: 240 },
+  { canonical: "오클로", symbol: "OKLO", market: "NYSE", sector: "원자력", fameRank: 520 },
+  { canonical: "뉴스케일파워", symbol: "SMR", market: "NYSE", sector: "원자력", fameRank: 560 },
+  { canonical: "콘스텔레이션에너지", symbol: "CEG", market: "NASDAQ", sector: "에너지", fameRank: 90 },
+  { canonical: "비스트라", symbol: "VST", market: "NYSE", sector: "에너지", fameRank: 135 },
+  { canonical: "GE버노바", symbol: "GEV", market: "NYSE", sector: "에너지", fameRank: 95 },
+  { canonical: "버티브", symbol: "VRT", market: "NYSE", sector: "전력인프라", fameRank: 125 },
+  { canonical: "이튼", symbol: "ETN", market: "NYSE", sector: "전력인프라", fameRank: 70 },
+  { canonical: "블룸에너지", symbol: "BE", market: "NYSE", sector: "에너지", fameRank: 580 },
+  { canonical: "퍼스트솔라", symbol: "FSLR", market: "NASDAQ", sector: "태양광", fameRank: 240 },
+  { canonical: "인페이즈에너지", symbol: "ENPH", market: "NASDAQ", sector: "태양광", fameRank: 300 },
+  { canonical: "리비안", symbol: "RIVN", market: "NASDAQ", sector: "전기차", fameRank: 260 },
+  { canonical: "루시드", symbol: "LCID", market: "NASDAQ", sector: "전기차", fameRank: 420 },
+  { canonical: "니오", symbol: "NIO", market: "NYSE", sector: "전기차", fameRank: 360 },
+  { canonical: "업스타트", symbol: "UPST", market: "NASDAQ", sector: "핀테크", fameRank: 600 },
+  { canonical: "어펌", symbol: "AFRM", market: "NASDAQ", sector: "핀테크", fameRank: 280 },
+  { canonical: "블록", symbol: "SQ", market: "NYSE", sector: "핀테크", fameRank: 180 },
+  { canonical: "소파이", symbol: "SOFI", market: "NASDAQ", sector: "핀테크", fameRank: 330 },
+  { canonical: "레딧", symbol: "RDDT", market: "NYSE", sector: "소셜", fameRank: 260 },
+  { canonical: "스포티파이", symbol: "SPOT", market: "NYSE", sector: "콘텐츠", fameRank: 115 },
+  { canonical: "넷플릭스", symbol: "NFLX", market: "NASDAQ", sector: "콘텐츠", fameRank: 35 },
+  { canonical: "로쿠", symbol: "ROKU", market: "NASDAQ", sector: "콘텐츠", fameRank: 500 },
+  { canonical: "듀오링고", symbol: "DUOL", market: "NASDAQ", sector: "교육", fameRank: 390 },
+  { canonical: "일라이릴리", symbol: "LLY", market: "NYSE", sector: "바이오", fameRank: 14 },
+  { canonical: "노보노디스크", symbol: "NVO", market: "NYSE", sector: "바이오", fameRank: 24 },
+  { canonical: "암젠", symbol: "AMGN", market: "NASDAQ", sector: "바이오", fameRank: 65 },
+  { canonical: "모더나", symbol: "MRNA", market: "NASDAQ", sector: "바이오", fameRank: 260 },
+  { canonical: "깅코바이오웍스", symbol: "DNA", market: "NYSE", sector: "바이오", fameRank: 760 },
+  { canonical: "로켓랩", symbol: "RKLB", market: "NASDAQ", sector: "우주", fameRank: 480 },
+  { canonical: "인튜이티브머신스", symbol: "LUNR", market: "NASDAQ", sector: "우주", fameRank: 720 },
+  { canonical: "아처에비에이션", symbol: "ACHR", market: "NYSE", sector: "항공", fameRank: 650 },
+  { canonical: "조비에비에이션", symbol: "JOBY", market: "NYSE", sector: "항공", fameRank: 590 },
+];
+
+const KNOWN_US_SYMBOLS: Record<string, string> = Object.fromEntries(
+  US_DISCOVERY_SYMBOLS.flatMap((item) => [
+    [item.canonical, item.symbol],
+    [item.symbol, item.symbol],
+  ])
+);
 
 const SEC_CIK_BY_SYMBOL: Record<string, string> = {
   AAPL: "0000320193",
@@ -43,4 +114,20 @@ export function secCikForSymbol(symbol: string): string | undefined {
 
 export function usStockDefs(): StockDef[] {
   return STOCK_VOCAB.filter((def) => def.country !== "KR" && def.market !== "COIN").map((def) => ({ ...def }));
+}
+
+export function usDiscoveryUniverse(): UsDiscoverySymbol[] {
+  const bySymbol = new Map<string, UsDiscoverySymbol>();
+  for (const item of US_DISCOVERY_SYMBOLS) bySymbol.set(item.symbol, { ...item });
+  for (const def of usStockDefs()) {
+    const symbol = usSymbolForStock(def.canonical);
+    if (!symbol || bySymbol.has(symbol)) continue;
+    bySymbol.set(symbol, {
+      canonical: def.canonical,
+      symbol,
+      market: def.market === "NYSE" ? "NYSE" : "NASDAQ",
+      sector: "미국주식",
+    });
+  }
+  return [...bySymbol.values()];
 }


### PR DESCRIPTION
## Summary
- expand the US discovery universe beyond the 9 mega-cap seed list so US discovery can surface mid/smaller names
- hydrate Twelve Data quote + time_series in batch and keep Yahoo chart endpoints out of the adapter
- use the latest ET session date for US discovery and hide curated fame ranks from the UI
- apply US news material/noise filtering and convert US material hooks to Korean category copy

## Verification
- npm test -- apps/web/__tests__/lib/us-market-source.test.ts
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm run typecheck:web
- npm run typecheck:fomo-web
- npm run typecheck:fomo-core
- npm run build:web
- npm run build:fomo-web
- npm run guard:discovery
- npm run lint

## Notes
- KR discovery path is unchanged except for shared optional row metadata.
- If TWELVE_DATA_API_KEY is absent, US rows remain verified seeds without synthetic price/chart values; Yahoo/SEC material can still populate cards.