### PR TITLE
fix(discovery): restore concrete hook headlines

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -150,7 +150,7 @@ function FomoMeter({ score, color }: { score: number; color: string }) {
 const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
 const PRICE_ONLY_REASON_PATTERN = /^오늘 가격이 [+-]?\d+(?:\.\d+)?% 움직였어요/;
 const SURFACE_PRICE_HOOK_PATTERN =
-  /(?:가격|올랐|상승|하락|빠졌|강했어요|많이 올랐|움직였|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트)/;
+  /(?:^오늘 가격이|가격 먼저 움직임|가격은 .*거래량|가격은 .*뉴스|오늘 .*제일 많이|오늘 .*가장 강|섹터 평균|평균보다|많이 올랐|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트)/;
 
 function nonPriceOnlyHeadline(text: string | undefined): string | undefined {
   if (!text || PRICE_ONLY_REASON_PATTERN.test(text) || SURFACE_PRICE_HOOK_PATTERN.test(text)) return undefined;
@@ -173,11 +173,17 @@ function compactEvidenceLine(text: string | undefined): string | undefined {
 }
 
 function compactReasonHeadlineSeed(text: string | undefined): string | undefined {
-  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  const clean = (text ?? "")
+    .replace(/\s+/g, " ")
+    .replace(
+      /^(?:오늘|최근)\s+(?:이 종목을 직접 언급한 뉴스가 있어요|이 종목을 직접 다룬 리서치가 있어요|이 종목 뉴스 탭에 함께 묶인 흐름이 있어요|공시가 확인됐어요):\s*/,
+      ""
+    )
+    .trim();
   if (!clean) return undefined;
-  if (!/오늘|최근|공시|뉴스|리서치|수급|외국인|기관|거래량|가격|테마|흐름|순매수|신고가/.test(clean)) return undefined;
+  if (!/오늘|최근|공시|뉴스|리서치|수급|외국인|기관|거래량|가격|테마|흐름|순매수|신고가|계약|공급|실적|가이던스|revenue|guidance|earnings|contract|supply|partnership|SEC|filing/i.test(clean)) return undefined;
   if (/전문\s?기업|플랫폼\s?리더|도약\s?중|안정화\s?예상|사업\s?영역|서비스\s?제공/.test(clean)) return undefined;
-  return clean.length > 38 ? `${clean.slice(0, 37)}…` : clean;
+  return clean.length > 56 ? `${clean.slice(0, 55)}…` : clean;
 }
 
 function FeedSignalStrip({
@@ -582,7 +588,7 @@ export function StockSwipeDeck({
       ...(typeof e?.signals.changePct === "number" ? { changePct: e.signals.changePct } : {}),
       ...(typeof e?.signals.marketCapRank?.rank === "number" ? { marketCapRank: e.signals.marketCapRank.rank } : {}),
     });
-    const fallbackHeadline = stock.sector ? `${stock.sector} 흐름에서 새로 확인하는 종목이에요.` : baseView.headline;
+    const fallbackHeadline = stock.sector ? `${stock.sector} 안에서 더 살펴볼 종목이에요.` : baseView.headline;
     const headline =
       discoveryHeadline ??
       nonPriceOnlyHeadline(axisHook?.hookText) ??

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { DiscoveryCandidate, DiscoveryEventKind } from "@fomo/core";
 
-import { cleanMaterialTitle, formatSectorMarketContextLabel, formatThemeDiscoveryLabel, recoverDiscoveryCandidates } from "../../lib/discovery-supply";
+import {
+  cleanMaterialTitle,
+  cleanUsMaterialTitle,
+  formatSectorMarketContextLabel,
+  formatThemeDiscoveryLabel,
+  recoverDiscoveryCandidates,
+} from "../../lib/discovery-supply";
 
 const asOf = "2026-06-27";
 
@@ -49,10 +55,20 @@ describe("discovery material news filter", () => {
     expect(cleanMaterialTitle("특징주 모음, 2차전지주 동반 상승")).toBeUndefined();
     expect(cleanMaterialTitle("장중 시황, 반도체주 차익 실현")).toBeUndefined();
   });
+
+  it("keeps concrete US catalyst titles instead of collapsing them into generic foreign-news labels", () => {
+    expect(cleanUsMaterialTitle("SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance")).toBe(
+      "SoundHound AI Reports First Quarter Revenue Growth and Raises…"
+    );
+    expect(cleanUsMaterialTitle("D-Wave Quantum Announces New Partnership With Aerospace Customer")).toBe(
+      "D-Wave Quantum Announces New Partnership With Aerospace Customer"
+    );
+    expect(cleanUsMaterialTitle("Analyst raises price target on Micron shares")).toBeUndefined();
+  });
 });
 
 describe("discovery specific hook copy", () => {
-  const surfacePricePattern = /(?:가격|올랐|상승|하락|빠졌|강했어요|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트)/;
+  const surfacePricePattern = /(?:가격|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트|섹터 평균|평균보다)/;
 
   it("keeps same-sector leaders specific instead of collapsing to one generic sentence", () => {
     const hpsp = formatThemeDiscoveryLabel({
@@ -80,11 +96,11 @@ describe("discovery specific hook copy", () => {
       changePct: 3.18,
     });
 
-    expect(hpsp).toBe("오늘 반도체 14개 종목 중 가장 먼저 신호가 잡혔어요.");
-    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 신호가 잡혔어요.");
-    expect(outperformer).toBe("반도체 흐름 안에서 다른 종목보다 먼저 포착됐어요.");
+    expect(hpsp).toBe("오늘 반도체 14개 종목 중 가장 먼저 눈에 띄었어요.");
+    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 눈에 띄었어요.");
+    expect(outperformer).toBe("반도체 안에서 주변 종목보다 먼저 눈에 들어왔어요.");
     expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
-    expect([hpsp, wonik, outperformer].some((text) => /흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
+    expect([hpsp, wonik, outperformer].some((text) => /신호가|흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
     expect([hpsp, wonik, outperformer].every((text) => !surfacePricePattern.test(text))).toBe(true);
   });
 
@@ -102,9 +118,10 @@ describe("discovery specific hook copy", () => {
       change: "+4.20%",
     });
 
-    expect(spike).toBe("건설 안에서 시총 461위권 종목의 신호가 새로 잡혔어요.");
-    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목이 같이 포착됐어요.");
+    expect(spike).toBe("건설 안에서 시총 461위권 종목이 새로 눈에 들어왔어요.");
+    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목도 함께 눈에 들어왔어요.");
     expect([spike, ordinary].some((text) => /흐름에서 (?:먼저|같이|새로) 확인/.test(text))).toBe(false);
+    expect([spike, ordinary].some((text) => /신호가/.test(text))).toBe(false);
     expect([spike, ordinary].every((text) => !surfacePricePattern.test(text))).toBe(true);
   });
 });

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -282,6 +282,22 @@ export function cleanMaterialTitle(title: string): string | undefined {
   return isFrontHookSafe(`${compact} 소식이 나왔어요.`) ? compact : undefined;
 }
 
+export function cleanUsMaterialTitle(title: string): string | undefined {
+  const cleaned = decodeHtmlEntities(title)
+    .replace(/^\s*(?:\[[^\]]+\]|【[^】]+】|\([^)]*\))\s*/g, "")
+    .replace(/[“”"]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?。]+$/g, "")
+    .trim();
+  if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned) || US_MATERIAL_NEWS_NOISE.test(cleaned)) {
+    return undefined;
+  }
+  if (!US_MATERIAL_NEWS_CATALYST.test(cleaned)) return undefined;
+  if (/[\[\]{}<>]/.test(cleaned)) return undefined;
+  const compact = cleaned.length > 68 ? `${cleaned.slice(0, 66).replace(/\s+\S*$/, "").trim()}…` : cleaned;
+  return isFrontHookSafe(`${compact} 소식이 나왔어요.`) ? compact : undefined;
+}
+
 function isPrimaryStockArticle(canonical: string, article: RawArticle): boolean {
   return stockMentionRole(canonical, {
     title: article.title,
@@ -306,15 +322,8 @@ function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallb
 }
 
 function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
-  const cleaned = decodeHtmlEntities(article.title)
-    .replace(/[“”"]/g, "")
-    .replace(/\s+/g, " ")
-    .replace(/[.!?。]+$/g, "")
-    .trim();
-  if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned) || US_MATERIAL_NEWS_NOISE.test(cleaned)) return null;
-  if (!US_MATERIAL_NEWS_CATALYST.test(cleaned)) return null;
-  const label = usMaterialLabel(cleaned);
-  if (!isFrontHookSafe(label)) return null;
+  const label = cleanUsMaterialTitle(article.title);
+  if (!label) return null;
   return {
     kind: "news_mention",
     firstSeen: true,
@@ -324,24 +333,6 @@ function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFal
     confidence: "M",
     label,
   };
-}
-
-function usMaterialLabel(title: string): string {
-  if (/8-k|10-q|filing|sec/i.test(title)) return "SEC 공시로 확인된 재료가 있어요.";
-  if (/earnings|results|revenue|profit|margin|guidance|forecast|quarter|q[1-4]/i.test(title)) {
-    return "실적·가이던스 이슈를 직접 다룬 외신이 나왔어요.";
-  }
-  if (/contract|deal|order|supply|supplier|customer|partnership/i.test(title)) {
-    return "계약·공급망 이슈를 직접 다룬 외신이 나왔어요.";
-  }
-  if (/launch|unveil|product|chip|gpu|ai|data center/i.test(title)) {
-    return "제품·AI 인프라 이슈를 직접 다룬 외신이 나왔어요.";
-  }
-  if (/approval|fda|trial|drug/i.test(title)) return "임상·허가 이슈를 직접 다룬 외신이 나왔어요.";
-  if (/acquisition|merger|stake|investment|buyback authorization|dividend/i.test(title)) {
-    return "투자·자본정책 이슈를 직접 다룬 외신이 나왔어요.";
-  }
-  return "이 종목을 직접 다룬 외신 재료가 나왔어요.";
 }
 
 async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
@@ -428,13 +419,13 @@ export function formatThemeDiscoveryLabel(input: {
   changePct: number;
 }): string {
   if (input.rank <= 3) {
-    const orderText = input.rank === 1 ? "가장 먼저 신호가" : `${ordinalText(input.rank)} 신호가`;
-    return `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${orderText} 잡혔어요.`;
+    const orderText = input.rank === 1 ? "가장 먼저 눈에 띄었어요" : `${ordinalText(input.rank)} 눈에 띄었어요`;
+    return `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${orderText}.`;
   }
   if (input.averageChangePct < 0 && input.changePct > 0) {
-    return `${input.sector} 흐름이 약한 날, 이 종목은 따로 포착됐어요.`;
+    return `${input.sector} 흐름이 약한 날에도 따로 눈에 띄었어요.`;
   }
-  return `${input.sector} 흐름 안에서 다른 종목보다 먼저 포착됐어요.`;
+  return `${input.sector} 안에서 주변 종목보다 먼저 눈에 들어왔어요.`;
 }
 
 export function formatSectorMarketContextLabel(input: {
@@ -445,9 +436,9 @@ export function formatSectorMarketContextLabel(input: {
 }): string {
   const positive = input.changePct > 0;
   const largeMove = Math.abs(input.changePct) >= 10;
-  if (positive && largeMove) return `${input.sector} 안에서 ${input.rankText} 종목의 신호가 새로 잡혔어요.`;
-  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목이 같이 포착됐어요.`;
-  return `${input.sector} 안에서 ${input.rankText} 종목의 약한 흐름도 같이 확인해요.`;
+  if (positive && largeMove) return `${input.sector} 안에서 ${input.rankText} 종목이 새로 눈에 들어왔어요.`;
+  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목도 함께 눈에 들어왔어요.`;
+  return `${input.sector} 안에서 ${input.rankText} 종목의 약한 흐름도 같이 살펴봐요.`;
 }
 
 function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
@@ -498,10 +489,10 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
-        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "가장 먼저 신호가" : `${ordinalText(theme.rank)} 신호가`} 잡혔어요.`
+        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "가장 먼저 눈에 띄었어요" : `${ordinalText(theme.rank)} 눈에 띄었어요`}.`
         : changePct > 0
-          ? `오늘 ${sector} 안에서 함께 포착된 종목이에요.`
-          : `오늘 ${sector} 안에서 약한 쪽 흐름도 같이 확인해요.`;
+          ? `오늘 ${sector} 안에서 함께 눈에 들어온 종목이에요.`
+          : `오늘 ${sector} 안에서 약한 쪽 흐름도 같이 살펴봐요.`;
     return {
       kind: "market_context",
       firstSeen: true,
@@ -531,7 +522,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
       source,
       asOf,
       confidence: "M",
-      label: `${sector} 흐름에서 새로 확인하는 종목이에요.`,
+      label: `${sector} 안에서 더 살펴볼 종목이에요.`,
     };
   }
   if (typeof changePct === "number" && change) {

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -71,20 +71,22 @@ describe("WO-05 discovery supply engine", () => {
     expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
   });
 
-  it("names research evidence as research instead of news", () => {
+  it("surfaces the concrete research label instead of wrapping it in a generic source sentence", () => {
     const row = candidate("리서치", 0.7, "news_mention", "신규 설비 증설 점검");
     row.events[0]!.source = "한화투자증권 리서치";
 
-    expect(discoveryWhy(row)).toContain("직접 다룬 리서치");
+    expect(discoveryWhy(row)).toBe("오늘 신규 설비 증설 점검");
     expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
+    expect(discoveryWhy(row)).not.toContain("직접 다룬 리서치");
   });
 
-  it("labels linked stock-tab articles honestly instead of direct mentions", () => {
+  it("surfaces the concrete linked article label instead of wrapping it in a generic source sentence", () => {
     const row = candidate("연결기사", 0.7, "news_mention", "업종 흐름 기사");
     row.events[0]!.source = "네이버 종목뉴스 연결";
 
-    expect(discoveryWhy(row)).toContain("뉴스 탭에 함께 묶인 흐름");
+    expect(discoveryWhy(row)).toBe("오늘 업종 흐름 기사");
     expect(discoveryWhy(row)).not.toContain("직접 언급한 뉴스");
+    expect(discoveryWhy(row)).not.toContain("뉴스 탭에 함께 묶인 흐름");
   });
 
   it("ranks direct material above linked stock-tab material", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -227,24 +227,13 @@ export function discoveryWhy(candidate: DiscoveryCandidate): string {
   if (strongest.kind === "disclosure") {
     const prefix = eventTimePrefix(strongest, candidate);
     return strongest.label
-      ? `${prefix} 공시가 확인됐어요: ${strongest.label}`
+      ? `${prefix} ${strongest.label}`
       : `${prefix} 이 종목의 공시가 확인됐어요.`;
   }
   if (strongest.kind === "news_mention") {
     const prefix = eventTimePrefix(strongest, candidate);
-    const isResearch = /리서치|증권|투자증권|자산운용|Research/i.test(strongest.source);
-    if (isResearch) {
-      return strongest.label
-        ? `${prefix} 이 종목을 직접 다룬 리서치가 있어요: ${strongest.label}`
-        : `${prefix} 이 종목을 직접 다룬 리서치가 있어요.`;
-    }
-    if (/종목뉴스\s?연결/i.test(strongest.source)) {
-      return strongest.label
-        ? `${prefix} 이 종목 뉴스 탭에 함께 묶인 흐름이 있어요: ${strongest.label}`
-        : `${prefix} 이 종목 뉴스 탭에 함께 묶인 흐름이 있어요.`;
-    }
     return strongest.label
-      ? `${prefix} 이 종목을 직접 언급한 뉴스가 있어요: ${strongest.label}`
+      ? `${prefix} ${strongest.label}`
       : `${prefix} 이 종목을 직접 언급한 뉴스가 있어요.`;
   }
   if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";


### PR DESCRIPTION
## Summary
- restore concrete discovery hook copy after #708 over-collapsed KR hooks into vague signal language
- preserve actual KR news/disclosure labels as the surface reason instead of wrapping them in generic source sentences
- keep concrete US catalyst titles instead of collapsing every US material into generic foreign-news categories
- narrow the front-end price-only filter so it still blocks raw price/% hooks without discarding real news titles

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm test -- apps/web/__tests__/lib/discovery-supply-material.test.ts
- npm run typecheck
- npm run lint
- npm run build:web
- npm run build:fomo-web

## Guardrails
- raw price/% headlines remain blocked
- "신호가 잡혔어요" and generic foreign-news labels are covered by tests
- existing untracked .codebase-memory/ was not touched