### PR TITLE
툴링 후보 일일 생성과 제품 모니터 웹 여정 검사 보강

### DIFF
--- a/.github/workflows/agent-tooling-scout.yml
+++ b/.github/workflows/agent-tooling-scout.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: "60"
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 * * *" # 09:00 KST
 
 permissions:
   contents: read

--- a/.github/workflows/daily-product-monitor.yml
+++ b/.github/workflows/daily-product-monitor.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Install Playwright browser
+        run: npx playwright install chromium --with-deps
+
       - name: Inspect product health
         id: inspect
         env:
@@ -225,17 +228,67 @@ jobs:
           console.log(`summary=${summary}`);
           NODE
 
+      - name: Inspect FOMO web journey
+        id: webjourney
+        env:
+          FOMO_WEB_URL: "https://fomo-web-mlender-ais-projects.vercel.app"
+          FOMO_WEB_SMOKE_JSON_OUT: "/tmp/fomo-web-journey-smoke.json"
+          FOMO_WEB_SMOKE_MD_OUT: "/tmp/fomo-web-journey-smoke.md"
+          FOMO_WEB_SMOKE_TIMEOUT_MS: "15000"
+          FOMO_WEB_SMOKE_HOLD_MS: "4500"
+        run: |
+          set -euo pipefail
+          set +e
+          npm run smoke:fomo-web > /tmp/fomo-web-journey.stdout 2> /tmp/fomo-web-journey.stderr
+          STATUS=$?
+          set -e
+
+          if [ ! -f /tmp/fomo-web-journey-smoke.json ]; then
+            {
+              echo "# FOMO Web Journey Smoke"
+              echo
+              echo "상태: critical"
+              echo
+              echo "웹 여정 스모크 스크립트가 리포트를 만들지 못했습니다."
+              echo
+              echo "## stdout"
+              sed 's/^/    /' /tmp/fomo-web-journey.stdout || true
+              echo
+              echo "## stderr"
+              sed 's/^/    /' /tmp/fomo-web-journey.stderr || true
+            } > /tmp/fomo-web-journey-smoke.md
+            echo '{"findings":[{"severity":"critical","message":"웹 여정 스모크 리포트 생성 실패"}]}' > /tmp/fomo-web-journey-smoke.json
+          fi
+
+          node - <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require("fs");
+          const report = JSON.parse(fs.readFileSync("/tmp/fomo-web-journey-smoke.json", "utf8"));
+          const findings = Array.isArray(report.findings) ? report.findings : [];
+          const critical = findings.filter((f) => f.severity === "critical").length;
+          const warn = findings.filter((f) => f.severity === "warn").length;
+          const summary = findings.map((f) => `${String(f.severity).toUpperCase()}: ${f.message}`).slice(0, 3).join(" / ") || "ok";
+          console.log(`critical_count=${critical}`);
+          console.log(`warn_count=${warn}`);
+          console.log(`summary=${summary}`);
+          NODE
+
+          if [ "$STATUS" != "0" ]; then
+            echo "웹 여정 스모크가 critical 상태를 반환했습니다. Monitor issue 생성 단계로 넘깁니다."
+          fi
+
       - name: Combine monitor report
         id: combine
         env:
           INSPECT_CRITICAL: ${{ steps.inspect.outputs.critical_count }}
           QUALITY_CRITICAL: ${{ steps.quality.outputs.critical_count }}
           QUALITY_WARN: ${{ steps.quality.outputs.warn_count }}
+          WEB_JOURNEY_CRITICAL: ${{ steps.webjourney.outputs.critical_count }}
+          WEB_JOURNEY_WARN: ${{ steps.webjourney.outputs.warn_count }}
         run: |
           set -euo pipefail
-          TOTAL=$(( ${INSPECT_CRITICAL:-0} + ${QUALITY_CRITICAL:-0} ))
+          TOTAL=$(( ${INSPECT_CRITICAL:-0} + ${QUALITY_CRITICAL:-0} + ${WEB_JOURNEY_CRITICAL:-0} ))
           echo "critical_count=$TOTAL" >> "$GITHUB_OUTPUT"
-          WARN=${QUALITY_WARN:-0}
+          WARN=$(( ${QUALITY_WARN:-0} + ${WEB_JOURNEY_WARN:-0} ))
           SIGNAL=$(( TOTAL + WARN ))
           echo "signal_count=$SIGNAL" >> "$GITHUB_OUTPUT"
           if [ "$TOTAL" != "0" ]; then
