### PR TITLE
fix(us): keep fast discovery material and chart data

### DIFF
--- a/apps/web/__tests__/api/fomo/discovery-route.test.ts
+++ b/apps/web/__tests__/api/fomo/discovery-route.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldUseTargetedMaterial } from "../../../lib/discovery-route-policy";
+
+describe("discovery route loading policy", () => {
+  it("keeps US material hooks enabled even on the fast first-load path", () => {
+    expect(shouldUseTargetedMaterial("US", true)).toBe(true);
+    expect(shouldUseTargetedMaterial("US", false)).toBe(true);
+  });
+
+  it("keeps KR fast path lightweight", () => {
+    expect(shouldUseTargetedMaterial("KR", true)).toBe(false);
+    expect(shouldUseTargetedMaterial("KR", false)).toBe(true);
+  });
+});

--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -8,18 +8,44 @@ describe("US market source", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses a verified seed universe without synthetic quotes when Twelve Data key is absent", async () => {
+  it("uses Nasdaq daily data when Twelve Data key is absent", async () => {
     vi.stubEnv("TWELVE_DATA_API_KEY", "");
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("api.nasdaq.com") && url.includes("/SMCI/")) {
+        return Response.json({
+          data: {
+            tradesTable: {
+              rows: [
+                { date: "06/26/2026", close: "$49.20", volume: "2,000" },
+                { date: "06/25/2026", close: "$46.10", volume: "1,000" },
+              ],
+            },
+          },
+        });
+      }
+      if (url.includes("api.nasdaq.com") && url.includes("/IONQ/")) {
+        return Response.json({
+          data: {
+            tradesTable: {
+              rows: [
+                { date: "06/26/2026", close: "$38.10", volume: "2,000" },
+                { date: "06/25/2026", close: "$36.90", volume: "1,000" },
+              ],
+            },
+          },
+        });
+      }
+      return Response.json({ data: { tradesTable: { rows: [] } } });
+    });
     const { fetchUsMarketRows } = await import("../../lib/us-market-source");
 
     const rows = await fetchUsMarketRows();
-    expect(rows.length).toBeGreaterThan(30);
+    expect(rows.length).toBe(2);
     expect(rows.every((row) => row.country !== "KR" && row.symbol && row.currency === "USD")).toBe(true);
