### PR TITLE
feat(fomo-web): 로딩 UI를 Flicker ripple 스피너로 교체

### DIFF
--- a/apps/fomo-web/components/FlickerSpinner.tsx
+++ b/apps/fomo-web/components/FlickerSpinner.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * Flicker Ripple Spinner — 7×7 점 격자가 중심에서 바깥으로 opacity 파동치는 로더.
+ * (laurie.fyi/flicker 의 ripple 스피너를 우리 색으로 옮김 — 회전 아님, opacity ripple.)
+ *
+ * 색: 프라이머리 = 네온옐로우(text-neon, currentColor). off 상태는 같은 색 저(低)opacity.
+ * 기본 크기 16×16(px). prefers-reduced-motion 존중.
+ */
+
+const COORDS = [3, 9, 15, 21, 27, 33, 39] as const; // 42 viewBox, 6칸 간격
+const CENTER = 21;
+const DURATION_S = 1.35;
+
+// 각 점의 중심거리 → 링(파동 단계). 바깥일수록 늦게 켜져 중심→밖 ripple.
+const DOTS = COORDS.flatMap((cy) =>
+  COORDS.map((cx) => ({
+    cx,
+    cy,
+    ring: Math.round(Math.hypot((cx - CENTER) / 6, (cy - CENTER) / 6)),
+  }))
+);
+const MAX_RING = Math.max(...DOTS.map((d) => d.ring));
+
+export function FlickerSpinner({
+  size = 16,
+  className = "",
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 42 42"
+      role="img"
+      aria-label="로딩 중"
+      className={`text-neon ${className}`}
+    >
+      <title>로딩 중</title>
+      <style>{`
+        @keyframes flicker-ripple { 0%, 100% { opacity: 0.18; } 50% { opacity: 1; } }
+        .flicker-dot { animation: flicker-ripple ${DURATION_S}s ease-in-out infinite; }
+        @media (prefers-reduced-motion: reduce) {
+          .flicker-dot { animation: none; opacity: 0.5; }
+        }
+      `}</style>
+      {DOTS.map((d, i) => (
+        <circle
+          key={i}
+          cx={d.cx}
+          cy={d.cy}
+          r={2}
+          fill="currentColor"
+          className="flicker-dot"
+          style={{ animationDelay: `${-(d.ring / MAX_RING) * DURATION_S}s` }}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/apps/fomo-web/components/FullPageLoading.tsx
+++ b/apps/fomo-web/components/FullPageLoading.tsx
@@ -1,25 +1,25 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { FlickerSpinner } from "./FlickerSpinner";
 
 /**
- * 전체 화면 로딩 — 추정 프로그레스 바 + 단계 텍스트 (LOADING PROGRESS HANDOFF C안).
+ * 전체 화면 로딩 — Flicker ripple 스피너 + 단계 텍스트 (LOADING PROGRESS HANDOFF C안).
  *
  * 스켈레톤·빈 박스 대신 콘텐츠 영역을 통째로 덮어 "죽은 듯한 중간 상태"를 없앤다.
  * 메인/뎁스/종목 세 화면이 공유(추정시간·단계 텍스트만 prop 으로).
  *
  * 정직성:
- *  - LLM 은 정확한 진척을 안 주므로 *추정* 바(평균 소요 기준 차오름). 90%에서 멈춰 가짜 100% 금지.
+ *  - LLM 은 정확한 진척을 안 주므로 가짜 % 진열 대신 indeterminate 스피너로 표현.
  *  - 실제 완료는 부모가 loading=false 로 이 컴포넌트를 언마운트하며 콘텐츠로 전환.
- *  - 추정 초과 시 마지막 단계("거의 다 됐어")로 안내.
+ *  - 단계 텍스트는 추정시간 기준 롤링, 추정 초과 시 대기 멘트로 전환(멈춰 보이지 않게).
  * warm(캐시 적중): REVEAL_DELAY_MS 이내 완료면 로딩 화면 자체를 안 그려 깜빡임 방지.
  *
- * 카피·바 디자인 최종본은 광혁 영역 — 여기선 상태·추정시간만 정확히 표현.
+ * 카피 최종본은 광혁 영역 — 여기선 상태·추정시간만 정확히 표현.
  */
 const REVEAL_DELAY_MS = 150; // 이 시간 내 완료(warm)면 로딩 화면이 아예 안 뜸
 const TICK_MS = 100;
-const MAX_RATIO = 0.9; // 가짜 100% 금지 — 추정 바는 90%에서 정지
-const ROLL_MS = 2_500; // 추정 초과(바 정지) 시 대기 멘트 롤링 주기
+const ROLL_MS = 2_500; // 추정 초과 시 대기 멘트 롤링 주기
 
 /** 추정 초과(바가 90%에서 멈춤) 시 롤링되는 대기 멘트 — 멈춰 보이지 않게. 카피 최종본은 광혁. */
 const WAITING_MESSAGES = ["거의 다 됐어요", "조금만 기다려주세요", "원문을 꼼꼼히 읽고 있어요"] as const;
@@ -46,8 +46,6 @@ export function FullPageLoading({
 
   if (!shown) return null;
 
-  const ratio = Math.min(MAX_RATIO, estimateMs > 0 ? elapsed / estimateMs : MAX_RATIO);
-  const pct = Math.round(ratio * 100);
   const overEstimate = elapsed >= estimateMs;
   // 단계 텍스트 — 추정 내엔 진척 비율로 단계, 추정 초과(바 정지)면 대기 멘트를 롤링(멈춰 보이지 않게).
   const label = overEstimate
@@ -60,15 +58,7 @@ export function FullPageLoading({
       aria-busy="true"
       role="status"
     >
-      <div className="flex w-full max-w-xs items-center gap-3">
-        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-elevated">
-          <div
-            className="h-full rounded-full bg-whiteout transition-[width] duration-300 ease-out"
-            style={{ width: `${pct}%` }}
-          />
-        </div>
-        <span className="text-xs font-medium tabular-nums text-muted">{pct}%</span>
-      </div>
+      <FlickerSpinner size={16} />
       <p className="text-sm leading-6 text-muted">{label}</p>
     </div>
   );


### PR DESCRIPTION
## 무엇
전체화면 로딩의 진행바를 **7×7 점 ripple 스피너**로 교체. 멘트(단계/대기 텍스트)는 그대로.

- 신규 `FlickerSpinner` — 중심→바깥 opacity 파동(회전 아님, 1.35s 루프), `prefers-reduced-motion` 존중
- 프라이머리 = **네온옐로우**(`text-neon`/`currentColor`, 토큰 준수 — 하드코딩 없음), 기본 **16×16**
- 가짜 % 진열 제거 → indeterminate 스피너(정직성 정합). `FullPageLoading` 멘트·롤링 로직 유지

## 검증
- typecheck 통과
- 브라우저 렌더 확인: 7×7 네온 점 격자, 중심→밖 ripple, 16/64/120 크기 정상

레퍼런스: laurie.fyi Flicker ripple 스피너 디자인을 우리 색/크기로 옮김.

🤖 Generated with [Claude Code](https://claude.com/claude-code)