### PR TITLE
fix(discovery): isolate US deck from KR cache leaks

### DIFF
--- a/apps/fomo-web/__tests__/discovery-country-scope.test.ts
+++ b/apps/fomo-web/__tests__/discovery-country-scope.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { discoveryMatchesCountry, type DiscoveryScopeResponse } from "../lib/discoveryCountryScope";
+
+const baseDiscovery: DiscoveryScopeResponse = {
+  asOf: "2026-06-28",
+  country: "US",
+  stocks: [
+    {
+      kind: "stock",
+      canonical: "루시드",
+      market: "NASDAQ",
+      country: "US",
+      symbol: "LCID",
+      marquee: false,
+      sector: "전기차",
+    },
+  ],
+  cards: [
+    {
+      kind: "stock",
+      canonical: "루시드",
+      market: "NASDAQ",
+      country: "US",
+      symbol: "LCID",
+      marquee: false,
+      sector: "전기차",
+    },
+  ],
+  fronts: {},
+  confidence: "M",
+  source: "Twelve Data/US 시세",
+};
+
+describe("discovery country scope", () => {
+  it("accepts US decks only when stock cards are US exchange symbols", async () => {
+    expect(discoveryMatchesCountry(baseDiscovery, "US")).toBe(true);
+  });
+
+  it("rejects KR cards accidentally stored or emitted into the US deck", async () => {
+    const polluted: DiscoveryScopeResponse = {
+      ...baseDiscovery,
+      stocks: [
+        {
+          kind: "stock",
+          canonical: "엠게임",
+          market: "KOSDAQ",
+          country: "KR",
+          naverCode: "058630",
+          marquee: false,
+          sector: "게임",
+        },
+      ],
+      cards: [
+        {
+          kind: "stock",
+          canonical: "엠게임",
+          market: "KOSDAQ",
+          country: "KR",
+          naverCode: "058630",
+          marquee: false,
+          sector: "게임",
+        },
+      ],
+    };
+
+    expect(discoveryMatchesCountry(polluted, "US")).toBe(false);
+  });
+});

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
-import { DISCOVERY_UPDATED_EVENT, fetchDiscovery, type DiscoveryCountryScope, type DiscoveryResponse } from "@/lib/fomoApi";
+import {
+  DISCOVERY_UPDATED_EVENT,
+  fetchDiscovery,
+  type DiscoveryCountryScope,
+  type DiscoveryResponse,
+  type DiscoveryUpdatedDetail,
+} from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import { MIN_DISCOVERY_STOCKS, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
@@ -55,7 +61,9 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
       setState({ kind: "ready", cards, fronts: discovery.fronts as Record<string, FrontEntry> });
     };
     const onDiscoveryUpdated = (event: Event) => {
-      const discovery = (event as CustomEvent<DiscoveryResponse>).detail;
+      const detail = (event as CustomEvent<DiscoveryUpdatedDetail>).detail;
+      const discovery = detail?.discovery;
+      if (detail?.country !== country) return;
       if (!alive || !discovery) return;
       applyDiscovery(discovery);
     };

