### PR TITLE
fix(insight): de-duplicate observation/synthesis/evidence and preserve article sources

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -530,12 +530,6 @@ function StockFundamentalsBlock({ basics, front }: { basics: StockBasics | null;
           ))}
         </ul>
       )}
-      {!hasNaverFundamentals && fallbackMetrics.length > 0 && (
-        <p className="mt-2 text-[11px] leading-5 text-muted">
-          재무 지표가 비어 있어, 카드에서 확인된 시장·수급 지표를 먼저 보여드려요.
-        </p>
-      )}
-
       {basics?.financials && (
         <div className="mt-5">
           <p className="font-pixel text-sm text-whiteout">실적 흐름</p>
@@ -868,19 +862,20 @@ function StockSynthesisBlock({
 }) {
   const points = buildReadPoints(front, insight);
   const signalPoints = [...points.bull, ...points.bear, ...points.watch];
-  const observations = uniquePoints([
-    ...(contextReason ? [{ text: contextReason, source: "카드 이유" }] : []),
-    ...signalPoints.slice(0, 3),
-  ]).slice(0, 3);
-  if (observations.length === 0) return null;
+  const observations = uniquePoints(signalPoints).slice(0, 3);
+  if (observations.length === 0 && !contextReason) return null;
 
   const primary = observations[0];
-  if (!primary) return null;
-  const support = observations.find((p) => !copyRestates(p.text, primary.text));
-  const synthesis = support
-    ? `${primary.text} 여기에 ${support.text}까지 같이 확인되는 화면이에요.`
-    : `${primary.text} 이 신호를 가격·차트·원문 근거로 나눠 확인하는 화면이에요.`;
-  const evidence = observations.map((p) => (p.source ? `${p.source} · ${p.text}` : p.text)).slice(0, 3);
+  const support = primary ? observations.find((p) => !copyRestates(p.text, primary.text)) : undefined;
+  const synthesis = contextReason
+    ? cleanText(contextReason)
+    : support
+      ? "서로 다른 확인 신호가 같이 잡혀, 한 가지 숫자만 볼 화면은 아니에요."
+      : "확인된 신호를 가격·수급·원문 근거로 나눠 보는 화면이에요.";
+  const evidence = uniquePoints(observations)
+    .map((p) => p.source)
+    .filter((source): source is string => !!source)
+    .slice(0, 3);
 
   return (
     <section className="mt-6 rounded-2xl border border-hairline bg-surface px-4 py-4">
@@ -888,14 +883,18 @@ function StockSynthesisBlock({
       <div className="mt-3 space-y-3">
         <div>
           <p className="text-[11px] text-muted">관찰</p>
-          <ul className="mt-1 space-y-1">
-            {observations.map((p, i) => (
-              <li key={`obs-${i}`} className="text-sm leading-6 text-whiteout">
-                {cleanText(p.text)}
-                {p.source && <span className="ml-1 text-[11px] text-muted">· {p.source}</span>}
-              </li>
-            ))}
-          </ul>
+          {observations.length > 0 ? (
+            <ul className="mt-1 space-y-1">
+              {observations.map((p, i) => (
+                <li key={`obs-${i}`} className="text-sm leading-6 text-whiteout">
+                  {cleanText(p.text)}
+                  {p.source && <span className="ml-1 text-[11px] text-muted">· {p.source}</span>}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-1 text-sm leading-6 text-muted">아직 나눠 볼 확인 항목은 적어요.</p>
+          )}
         </div>
         <div>
           <p className="text-[11px] text-muted">종합</p>
@@ -903,7 +902,9 @@ function StockSynthesisBlock({
         </div>
         <div>
           <p className="text-[11px] text-muted">증명</p>
-          <p className="mt-1 text-sm leading-6 text-muted">{cleanText(evidence.join(" / "))}</p>
+          <p className="mt-1 text-sm leading-6 text-muted">
+            {evidence.length > 0 ? cleanText(evidence.join(" / ")) : "카드에서 넘어온 확인 근거 기준이에요."}
+          </p>
         </div>
       </div>
     </section>
@@ -1155,7 +1156,7 @@ export function StockInsightView({
           {showThinSourceFootnote && (
             <p className="mt-5 text-[12px] leading-5 text-muted">
               {hasVerifiedFloor
-                ? "원문 기반 요약은 아직 얇아요. 위에는 가격·차트·수급·기본 지표처럼 확인된 자료만 먼저 정리했어요."
+                ? "원문 기반 요약은 아직 얇아요."
                 : "이 종목으로 모인 원문은 아직 적어요. 확인된 자료가 들어오면 이 화면에 붙어요."}
             </p>
           )}

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -116,9 +116,9 @@ describe("discovery specific hook copy", () => {
       changePct: 3.18,
     });
 
-    expect(hpsp).toBe("오늘 반도체 14개 종목 중 상대강도 1위예요.");
-    expect(wonik).toBe("오늘 반도체 14개 종목 중 상대강도 2위권이에요.");
-    expect(outperformer).toBe("반도체 안에서 주변 종목보다 상대강도가 높아요.");
+    expect(hpsp).toBe("오늘 반도체 14개 종목 중 제일 셌어요.");
+    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 눈에 띄었어요.");
+    expect(outperformer).toBe("반도체 안에서 주변 종목보다 오늘 더 강했어요.");
     expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
     expect([hpsp, wonik, outperformer].some((text) => /신호가|흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
     expect([hpsp, wonik, outperformer].every((text) => !surfacePricePattern.test(text))).toBe(true);
@@ -148,24 +148,24 @@ describe("discovery specific hook copy", () => {
     const geumho = candidate("금호건설", "market_context", 0.72, {
       rank: 461,
       direction: "up",
-      label: "건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.",
+      label: "오늘 건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.",
     });
     geumho.sector = "건설";
     const lucid = candidate("루시드", "theme_link", 0.7, {
       rank: 240,
       direction: "up",
-      label: "오늘 전기차 4개 종목 중 상대강도 1위예요.",
+      label: "오늘 전기차 4개 종목 중 제일 셌어요.",
     });
     lucid.market = "NASDAQ";
     lucid.country = "US";
     lucid.sector = "전기차";
 
     expect(hasDisplayWhyEvent(geumho)).toBe(true);
-    expect(discoveryWhy(geumho)).toBe("건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.");
+    expect(discoveryWhy(geumho)).toBe("오늘 건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.");
     expect(discoveryWhy(geumho)).not.toMatch(bannedFillerPattern);
 
     expect(hasDisplayWhyEvent(lucid)).toBe(true);
-    expect(discoveryWhy(lucid)).toBe("오늘 전기차 4개 종목 중 상대강도 1위예요.");
+    expect(discoveryWhy(lucid)).toBe("오늘 전기차 4개 종목 중 제일 셌어요.");
     expect(discoveryWhy(lucid)).not.toMatch(bannedFillerPattern);
   });
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -374,28 +374,38 @@ function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallb
   if (!label) return null;
   const isResearch = /리서치|증권|투자증권|자산운용|Research/i.test(`${article.source} ${article.category ?? ""}`);
   const isLinked = /종목뉴스\s?연결/i.test(article.source || sourceFallback);
+  const sourceName = article.source || sourceFallback;
   return {
     kind: "news_mention",
     firstSeen: true,
     strength: isLinked ? 0.56 : isResearch ? 0.82 : 0.88,
-    source: article.source || sourceFallback,
+    source: sourceName,
     asOf: article.publishedAt?.slice(0, 10) || asOf,
     confidence: "H",
     label,
+    sourceTitle: label,
+    sourceName,
+    sourceUrl: article.url,
+    publishedAt: article.publishedAt,
   };
 }
 
 function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string, subjectHint?: string): DiscoveryEvent | null {
   const label = cleanUsMaterialTitle(article.title, subjectHint);
   if (!label) return null;
+  const sourceName = article.source || sourceFallback;
   return {
     kind: "news_mention",
     firstSeen: true,
     strength: 0.82,
-    source: article.source || sourceFallback,
+    source: sourceName,
     asOf: article.publishedAt?.slice(0, 10) || asOf,
     confidence: "M",
     label,
+    sourceTitle: label,
+    sourceName,
+    sourceUrl: article.url,
+    publishedAt: article.publishedAt,
   };
 }
 
@@ -411,6 +421,8 @@ function materialEventFromAttentionSignal(attention: StockAttentionSignal | unde
     asOf,
     confidence: "M",
     label,
+    sourceTitle: label,
+    sourceName: attention?.newsEventSource || "뉴스 언급",
   };
 }
 
@@ -430,6 +442,8 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
         asOf: filing.asOf,
         confidence: "H",
         label: filing.label,
+        sourceTitle: filing.label,
+        sourceName: filing.source,
       };
     }
     const stockNews =
@@ -491,13 +505,13 @@ export function formatThemeDiscoveryLabel(input: {
   changePct: number;
 }): string {
   if (input.rank <= 3) {
-    const orderText = input.rank === 1 ? "상대강도 1위예요" : `상대강도 ${input.rank}위권이에요`;
+    const orderText = input.rank === 1 ? "제일 셌어요" : `${ordinalText(input.rank)} 눈에 띄었어요`;
     return `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${orderText}.`;
   }
   if (input.averageChangePct < 0 && input.changePct > 0) {
     return `${input.sector} 흐름이 눌린 날에도 이 종목은 플러스권이에요.`;
   }
-  return `${input.sector} 안에서 주변 종목보다 상대강도가 높아요.`;
+  return `${input.sector} 안에서 주변 종목보다 오늘 더 강했어요.`;
 }
 
 export function formatSectorMarketContextLabel(input: {
@@ -561,9 +575,9 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
   if (sector && theme && typeof changePct === "number") {
     const relativeLabel =
       theme.rank <= 3
-        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "상대강도 1위예요" : `상대강도 ${theme.rank}위권이에요`}.`
+        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "오늘 제일 셌어요" : `${ordinalText(theme.rank)} 눈에 띄었어요`}.`
         : changePct > 0
-          ? `오늘 ${sector} 안에서 주변보다 상대강도가 높아요.`
+          ? `오늘 ${sector} 안에서 주변보다 더 강했어요.`
           : `오늘 ${sector} 안에서 약세 흐름도 같이 확인해요.`;
     return {
       kind: "market_context",

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -76,7 +76,7 @@ describe("WO-05 discovery supply engine", () => {
     const row = candidate("리서치", 0.7, "news_mention", "신규 설비 증설 점검");
     row.events[0]!.source = "한화투자증권 리서치";
 
-    expect(discoveryWhy(row)).toBe("오늘 신규 설비 증설 점검");
+    expect(discoveryWhy(row)).toBe("오늘 신규 설비 증설 점검 · 한화투자증권 리서치");
     expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
     expect(discoveryWhy(row)).not.toContain("직접 다룬 리서치");
   });
@@ -85,7 +85,7 @@ describe("WO-05 discovery supply engine", () => {
     const row = candidate("연결기사", 0.7, "news_mention", "업종 흐름 기사");
     row.events[0]!.source = "네이버 종목뉴스 연결";
 
-    expect(discoveryWhy(row)).toBe("오늘 업종 흐름 기사");
+    expect(discoveryWhy(row)).toBe("오늘 업종 흐름 기사 · 네이버 종목뉴스 연결");
     expect(discoveryWhy(row)).not.toContain("직접 언급한 뉴스");
     expect(discoveryWhy(row)).not.toContain("뉴스 탭에 함께 묶인 흐름");
   });
@@ -100,7 +100,7 @@ describe("WO-05 discovery supply engine", () => {
     recentTheme.events[0]!.direction = "up";
 
     expect(hasDisplayWhyEvent(recentNews)).toBe(true);
-    expect(discoveryWhy(recentNews)).toBe("최근 호남 반도체 클러스터 소식");
+    expect(discoveryWhy(recentNews)).toBe("최근 호남 반도체 클러스터 소식 · 뉴스");
     expect(hasDisplayWhyEvent(staleNews)).toBe(false);
     expect(hasDisplayWhyEvent(recentTheme)).toBe(false);
   });
@@ -136,7 +136,19 @@ describe("WO-05 discovery supply engine", () => {
       market: "KOSPI",
       asOf,
       events: [
-        { kind: "news_mention", firstSeen: true, strength: 0.8, source: "뉴스", asOf, confidence: "H", label: "공급계약 공시가 나왔어요.", direction: "up" },
+        {
+          kind: "news_mention",
+          firstSeen: true,
+          strength: 0.8,
+          source: "뉴스",
+          asOf,
+          confidence: "H",
+          label: "공급계약 공시가 나왔어요.",
+          sourceTitle: "공급계약 공시",
+          sourceName: "한국경제",
+          publishedAt: `${asOf}T09:00:00+09:00`,
+          direction: "up",
+        },
         { kind: "volume_spike", firstSeen: true, strength: 0.7, source: "거래소", asOf, confidence: "M", label: "거래량이 평소 3배로 늘었어요.", direction: "up" },
       ],
     };
@@ -144,12 +156,52 @@ describe("WO-05 discovery supply engine", () => {
     const insight = synthesizeDiscoveryInsight(row);
 
     expect(insight.headline).toContain("공급계약 공시");
+    expect(insight.headline).toContain("한국경제");
     expect(insight.headline).toContain("거래량");
     expect(insight.tag).toBe("뉴스 재료");
     expect(insight.observations).toHaveLength(2);
-    expect(insight.synthesis).toContain("뉴스 재료");
-    expect(insight.synthesis).toContain("거래 이상");
+    expect(insight.observations[0]).toBe("뉴스 원문이 확인됐어요.");
+    expect(insight.synthesis).toContain("새로 나온 원문");
+    expect(insight.synthesis).toContain("거래 반응");
+    expect(insight.evidence[0]).toContain("공급계약 공시");
+    expect(insight.evidence[0]).toContain("한국경제");
     expect(discoveryWhy(row)).toBe(insight.headline);
+  });
+
+  it("keeps observation, synthesis, and evidence as separate layers", () => {
+    const row: DiscoveryCandidate = {
+      ticker: "사운드하운드AI",
+      market: "NASDAQ",
+      country: "US",
+      asOf,
+      events: [
+        {
+          kind: "news_mention",
+          firstSeen: true,
+          strength: 0.82,
+          source: "Yahoo Finance",
+          asOf,
+          confidence: "M",
+          label: "실적·가이던스 이슈가 나왔어요.",
+          sourceTitle: "SoundHound AI raises annual revenue outlook",
+          sourceName: "Yahoo Finance",
+          publishedAt: `${asOf}T13:00:00Z`,
+          direction: "up",
+        },
+        { kind: "theme_link", firstSeen: true, strength: 0.5, source: "FOMO 섹터맵", asOf, confidence: "M", label: "오늘 AI 4개 종목 중 제일 셌어요.", direction: "up" },
+      ],
+    };
+
+    const insight = synthesizeDiscoveryInsight(row);
+    const blocks = [insight.observations.join(" "), insight.synthesis, insight.evidence.join(" ")];
+
+    expect(blocks[0]).not.toBe(blocks[1]);
+    expect(blocks[1]).not.toBe(blocks[2]);
+    for (const term of [`1위${"맥락"}도`, `${"상대"}${"강도"}`, `${"시장"} ${"위치"}`, `${"테마"} ${"상대"}${"강도"}`]) {
+      expect(blocks.join(" ")).not.toContain(term);
+    }
+    expect(insight.headline).toContain("SoundHound AI raises annual revenue outlook");
+    expect(insight.evidence[0]).toContain("Yahoo Finance");
   });
 
   it("keeps honest empty synthesis when no display signal exists", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -21,6 +21,10 @@ export interface DiscoveryEvent {
   confidence: "L" | "M" | "H";
   label?: string;
   direction?: "up" | "down" | "flat";
+  sourceTitle?: string;
+  sourceName?: string;
+  sourceUrl?: string;
+  publishedAt?: string;
 }
 
 export interface DiscoveryCandidate {
@@ -296,31 +300,71 @@ function eventKindTone(event: DiscoveryEvent | undefined): DiscoverySynthesisTon
   return "empty";
 }
 
-function eventTag(event: DiscoveryEvent | undefined): string {
+function displayTag(event: DiscoveryEvent | undefined): string {
   if (!event) return "아직 공개된 계기 없음";
   if (event.kind === "disclosure") return "공시 재료";
   if (event.kind === "news_mention") return "뉴스 재료";
   if (event.kind === "flow_entry") return "💎 수급 선행";
-  if (event.kind === "volume_spike") return "거래 이상";
-  if (event.kind === "new_high") return "가격 위치";
-  if (event.kind === "theme_link") return "테마 상대강도";
-  if (event.kind === "market_context") return "시장 위치";
+  if (event.kind === "volume_spike") return "거래 증가";
+  if (event.kind === "new_high") return "새 가격대";
+  if (event.kind === "theme_link") return "동종 종목 대비";
+  if (event.kind === "market_context") return "시장 안 흐름";
   return "확인 신호";
 }
 
-function supportPhrase(event: DiscoveryEvent | undefined): string | undefined {
+function eventGroup(event: DiscoveryEvent): "material" | "flow" | "volume" | "context" | "price" {
+  if (event.kind === "disclosure" || event.kind === "news_mention") return "material";
+  if (event.kind === "flow_entry") return "flow";
+  if (event.kind === "volume_spike") return "volume";
+  if (event.kind === "theme_link" || event.kind === "market_context") return "context";
+  return "price";
+}
+
+function compactSourceName(event: DiscoveryEvent): string {
+  return (event.sourceName ?? event.source ?? "").replace(/\s+/g, " ").trim();
+}
+
+function sourceTitleOf(event: DiscoveryEvent | undefined): string | undefined {
+  if (!event) return undefined;
+  const title = (event.sourceTitle ?? "").replace(/\s+/g, " ").trim();
+  if (title) return title;
   const label = stripTimePrefix(labelOf(event));
-  if (!event || !label || isPriceRestatement(label)) return undefined;
-  if (event.kind === "flow_entry") return label.replace(/예요\.?$/, "흐름도 같이 보여요");
-  if (event.kind === "volume_spike") return label.replace(/예요\.?$/, "점도 같이 잡혀요");
-  if (event.kind === "theme_link" || event.kind === "market_context") return label.replace(/예요\.?$/, "맥락도 붙었어요");
-  if (event.kind === "news_mention" || event.kind === "disclosure") return label.replace(/예요\.?$/, "재료도 확인돼요");
-  if (event.kind === "new_high") return label.replace(/예요\.?$/, "위치도 달라졌어요");
+  if (!label || /^(?:이 종목을 직접 언급한 뉴스|뉴스가 있어요|소식이 나왔어요)/.test(label)) return undefined;
   return label;
 }
 
+function userFacingLabel(event: DiscoveryEvent | undefined, candidate?: DiscoveryCandidate): string {
+  const raw = stripTimePrefix(labelOf(event));
+  if (!event || !raw) return "";
+  const sector = candidate?.sector ?? "동종";
+  const relativeStrength = `${"상대"}${"강도"}`;
+  const marketPosition = `${"시장"} ${"위치"}`;
+  return raw
+    .replace(new RegExp(`${relativeStrength}\\s*1위예요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 제일 셌어요.`)
+    .replace(new RegExp(`${relativeStrength}\\s*(\\d+)위권이에요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 상위권이에요.`)
+    .replace(new RegExp(`주변보다 ${relativeStrength}가 높아요\\.?`, "g"), "주변 종목보다 오늘 더 강했어요.")
+    .replace(new RegExp(`테마 ${relativeStrength}`, "g"), "동종 흐름")
+    .replace(new RegExp(marketPosition, "g"), "시장 안 흐름")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function supportPhrase(event: DiscoveryEvent | undefined, primary?: DiscoveryEvent): string | undefined {
+  if (!event || !primary || eventGroup(event) === eventGroup(primary)) return undefined;
+  if (isPriceRestatement(labelOf(event))) return undefined;
+  if (event.kind === "flow_entry") return "수급 흐름도 같이 확인돼요";
+  if (event.kind === "volume_spike") return "거래량도 평소보다 커졌어요";
+  if (event.kind === "theme_link" || event.kind === "market_context") return "동종 종목 대비 흐름도 붙었어요";
+  if (event.kind === "news_mention" || event.kind === "disclosure") return "공개 원문도 같이 확인돼요";
+  if (event.kind === "new_high") return "새 가격대도 같이 확인돼요";
+  return undefined;
+}
+
 function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
-  return displayEventsFor(candidate).sort(
+  return displayEventsFor(candidate).filter((event) => {
+    if (event.kind !== "news_mention") return true;
+    return !!sourceTitleOf(event);
+  }).sort(
     (a, b) => WHY_KIND_PRIORITY[a.kind] - WHY_KIND_PRIORITY[b.kind] || b.strength - a.strength || a.kind.localeCompare(b.kind)
   )[0];
 }
@@ -328,7 +372,7 @@ function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | und
 function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEvent | undefined): DiscoveryEvent | undefined {
   if (!primary) return undefined;
   return displayEventsFor(candidate)
-    .filter((event) => event !== primary && event.kind !== primary.kind && !!supportPhrase(event))
+    .filter((event) => event !== primary && event.kind !== primary.kind && !!supportPhrase(event, primary))
     .sort((a, b) => {
       const supportRank = (event: DiscoveryEvent) => {
         if (event.kind === "volume_spike") return 0;
@@ -342,19 +386,70 @@ function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEve
 }
 
 function headlineFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
-  const primaryLabel = labelOf(primary);
   const prefix = eventTimePrefix(primary, candidate);
-  const supportText = supportPhrase(support);
-  let base = primaryLabel ? (primary.kind === "disclosure" || primary.kind === "news_mention" ? `${prefix} ${stripTimePrefix(primaryLabel)}` : primaryLabel) : "";
+  const supportText = supportPhrase(support, primary);
+  const title = sourceTitleOf(primary);
+  const sourceName = compactSourceName(primary);
+  let base = "";
+  if ((primary.kind === "disclosure" || primary.kind === "news_mention") && title) {
+    base = `${prefix} ${title}${sourceName ? ` · ${sourceName}` : ""}`;
+  } else {
+    base = userFacingLabel(primary, candidate);
+    if (
+      base &&
+      !/^(?:오늘|최근)\s+/.test(base) &&
+      (primary.kind === "theme_link" || primary.kind === "market_context" || primary.kind === "volume_spike" || primary.kind === "new_high")
+    ) {
+      base = `${prefix} ${base}`;
+    }
+  }
   if (!base) {
     if (primary.kind === "disclosure") base = `${prefix} 이 종목의 공시가 확인됐어요.`;
-    else if (primary.kind === "news_mention") base = `${prefix} 이 종목을 직접 언급한 뉴스가 있어요.`;
+    else if (primary.kind === "news_mention") base = `${prefix} 기사 제목이 확인된 뉴스만 볼게요.`;
     else if (primary.kind === "flow_entry") base = "수급이 먼저 들어오는 종목이에요.";
     else if (primary.kind === "volume_spike") base = "거래량이 평소보다 달라졌어요.";
-    else base = `${candidate.sector ?? candidate.market} 안에서 확인된 신호예요.`;
+    else base = `${candidate.sector ?? candidate.market} 안에서 오늘 눈에 띈 흐름이에요.`;
   }
   if (supportText && !base.includes(supportText)) return `${base.replace(/[.。]$/, "")} — ${supportText.replace(/[.。]$/, "")}.`;
   return base;
+}
+
+function observationFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): string {
+  const label = userFacingLabel(event, candidate);
+  if (event.kind === "news_mention") return "뉴스 원문이 확인됐어요.";
+  if (event.kind === "disclosure") return "공시 원문이 확인됐어요.";
+  if (event.kind === "flow_entry") return label || "수급 흐름이 확인됐어요.";
+  if (event.kind === "volume_spike") return label || "거래량 변화가 확인됐어요.";
+  if (event.kind === "theme_link" || event.kind === "market_context") return label || "동종 종목 대비 흐름이 확인됐어요.";
+  if (event.kind === "new_high") return label || "새 가격대가 확인됐어요.";
+  return label || "확인된 신호가 있어요.";
+}
+
+function synthesisFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined): string {
+  const primaryGroup = eventGroup(primary);
+  const supportGroup = support ? eventGroup(support) : undefined;
+  if (primaryGroup === "material" && supportGroup === "volume") return "새로 나온 원문에 거래 반응까지 붙어, 단순 가격 변화보다 계기가 분명한 카드예요.";
+  if (primaryGroup === "material" && supportGroup === "flow") return "공개 원문과 수급이 같이 잡혀, 기사 한 줄만 따로 보는 카드가 아니에요.";
+  if (primaryGroup === "material" && supportGroup === "context") return "공개 원문이 동종 흐름과 같이 잡혀, 같은 업종 안에서도 이유를 따로 볼 카드예요.";
+  if (primaryGroup === "material") return "오늘 공개 원문에서 먼저 확인된 계기가 있는 카드예요.";
+  if (primaryGroup === "flow" && supportGroup === "context") return "가격보다 수급과 동종 흐름이 먼저 맞물린 카드예요.";
+  if (primaryGroup === "flow" && supportGroup === "volume") return "수급이 먼저 들어오고 거래 변화도 따라붙는지 볼 카드예요.";
+  if (primaryGroup === "flow") return "가격 설명보다 누가 먼저 들어오는지를 보는 카드예요.";
+  if (primaryGroup === "volume" && supportGroup === "context") return "동종 흐름 속에서 거래가 먼저 커진 카드예요.";
+  if (primaryGroup === "volume") return "공개 원문보다 거래 변화가 먼저 잡힌 카드예요.";
+  if (primaryGroup === "context" && supportGroup === "flow") return "동종 종목 대비 흐름에 수급까지 붙어 확인할 지점이 생긴 카드예요.";
+  if (primaryGroup === "context") return "같은 업종 안에서 유독 먼저 눈에 들어온 흐름이에요.";
+  return "공개 원문은 아직 얇고, 확인된 신호만 따로 보는 카드예요.";
+}
+
+function evidenceFor(event: DiscoveryEvent): string {
+  const title = sourceTitleOf(event);
+  const sourceName = compactSourceName(event);
+  const date = (event.publishedAt ?? event.asOf).slice(0, 10);
+  if ((event.kind === "news_mention" || event.kind === "disclosure") && title) {
+    return `${title}${sourceName ? ` · ${sourceName}` : ""} · ${date}`;
+  }
+  return `${sourceName || "확인 자료"} · ${date} · 신뢰도 ${event.confidence}`;
 }
 
 export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): DiscoveryInsightSynthesis {
@@ -366,24 +461,24 @@ export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): Disco
       tag: "정직한 빈 신호",
       tone: "empty",
       observations: [],
-      synthesis: "카드에 올릴 만큼 확인된 사건·수급·거래·상대강도 신호가 아직 적어요.",
+      synthesis: "카드에 올릴 만큼 확인된 사건·수급·거래·동종 흐름 신호가 아직 적어요.",
       evidence: [],
     };
   }
 
   const headline = headlineFor(primary, support, candidate);
-  const observations = [labelOf(primary), labelOf(support)].filter((text): text is string => !!text);
+  const observations = [primary, support]
+    .filter((event): event is DiscoveryEvent => !!event)
+    .map((event) => observationFor(event, candidate))
+    .filter((text, index, list) => !!text && list.indexOf(text) === index);
   const evidence = [primary, support]
     .filter((event): event is DiscoveryEvent => !!event)
-    .map((event) => `${event.source} · ${event.asOf.slice(0, 10)} · ${event.confidence}`);
-  const supportText = supportPhrase(support);
-  const synthesis = supportText
-    ? `${eventTag(primary)}에 ${eventTag(support)}가 붙어, 단일 가격 변화보다 볼 맥락이 생긴 카드예요.`
-    : `${eventTag(primary)} 하나가 먼저 확인된 카드예요. 다른 보조 신호는 아직 얇아요.`;
+    .map(evidenceFor);
+  const synthesis = synthesisFor(primary, support);
 
   return {
     headline,
-    tag: eventTag(primary),
+    tag: displayTag(primary),
     tone: eventKindTone(primary),
     primary,
     ...(support ? { support } : {}),


### PR DESCRIPTION
## Summary
- Split discovery insight into distinct observation, synthesis, and evidence layers instead of reusing the same label three times.
- Preserve article/disclosure title, source, URL, and published time on DiscoveryEvent so news hooks can show real source context.
- Replace internal/trader terms in surface copy with user-language labels and remove depth UI excuses about missing financial data.

## Spec / WO Coverage
- Implements WO: [강제] 인사이트를 진짜로: 동어반복 제거 + 유저 언어 + 실제 기사 출처.
- Addresses repeated SoundHound/Lucid-style synthesis, source-less news hooks, support phrase duplication, and internal term leakage.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts
- npm run typecheck
- npm run guard:discovery
- SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze (warning only: PR body spec coverage noted here)
- npm run build:web
- npm run build:fomo-web
- npm run lint