-    expect(rows.every((row) => row.priceText === undefined && row.changePct === undefined && row.changeText === undefined)).toBe(true);
-    expect(rows.some((row) => row.symbol === "SMCI")).toBe(true);
-    expect(rows.some((row) => row.sectorHint === "양자")).toBe(true);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(rows.find((row) => row.symbol === "SMCI")?.priceText).toBe("$49.20");
+    expect(rows.find((row) => row.symbol === "SMCI")?.sparkline).toEqual([46.1, 49.2]);
+    expect(rows.find((row) => row.symbol === "IONQ")?.sectorHint).toBe("양자");
   });
 
   it("hydrates US quotes and sparklines without Yahoo chart endpoints", async () => {
@@ -57,5 +83,16 @@ describe("US market source", () => {
   it("does not wire Yahoo chart endpoints into the US quote adapter", () => {
     const source = readFileSync(fileURLToPath(new URL("../../lib/us-market-source.ts", import.meta.url)), "utf8");
     expect(source).not.toMatch(/query[12]\.finance\.yahoo\.com|chart\/|finance\.yahoo\.com\/v8/i);
+  });
+
+  it("keeps a verified no-price seed universe when all market data sources fail", async () => {
+    vi.stubEnv("TWELVE_DATA_API_KEY", "");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("blocked", { status: 403 }));
+    const { fetchUsMarketRows } = await import("../../lib/us-market-source");
+
+    const rows = await fetchUsMarketRows();
+    expect(rows.length).toBeGreaterThan(30);
+    expect(rows.some((row) => row.symbol === "SMCI")).toBe(true);
+    expect(rows.every((row) => row.priceText === undefined && row.changePct === undefined && row.changeText === undefined)).toBe(true);
   });
 });

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -3,6 +3,7 @@ import { unstable_cache } from "next/cache";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { buildDiscoveryResponse, type DiscoveryResponse } from "../../../../lib/discovery-supply";
 import type { DiscoveryCountryScope } from "../../../../lib/market-source-types";
+import { shouldUseTargetedMaterial } from "../../../../lib/discovery-route-policy";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -22,8 +23,9 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     const fast = url.searchParams.get("fast") === "1";
     const country = discoveryCountry(url.searchParams.get("country"));
+    const targetedMaterial = shouldUseTargetedMaterial(country, fast);
     const load = unstable_cache(
-      async () => buildDiscoveryResponse({ targetedMaterial: !fast, country }),
+      async () => buildDiscoveryResponse({ targetedMaterial, country }),
       ["fomo-discovery", cacheVersion(), kstDate(), country, fast ? "fast" : "full"],
       { revalidate: REVALIDATE_S }
     );

--- a/apps/web/lib/discovery-route-policy.ts
+++ b/apps/web/lib/discovery-route-policy.ts
@@ -1,0 +1,6 @@
+import type { DiscoveryCountryScope } from "./market-source-types";
+
+export function shouldUseTargetedMaterial(country: DiscoveryCountryScope, fast: boolean): boolean {
+  // US fast deck has no KR-style sector/news cache yet, so keep cheap per-symbol material on.
+  return country === "US" ? true : !fast;
+}

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -5,9 +5,14 @@ import { usDiscoveryUniverse, type UsDiscoverySymbol } from "./us-symbols";
 const TWELVE_DATA_URL = "https://api.twelvedata.com/quote";
 const TWELVE_TIME_SERIES_URL = "https://api.twelvedata.com/time_series";
 const TWELVE_MARKET_MOVERS_URL = "https://api.twelvedata.com/market_movers/stocks";
+const NASDAQ_HISTORICAL_URL = "https://api.nasdaq.com/api/quote";
 const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
+const NASDAQ_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
 const US_QUOTE_LIMIT = 80;
 const US_SPARKLINE_LIMIT = 60;
+const US_NASDAQ_FALLBACK_LIMIT = 50;
+const US_NASDAQ_FALLBACK_CONCURRENCY = 12;
 
 interface TwelveQuote {
   symbol?: string;
@@ -31,12 +36,18 @@ interface TwelveTimeSeries {
   values?: TwelveTimeSeriesValue[];
 }
 
+interface NasdaqDailyPoint {
+  date: string;
+  close: number;
+  volume?: number;
+}
+
 function tdKey(): string | undefined {
   return process.env.TWELVE_DATA_API_KEY?.trim();
 }
 
 function num(value: string | number | undefined): number | undefined {
-  const n = typeof value === "number" ? value : Number(String(value ?? "").replace(/,/g, ""));
+  const n = typeof value === "number" ? value : Number(String(value ?? "").replace(/[$,%]/g, ""));
   return Number.isFinite(n) ? n : undefined;
 }
 
@@ -81,12 +92,33 @@ function isSimpleUsMarketHoliday(date: Date): boolean {
 }
 
 export function latestUsSessionAsOf(now = new Date()): { date: string; label: string } {
-  const date = latestUsSessionDate(now);
+  return usSessionAsOfLabel(latestUsSessionDate(now));
+}
+
+function usSessionAsOfLabel(date: string): { date: string; label: string } {
   const [, month, day] = date.match(/^\d{4}-(\d{2})-(\d{2})$/) ?? [];
   return {
     date,
     label: month && day ? `${Number(month)}월 ${Number(day)}일(ET) 종가 기준` : `${date}(ET) 기준`,
   };
+}
+
+async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let cursor = 0;
+  async function worker() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      try {
+        results[index] = { status: "fulfilled", value: await fn(items[index] as T) };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return results;
 }
 
 function parseQuote(seed: UsDiscoverySymbol, quote: TwelveQuote | undefined, sparkline?: number[]): DiscoveryMarketRow | null {
@@ -117,6 +149,100 @@ function parseQuote(seed: UsDiscoverySymbol, quote: TwelveQuote | undefined, spa
     sectorHint: seed.sector,
     sessionLabel: session.label,
   };
+}
+
+function isoFromNasdaqDate(value: string | undefined): string | undefined {
+  const match = value?.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!match) return undefined;
+  return `${match[3]}-${match[1]}-${match[2]}`;
+}
+
+function parseNasdaqHistorical(data: unknown): NasdaqDailyPoint[] {
+  if (!data || typeof data !== "object") return [];
+  const rows = (((data as Record<string, unknown>).data as Record<string, unknown> | undefined)?.tradesTable as Record<string, unknown> | undefined)
+    ?.rows;
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => {
+      if (!row || typeof row !== "object") return null;
+      const record = row as Record<string, unknown>;
+      const date = isoFromNasdaqDate(String(record.date ?? ""));
+      const close = num(String(record.close ?? ""));
+      if (!date || typeof close !== "number") return null;
+      const volume = num(String(record.volume ?? ""));
+      return {
+        date,
+        close,
+        ...(typeof volume === "number" ? { volume } : {}),
+      } satisfies NasdaqDailyPoint;
+    })
+    .filter((row): row is NasdaqDailyPoint => row !== null)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function parseNasdaqRow(seed: UsDiscoverySymbol, points: readonly NasdaqDailyPoint[]): DiscoveryMarketRow | null {
+  const valid = points.filter((point) => Number.isFinite(point.close));
+  if (valid.length < 2) return null;
+  const latest = valid.at(-1);
+  const previous = valid.at(-2);
+  if (!latest || !previous) return null;
+  const change = latest.close - previous.close;
+  const pct = previous.close !== 0 ? (change / previous.close) * 100 : undefined;
+  const session = usSessionAsOfLabel(latest.date);
+  const sparkline = valid.slice(-42).map((point) => point.close);
+  const priceText = money(latest.close);
+  return {
+    canonical: seed.canonical,
+    symbol: seed.symbol,
+    market: marketFor(seed.market, undefined),
+    country: "US",
+    currency: "USD",
+    ...(seed.fameRank ? { marketCapRank: seed.fameRank, marketCapRankSource: "curated" as const } : {}),
+    ...(priceText ? { priceText } : {}),
+    ...(typeof pct === "number" ? { changePct: pct } : {}),
+    changeText: `${change > 0 ? "+" : ""}${change.toFixed(2)} (${typeof pct === "number" ? `${pct > 0 ? "+" : ""}${pct.toFixed(2)}%` : "0.00%"})`,
+    changeDir: change > 0 ? "up" : change < 0 ? "down" : "flat",
+    ...(typeof latest.volume === "number" ? { tradingValue: latest.volume } : {}),
+    ...(sparkline.length >= 2 ? { sparkline } : {}),
+    sectorHint: seed.sector,
+    sessionLabel: session.label,
+  };
+}
+
+function historyRange(): { from: string; to: string } {
+  const to = latestUsSessionDate();
+  const fromDate = new Date(`${to}T12:00:00Z`);
+  fromDate.setUTCDate(fromDate.getUTCDate() - 120);
+  return { from: fromDate.toISOString().slice(0, 10), to };
+}
+
+async function fetchNasdaqDaily(seed: UsDiscoverySymbol): Promise<DiscoveryMarketRow | null> {
+  const { from, to } = historyRange();
+  const url = new URL(`${NASDAQ_HISTORICAL_URL}/${encodeURIComponent(seed.symbol)}/historical`);
+  url.searchParams.set("assetclass", "stocks");
+  url.searchParams.set("fromdate", from);
+  url.searchParams.set("todate", to);
+  url.searchParams.set("limit", "42");
+  const res = await fetch(url.toString(), {
+    headers: {
+      accept: "application/json, text/plain, */*",
+      "user-agent": NASDAQ_UA,
+      origin: "https://www.nasdaq.com",
+      referer: "https://www.nasdaq.com/",
+    },
+    signal: AbortSignal.timeout(4_000),
+    next: { revalidate: 1_800 },
+  });
+  if (!res.ok) return null;
+  return parseNasdaqRow(seed, parseNasdaqHistorical(await res.json()));
+}
+
+async function fetchNasdaqRows(seeds: readonly UsDiscoverySymbol[]): Promise<DiscoveryMarketRow[]> {
+  const settled = await mapLimit(seeds.slice(0, US_NASDAQ_FALLBACK_LIMIT), US_NASDAQ_FALLBACK_CONCURRENCY, fetchNasdaqDaily);
+  return settled
+    .filter((row): row is PromiseFulfilledResult<DiscoveryMarketRow | null> => row.status === "fulfilled")
+    .map((row) => row.value)
+    .filter((row): row is DiscoveryMarketRow => row !== null);
 }
 
 function seedRows(): DiscoveryMarketRow[] {
@@ -245,8 +371,11 @@ async function fetchSparklines(symbols: readonly string[], key: string): Promise
  */
 export async function fetchUsMarketRows(): Promise<DiscoveryMarketRow[]> {
   const key = tdKey();
-  if (!key) return seedRows();
   const seeds = usDiscoveryUniverse();
+  if (!key) {
+    const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
+    return nasdaqRows.length > 0 ? nasdaqRows : seedRows();
+  }
   const bySymbol = new Map(seeds.map((seed) => [seed.symbol.toUpperCase(), seed]));
   try {
     const moverSymbols = await fetchMoverSymbols(key);
@@ -271,9 +400,22 @@ export async function fetchUsMarketRows(): Promise<DiscoveryMarketRow[]> {
       const row = parseQuote(seed, quote, sparklines[upper]);
       if (row) rows.push(row);
     }
-    return rows.length > 0 ? rows : seedRows();
+    if (rows.length === 0) {
+      const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
+      return nasdaqRows.length > 0 ? nasdaqRows : seedRows();
+    }
+    if (Object.keys(sparklines).length === 0) {
+      const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
+      const nasdaqBySymbol = new Map(nasdaqRows.map((row) => [row.symbol.toUpperCase(), row]));
+      return rows.map((row) => {
+        const fallback = nasdaqBySymbol.get(row.symbol.toUpperCase());
+        return fallback?.sparkline && (row.sparkline?.length ?? 0) < 2 ? { ...row, sparkline: fallback.sparkline } : row;
+      });
+    }
+    return rows;
   } catch (err) {
     console.warn("[us-market-source] Twelve Data quote failed", (err as Error)?.message);
-    return seedRows();
+    const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
+    return nasdaqRows.length > 0 ? nasdaqRows : seedRows();
   }
 }


### PR DESCRIPTION
## Summary
- keep targeted material hooks enabled for US fast discovery so cards do not fall back to generic sector copy
- add a no-key Nasdaq historical fallback for US price/change/sparkline data while keeping Yahoo chart endpoints forbidden
- keep fail-closed seed rows when all market data sources fail

## Verification
- npm test -- apps/web/__tests__/lib/us-market-source.test.ts apps/web/__tests__/api/fomo/discovery-route.test.ts
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm run typecheck:web
- npm run typecheck:fomo-core
- npm run build:web
- npm run build:fomo-web
- npm run typecheck:fomo-web
- npm run lint
- live local builder: US discovery returned material hooks and 42-point sparklines for front cards

## Notes
- left unrelated local changes in apps/fomo-web/app/page.tsx and .codebase-memory untouched