### PR TITLE
fix(discovery): remove price hooks and sync US front seeds

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -149,9 +149,11 @@ function FomoMeter({ score, color }: { score: number; color: string }) {
 /** 봉인색 — 등락 데이터 전용(DESIGN.md §2). 브랜드(오렌지/네온)와 분리. 상승 적·하락 청(KR 관습). */
 const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
 const PRICE_ONLY_REASON_PATTERN = /^오늘 가격이 [+-]?\d+(?:\.\d+)?% 움직였어요/;
+const SURFACE_PRICE_HOOK_PATTERN =
+  /(?:가격|올랐|상승|하락|빠졌|강했어요|많이 올랐|움직였|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트)/;
 
 function nonPriceOnlyHeadline(text: string | undefined): string | undefined {
-  if (!text || PRICE_ONLY_REASON_PATTERN.test(text)) return undefined;
+  if (!text || PRICE_ONLY_REASON_PATTERN.test(text) || SURFACE_PRICE_HOOK_PATTERN.test(text)) return undefined;
   return text;
 }
 
@@ -497,6 +499,11 @@ export function StockSwipeDeck({
   // 앞면 FOMO 신호 — ④ 정렬 때 풀 전체를 이미 받아 seed(initialFronts). 빠진 종목만 도달 시 lazy 보강.
   const [front, setFront] = useState<Record<string, FrontEntry>>(initialFronts ?? {});
   const inflight = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!initialFronts) return;
+    setFront((prev) => ({ ...prev, ...initialFronts }));
+  }, [initialFronts]);
 
   const at = (i: number) => stocks[((i % stocks.length) + stocks.length) % stocks.length]!;
 

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -140,6 +140,7 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
     <>
       {scopeTabs}
       <StockSwipeDeck
+        key={country}
         stocks={state.cards.slice(0, Math.max(MIN_DISCOVERY_STOCKS, state.cards.length))}
         initialFronts={state.fronts}
         contextLabel={country === "US" ? "미국 발견" : "오늘의 발견"}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -455,8 +455,8 @@ export interface DiscoveryResponse {
   source: string;
 }
 
-const discoveryKey = (country: DiscoveryCountryScope = "KR") => `discovery:today:v4:${country}:${kstDateKey()}`;
-const discoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `fomo:discovery:${country}:${kstDateKey()}`;
+const discoveryKey = (country: DiscoveryCountryScope = "KR") => `discovery:today:v5:${country}:${kstDateKey()}`;
+const discoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `fomo:discovery:v5:${country}:${kstDateKey()}`;
 const LAST_DISCOVERY_STORAGE_KEY = "fomo:discovery:last-good";
 const lastDiscoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `${LAST_DISCOVERY_STORAGE_KEY}:${country}`;
 