--- a/apps/fomo-web/lib/discoveryCountryScope.ts
+++ b/apps/fomo-web/lib/discoveryCountryScope.ts
@@ -1,0 +1,50 @@
+import type { StockCountry, StockMarket } from "@fomo/core";
+
+export type DiscoveryCountryScope = "KR" | "US" | "all";
+
+export interface DiscoveryScopeStock {
+  kind?: "stock";
+  canonical?: string;
+  market: StockMarket;
+  country?: StockCountry;
+  naverCode?: string;
+  symbol?: string;
+  marquee?: boolean;
+  sector?: string;
+}
+
+export interface DiscoveryScopeThemeBundle {
+  kind: "theme_bundle";
+  items: DiscoveryScopeStock[];
+}
+
+export interface DiscoveryScopeResponse {
+  asOf?: string;
+  country?: DiscoveryCountryScope;
+  stocks: DiscoveryScopeStock[];
+  cards?: Array<DiscoveryScopeStock | DiscoveryScopeThemeBundle>;
+  fronts: Record<string, unknown>;
+  confidence?: "L" | "M" | "H";
+  source?: string;
+}
+
+function stockMatchesCountry(stock: DiscoveryScopeStock, country: DiscoveryCountryScope): boolean {
+  if (country === "all") return true;
+  if (country === "KR") return stock.country === "KR" && (stock.market === "KOSPI" || stock.market === "KOSDAQ");
+  return stock.country === "US" && (stock.market === "NASDAQ" || stock.market === "NYSE") && !!stock.symbol && !stock.naverCode;
+}
+
+function cardMatchesCountry(card: DiscoveryScopeStock | DiscoveryScopeThemeBundle, country: DiscoveryCountryScope): boolean {
+  if (country === "all") return true;
+  if (card.kind === "theme_bundle") return card.items.length > 0 && card.items.every((item) => stockMatchesCountry(item, country));
+  return stockMatchesCountry(card, country);
+}
+
+export function discoveryMatchesCountry(
+  value: DiscoveryScopeResponse | null | undefined,
+  country: DiscoveryCountryScope,
+): value is DiscoveryScopeResponse {
+  if (!value || !Array.isArray(value.stocks) || !value.fronts || typeof value.fronts !== "object") return false;
+  if (value.country && value.country !== country) return false;
+  return value.stocks.every((stock) => stockMatchesCountry(stock, country)) && (value.cards ?? []).every((card) => cardMatchesCountry(card, country));
+}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -11,6 +11,7 @@ import type {
 } from "@fomo/core";
 import { getSessionId } from "@/lib/session";
 import { cachedGet, readCached, refreshCached, setCached } from "./apiCache";
+import { discoveryMatchesCountry, type DiscoveryCountryScope } from "./discoveryCountryScope";
 
 export type { BannerItem } from "@fomo/core";
 
@@ -39,7 +40,7 @@ const INDEX_REVALIDATE_TIMEOUT_MS = 8_000;
 const DISCOVERY_SAME_ORIGIN_TIMEOUT_MS = 11_500;
 const DISCOVERY_BACKEND_TIMEOUT_MS = 18_000;
 const DISCOVERY_REVALIDATE_TIMEOUT_MS = 24_000;
-export type DiscoveryCountryScope = "KR" | "US" | "all";
+export type { DiscoveryCountryScope } from "./discoveryCountryScope";
 
 function discoveryFastPath(country: DiscoveryCountryScope = "KR"): string {
   return `/api/fomo/discovery?fast=1&country=${encodeURIComponent(country)}`;
@@ -448,11 +449,17 @@ export type DiscoveryCardResponse = DiscoveryStockResponse | DiscoveryThemeBundl
 
 export interface DiscoveryResponse {
   asOf: string;
+  country?: DiscoveryCountryScope;
   stocks: DiscoveryStockResponse[];
   cards?: DiscoveryCardResponse[];
   fronts: Record<string, StockFrontResponse>;
   confidence: "L" | "M" | "H";
   source: string;
+}
+
+export interface DiscoveryUpdatedDetail {
+  country: DiscoveryCountryScope;
+  discovery: DiscoveryResponse;
 }
 
 const discoveryKey = (country: DiscoveryCountryScope = "KR") => `discovery:today:v5:${country}:${kstDateKey()}`;
@@ -465,8 +472,8 @@ function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
   return !!candidate && Array.isArray(candidate.stocks) && !!candidate.fronts && typeof candidate.fronts === "object";
 }
 
