### PR TITLE
스플래쉬가 CTA 전 자동으로 사라지지 않게 수정

### DIFF
--- a/apps/fomo-web/app/page.tsx
+++ b/apps/fomo-web/app/page.tsx
@@ -29,24 +29,6 @@ import {
 } from "@/lib/fomoApi";
 
 type Phase = "splash" | "splashLeaving" | "gate" | "home";
-const SPLASH_SESSION_KEY = "fomo_splash_seen_session";
-
-function shouldShowSplash(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.sessionStorage.getItem(SPLASH_SESSION_KEY) !== "1";
-  } catch {
-    return true;
-  }
-}
-
-function markSplashSeen(): void {
-  try {
-    window.sessionStorage.setItem(SPLASH_SESSION_KEY, "1");
-  } catch {
-    /* 세션 저장이 막혀도 스플래시 종료 흐름은 유지한다. */
-  }
-}
 
 /**
  * 진입 여정 오케스트레이터 — 스플래시가 떠 있는 동안 발견 덱 데이터를 먼저 당긴다.
@@ -55,11 +37,13 @@ function markSplashSeen(): void {
 export default function Home() {
   const [phase, setPhase] = useState<Phase>("splash");
   const [gateReopen, setGateReopen] = useState(false);
+  const splashDismissedRef = useRef(false);
+  const pendingGateRef = useRef(false);
 
   const dismissSplash = useCallback(() => {
-    markSplashSeen();
+    splashDismissedRef.current = true;
     setPhase("splashLeaving");
-    setTimeout(() => setPhase("home"), 500);
+    setTimeout(() => setPhase(pendingGateRef.current ? "gate" : "home"), 500);
   }, []);
 
   const [index, setIndex] = useState<FomoIndexResponse | null>(null);
@@ -72,10 +56,6 @@ export default function Home() {
   const [news, setNews] = useState<NewsResponse | null>(null);
   const [mine, setMine] = useState<EmotionType | null>(null);
   const [loggedIn, setLoggedIn] = useState(false);
-
-  useEffect(() => {
-    if (!shouldShowSplash()) setPhase("home");
-  }, []);
 
   useEffect(() => {
     const onIndexUpdated = (event: Event) => {
@@ -99,7 +79,7 @@ export default function Home() {
       .catch(() => setNews({ deck: [], lang: "ko" }));
   }, []);
 
-  // 진입 즉시 백그라운드 데이터 로드(스플래시 없음). 도착 전엔 HomeView 내부 로딩 상태가 담당.
+  // 진입 즉시 백그라운드 데이터 로드. 도착 전엔 HomeView 내부 로딩 상태가 담당.
   const startedRef = useRef(false);
   useEffect(() => {
     if (startedRef.current) return;
@@ -143,8 +123,11 @@ export default function Home() {
     });
 
     load.then((todays) => {
-      // 감정 투표 flag 가 켜져 있고 오늘 미선택이면만 게이트. 현재 OFF → 항상 home 유지.
-      if (FEATURE_EMOTION_VOTE && !todays) setPhase("gate");
+      // CTA 전에는 스플래시를 절대 닫지 않는다. 게이트 필요 여부만 예약한다.
+      if (FEATURE_EMOTION_VOTE && !todays) {
+        if (splashDismissedRef.current) setPhase("gate");
+        else pendingGateRef.current = true;
+      }
     });
   }, []);
 


### PR DESCRIPTION
## 요약
- 스플래쉬를 세션당 1회만 보여주던 sessionStorage 스킵 로직을 제거했습니다.
- 데이터 로드 후 감정 게이트 조건이 맞아도 CTA 클릭 전에는 phase를 바꾸지 않도록 잠갔습니다.
- 게이트 이동이 필요하면 CTA 클릭 이후에만 진행되도록 예약 방식으로 바꿨습니다.

## 확인
- NEXT_PUBLIC_FEATURE_EMOTION_VOTE=true 상태에서 4.5초 동안 CTA를 누르지 않아도 스플래쉬 유지 확인
- CTA 클릭 후에만 스플래쉬가 사라지고 다음 화면으로 이동 확인
- npm run build:fomo-web 성공
- npm run typecheck:fomo-web 성공

## 범위
- 제품 UI/데이터는 건드리지 않고 진입 phase 제어만 수정했습니다.