@@ -252,6 +305,14 @@ jobs:
               echo "---"
               echo
               cat /tmp/fomo-quality-report.md
+            } >> /tmp/monitor-combined-body.md
+          fi
+          if [ -f /tmp/fomo-web-journey-smoke.md ]; then
+            {
+              echo
+              echo "---"
+              echo
+              cat /tmp/fomo-web-journey-smoke.md
             } >> /tmp/monitor-combined-body.md
           fi
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "supply:collect": "tsx scripts/supply-demand-collect.ts",
     "metrics:fomo": "tsx scripts/fomo-product-metrics.ts",
     "quality:fomo": "tsx scripts/fomo-quality-report.ts",
+    "smoke:fomo-web": "tsx scripts/fomo-web-journey-smoke.ts",
     "guard:discovery": "tsx scripts/discovery-regression-gate.ts",
     "guard:product": "npm run guard:discovery",
     "eval:understanding": "tsx scripts/eval-understanding.ts",

--- a/scripts/fomo-web-journey-smoke.ts
+++ b/scripts/fomo-web-journey-smoke.ts
@@ -1,0 +1,152 @@
+import { chromium, type Browser, type Page } from "@playwright/test";
+import { promises as fs } from "node:fs";
+
+type Severity = "ok" | "warn" | "critical";
+
+interface JourneyFinding {
+  severity: Severity;
+  message: string;
+}
+
+const DEFAULT_WEB_URL = "https://fomo-web-mlender-ais-projects.vercel.app";
+const WEB_URL = (process.env.FOMO_WEB_URL ?? DEFAULT_WEB_URL).replace(/\/$/, "");
+const TIMEOUT_MS = positiveInt(process.env.FOMO_WEB_SMOKE_TIMEOUT_MS, 15000);
+const HOLD_MS = positiveInt(process.env.FOMO_WEB_SMOKE_HOLD_MS, 4500);
+const OUT_JSON = process.env.FOMO_WEB_SMOKE_JSON_OUT ?? "fomo-web-journey-smoke.json";
+const OUT_MD = process.env.FOMO_WEB_SMOKE_MD_OUT ?? "fomo-web-journey-smoke.md";
+const CHROME_PATH = process.env.FOMO_WEB_SMOKE_CHROME_PATH?.trim();
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function kstDate(now = new Date()): string {
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+async function bodyText(page: Page): Promise<string> {
+  return page.locator("body").innerText({ timeout: 5000 }).catch(() => "");
+}
+
+function ignoredConsole(text: string): boolean {
+  return /favicon|chrome-extension|ResizeObserver loop/i.test(text);
+}
+
+async function runJourney(): Promise<{
+  findings: JourneyFinding[];
+  beforeText: string;
+  afterText: string;
+  consoleErrors: string[];
+  pageErrors: string[];
+}> {
+  const findings: JourneyFinding[] = [];
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  let browser: Browser | null = null;
+
+  try {
+    browser = await chromium.launch({ headless: true, ...(CHROME_PATH ? { executablePath: CHROME_PATH } : {}) });
+    const page = await browser.newPage({
+      viewport: { width: 390, height: 844 },
+      locale: "ko-KR",
+    });
+
+    page.on("console", (message) => {
+      if (message.type() === "error" && !ignoredConsole(message.text())) {
+        consoleErrors.push(message.text().slice(0, 500));
+      }
+    });
+    page.on("pageerror", (error) => {
+      pageErrors.push(error.message.slice(0, 500));
+    });
+
+    await page.goto(WEB_URL, { waitUntil: "domcontentloaded", timeout: TIMEOUT_MS });
+    const cta = page.getByRole("button", { name: "발견 시작" });
+    await cta.waitFor({ state: "visible", timeout: 10000 });
+
+    await page.waitForTimeout(HOLD_MS);
+    const beforeText = await bodyText(page);
+    const splashStillVisible = await cta.isVisible().catch(() => false);
+    if (!splashStillVisible) {
+      findings.push({ severity: "critical", message: `CTA를 누르기 전 ${HOLD_MS}ms 안에 스플래쉬가 사라졌습니다.` });
+    }
+    if (!beforeText.includes("취향투자 클럽") || !beforeText.includes("발견 시작")) {
+      findings.push({ severity: "critical", message: "스플래쉬 핵심 문구 또는 CTA가 첫 화면에 없습니다." });
+    }
+
+    if (splashStillVisible) {
+      await cta.click();
+      await page.waitForTimeout(1400);
+    }
+
+    const afterText = await bodyText(page);
+    const ctaAfterClick = await cta.isVisible().catch(() => false);
+    if (ctaAfterClick) {
+      findings.push({ severity: "critical", message: "CTA 클릭 후에도 스플래쉬 CTA가 남아 있습니다." });
+    }
+    if (!afterText || afterText === beforeText) {
+      findings.push({ severity: "critical", message: "CTA 클릭 후 메인 화면 텍스트로 전환되지 않았습니다." });
+    }
+    if (!/(오늘의 시장 온도|관심|카드|FOMO CLUB)/.test(afterText)) {
+      findings.push({ severity: "warn", message: "CTA 이후 홈 화면의 핵심 텍스트를 확인하지 못했습니다." });
+    }
+
+    for (const error of pageErrors) {
+      findings.push({ severity: "critical", message: `브라우저 pageerror: ${error}` });
+    }
+    for (const error of consoleErrors) {
+      findings.push({ severity: "warn", message: `브라우저 console.error: ${error}` });
+    }
+
+    if (findings.length === 0) {
+      findings.push({ severity: "ok", message: "스플래쉬가 CTA 전까지 유지되고, CTA 후 메인 화면으로 전환됩니다." });
+    }
+
+    return { findings, beforeText, afterText, consoleErrors, pageErrors };
+  } catch (error) {
+    findings.push({ severity: "critical", message: `웹 여정 스모크 실행 실패: ${error instanceof Error ? error.message : String(error)}` });
+    return { findings, beforeText: "", afterText: "", consoleErrors, pageErrors };
+  } finally {
+    await browser?.close().catch(() => undefined);
+  }
+}
+
+function renderMarkdown(report: Awaited<ReturnType<typeof runJourney>> & { date: string; webUrl: string }): string {
+  return [
+    `# FOMO Web Journey Smoke — ${report.date}`,
+    "",
+    `Web: ${report.webUrl}`,
+    "",
+    "## Findings",
+    ...report.findings.map((finding) => `- ${finding.severity.toUpperCase()}: ${finding.message}`),
+    "",
+    "## Snapshot",
+    `- Before CTA: ${compact(report.beforeText)}`,
+    `- After CTA: ${compact(report.afterText)}`,
+    "",
+  ].join("\n");
+}
+
+function compact(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, 240) || "n/a";
+}
+
+async function main(): Promise<void> {
+  const date = kstDate();
+  const result = await runJourney();
+  const report = { date, webUrl: WEB_URL, ...result };
+  const md = renderMarkdown(report);
+  await fs.writeFile(OUT_JSON, `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(OUT_MD, md);
+  process.stdout.write(md);
+
+  if (report.findings.some((finding) => finding.severity === "critical")) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((error) => {
+  console.error("[fomo-web-journey-smoke] failed", error);
+  process.exitCode = 2;
+});


### PR DESCRIPTION
## 요약
- Agent Tooling Scout 스케줄을 주 1회에서 매일 09:00 KST로 변경했습니다.
- Daily Product Monitor에 production fomo-web 사용자 여정 스모크 검사를 추가했습니다.
- 스플래쉬가 CTA 전 사라지거나 CTA 후 전환되지 않으면 critical로 이슈/자동수정 경로에 올라가게 했습니다.
- 콘솔 에러는 noisy false positive를 피하기 위해 warn으로 기록합니다.

## 확인
- npm run smoke:fomo-web 성공: production에서 스플래쉬 유지 + CTA 후 전환 확인
- npm run agent:tooling-scout 성공: NVIDIA/SkillSpector 후보 1개 생성
- npm run typecheck 성공
- npm run test 성공
- npm run build 성공

## 왜 필요한가
- 툴링 후보가 며칠째 안 나온 원인은 스케줄이 월요일 1회였기 때문입니다.
- 제품 모니터가 실제 UI 버그를 못 잡은 원인은 API/수치 중심 검사만 있었고 웹 사용자 여정 검사가 없었기 때문입니다.