-function hasDiscoveryCards(value: DiscoveryResponse | null | undefined): value is DiscoveryResponse {
-  return !!value && isDiscoveryResponse(value) && (value.stocks.length > 0 || (value.cards?.length ?? 0) > 0);
+function hasDiscoveryCards(value: DiscoveryResponse | null | undefined, country: DiscoveryCountryScope = "all"): value is DiscoveryResponse {
+  return discoveryMatchesCountry(value, country) && (value.stocks.length > 0 || (value.cards?.length ?? 0) > 0);
 }
 
 function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryResponse | null {
@@ -476,7 +483,7 @@ function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryRe
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     const discovery = isDiscoveryResponse(parsed) ? parsed : null;
-    if (hasDiscoveryCards(discovery)) return discovery;
+    if (hasDiscoveryCards(discovery, country)) return discovery;
     window.localStorage.removeItem(discoveryStorageKey(country));
     window.localStorage.removeItem(lastDiscoveryStorageKey(country));
     return null;
@@ -488,7 +495,7 @@ function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryRe
 
 function writeStoredDiscovery(value: DiscoveryResponse, country: DiscoveryCountryScope = "KR"): void {
   if (typeof window === "undefined") return;
-  if (!hasDiscoveryCards(value)) return;
+  if (!hasDiscoveryCards(value, country)) return;
   try {
     window.localStorage.setItem(discoveryStorageKey(country), JSON.stringify(value));
     window.localStorage.setItem(lastDiscoveryStorageKey(country), JSON.stringify(value));
@@ -497,9 +504,9 @@ function writeStoredDiscovery(value: DiscoveryResponse, country: DiscoveryCountr
   }
 }
 
-function emitDiscoveryUpdated(value: DiscoveryResponse): void {
+function emitDiscoveryUpdated(country: DiscoveryCountryScope, value: DiscoveryResponse): void {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent<DiscoveryResponse>(DISCOVERY_UPDATED_EVENT, { detail: value }));
+  window.dispatchEvent(new CustomEvent<DiscoveryUpdatedDetail>(DISCOVERY_UPDATED_EVENT, { detail: { country, discovery: value } }));
 }
 
 async function fetchDiscoveryNetwork({
@@ -546,7 +553,7 @@ export const getCachedDiscovery = (country: DiscoveryCountryScope = "KR") => rea
 export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Promise<DiscoveryResponse> {
   const key = discoveryKey(country);
   const cached = readCached<DiscoveryResponse>(key);
-  if (hasDiscoveryCards(cached)) return cached;
+  if (hasDiscoveryCards(cached, country)) return cached;
 
   const stored = readStoredDiscovery(country);
   if (stored) {
@@ -560,11 +567,11 @@ export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Pro
           backendTimeoutMs: DISCOVERY_REVALIDATE_TIMEOUT_MS,
         }),
       CACHE_TTL.stockFront
-    )
+      )
       .then((fresh) => {
-        if (!hasDiscoveryCards(fresh)) return;
+        if (!hasDiscoveryCards(fresh, country)) return;
         writeStoredDiscovery(fresh, country);
-        emitDiscoveryUpdated(fresh);
+        emitDiscoveryUpdated(country, fresh);
       })
       .catch((err) => {
         if (process.env.NODE_ENV !== "production") {
@@ -575,7 +582,8 @@ export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Pro
   }
 
   const fresh = await fetchDiscoveryNetwork({ country });
-  if (hasDiscoveryCards(fresh)) setCached(key, fresh, CACHE_TTL.stockFront);
+  if (!hasDiscoveryCards(fresh, country)) throw new Error(`GET /api/fomo/discovery returned invalid ${country} deck`);
+  setCached(key, fresh, CACHE_TTL.stockFront);
   writeStoredDiscovery(fresh, country);
   return fresh;
 }

--- a/apps/web/__tests__/lib/discovery-country-scope.test.ts
+++ b/apps/web/__tests__/lib/discovery-country-scope.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isDiscoveryRowAllowedForScope } from "../../lib/discovery-supply";
+import type { DiscoveryMarketRow } from "../../lib/market-source-types";
+
+describe("discovery market country scope", () => {
+  it("rejects KR rows from the US discovery scope", () => {
+    const mgame: DiscoveryMarketRow = {
+      canonical: "엠게임",
+      symbol: "058630",
+      naverCode: "058630",
+      market: "KOSDAQ",
+      country: "KR",
+      currency: "KRW",
+      priceText: "4,040원",
+    };
+
+    expect(isDiscoveryRowAllowedForScope(mgame, "US")).toBe(false);
+    expect(isDiscoveryRowAllowedForScope(mgame, "KR")).toBe(true);
+  });
+
+  it("accepts only USD exchange symbols for the US discovery scope", () => {
+    const lucid: DiscoveryMarketRow = {
+      canonical: "루시드",
+      symbol: "LCID",
+      market: "NASDAQ",
+      country: "US",
+      currency: "USD",
+      priceText: "$2.10",
+    };
+
+    expect(isDiscoveryRowAllowedForScope(lucid, "US")).toBe(true);
+    expect(isDiscoveryRowAllowedForScope({ ...lucid, market: "KOSDAQ" }, "US")).toBe(false);
+    expect(isDiscoveryRowAllowedForScope({ ...lucid, currency: "KRW" }, "US")).toBe(false);
+    expect(isDiscoveryRowAllowedForScope({ ...lucid, naverCode: "058630" }, "US")).toBe(false);
+  });
+});

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -121,6 +121,7 @@ export type DiscoveryDeckCardPayload =
 
 export interface DiscoveryResponse {
   asOf: string;
+  country?: DiscoveryCountryScope;
   stocks: DiscoveryStockPayload[];
   cards?: DiscoveryDeckCardPayload[];
   fronts: Record<string, DiscoveryFrontSeed>;
@@ -237,6 +238,18 @@ async function fetchMarketRows(scope: DiscoveryCountryScope): Promise<DiscoveryM
     scope === "US" ? [fetchUsMarketRows()] : scope === "all" ? [fetchKrMarketRows(), fetchUsMarketRows()] : [fetchKrMarketRows()];
   const settled = await Promise.allSettled(sources);
   return settled.flatMap((result) => (result.status === "fulfilled" ? result.value : []));
+}
+
+export function isDiscoveryRowAllowedForScope(row: DiscoveryMarketRow, scope: DiscoveryCountryScope): boolean {
+  if (scope === "all") return true;
+  if (scope === "KR") return row.country === "KR" && (row.market === "KOSPI" || row.market === "KOSDAQ");
+  return (
+    row.country === "US" &&
+    (row.market === "NASDAQ" || row.market === "NYSE") &&
+    row.currency === "USD" &&
+    !row.naverCode &&
+    /^[A-Z.]{1,6}$/.test(row.symbol)
+  );
 }
 
 async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<PromiseSettledResult<R>[]> {
@@ -1067,7 +1080,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
   ]);
   const vocabByCode = new Map(STOCK_VOCAB.filter((s) => s.naverCode).map((s) => [s.naverCode!, s]));
-  const normalizedRows = rows.map((row) => {
+  const scopedRows = rows.filter((row) => isDiscoveryRowAllowedForScope(row, scope));
+  const normalizedRows = scopedRows.map((row) => {
     const def = row.naverCode ? vocabByCode.get(row.naverCode) : undefined;
     return { ...row, canonical: def?.canonical ?? row.canonical };
   });
@@ -1242,6 +1256,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
 
   return {
     asOf,
+    country: scope,
     stocks,
     cards: interleaveThemeBundles(stocks, bundleCards),
     fronts,


### PR DESCRIPTION
## Summary
- Prevent KR stocks from leaking into the US discovery tab via stale cache or cross-country refresh events.
- Add backend scope filtering so US discovery rows must be US/NASDAQ-or-NYSE/USD/alphabetic symbols with no naverCode.
- Add frontend discovery country validation before reading/writing cache and before applying refresh events.

## Root Cause
- DISCOVERY_UPDATED_EVENT previously carried only the discovery payload, not the country, so a KR refresh could be applied while the US tab was active.
- Stored discovery payloads were not validated against the requested country, so a previously polluted US cache could keep rendering KR cards such as 엠게임.

## Verification
- `npm test -- apps/fomo-web/__tests__/discovery-country-scope.test.ts apps/web/__tests__/lib/discovery-country-scope.test.ts apps/web/__tests__/lib/us-market-source.test.ts`
- `npm run typecheck`
- `npm run guard:discovery`
- `SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze` (warning only: PR body includes coverage)
- `npm run build:web`
- `npm run build:fomo-web`
- `npm run lint`

## Notes
- `.codebase-memory/` remains local and is not included.
