### PR TITLE
feat(fomo-web): 미국주식 티커 로고 추가(국내와 동일)

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -77,14 +77,27 @@ function normalizeChangeText(text: string | undefined): string | undefined {
   return text.replace(/^--+/, "-").replace(/^\+\++/, "+");
 }
 
-/** 종목 로고 — 네이버 심볼 이미지(불러와지면), 실패 시 이니셜 원형 폴백. */
-function LogoBadge({ name, code }: { name: string; code?: string | undefined }) {
+/** 종목 로고 — 국내는 네이버 심볼, 미국은 티커 로고(Parqet), 실패 시 이니셜 원형 폴백. */
+function LogoBadge({
+  name,
+  naverCode,
+  symbol,
+}: {
+  name: string;
+  naverCode?: string | undefined;
+  symbol?: string | undefined;
+}) {
   const [failed, setFailed] = useState(false);
   const ch = name.trim().slice(0, 1) || "·";
-  if (code && !failed) {
+  const src = naverCode
+    ? `https://ssl.pstatic.net/imgstock/fn/real/logo/stock/Stock${naverCode}.svg`
+    : symbol
+      ? `https://assets.parqet.com/logos/symbol/${encodeURIComponent(symbol)}`
+      : undefined;
+  if (src && !failed) {
     return (
       <img
-        src={`https://ssl.pstatic.net/imgstock/fn/real/logo/stock/Stock${code}.svg`}
+        src={src}
         alt=""
         aria-hidden
         onError={() => setFailed(true)}
@@ -330,7 +343,7 @@ function StockCardFace({
     <div className="flex h-full min-h-0 flex-col">
       {/* 1행 — 정체성: 로고 + 종목명 + 시장·시총순위 */}
       <div className="flex shrink-0 items-center gap-2.5">
-        <LogoBadge name={stock.canonical} code={stock.naverCode} />
+        <LogoBadge name={stock.canonical} naverCode={stock.naverCode} symbol={stock.symbol} />
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <span className="truncate text-2xl font-bold text-whiteout">{stock.canonical}</span>
@@ -430,7 +443,7 @@ function StockCardLoadingFace({
   return (
     <div className="flex h-full flex-col" aria-busy="true" aria-live="polite">
       <div className="flex items-center gap-2.5">
-        <LogoBadge name={stock.canonical} code={stock.naverCode} />
+        <LogoBadge name={stock.canonical} naverCode={stock.naverCode} symbol={stock.symbol} />
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <span className="truncate text-2xl font-bold text-whiteout">{stock.canonical}</span>


### PR DESCRIPTION
## 무엇
발견 덱 카드의 종목 로고(`LogoBadge`)가 국내(naverCode→네이버 심볼 SVG)만 이미지를 띄우고, 미국주는 이니셜 폴백만 떴음. 미국주(`symbol`)도 **Parqet 로고 CDN**(`assets.parqet.com/logos/symbol/{TICKER}`)으로 국내와 **동일한 둥근 흰 배지**로 렌더.

- 국내 경로 무변경(네이버 심볼 그대로)
- 실패 시 기존 이니셜 폴백 유지(`onError`)
- 카드 앞/뒤면 두 LogoBadge 호출부 모두 `naverCode`+`symbol` 전달

## 검증
- typecheck 통과
- 브라우저 렌더 확인: NVDA·AAPL·TSLA·PLTR·AMD·COIN 로고 정상(broken 0), 국내(삼성전자·SK하이닉스)와 동일 스타일

## 비고
순수 시각(로고 이미지) 변경 — 덱 크기·훅·정렬·칩·섹터 라벨·reason 무영향(랭킹/수집 로직 미변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)