--- a/apps/web/__tests__/api/fomo/discovery-route.test.ts
+++ b/apps/web/__tests__/api/fomo/discovery-route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldUseTargetedMaterial } from "../../../lib/discovery-route-policy";
+import { shouldUseTargetedMaterial, targetedMaterialLimitFor } from "../../../lib/discovery-route-policy";
 
 describe("discovery route loading policy", () => {
   it("keeps US material hooks enabled even on the fast first-load path", () => {
@@ -8,8 +8,15 @@ describe("discovery route loading policy", () => {
     expect(shouldUseTargetedMaterial("US", false)).toBe(true);
   });
 
-  it("keeps KR fast path lightweight", () => {
-    expect(shouldUseTargetedMaterial("KR", true)).toBe(false);
+  it("keeps KR material hooks enabled with a capped fast budget", () => {
+    expect(shouldUseTargetedMaterial("KR", true)).toBe(true);
     expect(shouldUseTargetedMaterial("KR", false)).toBe(true);
+  });
+
+  it("caps targeted material work on fast routes instead of disabling hooks", () => {
+    expect(targetedMaterialLimitFor("KR", true)).toBe(36);
+    expect(targetedMaterialLimitFor("US", true)).toBe(50);
+    expect(targetedMaterialLimitFor("KR", false)).toBe(120);
+    expect(targetedMaterialLimitFor("US", false)).toBe(80);
   });
 });

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -52,6 +52,8 @@ describe("discovery material news filter", () => {
 });
 
 describe("discovery specific hook copy", () => {
+  const surfacePricePattern = /(?:가격|올랐|상승|하락|빠졌|강했어요|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트)/;
+
   it("keeps same-sector leaders specific instead of collapsing to one generic sentence", () => {
     const hpsp = formatThemeDiscoveryLabel({
       sector: "반도체",
@@ -78,12 +80,12 @@ describe("discovery specific hook copy", () => {
       changePct: 3.18,
     });
 
-    expect(hpsp).toBe("오늘 반도체 14개 종목 중 가장 강했어요(+3.33%).");
-    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 강했어요(+5.88%).");
-    expect(outperformer).toBe("오늘 반도체 평균(+1.50%)보다 1.7포인트 더 강했어요(+3.18%).");
+    expect(hpsp).toBe("오늘 반도체 14개 종목 중 가장 먼저 신호가 잡혔어요.");
+    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 신호가 잡혔어요.");
+    expect(outperformer).toBe("반도체 흐름 안에서 다른 종목보다 먼저 포착됐어요.");
     expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
     expect([hpsp, wonik, outperformer].some((text) => /흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
-    expect([hpsp, wonik, outperformer].every((text) => !/^오늘 가격이/.test(text))).toBe(true);
+    expect([hpsp, wonik, outperformer].every((text) => !surfacePricePattern.test(text))).toBe(true);
   });
 
   it("keeps sector-only movers contextual instead of generic or raw price-only copy", () => {
@@ -100,10 +102,10 @@ describe("discovery specific hook copy", () => {
       change: "+4.20%",
     });
 
-    expect(spike).toBe("건설 안에서도 시총 461위권 종목의 큰 움직임이 새로 잡혔어요(+30.00%).");
-    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목이 같이 움직였어요(+4.20%).");
+    expect(spike).toBe("건설 안에서 시총 461위권 종목의 신호가 새로 잡혔어요.");
+    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목이 같이 포착됐어요.");
     expect([spike, ordinary].some((text) => /흐름에서 (?:먼저|같이|새로) 확인/.test(text))).toBe(false);
-    expect([spike, ordinary].every((text) => !/^오늘 가격이/.test(text))).toBe(true);
+    expect([spike, ordinary].every((text) => !surfacePricePattern.test(text))).toBe(true);
   });
 });
 

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -3,7 +3,7 @@ import { unstable_cache } from "next/cache";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
 import { buildDiscoveryResponse, type DiscoveryResponse } from "../../../../lib/discovery-supply";
 import type { DiscoveryCountryScope } from "../../../../lib/market-source-types";
-import { shouldUseTargetedMaterial } from "../../../../lib/discovery-route-policy";
+import { shouldUseTargetedMaterial, targetedMaterialLimitFor } from "../../../../lib/discovery-route-policy";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -24,9 +24,15 @@ export async function GET(request: Request) {
     const fast = url.searchParams.get("fast") === "1";
     const country = discoveryCountry(url.searchParams.get("country"));
     const targetedMaterial = shouldUseTargetedMaterial(country, fast);
+    const targetedMaterialLimit = targetedMaterialLimitFor(country, fast);
     const load = unstable_cache(
-      async () => buildDiscoveryResponse({ targetedMaterial, country }),
-      ["fomo-discovery", cacheVersion(), kstDate(), country, fast ? "fast" : "full"],
+      async () =>
+        buildDiscoveryResponse({
+          targetedMaterial,
+          country,
+          ...(typeof targetedMaterialLimit === "number" ? { targetedMaterialLimit } : {}),
+        }),
+      ["fomo-discovery", cacheVersion(), kstDate(), country, fast ? "fast" : "full", String(targetedMaterialLimit ?? "default")],
       { revalidate: REVALIDATE_S }
     );
     return withCors(

--- a/apps/web/lib/discovery-route-policy.ts
+++ b/apps/web/lib/discovery-route-policy.ts
@@ -1,6 +1,11 @@
 import type { DiscoveryCountryScope } from "./market-source-types";
 
 export function shouldUseTargetedMaterial(country: DiscoveryCountryScope, fast: boolean): boolean {
-  // US fast deck has no KR-style sector/news cache yet, so keep cheap per-symbol material on.
-  return country === "US" ? true : !fast;
+  // Fast cards still need material hooks; cap the work in the route instead of disabling it.
+  return true;
+}
+
+export function targetedMaterialLimitFor(country: DiscoveryCountryScope, fast: boolean): number | undefined {
+  if (fast) return country === "US" ? 50 : 36;
+  return country === "US" ? 80 : 120;
 }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -128,6 +128,7 @@ export interface DiscoveryResponse {
 
 export interface BuildDiscoveryResponseOptions {
   targetedMaterial?: boolean;
+  targetedMaterialLimit?: number;
   country?: DiscoveryCountryScope;
 }
 
@@ -426,9 +427,14 @@ export function formatThemeDiscoveryLabel(input: {
   relativeChangePct: number;
   changePct: number;
 }): string {
-  return input.rank <= 3
-    ? `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${ordinalText(input.rank)} 강했어요(${pctText(input.changePct)}).`
-    : `오늘 ${input.sector} 평균(${pctText(input.averageChangePct)})보다 ${pointText(input.relativeChangePct)}포인트 더 강했어요(${pctText(input.changePct)}).`;
+  if (input.rank <= 3) {
+    const orderText = input.rank === 1 ? "가장 먼저 신호가" : `${ordinalText(input.rank)} 신호가`;
+    return `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${orderText} 잡혔어요.`;
+  }
+  if (input.averageChangePct < 0 && input.changePct > 0) {
+    return `${input.sector} 흐름이 약한 날, 이 종목은 따로 포착됐어요.`;
+  }
+  return `${input.sector} 흐름 안에서 다른 종목보다 먼저 포착됐어요.`;
 }
 
 export function formatSectorMarketContextLabel(input: {
@@ -439,9 +445,9 @@ export function formatSectorMarketContextLabel(input: {
 }): string {
   const positive = input.changePct > 0;
   const largeMove = Math.abs(input.changePct) >= 10;
-  if (positive && largeMove) return `${input.sector} 안에서도 ${input.rankText} 종목의 큰 움직임이 새로 잡혔어요(${input.change}).`;
-  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목이 같이 움직였어요(${input.change}).`;
-  return `${input.sector} 안에서 ${input.rankText} 종목의 약한 흐름도 같이 확인해요(${input.change}).`;
+  if (positive && largeMove) return `${input.sector} 안에서 ${input.rankText} 종목의 신호가 새로 잡혔어요.`;
+  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목이 같이 포착됐어요.`;
+  return `${input.sector} 안에서 ${input.rankText} 종목의 약한 흐름도 같이 확인해요.`;
 }
 
 function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
@@ -469,10 +475,6 @@ function pctText(value: number): string {
   return `${sign}${value.toFixed(2)}%`;
 }
 
-function pointText(value: number): string {
-  return Math.abs(value).toFixed(1);
-}
-
 function ordinalText(rank: number): string {
   if (rank === 1) return "가장";
   if (rank === 2) return "두 번째로";
@@ -496,10 +498,10 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
-        ? `${theme.peerCount}개 ${sector} 종목 중 ${ordinalText(theme.rank)} 강하게 움직였어요.`
+        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "가장 먼저 신호가" : `${ordinalText(theme.rank)} 신호가`} 잡혔어요.`
         : changePct > 0
-          ? `오늘 ${sector} 안에서 같이 오른 쪽이에요(${change}).`
-          : `오늘 ${sector} 안에서 약한 쪽 흐름이에요(${change}).`;
+          ? `오늘 ${sector} 안에서 함께 포착된 종목이에요.`
+          : `오늘 ${sector} 안에서 약한 쪽 흐름도 같이 확인해요.`;
     return {
       kind: "market_context",
       firstSeen: true,
@@ -948,7 +950,9 @@ function interleaveThemeBundles(
 export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOptions = {}): Promise<DiscoveryResponse> {
   const scope = options.country ?? "KR";
   const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
-  const targetedMaterialLimit = targetedMaterialEnabled ? TARGETED_MATERIAL_CANDIDATE_LIMIT : 0;
+  const targetedMaterialLimit = targetedMaterialEnabled
+    ? Math.max(0, Math.min(TARGETED_MATERIAL_CANDIDATE_LIMIT, options.targetedMaterialLimit ?? TARGETED_MATERIAL_CANDIDATE_LIMIT))
+    : 0;
   const asOf = discoveryAsOf(scope);
   const [rows, attentionMap] = await Promise.all([
     fetchMarketRows(scope),


### PR DESCRIPTION
## Summary
- remove price/% surface copy from discovery theme and market-context hooks
- keep targeted material enabled on fast discovery routes with capped budgets so material hooks can win before generic fallbacks
- sync StockSwipeDeck front state when discovery fronts arrive, remount on country switch, and bump discovery localStorage cache to avoid stale US skeleton cards

## Verification
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm test -- apps/web/__tests__/api/fomo/discovery-route.test.ts
- npm run typecheck:web
- npm run typecheck:fomo-web
- npm run build:web
- npm run build:fomo-web
- npm run typecheck
- npm run lint