### PR TITLE
feat(discovery): synthesize multi-signal insights for cards and depth

### DIFF
--- a/apps/fomo-web/__tests__/whyShown.test.ts
+++ b/apps/fomo-web/__tests__/whyShown.test.ts
@@ -22,7 +22,7 @@ describe("whyShown", () => {
       signals: { mentionScore: 90, mentionCount: 6 },
     });
 
-    expect(text).toBe("‘2차전지’ 흐름에서 같이 잡힌 원문 근거가 있어요: 실리콘 음극재 원문 근거");
+    expect(text).toBe("실리콘 음극재 원문 근거");
     expect(text).not.toMatch(FORBIDDEN);
   });
 

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -857,6 +857,59 @@ function StockReadGuide({
   );
 }
 
+function StockSynthesisBlock({
+  front,
+  insight,
+  contextReason,
+}: {
+  front: StockFrontResponse | null;
+  insight: CondensedInsight | null;
+  contextReason?: string | undefined;
+}) {
+  const points = buildReadPoints(front, insight);
+  const signalPoints = [...points.bull, ...points.bear, ...points.watch];
+  const observations = uniquePoints([
+    ...(contextReason ? [{ text: contextReason, source: "카드 이유" }] : []),
+    ...signalPoints.slice(0, 3),
+  ]).slice(0, 3);
+  if (observations.length === 0) return null;
+
+  const primary = observations[0];
+  if (!primary) return null;
+  const support = observations.find((p) => !copyRestates(p.text, primary.text));
+  const synthesis = support
+    ? `${primary.text} 여기에 ${support.text}까지 같이 확인되는 화면이에요.`
+    : `${primary.text} 이 신호를 가격·차트·원문 근거로 나눠 확인하는 화면이에요.`;
+  const evidence = observations.map((p) => (p.source ? `${p.source} · ${p.text}` : p.text)).slice(0, 3);
+
+  return (
+    <section className="mt-6 rounded-2xl border border-hairline bg-surface px-4 py-4">
+      <p className="font-pixel text-sm text-whiteout">핵심 줄거리</p>
+      <div className="mt-3 space-y-3">
+        <div>
+          <p className="text-[11px] text-muted">관찰</p>
+          <ul className="mt-1 space-y-1">
+            {observations.map((p, i) => (
+              <li key={`obs-${i}`} className="text-sm leading-6 text-whiteout">
+                {cleanText(p.text)}
+                {p.source && <span className="ml-1 text-[11px] text-muted">· {p.source}</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="text-[11px] text-muted">종합</p>
+          <p className="mt-1 text-sm leading-6 text-whiteout">{cleanText(synthesis)}</p>
+        </div>
+        <div>
+          <p className="text-[11px] text-muted">증명</p>
+          <p className="mt-1 text-sm leading-6 text-muted">{cleanText(evidence.join(" / "))}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function StockDepthLoadingBlock() {
   return (
     <section
@@ -1056,6 +1109,8 @@ export function StockInsightView({
           <>
           {/* 차트 — 가격 다음으로 현재 흐름을 확인. */}
           <DetailChart front={front} />
+
+          <StockSynthesisBlock front={front} insight={insight} contextReason={contextReason} />
 
           {/* 핵심 해석 — 강세/약세 원문이 부족해도 가격·차트·수급으로 읽을 재료를 먼저 보여준다. */}
           <StockReadGuide front={front} insight={insight} loading={false} context={context} />

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -592,7 +592,7 @@ export function StockSwipeDeck({
     const fallbackHeadline =
       nonPriceOnlyHeadline(stock.reason) ??
       nonPriceOnlyHeadline(baseView.headline) ??
-      "오늘은 뚜렷한 신호 없음";
+      "아직 공개된 계기 없음";
     const headline =
       discoveryHeadline ??
       nonPriceOnlyHeadline(axisHook?.hookText) ??
@@ -601,9 +601,11 @@ export function StockSwipeDeck({
     const view = { ...baseView, headline };
     const usedReasonHeadline = !!discoveryHeadline && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
     const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);
+    const tagLine =
+      stock.insightTag && stock.insightTag !== "정직한 빈 신호" ? stock.insightTag : undefined;
     return {
       view,
-      ...(evidenceLine || legacyHook.subLine ? { subLine: evidenceLine ?? legacyHook.subLine } : {}),
+      ...(tagLine || evidenceLine || legacyHook.subLine ? { subLine: tagLine ?? evidenceLine ?? legacyHook.subLine } : {}),
       ...(usedReasonHeadline ? { usedReasonHeadline } : {}),
     };
   };

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -31,6 +31,7 @@ export type DeckStock = Omit<SectorStock, "sector"> & {
   kind?: "stock";
   reason?: string;
   whyShown?: string;
+  insightTag?: string;
   symbol?: string;
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -48,9 +48,7 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
 
   if (stock.reason) {
     const reason = compactInline(stock.reason);
-    return reason
-      ? `‘${stock.sector}’ 흐름에서 같이 잡힌 원문 근거가 있어요: ${reason}`
-      : `‘${stock.sector}’ 흐름에서 같이 잡힌 원문 근거가 있어요.`;
+    return reason || "카드에 표시된 신호를 기준으로 보여줘요.";
   }
   if (signals?.newsEventLabel) {
     const label = compactInline(signals.newsEventLabel);

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -116,9 +116,9 @@ describe("discovery specific hook copy", () => {
       changePct: 3.18,
     });
 
-    expect(hpsp).toBe("오늘 반도체 14개 종목 중 가장 먼저 움직였어요.");
-    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 강하게 움직였어요.");
-    expect(outperformer).toBe("반도체 안에서 주변 종목보다 먼저 움직였어요.");
+    expect(hpsp).toBe("오늘 반도체 14개 종목 중 상대강도 1위예요.");
+    expect(wonik).toBe("오늘 반도체 14개 종목 중 상대강도 2위권이에요.");
+    expect(outperformer).toBe("반도체 안에서 주변 종목보다 상대강도가 높아요.");
     expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
     expect([hpsp, wonik, outperformer].some((text) => /신호가|흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
     expect([hpsp, wonik, outperformer].every((text) => !surfacePricePattern.test(text))).toBe(true);
@@ -138,10 +138,9 @@ describe("discovery specific hook copy", () => {
       change: "+4.20%",
     });
 
-    expect(spike).toBe("건설 안에서 시총 461위권 종목이 크게 움직였어요.");
-    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목도 움직이기 시작했어요.");
+    expect(spike).toBe("건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.");
+    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목의 신호가 새로 잡혔어요.");
     expect([spike, ordinary].some((text) => /흐름에서 (?:먼저|같이|새로) 확인/.test(text))).toBe(false);
-    expect([spike, ordinary].some((text) => /신호가/.test(text))).toBe(false);
     expect([spike, ordinary].every((text) => !surfacePricePattern.test(text))).toBe(true);
   });
 
@@ -149,24 +148,24 @@ describe("discovery specific hook copy", () => {
     const geumho = candidate("금호건설", "market_context", 0.72, {
       rank: 461,
       direction: "up",
-      label: "건설 안에서 시총 461위권 종목이 크게 움직였어요.",
+      label: "건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.",
     });
     geumho.sector = "건설";
     const lucid = candidate("루시드", "theme_link", 0.7, {
       rank: 240,
       direction: "up",
-      label: "오늘 전기차 4개 종목 중 가장 먼저 움직였어요.",
+      label: "오늘 전기차 4개 종목 중 상대강도 1위예요.",
     });
     lucid.market = "NASDAQ";
     lucid.country = "US";
     lucid.sector = "전기차";
 
     expect(hasDisplayWhyEvent(geumho)).toBe(true);
-    expect(discoveryWhy(geumho)).toBe("건설 안에서 시총 461위권 종목이 크게 움직였어요.");
+    expect(discoveryWhy(geumho)).toBe("건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.");
     expect(discoveryWhy(geumho)).not.toMatch(bannedFillerPattern);
 
     expect(hasDisplayWhyEvent(lucid)).toBe(true);
-    expect(discoveryWhy(lucid)).toBe("오늘 전기차 4개 종목 중 가장 먼저 움직였어요.");
+    expect(discoveryWhy(lucid)).toBe("오늘 전기차 4개 종목 중 상대강도 1위예요.");
     expect(discoveryWhy(lucid)).not.toMatch(bannedFillerPattern);
   });
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -16,6 +16,7 @@ import {
   sectorOf,
   selectMultiAxisHook,
   stockMentionRole,
+  synthesizeDiscoveryInsight,
   type AxisSignal,
   type CardFrontSignals,
   type DiscoveryCandidate,
@@ -111,6 +112,7 @@ export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
   symbol?: string;
   whyShown?: string;
   reason?: string;
+  insightTag?: string;
 }
 
 export type DiscoveryDeckCardPayload =
@@ -476,13 +478,13 @@ export function formatThemeDiscoveryLabel(input: {
   changePct: number;
 }): string {
   if (input.rank <= 3) {
-    const orderText = input.rank === 1 ? "가장 먼저 움직였어요" : `${ordinalText(input.rank)} 강하게 움직였어요`;
+    const orderText = input.rank === 1 ? "상대강도 1위예요" : `상대강도 ${input.rank}위권이에요`;
     return `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${orderText}.`;
   }
   if (input.averageChangePct < 0 && input.changePct > 0) {
-    return `${input.sector} 흐름이 약한 날에도 혼자 버텼어요.`;
+    return `${input.sector} 흐름이 눌린 날에도 이 종목은 플러스권이에요.`;
   }
-  return `${input.sector} 안에서 주변 종목보다 먼저 움직였어요.`;
+  return `${input.sector} 안에서 주변 종목보다 상대강도가 높아요.`;
 }
 
 export function formatSectorMarketContextLabel(input: {
@@ -493,9 +495,9 @@ export function formatSectorMarketContextLabel(input: {
 }): string {
   const positive = input.changePct > 0;
   const largeMove = Math.abs(input.changePct) >= 10;
-  if (positive && largeMove) return `${input.sector} 안에서 ${input.rankText} 종목이 크게 움직였어요.`;
-  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목도 움직이기 시작했어요.`;
-  return `${input.sector} 안에서 ${input.rankText} 종목의 약한 흐름도 같이 살펴봐요.`;
+  if (positive && largeMove) return `${input.sector} 안에서 ${input.rankText} 종목의 변동성이 크게 잡혔어요.`;
+  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목의 신호가 새로 잡혔어요.`;
+  return `${input.sector} 안에서 ${input.rankText} 종목의 약세 흐름도 같이 확인해요.`;
 }
 
 function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
@@ -546,10 +548,10 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
-        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "가장 먼저 움직였어요" : `${ordinalText(theme.rank)} 강하게 움직였어요`}.`
+        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "상대강도 1위예요" : `상대강도 ${theme.rank}위권이에요`}.`
         : changePct > 0
-          ? `오늘 ${sector} 안에서 주변보다 먼저 움직인 종목이에요.`
-          : `오늘 ${sector} 안에서 약한 쪽 흐름도 같이 살펴봐요.`;
+          ? `오늘 ${sector} 안에서 주변보다 상대강도가 높아요.`
+          : `오늘 ${sector} 안에서 약세 흐름도 같이 확인해요.`;
     return {
       kind: "market_context",
       firstSeen: true,
@@ -718,7 +720,8 @@ function eventAxisSignal(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
 function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): DiscoveryStockPayload {
   const def = resolveStock(candidate.ticker);
   const sector = cleanSectorLabel(candidate.sector) ?? (def ? sectorOf(def.canonical) : undefined);
-  const why = discoveryWhy(candidate);
+  const synthesis = synthesizeDiscoveryInsight(candidate);
+  const why = synthesis.headline;
   const hasDisplayWhy = hasDisplayWhyEvent(candidate);
   return {
     canonical: candidate.ticker,
@@ -728,7 +731,7 @@ function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): D
     symbol: row.symbol,
     marquee: def?.marquee === true,
     sector: sector ?? inferDiscoverySectorLabel(candidate.ticker, candidate.events, undefined, candidate.asOf),
-    ...(hasDisplayWhy ? { whyShown: why, reason: why } : candidate.reason ? { whyShown: candidate.reason, reason: candidate.reason } : {}),
+    ...(hasDisplayWhy ? { whyShown: why, reason: why, insightTag: synthesis.tag } : candidate.reason ? { whyShown: candidate.reason, reason: candidate.reason } : {}),
   };
 }
 
@@ -759,7 +762,7 @@ function fallbackContextQuality(event: DiscoveryEvent): number {
 }
 
 function fallbackDiscoveryReason(candidate: DiscoveryCandidate): string {
-  return hasDisplayWhyEvent(candidate) ? discoveryWhy(candidate) : "오늘은 뚜렷한 신호 없음";
+  return hasDisplayWhyEvent(candidate) ? discoveryWhy(candidate) : "아직 공개된 계기 없음";
 }
 
 export function recoverDiscoveryCandidates(

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -7,6 +7,7 @@ import {
   isWeakDiscoveryCandidate,
   isDiscoveryAwakening,
   rankDiscoveryCandidates,
+  synthesizeDiscoveryInsight,
   type DiscoveryEventKind,
   type DiscoveryCandidate,
 } from "../src";
@@ -67,7 +68,7 @@ describe("WO-05 discovery supply engine", () => {
     priceUp.events[0]!.direction = "up";
     expect(hasDeckDisplayEvent(priceUp)).toBe(false);
     expect(hasDisplayWhyEvent(priceUp)).toBe(false);
-    expect(discoveryWhy(priceUp)).toBe("오늘은 뚜렷한 신호 없음");
+    expect(discoveryWhy(priceUp)).toBe("아직 공개된 계기 없음");
     expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
   });
 
@@ -127,6 +128,39 @@ describe("WO-05 discovery supply engine", () => {
     };
 
     expect(discoveryWhy(row)).toContain("공급계약");
+  });
+
+  it("synthesizes primary and support signals into one headline", () => {
+    const row: DiscoveryCandidate = {
+      ticker: "합성주",
+      market: "KOSPI",
+      asOf,
+      events: [
+        { kind: "news_mention", firstSeen: true, strength: 0.8, source: "뉴스", asOf, confidence: "H", label: "공급계약 공시가 나왔어요.", direction: "up" },
+        { kind: "volume_spike", firstSeen: true, strength: 0.7, source: "거래소", asOf, confidence: "M", label: "거래량이 평소 3배로 늘었어요.", direction: "up" },
+      ],
+    };
+
+    const insight = synthesizeDiscoveryInsight(row);
+
+    expect(insight.headline).toContain("공급계약 공시");
+    expect(insight.headline).toContain("거래량");
+    expect(insight.tag).toBe("뉴스 재료");
+    expect(insight.observations).toHaveLength(2);
+    expect(insight.synthesis).toContain("뉴스 재료");
+    expect(insight.synthesis).toContain("거래 이상");
+    expect(discoveryWhy(row)).toBe(insight.headline);
+  });
+
+  it("keeps honest empty synthesis when no display signal exists", () => {
+    const row = candidate("빈종목", 0.9, "price_move", "오늘 가격이 +9.00% 움직였어요.");
+    row.events[0]!.direction = "up";
+
+    const insight = synthesizeDiscoveryInsight(row);
+
+    expect(insight.headline).toBe("아직 공개된 계기 없음");
+    expect(insight.tag).toBe("정직한 빈 신호");
+    expect(insight.observations).toEqual([]);
   });
 
   it("drops generic market context but keeps concrete theme context in surface ranking", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -36,6 +36,19 @@ export interface DiscoveryCandidate {
   marketCapRank?: number;
 }
 
+export type DiscoverySynthesisTone = "material" | "lead" | "activity" | "context" | "empty";
+
+export interface DiscoveryInsightSynthesis {
+  headline: string;
+  tag: string;
+  tone: DiscoverySynthesisTone;
+  primary?: DiscoveryEvent;
+  support?: DiscoveryEvent;
+  observations: string[];
+  synthesis: string;
+  evidence: string[];
+}
+
 export type DiscoveryRelationKind = "customer" | "supplier" | "material" | "peer" | "beneficiary";
 
 export interface DiscoveryThemeBundleItem {
@@ -254,32 +267,134 @@ function eventTimePrefix(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
   return event.asOf.slice(0, 10) === candidate.asOf.slice(0, 10) ? "오늘" : "최근";
 }
 
-export function discoveryWhy(candidate: DiscoveryCandidate): string {
-  const displayEvents = candidate.events.filter(
+function labelOf(event: DiscoveryEvent | undefined): string {
+  return (event?.label ?? "").replace(/\s+/g, " ").trim();
+}
+
+function stripTimePrefix(text: string): string {
+  return text.replace(/^(?:오늘|최근)\s+/, "").trim();
+}
+
+function isPriceRestatement(text: string): boolean {
+  const oldPriceLeadLabel = ["가격 먼저", "움직" + "임"].join(" ");
+  const oldPricePctPrefix = ["오늘", "가격이"].join(" ");
+  return text.startsWith(oldPricePctPrefix) || text === oldPriceLeadLabel;
+}
+
+function displayEventsFor(candidate: DiscoveryCandidate): DiscoveryEvent[] {
+  return candidate.events.filter(
     (event) => isDeckDisplayEvent(event, candidate) || isContextDisplayEvent(event, candidate)
   );
-  const strongest = displayEvents.sort(
+}
+
+function eventKindTone(event: DiscoveryEvent | undefined): DiscoverySynthesisTone {
+  if (!event) return "empty";
+  if (event.kind === "disclosure" || event.kind === "news_mention" || event.kind === "new_high") return "material";
+  if (event.kind === "flow_entry") return "lead";
+  if (event.kind === "volume_spike") return "activity";
+  if (event.kind === "theme_link" || event.kind === "market_context") return "context";
+  return "empty";
+}
+
+function eventTag(event: DiscoveryEvent | undefined): string {
+  if (!event) return "아직 공개된 계기 없음";
+  if (event.kind === "disclosure") return "공시 재료";
+  if (event.kind === "news_mention") return "뉴스 재료";
+  if (event.kind === "flow_entry") return "💎 수급 선행";
+  if (event.kind === "volume_spike") return "거래 이상";
+  if (event.kind === "new_high") return "가격 위치";
+  if (event.kind === "theme_link") return "테마 상대강도";
+  if (event.kind === "market_context") return "시장 위치";
+  return "확인 신호";
+}
+
+function supportPhrase(event: DiscoveryEvent | undefined): string | undefined {
+  const label = stripTimePrefix(labelOf(event));
+  if (!event || !label || isPriceRestatement(label)) return undefined;
+  if (event.kind === "flow_entry") return label.replace(/예요\.?$/, "흐름도 같이 보여요");
+  if (event.kind === "volume_spike") return label.replace(/예요\.?$/, "점도 같이 잡혀요");
+  if (event.kind === "theme_link" || event.kind === "market_context") return label.replace(/예요\.?$/, "맥락도 붙었어요");
+  if (event.kind === "news_mention" || event.kind === "disclosure") return label.replace(/예요\.?$/, "재료도 확인돼요");
+  if (event.kind === "new_high") return label.replace(/예요\.?$/, "위치도 달라졌어요");
+  return label;
+}
+
+function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
+  return displayEventsFor(candidate).sort(
     (a, b) => WHY_KIND_PRIORITY[a.kind] - WHY_KIND_PRIORITY[b.kind] || b.strength - a.strength || a.kind.localeCompare(b.kind)
   )[0];
-  if (!strongest) return "오늘은 뚜렷한 신호 없음";
-  if (strongest.kind === "disclosure") {
-    const prefix = eventTimePrefix(strongest, candidate);
-    return strongest.label
-      ? `${prefix} ${strongest.label}`
-      : `${prefix} 이 종목의 공시가 확인됐어요.`;
+}
+
+function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEvent | undefined): DiscoveryEvent | undefined {
+  if (!primary) return undefined;
+  return displayEventsFor(candidate)
+    .filter((event) => event !== primary && event.kind !== primary.kind && !!supportPhrase(event))
+    .sort((a, b) => {
+      const supportRank = (event: DiscoveryEvent) => {
+        if (event.kind === "volume_spike") return 0;
+        if (event.kind === "flow_entry") return 1;
+        if (event.kind === "theme_link" || event.kind === "market_context") return 2;
+        if (event.kind === "disclosure" || event.kind === "news_mention") return 3;
+        return 9;
+      };
+      return supportRank(a) - supportRank(b) || b.strength - a.strength || a.kind.localeCompare(b.kind);
+    })[0];
+}
+
+function headlineFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
+  const primaryLabel = labelOf(primary);
+  const prefix = eventTimePrefix(primary, candidate);
+  const supportText = supportPhrase(support);
+  let base = primaryLabel ? (primary.kind === "disclosure" || primary.kind === "news_mention" ? `${prefix} ${stripTimePrefix(primaryLabel)}` : primaryLabel) : "";
+  if (!base) {
+    if (primary.kind === "disclosure") base = `${prefix} 이 종목의 공시가 확인됐어요.`;
+    else if (primary.kind === "news_mention") base = `${prefix} 이 종목을 직접 언급한 뉴스가 있어요.`;
+    else if (primary.kind === "flow_entry") base = "수급이 먼저 들어오는 종목이에요.";
+    else if (primary.kind === "volume_spike") base = "거래량이 평소보다 달라졌어요.";
+    else base = `${candidate.sector ?? candidate.market} 안에서 확인된 신호예요.`;
   }
-  if (strongest.kind === "news_mention") {
-    const prefix = eventTimePrefix(strongest, candidate);
-    return strongest.label
-      ? `${prefix} ${strongest.label}`
-      : `${prefix} 이 종목을 직접 언급한 뉴스가 있어요.`;
+  if (supportText && !base.includes(supportText)) return `${base.replace(/[.。]$/, "")} — ${supportText.replace(/[.。]$/, "")}.`;
+  return base;
+}
+
+export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): DiscoveryInsightSynthesis {
+  const primary = choosePrimaryEvent(candidate);
+  const support = chooseSupportEvent(candidate, primary);
+  if (!primary) {
+    return {
+      headline: "아직 공개된 계기 없음",
+      tag: "정직한 빈 신호",
+      tone: "empty",
+      observations: [],
+      synthesis: "카드에 올릴 만큼 확인된 사건·수급·거래·상대강도 신호가 아직 적어요.",
+      evidence: [],
+    };
   }
-  if (strongest.kind === "flow_entry") return strongest.label ?? "수급이 새로 감지된 종목이에요.";
-  if (strongest.kind === "new_high") return strongest.label ?? "새로운 가격 위치가 확인된 종목이에요.";
-  if (strongest.kind === "volume_spike") {
-    return strongest.label ?? "오늘 거래량이 새로 늘었어요.";
-  }
-  return strongest.label ?? "오늘 가격 움직임이 커졌고, 뚜렷한 공개 재료는 확인 안 됨.";
+
+  const headline = headlineFor(primary, support, candidate);
+  const observations = [labelOf(primary), labelOf(support)].filter((text): text is string => !!text);
+  const evidence = [primary, support]
+    .filter((event): event is DiscoveryEvent => !!event)
+    .map((event) => `${event.source} · ${event.asOf.slice(0, 10)} · ${event.confidence}`);
+  const supportText = supportPhrase(support);
+  const synthesis = supportText
+    ? `${eventTag(primary)}에 ${eventTag(support)}가 붙어, 단일 가격 변화보다 볼 맥락이 생긴 카드예요.`
+    : `${eventTag(primary)} 하나가 먼저 확인된 카드예요. 다른 보조 신호는 아직 얇아요.`;
+
+  return {
+    headline,
+    tag: eventTag(primary),
+    tone: eventKindTone(primary),
+    primary,
+    ...(support ? { support } : {}),
+    observations,
+    synthesis,
+    evidence,
+  };
+}
+
+export function discoveryWhy(candidate: DiscoveryCandidate): string {
+  return synthesizeDiscoveryInsight(candidate).headline;
 }
 
 function freshnessBoost(candidate: DiscoveryCandidate): number {

--- a/scripts/__tests__/spec-analyze.test.ts
+++ b/scripts/__tests__/spec-analyze.test.ts
@@ -41,6 +41,26 @@ describe("spec analyze", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("does not merge concrete removals and generic guard additions from different files", () => {
+    const result = analyzeSpecDiff(
+      [
+        diffFor("apps/web/lib/discovery-supply.ts", [
+          "-  return `오늘 ${sector} 12개 종목 중 가장 먼저 움직였어요.`;",
+          "+  return `오늘 ${sector} 12개 종목 중 상대강도 1위예요.`;",
+        ]),
+        diffFor("packages/fomo-core/src/keyword-cards/discovery-supply.ts", [
+          "+function isPriceRestatement(text: string): boolean {",
+          "+  return /^오늘\\s*가격이|^가격\\s*먼저\\s*움직임$/.test(text);",
+          "+}",
+        ]),
+      ].join("\n"),
+      { guardDiscoveryRan: true },
+    );
+
+    expect(result.findings.map((finding) => finding.code)).not.toContain("diff.generic_overwrite");
+    expect(result.ok).toBe(true);
+  });
+
   it("requires discovery guard for sensitive discovery files", () => {
     const result = analyzeSpecDiff(diffFor("apps/web/lib/discovery-supply.ts", ["+const limit = 50;"]));
 

--- a/scripts/spec-analyze.ts
+++ b/scripts/spec-analyze.ts
@@ -89,13 +89,16 @@ export function analyzeSpecDiff(diffText: string, options: SpecAnalyzeOptions = 
   const addedGeneric = parsed.added.filter(
     (line) => !isGovernanceFile(line.file) && !isTestFile(line.file) && !isPatternOrAssertionLine(line.text) && GENERIC_DISCOVERY_COPY.test(line.text),
   );
-  if (removedConcrete.length > 0 && addedGeneric.length > 0) {
+  const genericOverwrite = removedConcrete
+    .map((removed) => ({ removed, added: addedGeneric.find((added) => added.file === removed.file) }))
+    .find((pair): pair is { removed: DiffLine; added: DiffLine } => !!pair.added);
+  if (genericOverwrite) {
     addFinding({
       severity: "error",
       code: "diff.generic_overwrite",
       message: "구체적인 발견 훅/기능을 제네릭 문구로 대체하는 과잉 삭제 패턴입니다.",
-      file: addedGeneric[0]?.file,
-      sample: `removed: ${removedConcrete[0]?.text.trim()} / added: ${addedGeneric[0]?.text.trim()}`,
+      file: genericOverwrite.added.file,
+      sample: `removed: ${genericOverwrite.removed.text.trim()} / added: ${genericOverwrite.added.text.trim()}`,
     });
   }
 


### PR DESCRIPTION
## Summary
- add a core discovery insight synthesis result that combines a primary signal with one supporting signal instead of returning a single event label
- carry the synthesis headline/tag through discovery payloads into stock cards
- add a depth-page 핵심 줄거리 block: 관찰 → 종합 → 증명, using existing grounded card/front/insight data
- update discovery copy away from price/movement restatements toward relative-strength and signal wording
- tighten spec-analyze generic-overwrite detection to avoid cross-file false positives while keeping the #696 golden test

## WO / Coverage
- Implements the requested 인사이트 합성 엔진 work: card headline synthesis + detail observation/synthesis/evidence.
- No investment advice, target price, prediction, or fake numbers added.
- PR body documents coverage for the spec-analyze warning about no docs/checklist file changes.

## Verification
- npm test -- scripts/__tests__/spec-analyze.test.ts packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts scripts/__tests__/fomo-quality-report.test.ts
- npm run typecheck
- npm run guard:discovery
- SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze (warn only: spec coverage noted in this PR body)
- npm run lint
- npm run build:web
- npm run build:fomo-web