### PR TITLE
fix(discovery): surface real discovery reason beyond price-rank, drop empty label boxes, compress headline

### DIFF
--- a/apps/fomo-web/__tests__/cardCopyDedupe.test.ts
+++ b/apps/fomo-web/__tests__/cardCopyDedupe.test.ts
@@ -51,4 +51,5 @@ describe("dedupeCardCopy", () => {
     expect(copy.why).toBe("큰 가격 움직임은 보였지만, 연결된 공개 재료는 아직 확인되지 않았어요.");
     expect(copy.subLine).toBeUndefined();
   });
+
 });

--- a/apps/fomo-web/__tests__/discoveryHeadline.test.ts
+++ b/apps/fomo-web/__tests__/discoveryHeadline.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { compactDiscoveryCardHeadline, splitDiscoveryReason } from "../lib/discoveryHeadline";
+
+describe("compactDiscoveryCardHeadline", () => {
+  it("turns material detail into one card-front sentence instead of a label plus prose", () => {
+    expect(
+      compactDiscoveryCardHeadline({
+        reason: "뉴스 재료 붙은 종목 — 최근 '해외 수주 2배' 마키나락스...장중 20% 가까이 급등 · 뉴시스. 동종 흐름도 같이 확인돼요.",
+        sector: "AI",
+        marketCapRank: 236,
+      })
+    ).toBe("해외 수주에 동종 흐름도 붙었어요");
+  });
+
+  it("keeps obscure theme leaders honest in one sentence", () => {
+    expect(
+      compactDiscoveryCardHeadline({
+        reason: "혼자 튄 무명주 — 시총 411위권인데 같은 화장품 종목들 중 오늘 제일 셌어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.",
+        sector: "화장품",
+      })
+    ).toBe("시총 411위 화장품주가 튀었지만 근거는 얇아요");
+  });
+
+  it("does not expose the split reason as a second line contract", () => {
+    const parts = splitDiscoveryReason("뉴스 재료 붙은 종목 — 오늘 공급계약 공시 · 한국경제.");
+
+    expect(parts.state).toBe("뉴스 재료 붙은 종목");
+    expect(compactDiscoveryCardHeadline({ reason: `${parts.state} — ${parts.detail}` })).toBe("계약에 직접 재료가 붙었어요");
+  });
+});

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -692,6 +692,21 @@ function DetailChart({ front }: { front: StockFrontResponse | null }) {
 
 type ReadPoint = { text: string; source?: string };
 
+const DISCOVERY_REASON_JOINER = " — ";
+
+function splitDiscoveryReason(text: string | undefined): { state?: string; detail?: string } {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  if (!clean || !clean.includes(DISCOVERY_REASON_JOINER)) return {};
+  const [rawState, ...rest] = clean.split(DISCOVERY_REASON_JOINER);
+  const state = rawState?.trim();
+  const detail = rest.join(DISCOVERY_REASON_JOINER).trim();
+  if (!state || state.length > 16) return {};
+  return {
+    state,
+    ...(detail ? { detail } : {}),
+  };
+}
+
 function uniquePoints(points: ReadPoint[]): ReadPoint[] {
   const seen = new Set<string>();
   return points.filter((p) => {
@@ -862,16 +877,29 @@ function StockSynthesisBlock({
 }) {
   const points = buildReadPoints(front, insight);
   const signalPoints = [...points.bull, ...points.bear, ...points.watch];
-  const observations = uniquePoints(signalPoints).slice(0, 3);
+  const contextParts = splitDiscoveryReason(contextReason);
+  const contextObservation =
+    contextParts.detail && !/뒤를 받칠 수급·거래·뉴스는 아직 안 보여요/.test(contextParts.detail)
+      ? { text: contextParts.detail, source: "카드 근거" }
+      : undefined;
+  const observations = uniquePoints([...(contextObservation ? [contextObservation] : []), ...signalPoints]).slice(0, 3);
   if (observations.length === 0 && !contextReason) return null;
 
   const primary = observations[0];
   const support = primary ? observations.find((p) => !copyRestates(p.text, primary.text)) : undefined;
-  const synthesis = contextReason
-    ? cleanText(contextReason)
-    : support
+  const contextSynthesis =
+    contextParts.state === "혼자 튄 무명주"
+      ? "남들이 덜 보는 종목이 섹터 안에서 먼저 튀었지만, 가격 외 신호는 아직 얇아요."
+      : contextParts.state === "이유 얇은 섹터선두"
+        ? "섹터 안에서 먼저 보인 결과는 있지만, 가격 외 신호는 아직 얇아요."
+        : contextParts.state
+          ? `${contextParts.state}이라서 먼저 확인하는 화면이에요.`
+          : undefined;
+  const synthesis =
+    contextSynthesis ??
+    (support
       ? "서로 다른 확인 신호가 같이 잡혀, 한 가지 숫자만 볼 화면은 아니에요."
-      : "확인된 신호를 가격·수급·원문 근거로 나눠 보는 화면이에요.";
+      : "확인된 신호를 가격·수급·원문 근거로 나눠 보는 화면이에요.");
   const evidence = uniquePoints(observations)
     .map((p) => p.source)
     .filter((source): source is string => !!source)
@@ -881,9 +909,9 @@ function StockSynthesisBlock({
     <section className="mt-6 rounded-2xl border border-hairline bg-surface px-4 py-4">
       <p className="font-pixel text-sm text-whiteout">핵심 줄거리</p>
       <div className="mt-3 space-y-3">
-        <div>
-          <p className="text-[11px] text-muted">관찰</p>
-          {observations.length > 0 ? (
+        {observations.length > 0 && (
+          <div>
+            <p className="text-[11px] text-muted">관찰</p>
             <ul className="mt-1 space-y-1">
               {observations.map((p, i) => (
                 <li key={`obs-${i}`} className="text-sm leading-6 text-whiteout">
@@ -892,20 +920,18 @@ function StockSynthesisBlock({
                 </li>
               ))}
             </ul>
-          ) : (
-            <p className="mt-1 text-sm leading-6 text-muted">아직 나눠 볼 확인 항목은 적어요.</p>
-          )}
-        </div>
+          </div>
+        )}
         <div>
           <p className="text-[11px] text-muted">종합</p>
           <p className="mt-1 text-sm leading-6 text-whiteout">{cleanText(synthesis)}</p>
         </div>
-        <div>
-          <p className="text-[11px] text-muted">증명</p>
-          <p className="mt-1 text-sm leading-6 text-muted">
-            {evidence.length > 0 ? cleanText(evidence.join(" / ")) : "카드에서 넘어온 확인 근거 기준이에요."}
-          </p>
-        </div>
+        {evidence.length > 0 && (
+          <div>
+            <p className="text-[11px] text-muted">증명</p>
+            <p className="mt-1 text-sm leading-6 text-muted">{cleanText(evidence.join(" / "))}</p>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -19,6 +19,7 @@ import type { DeckStock } from "@/lib/discoveryDeck";
 import { isThemeBundleCard, type DiscoveryDeckCard, type DeckThemeBundle } from "@/lib/discoveryDeck";
 import { whyShown } from "@/lib/whyShown";
 import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
+import { compactDiscoveryCardHeadline } from "@/lib/discoveryHeadline";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
 
@@ -178,12 +179,6 @@ function clampStyle(lines: number): CSSProperties {
     WebkitLineClamp: lines,
     overflow: "hidden",
   };
-}
-
-function compactEvidenceLine(text: string | undefined): string | undefined {
-  const clean = (text ?? "").replace(/\s+/g, " ").trim();
-  if (!clean) return undefined;
-  return clean.length > 58 ? `${clean.slice(0, 57)}…` : clean;
 }
 
 function compactReasonHeadlineSeed(text: string | undefined): string | undefined {
@@ -567,21 +562,30 @@ export function StockSwipeDeck({
 
   // 카드 표현 — 포모 점수(척추, 단일 출처) → fomoCardView.
   // 긴 원문 재료는 why/depth 로 보내고, 앞면은 잘리지 않는 핵심 독해만 남긴다.
-  const cardFor = (stock: DeckStock): { view: FomoCardView; subLine?: string; usedReasonHeadline?: boolean } => {
+  const cardFor = (stock: DeckStock): { view: FomoCardView; subLine?: string; usedDiscoveryHeadline?: boolean } => {
     const e = front[stock.canonical];
     if (!e) {
+      const discoveryHeadline = compactDiscoveryCardHeadline({
+        reason: stock.reason,
+        sector: stock.sector,
+      });
       const view: FomoCardView = {
         scoreText: "",
         emoji: "",
         badge: "신호 확인 중",
-        headline: nonPriceOnlyHeadline(stock.reason) ?? "가격·거래량 근거를 맞춰 불러오고 있어요.",
+        headline: nonPriceOnlyHeadline(discoveryHeadline) ?? "가격·거래량 근거를 맞춰 불러오고 있어요.",
         tone: "calm",
         isLeading: false,
       };
-      return { view, subLine: "가격·거래량 신호를 불러오고 있어요." };
+      return { view, ...(discoveryHeadline ? { usedDiscoveryHeadline: true } : { subLine: "가격·거래량 신호를 불러오고 있어요." }) };
     }
     const fomo = e?.fomo ?? EMPTY_FOMO;
-    const reasonHeadlineSeed = compactReasonHeadlineSeed(stock.reason);
+    const surfaceReasonHeadline = compactDiscoveryCardHeadline({
+      reason: stock.reason,
+      sector: stock.sector,
+      marketCapRank: e?.signals.marketCapRank?.rank,
+    });
+    const reasonHeadlineSeed = surfaceReasonHeadline ?? compactReasonHeadlineSeed(stock.reason);
     const discoveryHeadline = nonPriceOnlyHeadline(reasonHeadlineSeed);
     const signalsForHook: CardFrontSignals = {
       ...(e?.signals ?? {}),
@@ -612,14 +616,11 @@ export function StockSwipeDeck({
       nonPriceOnlyHeadline(legacyHook.headline) ??
       fallbackHeadline;
     const view = { ...baseView, headline };
-    const usedReasonHeadline = !!discoveryHeadline && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
-    const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);
-    const tagLine =
-      stock.insightTag && stock.insightTag !== "정직한 빈 신호" ? stock.insightTag : undefined;
+    const usedDiscoveryHeadline = !!discoveryHeadline && !!surfaceReasonHeadline;
     return {
       view,
-      ...(tagLine || evidenceLine || legacyHook.subLine ? { subLine: tagLine ?? evidenceLine ?? legacyHook.subLine } : {}),
-      ...(usedReasonHeadline ? { usedReasonHeadline } : {}),
+      ...(!usedDiscoveryHeadline && legacyHook.subLine ? { subLine: legacyHook.subLine } : {}),
+      ...(usedDiscoveryHeadline ? { usedDiscoveryHeadline } : {}),
     };
   };
   const rankLabelFor = (stock: DeckStock): string | undefined => {
@@ -645,10 +646,10 @@ export function StockSwipeDeck({
     if (!e) {
       return <StockCardLoadingFace stock={stock} themeLabel={stock.sector} progress={progress} />;
     }
-    const { view, subLine } = cardFor(stock);
+    const { view, subLine, usedDiscoveryHeadline } = cardFor(stock);
     const deduped = dedupeCardCopy({
       headline: view.headline,
-      why: whyFor(stock),
+      why: usedDiscoveryHeadline ? undefined : whyFor(stock),
       feedBull: e?.feedBull,
       feedBear: e?.feedBear,
       subLine,

--- a/apps/fomo-web/lib/cardCopyDedupe.ts
+++ b/apps/fomo-web/lib/cardCopyDedupe.ts
@@ -13,7 +13,7 @@ type CopyCluster =
 
 interface DedupeInput {
   headline: string;
-  why: string;
+  why?: string | undefined;
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
   subLine?: string | undefined;

--- a/apps/fomo-web/lib/discoveryHeadline.ts
+++ b/apps/fomo-web/lib/discoveryHeadline.ts
@@ -1,0 +1,122 @@
+const DISCOVERY_REASON_JOINER = " — ";
+
+export interface DiscoveryHeadlineInput {
+  reason?: string | undefined;
+  sector?: string | undefined;
+  marketCapRank?: number | undefined;
+}
+
+interface ReasonParts {
+  state?: string;
+  detail?: string;
+}
+
+function cleanInline(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function splitDiscoveryReason(text: string | undefined): ReasonParts {
+  const clean = cleanInline(text);
+  if (!clean || !clean.includes(DISCOVERY_REASON_JOINER)) return {};
+  const [rawState, ...rest] = clean.split(DISCOVERY_REASON_JOINER);
+  const state = rawState?.trim();
+  const detail = rest.join(DISCOVERY_REASON_JOINER).trim();
+  if (!state || state.length > 16) return {};
+  return {
+    state,
+    ...(detail ? { detail } : {}),
+  };
+}
+
+function stripSourceAndTime(text: string): string {
+  return text
+    .replace(/^(?:오늘|최근)\s+/, "")
+    .replace(/\s*·\s*[^.。]+[.。]?$/g, "")
+    .replace(/[.。]+$/g, "")
+    .trim();
+}
+
+function topicFromMaterial(detail: string): string {
+  const title = stripSourceAndTime(detail);
+  const lower = title.toLowerCase();
+  if (/해외\s*수주/.test(title)) return "해외 수주";
+  if (/공급계약|계약|contract|deal|order/.test(lower)) return "계약";
+  if (/수주/.test(title)) return "수주";
+  if (/실적|가이던스|매출|earnings|revenue|guidance|results/.test(lower)) return "실적";
+  if (/sec|공시|filing|8-k|10-q/.test(lower)) return "공시";
+  if (/파트너십|제휴|partnership|customer/.test(lower)) return "파트너십";
+  if (/제품|출시|인프라|launch|product|infrastructure/.test(lower)) return "제품";
+  const compact = title
+    .replace(/['"“”‘’]/g, "")
+    .split(/[,，:：\-–—]/)[0]
+    ?.trim();
+  return compact && compact.length <= 10 ? compact : "뉴스";
+}
+
+function supportFromDetail(detail: string): string {
+  if (/수급|외국인|기관|순매수|사는 중/.test(detail)) return "수급도 붙었어요";
+  if (/거래량|거래가|거래도/.test(detail)) return "거래도 붙었어요";
+  if (/동종|섹터|흐름|종목들 중/.test(detail)) return "동종 흐름도 붙었어요";
+  return "직접 재료가 붙었어요";
+}
+
+function sectorFromDetail(detail: string, fallback?: string): string {
+  const sameSector = detail.match(/같은\s+(.+?)\s+종목들/);
+  if (sameSector?.[1]) return sameSector[1].trim();
+  const inSector = detail.match(/([가-힣A-Za-z0-9]+)\s+안에서/);
+  if (inSector?.[1]) return inSector[1].trim();
+  return fallback?.trim() || "섹터";
+}
+
+function rankFromDetail(detail: string, fallback?: number): number | undefined {
+  if (typeof fallback === "number" && Number.isFinite(fallback)) return fallback;
+  const match = detail.match(/시총\s+(\d+)위/);
+  return match?.[1] ? Number(match[1]) : undefined;
+}
+
+function clipped(text: string, max = 34): string {
+  const clean = cleanInline(text);
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export function compactDiscoveryCardHeadline({
+  reason,
+  sector,
+  marketCapRank,
+}: DiscoveryHeadlineInput): string | undefined {
+  const clean = cleanInline(reason);
+  if (!clean) return undefined;
+
+  const parts = splitDiscoveryReason(clean);
+  const state = parts.state;
+  const detail = parts.detail ?? clean;
+
+  if (state === "혼자 튄 무명주") {
+    const displaySector = sectorFromDetail(detail, sector);
+    const rank = rankFromDetail(detail, marketCapRank);
+    const caveat = /뒤를 받칠/.test(detail);
+    const subject = rank ? `시총 ${rank}위 ${displaySector}주` : `${displaySector} 안의 무명주`;
+    return caveat ? clipped(`${subject}가 튀었지만 근거는 얇아요`) : clipped(`${subject}가 혼자 튀었어요`);
+  }
+
+  if (state === "이유 얇은 섹터선두") {
+    return clipped(`${sectorFromDetail(detail, sector)} 선두지만 근거는 얇아요`);
+  }
+
+  if (state === "뉴스 재료 붙은 종목" || state === "공시 먼저 뜬 종목" || (!state && /뉴스|공시|소식|계약|수주/.test(clean))) {
+    const topic = topicFromMaterial(detail);
+    const support = supportFromDetail(detail);
+    return topic === "뉴스" ? support : `${topic}에 ${support}`;
+  }
+
+  if (state?.includes("수급")) {
+    if (/외국인/.test(detail)) return "외국인 수급이 먼저 들어왔어요";
+    if (/기관/.test(detail)) return "기관 수급이 먼저 들어왔어요";
+    return "수급이 먼저 들어온 종목이에요";
+  }
+
+  if (state?.includes("거래")) return "거래가 먼저 커진 종목이에요";
+  if (state?.includes("새 가격대")) return "새 가격대까지 밟은 종목이에요";
+
+  return undefined;
+}

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -161,12 +161,17 @@ describe("discovery specific hook copy", () => {
     lucid.sector = "전기차";
 
     expect(hasDisplayWhyEvent(geumho)).toBe(true);
-    expect(discoveryWhy(geumho)).toBe("오늘 건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.");
+    expect(discoveryWhy(geumho)).toBe(
+      "혼자 튄 무명주 — 시총 461위권인데 건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요."
+    );
     expect(discoveryWhy(geumho)).not.toMatch(bannedFillerPattern);
 
     expect(hasDisplayWhyEvent(lucid)).toBe(true);
-    expect(discoveryWhy(lucid)).toBe("오늘 전기차 4개 종목 중 제일 셌어요.");
+    expect(discoveryWhy(lucid)).toBe(
+      "혼자 튄 무명주 — 시총 240위권인데 같은 전기차 종목들 중 오늘 제일 셌어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요."
+    );
     expect(discoveryWhy(lucid)).not.toMatch(bannedFillerPattern);
+    expect(discoveryWhy(lucid)).not.toBe("오늘 전기차 4개 종목 중 제일 셌어요.");
   });
 
   it("keeps banned filler headline strings out of active discovery/card paths", () => {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -792,6 +792,36 @@ function fallbackDiscoveryReason(candidate: DiscoveryCandidate): string {
   return hasDisplayWhyEvent(candidate) ? discoveryWhy(candidate) : "아직 공개된 계기 없음";
 }
 
+function logDiscoverySignalCoverage(stage: string, candidates: readonly DiscoveryCandidate[]): void {
+  const byKind = new Map<DiscoveryEvent["kind"], number>();
+  let material = 0;
+  let flow = 0;
+  let contextOnly = 0;
+  let priceOnly = 0;
+  let displayWhy = 0;
+  for (const candidate of candidates) {
+    const kinds = new Set(candidate.events.map((event) => event.kind));
+    for (const kind of kinds) byKind.set(kind, (byKind.get(kind) ?? 0) + 1);
+    if (kinds.has("disclosure") || kinds.has("news_mention")) material += 1;
+    if (kinds.has("flow_entry")) flow += 1;
+    if ((kinds.has("theme_link") || kinds.has("market_context")) && !kinds.has("disclosure") && !kinds.has("news_mention") && !kinds.has("flow_entry") && !kinds.has("volume_spike")) {
+      contextOnly += 1;
+    }
+    if (kinds.has("price_move") && kinds.size === 1) priceOnly += 1;
+    if (hasDisplayWhyEvent(candidate)) displayWhy += 1;
+  }
+  console.info("[discovery-supply] signal coverage", {
+    stage,
+    candidates: candidates.length,
+    displayWhy,
+    material,
+    flow,
+    contextOnly,
+    priceOnly,
+    byKind: Object.fromEntries([...byKind.entries()].sort((a, b) => a[0].localeCompare(b[0]))),
+  });
+}
+
 export function recoverDiscoveryCandidates(
   ranked: readonly DiscoveryCandidate[],
   candidates: readonly DiscoveryCandidate[],
@@ -1220,6 +1250,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       marquee: def?.marquee === true,
     };
   });
+  logDiscoverySignalCoverage("before-rank", candidates);
   const rowsByTicker = new Map([...byTicker.entries()].map(([ticker, value]) => [ticker, value.row]));
   let ranked = pushFamousCandidatesOutOfFrontBand(recoverDiscoveryCandidates(
     rankDiscoveryCandidates(candidates, { maxCandidates: DISCOVERY_DECK_CARD_COUNT }),
@@ -1229,6 +1260,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   if (targetedMaterialLimit > 0) {
     ranked = await hydrateFrontBandMaterial(ranked, rowsByTicker, asOf);
   }
+  logDiscoverySignalCoverage("after-rank", ranked);
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];
 

--- a/docs/WO-18_DISCOVERY_REASON_NOT_PRICE.md
+++ b/docs/WO-18_DISCOVERY_REASON_NOT_PRICE.md
@@ -1,0 +1,21 @@
+# WO-18 Discovery Reason Beyond Price Rank
+
+## Intent
+
+PRODUCT_VISION v5 defines discovery as unknown-stock awakening, not a restatement of price movement. This work order blocks card headlines that end at "today's strongest among peers" and makes the surface say what is known: material/news/flow/volume first, obscurity context when available, and an honest thin-reason caveat when price-rank context has no supporting signal.
+
+## Product Invariants
+
+- Card front headline is one compressed sentence, not a label plus prose detail.
+- Internal discovery synthesis may keep state/detail parts, but the swipe card must recombine them into one readable reason.
+- `theme_link` / market-context leaders do not output price-rank-only copy. They must combine non-price support or say the support is not visible yet.
+- Obscure sector leaders include market-cap-rank context such as "시총 411위권".
+- Empty or low-hierarchy label-only evidence boxes are not rendered on the stock card or stock depth synthesis.
+- Stock depth synthesis must summarize meaning, not repeat the observed price/rank sentence.
+
+## Verification
+
+- `npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts apps/fomo-web/__tests__/discoveryHeadline.test.ts apps/fomo-web/__tests__/cardCopyDedupe.test.ts`
+- `npm run typecheck`
+- `npm run guard:discovery`
+- `SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze`

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -76,7 +76,7 @@ describe("WO-05 discovery supply engine", () => {
     const row = candidate("리서치", 0.7, "news_mention", "신규 설비 증설 점검");
     row.events[0]!.source = "한화투자증권 리서치";
 
-    expect(discoveryWhy(row)).toBe("오늘 신규 설비 증설 점검 · 한화투자증권 리서치");
+    expect(discoveryWhy(row)).toBe("뉴스 재료 붙은 종목 — 오늘 신규 설비 증설 점검 · 한화투자증권 리서치.");
     expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
     expect(discoveryWhy(row)).not.toContain("직접 다룬 리서치");
   });
@@ -85,7 +85,7 @@ describe("WO-05 discovery supply engine", () => {
     const row = candidate("연결기사", 0.7, "news_mention", "업종 흐름 기사");
     row.events[0]!.source = "네이버 종목뉴스 연결";
 
-    expect(discoveryWhy(row)).toBe("오늘 업종 흐름 기사 · 네이버 종목뉴스 연결");
+    expect(discoveryWhy(row)).toBe("뉴스 재료 붙은 종목 — 오늘 업종 흐름 기사 · 네이버 종목뉴스 연결.");
     expect(discoveryWhy(row)).not.toContain("직접 언급한 뉴스");
     expect(discoveryWhy(row)).not.toContain("뉴스 탭에 함께 묶인 흐름");
   });
@@ -100,7 +100,7 @@ describe("WO-05 discovery supply engine", () => {
     recentTheme.events[0]!.direction = "up";
 
     expect(hasDisplayWhyEvent(recentNews)).toBe(true);
-    expect(discoveryWhy(recentNews)).toBe("최근 호남 반도체 클러스터 소식 · 뉴스");
+    expect(discoveryWhy(recentNews)).toBe("뉴스 재료 붙은 종목 — 최근 호남 반도체 클러스터 소식 · 뉴스.");
     expect(hasDisplayWhyEvent(staleNews)).toBe(false);
     expect(hasDisplayWhyEvent(recentTheme)).toBe(false);
   });
@@ -234,7 +234,23 @@ describe("WO-05 discovery supply engine", () => {
     expect(isWeakDiscoveryCandidate(market)).toBe(true);
     expect(hasDisplayWhyEvent(theme)).toBe(true);
     expect(isWeakDiscoveryCandidate(theme)).toBe(false);
-    expect(discoveryWhy(theme)).toBe("오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요.");
+    expect(discoveryWhy(theme)).toBe("이유 얇은 섹터선두 — 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.");
+  });
+
+  it("does not output price-rank-only headlines for theme leaders", () => {
+    const row = candidate("제닉", 0.7, "theme_link", "오늘 화장품 5개 종목 중 제일 셌어요.");
+    row.marketCapRank = 411;
+    row.sector = "화장품";
+    row.events[0]!.direction = "up";
+
+    const insight = synthesizeDiscoveryInsight(row);
+    const [state, detail = ""] = insight.headline.split(" — ");
+
+    expect(state.length).toBeLessThanOrEqual(16);
+    expect(state).toBe("혼자 튄 무명주");
+    expect(detail).toContain("시총 411위권");
+    expect(detail).toContain("뒤를 받칠 수급·거래·뉴스는 아직 안 보여요");
+    expect(insight.headline).not.toBe("오늘 화장품 5개 종목 중 제일 셌어요.");
   });
 
   it("does not treat flat or bearish theme comparison as a display WHY, but keeps an up leader", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -44,6 +44,8 @@ export type DiscoverySynthesisTone = "material" | "lead" | "activity" | "context
 
 export interface DiscoveryInsightSynthesis {
   headline: string;
+  headlineState: string;
+  headlineDetail?: string;
   tag: string;
   tone: DiscoverySynthesisTone;
   primary?: DiscoveryEvent;
@@ -260,12 +262,14 @@ const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
   disclosure: 0,
   news_mention: 1,
   flow_entry: 2,
-  theme_link: 3,
+  volume_spike: 3,
   new_high: 4,
-  volume_spike: 5,
+  theme_link: 5,
   price_move: 6,
   market_context: 99,
 };
+
+const DISCOVERY_HEADLINE_JOINER = " — ";
 
 function eventTimePrefix(event: DiscoveryEvent, candidate: DiscoveryCandidate): "오늘" | "최근" {
   return event.asOf.slice(0, 10) === candidate.asOf.slice(0, 10) ? "오늘" : "최근";
@@ -320,6 +324,11 @@ function eventGroup(event: DiscoveryEvent): "material" | "flow" | "volume" | "co
   return "price";
 }
 
+function isObscureCandidate(candidate: DiscoveryCandidate): boolean {
+  const rank = candidate.marketCapRank;
+  return typeof rank === "number" && Number.isFinite(rank) && rank >= DISCOVERY_AWAKENING_RANK_MIN;
+}
+
 function compactSourceName(event: DiscoveryEvent): string {
   return (event.sourceName ?? event.source ?? "").replace(/\s+/g, " ").trim();
 }
@@ -340,6 +349,7 @@ function userFacingLabel(event: DiscoveryEvent | undefined, candidate?: Discover
   const relativeStrength = `${"상대"}${"강도"}`;
   const marketPosition = `${"시장"} ${"위치"}`;
   return raw
+    .replace(new RegExp(`^${sector}\\s+\\d+개\\s*종목\\s*중\\s*(.+)$`), `같은 ${sector} 종목들 중 오늘 $1`)
     .replace(new RegExp(`${relativeStrength}\\s*1위예요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 제일 셌어요.`)
     .replace(new RegExp(`${relativeStrength}\\s*(\\d+)위권이에요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 상위권이에요.`)
     .replace(new RegExp(`주변보다 ${relativeStrength}가 높아요\\.?`, "g"), "주변 종목보다 오늘 더 강했어요.")
@@ -358,6 +368,55 @@ function supportPhrase(event: DiscoveryEvent | undefined, primary?: DiscoveryEve
   if (event.kind === "news_mention" || event.kind === "disclosure") return "공개 원문도 같이 확인돼요";
   if (event.kind === "new_high") return "새 가격대도 같이 확인돼요";
   return undefined;
+}
+
+function statePhraseFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
+  if (primary.kind === "disclosure") return "공시 먼저 뜬 종목";
+  if (primary.kind === "news_mention") return "뉴스 재료 붙은 종목";
+  if (primary.kind === "flow_entry") return "수급 먼저 들어온 종목";
+  if (primary.kind === "volume_spike") return "거래 먼저 튄 종목";
+  if (primary.kind === "new_high") return "새 가격대 밟은 종목";
+  if (primary.kind === "theme_link" || primary.kind === "market_context") {
+    if (support?.kind === "flow_entry") return isObscureCandidate(candidate) ? "무명주에 수급 붙음" : "수급 붙은 섹터선두";
+    if (support?.kind === "volume_spike") return isObscureCandidate(candidate) ? "무명주 거래 붙음" : "거래 붙은 섹터선두";
+    if (support?.kind === "new_high") return isObscureCandidate(candidate) ? "무명주 새 가격대" : "새 가격대 섹터선두";
+    if (support?.kind === "disclosure" || support?.kind === "news_mention") return "재료 붙은 섹터선두";
+    return isObscureCandidate(candidate) ? "혼자 튄 무명주" : "이유 얇은 섹터선두";
+  }
+  return "이유 아직 얇은 종목";
+}
+
+function detailFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
+  const prefix = eventTimePrefix(primary, candidate);
+  const supportText = supportPhrase(support, primary);
+  const title = sourceTitleOf(primary);
+  const sourceName = compactSourceName(primary);
+  const label = userFacingLabel(primary, candidate);
+  const sourceSuffix = sourceName ? ` · ${sourceName}` : "";
+
+  if ((primary.kind === "disclosure" || primary.kind === "news_mention") && title) {
+    const base = `${prefix} ${title}${sourceSuffix}`;
+    return supportText ? `${base}. ${supportText}.` : `${base}.`;
+  }
+  if (primary.kind === "flow_entry") {
+    const base = label || "수급 흐름이 확인됐어요";
+    return supportText ? `${base.replace(/[.。]$/, "")}. ${supportText}.` : `${base.replace(/[.。]$/, "")}.`;
+  }
+  if (primary.kind === "volume_spike") {
+    const base = label || "거래량이 평소보다 커졌어요";
+    return supportText ? `${base.replace(/[.。]$/, "")}. ${supportText}.` : `${base.replace(/[.。]$/, "")}.`;
+  }
+  if (primary.kind === "new_high") {
+    const base = label || "52주 위치가 새 구간에 들어왔어요";
+    return supportText ? `${base.replace(/[.。]$/, "")}. ${supportText}.` : `${base.replace(/[.。]$/, "")}.`;
+  }
+  if (primary.kind === "theme_link" || primary.kind === "market_context" || primary.kind === "price_move") {
+    const context = label || `${candidate.sector ?? candidate.market} 안에서 오늘 눈에 띈 흐름이에요.`;
+    if (supportText) return `${context.replace(/[.。]$/, "")}. ${supportText}.`;
+    const rankText = isObscureCandidate(candidate) && candidate.marketCapRank ? `시총 ${candidate.marketCapRank}위권인데 ` : "";
+    return `${rankText}${context.replace(/[.。]$/, "")}. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.`;
+  }
+  return label || "확인된 신호만 따로 보는 카드예요.";
 }
 
 function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
@@ -385,33 +444,18 @@ function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEve
     })[0];
 }
 
-function headlineFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
-  const prefix = eventTimePrefix(primary, candidate);
-  const supportText = supportPhrase(support, primary);
-  const title = sourceTitleOf(primary);
-  const sourceName = compactSourceName(primary);
-  let base = "";
-  if ((primary.kind === "disclosure" || primary.kind === "news_mention") && title) {
-    base = `${prefix} ${title}${sourceName ? ` · ${sourceName}` : ""}`;
-  } else {
-    base = userFacingLabel(primary, candidate);
-    if (
-      base &&
-      !/^(?:오늘|최근)\s+/.test(base) &&
-      (primary.kind === "theme_link" || primary.kind === "market_context" || primary.kind === "volume_spike" || primary.kind === "new_high")
-    ) {
-      base = `${prefix} ${base}`;
-    }
-  }
-  if (!base) {
-    if (primary.kind === "disclosure") base = `${prefix} 이 종목의 공시가 확인됐어요.`;
-    else if (primary.kind === "news_mention") base = `${prefix} 기사 제목이 확인된 뉴스만 볼게요.`;
-    else if (primary.kind === "flow_entry") base = "수급이 먼저 들어오는 종목이에요.";
-    else if (primary.kind === "volume_spike") base = "거래량이 평소보다 달라졌어요.";
-    else base = `${candidate.sector ?? candidate.market} 안에서 오늘 눈에 띈 흐름이에요.`;
-  }
-  if (supportText && !base.includes(supportText)) return `${base.replace(/[.。]$/, "")} — ${supportText.replace(/[.。]$/, "")}.`;
-  return base;
+function headlinePartsFor(
+  primary: DiscoveryEvent,
+  support: DiscoveryEvent | undefined,
+  candidate: DiscoveryCandidate
+): { state: string; detail: string; headline: string } {
+  const state = statePhraseFor(primary, support, candidate);
+  const detail = detailFor(primary, support, candidate);
+  return {
+    state,
+    detail,
+    headline: `${state}${DISCOVERY_HEADLINE_JOINER}${detail}`,
+  };
 }
 
 function observationFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): string {
@@ -425,7 +469,7 @@ function observationFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): s
   return label || "확인된 신호가 있어요.";
 }
 
-function synthesisFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined): string {
+function synthesisFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
   const primaryGroup = eventGroup(primary);
   const supportGroup = support ? eventGroup(support) : undefined;
   if (primaryGroup === "material" && supportGroup === "volume") return "새로 나온 원문에 거래 반응까지 붙어, 단순 가격 변화보다 계기가 분명한 카드예요.";
@@ -438,7 +482,14 @@ function synthesisFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefin
   if (primaryGroup === "volume" && supportGroup === "context") return "동종 흐름 속에서 거래가 먼저 커진 카드예요.";
   if (primaryGroup === "volume") return "공개 원문보다 거래 변화가 먼저 잡힌 카드예요.";
   if (primaryGroup === "context" && supportGroup === "flow") return "동종 종목 대비 흐름에 수급까지 붙어 확인할 지점이 생긴 카드예요.";
-  if (primaryGroup === "context") return "같은 업종 안에서 유독 먼저 눈에 들어온 흐름이에요.";
+  if (primaryGroup === "context" && supportGroup === "volume") return "섹터 안에서 먼저 튄 뒤 거래 변화까지 붙었는지 볼 카드예요.";
+  if (primaryGroup === "context" && supportGroup === "price") return "섹터 안에서 먼저 튄 뒤 새 가격대까지 겹친 카드예요.";
+  if (primaryGroup === "context" && supportGroup === "material") return "섹터 선두 맥락에 공개 재료가 같이 붙은 카드예요.";
+  if (primaryGroup === "context") {
+    return isObscureCandidate(candidate)
+      ? "남들이 덜 보는 종목이 섹터 안에서 먼저 튀었지만, 가격 외 신호는 아직 얇아요."
+      : "섹터 안에서 먼저 보인 결과는 있지만, 가격 외 신호는 아직 얇아요.";
+  }
   return "공개 원문은 아직 얇고, 확인된 신호만 따로 보는 카드예요.";
 }
 
@@ -458,6 +509,7 @@ export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): Disco
   if (!primary) {
     return {
       headline: "아직 공개된 계기 없음",
+      headlineState: "이유 아직 얇은 종목",
       tag: "정직한 빈 신호",
       tone: "empty",
       observations: [],
@@ -466,7 +518,7 @@ export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): Disco
     };
   }
 
-  const headline = headlineFor(primary, support, candidate);
+  const headline = headlinePartsFor(primary, support, candidate);
   const observations = [primary, support]
     .filter((event): event is DiscoveryEvent => !!event)
     .map((event) => observationFor(event, candidate))
@@ -474,10 +526,12 @@ export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): Disco
   const evidence = [primary, support]
     .filter((event): event is DiscoveryEvent => !!event)
     .map(evidenceFor);
-  const synthesis = synthesisFor(primary, support);
+  const synthesis = synthesisFor(primary, support, candidate);
 
   return {
-    headline,
+    headline: headline.headline,
+    headlineState: headline.state,
+    headlineDetail: headline.detail,
     tag: displayTag(primary),
     tone: eventKindTone(primary),
     primary,


### PR DESCRIPTION
## Summary
- Replace price-rank-only discovery headlines with a card-front one-sentence reason, not a label plus prose detail.
- Promote obscurity context for lower market-cap-rank sector leaders and add an honest thin-reason caveat when flow/volume/news/disclosure support is absent.
- Remove low-hierarchy material/tag subLine boxes from discovery-reason card fronts; the reason now lives in the main headline.
- Add a dedicated discovery headline compactor, signal coverage logging, and WO-18 verification note.

## Before / After
- 마키나락스 screenshot before: long news prose headline plus a separate material-label box. After: "해외 수주에 동종 흐름도 붙었어요" as the main card sentence, with no material-label box.
- 제닉 before: "오늘 화장품 5개 중 제일 셌어요." After: "시총 411위 화장품주가 튀었지만 근거는 얇아요."
- 루시드 before: "오늘 전기차 4개 종목 중 제일 셌어요." After: "시총 240위 전기차주가 튀었지만 근거는 얇아요."
- 스노우플레이크/애드바이오텍: same guard path now prevents theme/market context from ending as price-rank-only copy; material/flow/volume win when present, otherwise the card says price-outside support is thin.

## Golden Coverage
- Price-rank-only headline guard added for theme leaders.
- Discovery reason compactor turns material/detail prose into one card-front sentence.
- Empty or low-hierarchy subLine/evidence label boxes are skipped unless real independent content exists.
- Depth synthesis no longer copies the context reason verbatim when it is just rank/price context.

## Verification
- npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts apps/fomo-web/__tests__/discoveryHeadline.test.ts apps/fomo-web/__tests__/cardCopyDedupe.test.ts
- npm run typecheck
- npm run guard:discovery
- SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze
- npm run lint
- npm run build

## Screenshots
- User-provided screenshot drove this revision; no new capture attached in this run.
