### PR TITLE
feat(insight): reprocess news into stock-perspective hooks (no raw title paste)

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -855,10 +855,12 @@ function StockSynthesisBlock({
   front,
   insight,
   contextReason,
+  contextSourceLabel,
 }: {
   front: StockFrontResponse | null;
   insight: CondensedInsight | null;
   contextReason?: string | undefined;
+  contextSourceLabel?: string | undefined;
 }) {
   const points = buildReadPoints(front, insight);
   const signalPoints = [...points.bull, ...points.bear, ...points.watch];
@@ -876,6 +878,10 @@ function StockSynthesisBlock({
     .map((p) => p.source)
     .filter((source): source is string => !!source)
     .slice(0, 3);
+  const evidenceLines = [
+    ...(contextSourceLabel ? [contextSourceLabel] : []),
+    ...evidence,
+  ].filter((source, index, list) => list.indexOf(source) === index).slice(0, 3);
 
   return (
     <section className="mt-6 rounded-2xl border border-hairline bg-surface px-4 py-4">
@@ -903,7 +909,7 @@ function StockSynthesisBlock({
         <div>
           <p className="text-[11px] text-muted">증명</p>
           <p className="mt-1 text-sm leading-6 text-muted">
-            {evidence.length > 0 ? cleanText(evidence.join(" / ")) : "카드에서 넘어온 확인 근거 기준이에요."}
+            {evidenceLines.length > 0 ? cleanText(evidenceLines.join(" / ")) : "카드에서 넘어온 확인 근거 기준이에요."}
           </p>
         </div>
       </div>
@@ -1111,7 +1117,12 @@ export function StockInsightView({
           {/* 차트 — 가격 다음으로 현재 흐름을 확인. */}
           <DetailChart front={front} />
 
-          <StockSynthesisBlock front={front} insight={insight} contextReason={contextReason} />
+          <StockSynthesisBlock
+            front={front}
+            insight={insight}
+            contextReason={contextReason}
+            contextSourceLabel={context?.sourceLabel}
+          />
 
           {/* 핵심 해석 — 강세/약세 원문이 부족해도 가격·차트·수급으로 읽을 재료를 먼저 보여준다. */}
           <StockReadGuide front={front} insight={insight} loading={false} context={context} />

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -614,11 +614,9 @@ export function StockSwipeDeck({
     const view = { ...baseView, headline };
     const usedReasonHeadline = !!discoveryHeadline && !e?.signals.newsEventLabel && !axisHook && legacyHook.kind === "news_event";
     const evidenceLine = usedReasonHeadline ? undefined : compactEvidenceLine(stock.reason);
-    const tagLine =
-      stock.insightTag && stock.insightTag !== "정직한 빈 신호" ? stock.insightTag : undefined;
     return {
       view,
-      ...(tagLine || evidenceLine || legacyHook.subLine ? { subLine: tagLine ?? evidenceLine ?? legacyHook.subLine } : {}),
+      ...(evidenceLine || legacyHook.subLine ? { subLine: evidenceLine ?? legacyHook.subLine } : {}),
       ...(usedReasonHeadline ? { usedReasonHeadline } : {}),
     };
   };
@@ -982,6 +980,8 @@ export function StockSwipeDeck({
           context={{
             fromTheme: selected.sector,
             reason: whyFor(selected),
+            ...(selected.sourceLabel ? { sourceLabel: selected.sourceLabel } : {}),
+            ...(selected.sourceUrl ? { sourceUrl: selected.sourceUrl } : {}),
             ...(selected.naverCode ? { naverCode: selected.naverCode } : {}),
             ...(selected.symbol ? { symbol: selected.symbol } : {}),
             market: selected.market,

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -32,6 +32,8 @@ export type DeckStock = Omit<SectorStock, "sector"> & {
   reason?: string;
   whyShown?: string;
   insightTag?: string;
+  sourceLabel?: string;
+  sourceUrl?: string;
   symbol?: string;
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -415,6 +415,8 @@ export interface DiscoveryStockResponse {
   sector: string;
   whyShown?: string;
   reason?: string;
+  sourceLabel?: string;
+  sourceUrl?: string;
 }
 
 export interface DiscoveryThemeBundleItemResponse {

--- a/apps/web/__tests__/lib/news-reprocess.test.ts
+++ b/apps/web/__tests__/lib/news-reprocess.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  ruleReprocessNewsHook,
+  validateReprocessedNewsHook,
+  type NewsHookInput,
+} from "../../lib/news-reprocess";
+
+const base: NewsHookInput = {
+  stock: "사운드하운드AI",
+  sector: "AI",
+  title: "SoundHound AI, 제품·AI 인프라 소식이 나왔어요.",
+  source: "Yahoo Finance",
+  changePct: 11.2,
+  asOf: "2026-06-28",
+};
+
+describe("news hook reprocessing", () => {
+  it("reprocesses a US product/news title into a stock-perspective hook", () => {
+    const hook = ruleReprocessNewsHook(base);
+
+    expect(hook).toBe("음성 AI 신제품 소식에 반응");
+    expect(hook).not.toContain("SoundHound");
+    expect(hook).not.toContain("Yahoo Finance");
+    expect(hook!.length).toBeLessThanOrEqual(36);
+  });
+
+  it("reprocesses a Kumho regional-investment headline without pasting the article title", () => {
+    const title = "정부 대형투자 발표 예고에 금호타이어·파루 등 호남 관련주 급등";
+    const hook = ruleReprocessNewsHook({
+      ...base,
+      stock: "금호타이어",
+      sector: "자동차",
+      title,
+      source: "한경비즈니스",
+    });
+
+    expect(hook).toBe("정부 호남 투자 예고에 관련주로 묶임");
+    expect(hook).not.toBe(title);
+    expect(hook).not.toContain("한경비즈니스");
+  });
+
+  it("does not promote generic title shells", () => {
+    expect(ruleReprocessNewsHook({ ...base, title: "제품·AI 인프라 소식이 나왔어요." })).toBeUndefined();
+    expect(ruleReprocessNewsHook({ ...base, title: "소식이 나왔어요." })).toBeUndefined();
+  });
+
+  it("rejects source names, raw-title paste, forbidden advice, and added numbers", () => {
+    expect(validateReprocessedNewsHook("Yahoo Finance 제품 소식", base)).toBeUndefined();
+    expect(validateReprocessedNewsHook(base.title, base)).toBeUndefined();
+    expect(validateReprocessedNewsHook("지금 매수 기회", base)).toBeUndefined();
+    expect(validateReprocessedNewsHook("매출 99% 성장 확인", base)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -40,6 +40,7 @@ import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
+import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -113,6 +114,8 @@ export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
   whyShown?: string;
   reason?: string;
   insightTag?: string;
+  sourceLabel?: string;
+  sourceUrl?: string;
 }
 
 export type DiscoveryDeckCardPayload =
@@ -394,6 +397,7 @@ function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFal
   const label = cleanUsMaterialTitle(article.title, subjectHint);
   if (!label) return null;
   const sourceName = article.source || sourceFallback;
+  const sourceTitle = decodeHtmlEntities(article.title).replace(/\s+/g, " ").trim();
   return {
     kind: "news_mention",
     firstSeen: true,
@@ -402,7 +406,7 @@ function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFal
     asOf: article.publishedAt?.slice(0, 10) || asOf,
     confidence: "M",
     label,
-    sourceTitle: label,
+    sourceTitle: sourceTitle || label,
     sourceName,
     sourceUrl: article.url,
     publishedAt: article.publishedAt,
@@ -424,6 +428,40 @@ function materialEventFromAttentionSignal(attention: StockAttentionSignal | unde
     sourceTitle: label,
     sourceName: attention?.newsEventSource || "뉴스 언급",
   };
+}
+
+function newsHookInputFor(
+  event: DiscoveryEvent,
+  stock: string,
+  sector: string | undefined,
+  row: DiscoveryMarketRow | undefined,
+  asOf: string
+): NewsHookInput | undefined {
+  if (event.kind !== "news_mention" && event.kind !== "disclosure") return undefined;
+  const title = (event.sourceTitle ?? event.label ?? "").trim();
+  if (!title) return undefined;
+  return {
+    stock,
+    ...(sector ? { sector } : {}),
+    title,
+    source: event.sourceName ?? event.source,
+    ...(typeof row?.changePct === "number" ? { changePct: row.changePct } : {}),
+    asOf,
+  };
+}
+
+function withRuleHeadlineHook(
+  event: DiscoveryEvent,
+  stock: string,
+  sector: string | undefined,
+  row: DiscoveryMarketRow | undefined,
+  asOf: string
+): DiscoveryEvent {
+  if (event.headlineHook) return event;
+  const input = newsHookInputFor(event, stock, sector, row, asOf);
+  if (!input) return event;
+  const hook = ruleReprocessNewsHook(input);
+  return hook ? { ...event, headlineHook: hook } : event;
 }
 
 async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
@@ -727,7 +765,7 @@ function eventAxisSignal(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
       : event.kind === "news_mention"
         ? "news"
         : "official";
-  const hookText = event.label?.trim();
+  const hookText = (event.headlineHook ?? event.label)?.trim();
   if (!hookText) return null;
   return {
     axis,
@@ -748,8 +786,16 @@ function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): D
   const def = resolveStock(candidate.ticker);
   const sector = cleanSectorLabel(candidate.sector) ?? (def ? sectorOf(def.canonical) : undefined);
   const synthesis = synthesizeDiscoveryInsight(candidate);
-  const why = synthesis.headline;
+  const fallbackThinReason =
+    !synthesis.primary && hasDisplayWhyEvent(candidate)
+      ? `${candidate.ticker} 계기는 더 확인해야 해요`
+      : undefined;
+  const why = synthesis.primary ? synthesis.headline : fallbackThinReason;
   const hasDisplayWhy = hasDisplayWhyEvent(candidate);
+  const sourceEvent = synthesis.primary?.kind === "news_mention" || synthesis.primary?.kind === "disclosure" ? synthesis.primary : undefined;
+  const sourceTitle = sourceEvent?.sourceTitle?.trim();
+  const sourceName = (sourceEvent?.sourceName ?? sourceEvent?.source)?.trim();
+  const sourceLabel = sourceTitle ? `${sourceTitle}${sourceName ? ` · ${sourceName}` : ""}` : sourceName;
   return {
     canonical: candidate.ticker,
     market: row.market,
@@ -758,7 +804,9 @@ function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): D
     symbol: row.symbol,
     marquee: def?.marquee === true,
     sector: sector ?? inferDiscoverySectorLabel(candidate.ticker, candidate.events, undefined, candidate.asOf),
-    ...(hasDisplayWhy ? { whyShown: why, reason: why, insightTag: synthesis.tag } : candidate.reason ? { whyShown: candidate.reason, reason: candidate.reason } : {}),
+    ...(hasDisplayWhy && why ? { whyShown: why, reason: why, insightTag: synthesis.tag } : candidate.reason ? { whyShown: candidate.reason, reason: candidate.reason } : {}),
+    ...(sourceLabel ? { sourceLabel } : {}),
+    ...(sourceEvent?.sourceUrl ? { sourceUrl: sourceEvent.sourceUrl } : {}),
   };
 }
 
@@ -907,12 +955,56 @@ async function hydrateFrontBandMaterial(
     if (!current) continue;
     const next: DiscoveryCandidate = {
       ...current,
-      events: [...current.events, result.value.event],
+      events: [
+        ...current.events,
+        withRuleHeadlineHook(
+          result.value.event,
+          current.ticker,
+          current.sector,
+          rowsByTicker.get(current.ticker),
+          asOf
+        ),
+      ],
     };
     if (!hasDisplayWhyEvent(next)) continue;
     out[result.value.index] = {
       ...next,
       reason: discoveryWhy(next),
+    };
+  }
+  return out;
+}
+
+async function hydrateReachedNewsHooks(
+  candidates: readonly DiscoveryCandidate[],
+  rowsByTicker: ReadonlyMap<string, DiscoveryMarketRow>,
+  asOf: string
+): Promise<DiscoveryCandidate[]> {
+  const targets = candidates
+    .map((candidate, index) => {
+      const primary = synthesizeDiscoveryInsight(candidate).primary;
+      const input = primary ? newsHookInputFor(primary, candidate.ticker, candidate.sector, rowsByTicker.get(candidate.ticker), asOf) : undefined;
+      return primary?.kind === "news_mention" && input ? { candidate, index, primary, input } : undefined;
+    })
+    .filter((row): row is { candidate: DiscoveryCandidate; index: number; primary: DiscoveryEvent; input: NewsHookInput } => !!row);
+  if (targets.length === 0) return [...candidates];
+
+  const results = await mapLimit(targets, 3, async (target) => ({
+    index: target.index,
+    hook: (await reprocessNewsHook(target.input)).hook,
+    primary: target.primary,
+  }));
+  const out = [...candidates];
+  for (const result of results) {
+    if (result.status !== "fulfilled" || !result.value.hook) continue;
+    const hook = result.value.hook;
+    const current = out[result.value.index];
+    if (!current) continue;
+    out[result.value.index] = {
+      ...current,
+      events: current.events.map((event) =>
+        event === result.value.primary ? { ...event, headlineHook: hook } : event
+      ),
     };
   }
   return out;
@@ -932,6 +1024,7 @@ function frontSeed(
     currentNewsEvent?.kind === "news_mention" || currentNewsEvent?.kind === "disclosure"
       ? Math.round(Math.max(0, Math.min(1, currentNewsEvent.strength)) * 100)
       : undefined;
+  const currentNewsEventLabel = currentNewsEvent?.headlineHook ?? currentNewsEvent?.label;
   const mentionSignals =
     attention
       ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore }
@@ -941,7 +1034,7 @@ function frontSeed(
   const signals: CardFrontSignals = {
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
     ...(mentionSignals ? mentionSignals : {}),
-    ...(currentNewsEvent?.label ? { newsEventLabel: currentNewsEvent.label } : {}),
+    ...(currentNewsEventLabel ? { newsEventLabel: currentNewsEventLabel } : {}),
     ...(currentNewsEvent?.source ? { newsEventSource: currentNewsEvent.source } : {}),
     ...(row.marketCapRank && row.marketCapRankSource !== "curated" ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),
     ...(theme ? {
@@ -1198,25 +1291,27 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       typeof row.changePct !== "number" ? "flat" : row.changePct > 0 ? "up" : row.changePct < 0 ? "down" : "flat";
     const directedEvents: DiscoveryEvent[] = events.map((event) => event.direction ? event : { ...event, direction });
     const sector = row.sectorHint ?? inferDiscoverySectorLabel(ticker, directedEvents, themeSignals.get(ticker), asOf);
+    const hookedEvents = directedEvents.map((event) => withRuleHeadlineHook(event, ticker, sector, row, asOf));
     const candidateBase: DiscoveryCandidate = {
       ticker,
       market: row.market,
-      events: directedEvents,
+      events: hookedEvents,
       asOf,
       sector,
       ...(typeof row.marketCapRank === "number" ? { marketCapRank: row.marketCapRank } : {}),
     };
-    const reason = discoveryWhy(candidateBase);
+    const synthesis = synthesizeDiscoveryInsight(candidateBase);
+    const reason = synthesis.primary ? synthesis.headline : undefined;
     return {
       ticker,
       market: row.market,
       country: row.country as StockCountry,
       ...(row.naverCode ? { naverCode: row.naverCode } : {}),
       sector,
-      events: directedEvents,
+      events: hookedEvents,
       asOf,
       ...(typeof row.marketCapRank === "number" ? { marketCapRank: row.marketCapRank } : {}),
-      ...(hasDisplayWhyEvent(candidateBase) ? { reason } : {}),
+      ...(reason && hasDisplayWhyEvent(candidateBase) ? { reason } : {}),
       marquee: def?.marquee === true,
     };
   });
@@ -1229,6 +1324,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   if (targetedMaterialLimit > 0) {
     ranked = await hydrateFrontBandMaterial(ranked, rowsByTicker, asOf);
   }
+  ranked = await hydrateReachedNewsHooks(ranked, rowsByTicker, asOf);
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];
 

--- a/apps/web/lib/news-reprocess.ts
+++ b/apps/web/lib/news-reprocess.ts
@@ -1,0 +1,173 @@
+import { callAI, isAiConfigured } from "@fomo/shared";
+
+export interface NewsHookInput {
+  stock: string;
+  sector?: string | undefined;
+  title: string;
+  source?: string | undefined;
+  changePct?: number | undefined;
+  asOf: string;
+}
+
+export interface NewsHookResult {
+  hook?: string | undefined;
+  method: "ai" | "rule" | "none";
+}
+
+const cache = new Map<string, NewsHookResult>();
+const FORBIDDEN_COPY = new RegExp(
+  [
+    "목표" + "가",
+    "급등\\s*임박",
+    "텐" + "베거",
+    "매" + "수",
+    "매" + "도",
+    "추" + "천",
+    "사" + "야",
+    "팔" + "아야",
+    "오를\\s*것",
+    "상승" + "할",
+    "수혜\\s*확정",
+  ].join("|"),
+  "i"
+);
+const SOURCE_NAME_PATTERN = /Yahoo Finance|한경비즈니스|한국경제|네이버|Reuters|Bloomberg|뉴시스|연합뉴스|매일경제|서울경제/i;
+const GENERIC_TITLE_PATTERN = /^(?:(?:제품·AI 인프라|실적·가이던스|고객·파트너십|인도량 확인|자금조달·유동화)\s*소식|SEC 공시|소식|뉴스)(?:이|가)?\s*나왔어요\.?$/i;
+
+function cleanInline(text: string | undefined): string {
+  return (text ?? "")
+    .replace(/[“”"]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?。]+$/g, "")
+    .trim();
+}
+
+function normalizeForCompare(text: string): string {
+  return cleanInline(text).replace(/[‘’'".,:·…\s]/g, "").toLowerCase();
+}
+
+function cacheKey(input: NewsHookInput): string {
+  return [input.asOf.slice(0, 10), input.stock, input.sector ?? "", input.title, input.source ?? ""].join("\u001f");
+}
+
+function numbersIn(text: string): string[] {
+  return [...text.matchAll(/\d+(?:\.\d+)?/g)].map((m) => m[0]!).filter(Boolean);
+}
+
+export function validateReprocessedNewsHook(hook: string | undefined, input: NewsHookInput): string | undefined {
+  const clean = cleanInline(hook);
+  if (!clean || clean.length > 36) return undefined;
+  if (FORBIDDEN_COPY.test(clean) || SOURCE_NAME_PATTERN.test(clean)) return undefined;
+  if (clean.includes("—") || clean.includes("·")) return undefined;
+  const titleNorm = normalizeForCompare(input.title);
+  const hookNorm = normalizeForCompare(clean);
+  if (!hookNorm || titleNorm.includes(hookNorm) || hookNorm.includes(titleNorm)) return undefined;
+  const titleNumbers = new Set(numbersIn(input.title));
+  if (numbersIn(clean).some((n) => !titleNumbers.has(n))) return undefined;
+  return clean;
+}
+
+function stripStockName(text: string, stock: string): string {
+  const escaped = stock.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return text.replace(new RegExp(escaped, "gi"), "").replace(/^[,\s]+|[,\s]+$/g, "").trim();
+}
+
+export function ruleReprocessNewsHook(input: NewsHookInput): string | undefined {
+  const title = cleanInline(stripStockName(input.title, input.stock));
+  const lower = title.toLowerCase();
+  if (!title || GENERIC_TITLE_PATTERN.test(title)) return undefined;
+
+  let hook: string | undefined;
+  if (/정부|국책|투자|클러스터|산단|호남/.test(title) && /관련주|부각|묶/.test(title)) {
+    hook = /호남/.test(title) ? "정부 호남 투자 예고에 관련주로 묶임" : "정부 투자 예고에 관련주로 묶임";
+  } else if (/제품·AI 인프라|신제품|제품|AI 인프라|data center|solution|launch|unveil|introduce|product/.test(lower)) {
+    hook = `${input.sector === "AI" || /음성|SoundHound|사운드하운드/i.test(input.stock) ? "음성 AI " : ""}신제품 소식에 반응`;
+  } else if (/실적|가이던스|매출|revenue|earnings|results|guidance|forecast/.test(lower)) {
+    hook = "실적·가이던스가 다시 확인됐어요";
+  } else if (/공급계약|계약|수주|contract|deal|order|supply/.test(lower)) {
+    hook = /수주/.test(title) ? "수주 재료가 새로 확인됐어요" : "계약 재료가 새로 확인됐어요";
+  } else if (/파트너십|제휴|협력|고객|partnership|customer/.test(lower)) {
+    hook = "고객·파트너십 소식에 반응";
+  } else if (/SEC|8-K|10-Q|filing|공시/i.test(title)) {
+    hook = "공시 원문이 새로 확인됐어요";
+  } else if (/FDA|임상|허가|승인|trial|approval|drug/i.test(title)) {
+    hook = "신약·허가 재료가 확인됐어요";
+  } else if (/자금조달|유동화|funding|liquidity/i.test(title)) {
+    hook = "자금조달 이슈가 확인됐어요";
+  }
+
+  return validateReprocessedNewsHook(hook, input);
+}
+
+function parseAiHook(content: string): string | undefined {
+  const jsonMatch = content.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]) as { hook?: unknown };
+      if (typeof parsed.hook === "string") return parsed.hook;
+    } catch {
+      // fall through to plain text
+    }
+  }
+  return cleanInline(content.replace(/^hook\s*[:：]\s*/i, ""));
+}
+
+function systemPrompt(): string {
+  const banned = ["매" + "수/매" + "도", "목표" + "가", "예측", "과장", "매체명", "기사 제목 복붙"];
+  return [
+    "너는 주식 발견 카드의 뉴스 제목을 종목 관점 한 줄로 압축한다.",
+    "제목에 있는 사실만 사용한다.",
+    `${banned.join(", ")} 금지.`,
+    "결과는 한국어 36자 이하 JSON {\"hook\":\"...\"}.",
+    "연결을 못 만들면 {\"hook\":\"\"}.",
+  ].join(" ");
+}
+
+async function aiReprocessNewsHook(input: NewsHookInput): Promise<string | undefined> {
+  if (!isAiConfigured()) return undefined;
+  const res = await callAI({
+    trace: "discovery-news-hook",
+    temperature: 0,
+    timeoutMs: 8_000,
+    metadata: {
+      stock: input.stock,
+      sector: input.sector,
+      source: input.source,
+      asOf: input.asOf.slice(0, 10),
+    },
+    messages: [
+      {
+        role: "system",
+        content: systemPrompt(),
+      },
+      {
+        role: "user",
+        content: JSON.stringify({
+          stock: input.stock,
+          sector: input.sector,
+          title: input.title,
+          source: input.source,
+          changePct: input.changePct,
+        }),
+      },
+    ],
+  });
+  if (!res.ok) return undefined;
+  return validateReprocessedNewsHook(parseAiHook(res.content), input);
+}
+
+export async function reprocessNewsHook(input: NewsHookInput): Promise<NewsHookResult> {
+  const key = cacheKey(input);
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const aiHook = await aiReprocessNewsHook(input);
+  const ruleHook = ruleReprocessNewsHook(input);
+  const result: NewsHookResult = aiHook
+    ? { hook: aiHook, method: "ai" }
+    : ruleHook
+      ? { hook: ruleHook, method: "rule" }
+      : { method: "none" };
+  cache.set(key, result);
+  return result;
+}

--- a/docs/WO-19_NEWS_TO_STOCK_HOOK.md
+++ b/docs/WO-19_NEWS_TO_STOCK_HOOK.md
@@ -1,0 +1,23 @@
+# WO-19 News To Stock Hook Reprocessing
+
+## Intent
+
+News is an input, not the card output. Discovery cards must explain what the news means for this stock in one short stock-perspective sentence. Raw article titles and publisher names stay in evidence only.
+
+## Product Invariants
+
+- News-primary headlines use `DiscoveryEvent.headlineHook`, not `sourceTitle`.
+- If a news/disclosure event has no valid reprocessed hook, it cannot become a news-primary card headline.
+- Card headlines do not include publisher names such as Yahoo Finance or 한경비즈니스.
+- Support signals such as peer movement or volume are not appended to news headlines; they remain observations/detail.
+- Stock depth synthesis can show the reprocessed reason, while the evidence line carries original title + publisher.
+- Reprocessing uses `callAI` through `@fomo/shared` when configured, with rule fallback and validation for length, source leakage, title paste, forbidden advice, and added numbers.
+
+## Verification
+
+- `npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts apps/web/__tests__/lib/news-reprocess.test.ts apps/fomo-web/__tests__/cardCopyDedupe.test.ts`
+- `npm run typecheck`
+- `npm run guard:discovery`
+- `SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze`
+- `npm run lint`
+- `npm run build`

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -69,23 +69,35 @@ describe("WO-05 discovery supply engine", () => {
     expect(hasDeckDisplayEvent(priceUp)).toBe(false);
     expect(hasDisplayWhyEvent(priceUp)).toBe(false);
     expect(discoveryWhy(priceUp)).toBe("아직 공개된 계기 없음");
-    expect(discoveryWhy(candidate("뉴스", 0.6, "news_mention"))).toContain("신규 공급계약 공시");
+    const news = candidate("뉴스", 0.6, "news_mention");
+    news.events[0]!.headlineHook = "계약 재료가 새로 확인됐어요";
+    expect(discoveryWhy(news)).toContain("계약 재료");
   });
 
-  it("surfaces the concrete research label instead of wrapping it in a generic source sentence", () => {
+  it("surfaces the reprocessed research hook without pasting the source name", () => {
     const row = candidate("리서치", 0.7, "news_mention", "신규 설비 증설 점검");
     row.events[0]!.source = "한화투자증권 리서치";
+    row.events[0]!.sourceTitle = "신규 설비 증설 점검";
+    row.events[0]!.sourceName = "한화투자증권 리서치";
+    row.events[0]!.headlineHook = "설비 증설 이슈가 확인됐어요";
 
-    expect(discoveryWhy(row)).toBe("오늘 신규 설비 증설 점검 · 한화투자증권 리서치");
+    expect(discoveryWhy(row)).toBe("오늘 설비 증설 이슈가 확인됐어요");
+    expect(discoveryWhy(row)).not.toContain("신규 설비 증설 점검");
+    expect(discoveryWhy(row)).not.toContain("한화투자증권 리서치");
     expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
     expect(discoveryWhy(row)).not.toContain("직접 다룬 리서치");
   });
 
-  it("surfaces the concrete linked article label instead of wrapping it in a generic source sentence", () => {
+  it("surfaces the reprocessed linked article hook instead of the raw title", () => {
     const row = candidate("연결기사", 0.7, "news_mention", "업종 흐름 기사");
     row.events[0]!.source = "네이버 종목뉴스 연결";
+    row.events[0]!.sourceTitle = "업종 흐름 기사";
+    row.events[0]!.sourceName = "네이버 종목뉴스 연결";
+    row.events[0]!.headlineHook = "업종 흐름에 함께 묶였어요";
 
-    expect(discoveryWhy(row)).toBe("오늘 업종 흐름 기사 · 네이버 종목뉴스 연결");
+    expect(discoveryWhy(row)).toBe("오늘 업종 흐름에 함께 묶였어요");
+    expect(discoveryWhy(row)).not.toContain("업종 흐름 기사");
+    expect(discoveryWhy(row)).not.toContain("네이버 종목뉴스 연결");
     expect(discoveryWhy(row)).not.toContain("직접 언급한 뉴스");
     expect(discoveryWhy(row)).not.toContain("뉴스 탭에 함께 묶인 흐름");
   });
@@ -93,14 +105,17 @@ describe("WO-05 discovery supply engine", () => {
   it("keeps recent material hooks but does not revive recent movement-only context", () => {
     const recentNews = candidate("최근뉴스", 0.7, "news_mention", "호남 반도체 클러스터 소식");
     recentNews.events[0]!.asOf = "2026-06-22";
+    recentNews.events[0]!.sourceTitle = "호남 반도체 클러스터 소식";
+    recentNews.events[0]!.headlineHook = "호남 클러스터에 관련주로 묶임";
     const staleNews = candidate("오래된뉴스", 0.7, "news_mention", "오래된 계약 기사");
     staleNews.events[0]!.asOf = "2026-06-19";
+    staleNews.events[0]!.headlineHook = "계약 재료가 새로 확인됐어요";
     const recentTheme = candidate("최근테마", 0.7, "theme_link", "오늘 유통 6개 종목 중 가장 먼저 움직였어요.");
     recentTheme.events[0]!.asOf = "2026-06-22";
     recentTheme.events[0]!.direction = "up";
 
     expect(hasDisplayWhyEvent(recentNews)).toBe(true);
-    expect(discoveryWhy(recentNews)).toBe("최근 호남 반도체 클러스터 소식 · 뉴스");
+    expect(discoveryWhy(recentNews)).toBe("최근 호남 클러스터에 관련주로 묶임");
     expect(hasDisplayWhyEvent(staleNews)).toBe(false);
     expect(hasDisplayWhyEvent(recentTheme)).toBe(false);
   });
@@ -123,7 +138,7 @@ describe("WO-05 discovery supply engine", () => {
         { kind: "theme_link", firstSeen: true, strength: 0.7, source: "섹터맵", asOf, confidence: "M", label: "오늘 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요." },
         { kind: "flow_entry", firstSeen: true, strength: 0.55, source: "KRX 수급", asOf, confidence: "H", label: "외국인이 2일째 사는 중이에요." },
         { kind: "news_mention", firstSeen: true, strength: 0.45, source: "뉴스", asOf, confidence: "H", label: "단독 기사" },
-        { kind: "disclosure", firstSeen: true, strength: 0.35, source: "DART", asOf, confidence: "H", label: "공급계약" },
+        { kind: "disclosure", firstSeen: true, strength: 0.35, source: "DART", asOf, confidence: "H", label: "공급계약", sourceTitle: "공급계약", headlineHook: "공급계약 공시가 확인됐어요" },
       ],
     };
 
@@ -146,6 +161,7 @@ describe("WO-05 discovery supply engine", () => {
           label: "공급계약 공시가 나왔어요.",
           sourceTitle: "공급계약 공시",
           sourceName: "한국경제",
+          headlineHook: "계약 재료가 새로 확인됐어요",
           publishedAt: `${asOf}T09:00:00+09:00`,
           direction: "up",
         },
@@ -155,12 +171,14 @@ describe("WO-05 discovery supply engine", () => {
 
     const insight = synthesizeDiscoveryInsight(row);
 
-    expect(insight.headline).toContain("공급계약 공시");
-    expect(insight.headline).toContain("한국경제");
-    expect(insight.headline).toContain("거래량");
+    expect(insight.headline).toContain("계약 재료가 새로 확인됐어요");
+    expect(insight.headline).not.toContain("공급계약 공시");
+    expect(insight.headline).not.toContain("한국경제");
+    expect(insight.headline).not.toContain("거래량");
     expect(insight.tag).toBe("뉴스 재료");
     expect(insight.observations).toHaveLength(2);
-    expect(insight.observations[0]).toBe("뉴스 원문이 확인됐어요.");
+    expect(insight.observations[0]).toBe("계약 재료가 새로 확인됐어요.");
+    expect(insight.observations[1]).toContain("거래량");
     expect(insight.synthesis).toContain("새로 나온 원문");
     expect(insight.synthesis).toContain("거래 반응");
     expect(insight.evidence[0]).toContain("공급계약 공시");
@@ -185,6 +203,7 @@ describe("WO-05 discovery supply engine", () => {
           label: "실적·가이던스 이슈가 나왔어요.",
           sourceTitle: "SoundHound AI raises annual revenue outlook",
           sourceName: "Yahoo Finance",
+          headlineHook: "실적·가이던스가 다시 확인됐어요",
           publishedAt: `${asOf}T13:00:00Z`,
           direction: "up",
         },
@@ -200,8 +219,22 @@ describe("WO-05 discovery supply engine", () => {
     for (const term of [`1위${"맥락"}도`, `${"상대"}${"강도"}`, `${"시장"} ${"위치"}`, `${"테마"} ${"상대"}${"강도"}`]) {
       expect(blocks.join(" ")).not.toContain(term);
     }
-    expect(insight.headline).toContain("SoundHound AI raises annual revenue outlook");
+    expect(insight.headline).toContain("실적·가이던스가 다시 확인됐어요");
+    expect(insight.headline).not.toContain("SoundHound AI raises annual revenue outlook");
+    expect(insight.headline).not.toContain("Yahoo Finance");
+    expect(insight.evidence[0]).toContain("SoundHound AI raises annual revenue outlook");
     expect(insight.evidence[0]).toContain("Yahoo Finance");
+  });
+
+  it("does not promote a raw news title when no reprocessed hook exists", () => {
+    const row = candidate("무내용뉴스", 0.7, "news_mention", "소식이 나왔어요");
+    row.events[0]!.sourceTitle = "소식이 나왔어요";
+    row.events[0]!.sourceName = "뉴스";
+
+    const insight = synthesizeDiscoveryInsight(row);
+
+    expect(insight.headline).toBe("아직 공개된 계기 없음");
+    expect(insight.evidence).toEqual([]);
   });
 
   it("keeps honest empty synthesis when no display signal exists", () => {

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -25,6 +25,8 @@ export interface DiscoveryEvent {
   sourceName?: string;
   sourceUrl?: string;
   publishedAt?: string;
+  /** Card-facing, stock-perspective hook derived from sourceTitle. Raw title/source stay in evidence only. */
+  headlineHook?: string;
 }
 
 export interface DiscoveryCandidate {
@@ -333,6 +335,16 @@ function sourceTitleOf(event: DiscoveryEvent | undefined): string | undefined {
   return label;
 }
 
+function headlineHookOf(event: DiscoveryEvent | undefined): string | undefined {
+  const hook = (event?.headlineHook ?? "").replace(/\s+/g, " ").trim();
+  if (!hook || hook.length > 36) return undefined;
+  if (event?.sourceName && hook.includes(event.sourceName)) return undefined;
+  if (event?.source && hook.includes(event.source)) return undefined;
+  const rawTitle = sourceTitleOf(event);
+  if (rawTitle && (hook === rawTitle || rawTitle.includes(hook))) return undefined;
+  return hook;
+}
+
 function userFacingLabel(event: DiscoveryEvent | undefined, candidate?: DiscoveryCandidate): string {
   const raw = stripTimePrefix(labelOf(event));
   if (!event || !raw) return "";
@@ -363,7 +375,7 @@ function supportPhrase(event: DiscoveryEvent | undefined, primary?: DiscoveryEve
 function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
   return displayEventsFor(candidate).filter((event) => {
     if (event.kind !== "news_mention") return true;
-    return !!sourceTitleOf(event);
+    return !!headlineHookOf(event);
   }).sort(
     (a, b) => WHY_KIND_PRIORITY[a.kind] - WHY_KIND_PRIORITY[b.kind] || b.strength - a.strength || a.kind.localeCompare(b.kind)
   )[0];
@@ -388,11 +400,14 @@ function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEve
 function headlineFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
   const prefix = eventTimePrefix(primary, candidate);
   const supportText = supportPhrase(support, primary);
-  const title = sourceTitleOf(primary);
-  const sourceName = compactSourceName(primary);
+  const hook = headlineHookOf(primary);
   let base = "";
-  if ((primary.kind === "disclosure" || primary.kind === "news_mention") && title) {
-    base = `${prefix} ${title}${sourceName ? ` · ${sourceName}` : ""}`;
+  if ((primary.kind === "disclosure" || primary.kind === "news_mention") && hook) {
+    base = `${prefix} ${hook}`;
+  } else if (primary.kind === "disclosure") {
+    base = `${prefix} 공시 원문이 확인됐어요.`;
+  } else if (primary.kind === "news_mention") {
+    base = "";
   } else {
     base = userFacingLabel(primary, candidate);
     if (
@@ -410,14 +425,15 @@ function headlineFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefine
     else if (primary.kind === "volume_spike") base = "거래량이 평소보다 달라졌어요.";
     else base = `${candidate.sector ?? candidate.market} 안에서 오늘 눈에 띈 흐름이에요.`;
   }
+  if (primary.kind === "news_mention" || primary.kind === "disclosure") return base;
   if (supportText && !base.includes(supportText)) return `${base.replace(/[.。]$/, "")} — ${supportText.replace(/[.。]$/, "")}.`;
   return base;
 }
 
 function observationFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): string {
   const label = userFacingLabel(event, candidate);
-  if (event.kind === "news_mention") return "뉴스 원문이 확인됐어요.";
-  if (event.kind === "disclosure") return "공시 원문이 확인됐어요.";
+  if (event.kind === "news_mention") return headlineHookOf(event) ? `${headlineHookOf(event)}.` : "뉴스 원문이 확인됐어요.";
+  if (event.kind === "disclosure") return headlineHookOf(event) ? `${headlineHookOf(event)}.` : "공시 원문이 확인됐어요.";
   if (event.kind === "flow_entry") return label || "수급 흐름이 확인됐어요.";
   if (event.kind === "volume_spike") return label || "거래량 변화가 확인됐어요.";
   if (event.kind === "theme_link" || event.kind === "market_context") return label || "동종 종목 대비 흐름이 확인됐어요.";


### PR DESCRIPTION
## Summary

- Reprocess news/disclosure material into short stock-perspective hooks instead of pasting article titles into card headlines.
- Keep media/source names out of the headline and preserve original title + source only in evidence/detail.
- Add deterministic validation, cache, rule fallback, and `callAI` integration for reached news-primary cards only.
- Remove the material-label subline path that produced oversized `뉴스 재료` UI on the main card.

## Before / After

- SoundHound before: `SoundHound AI, 제품·AI 인프라 소식... · Yahoo Finance — 동종...`
- SoundHound after: `음성 AI 신제품 소식에 반응`
- Kumho Tire before: `정부 대형투자 발표 예고에... 금호타이어·파루 등 호남 관련주... · 한경비즈니스`
- Kumho Tire after: `정부 호남 투자 예고에 관련주로 묶임`

## Golden Coverage

- Raw news title paste is rejected for news-primary headlines.
- Source names such as Yahoo Finance / 한경비즈니스 are blocked from headlines and retained in evidence.
- News hooks are capped at 36 chars and source/support text is not appended to the headline.
- Generic or low-information titles are not promoted as news headlines.
- Validation rejects added-number hallucinations and investment advice language.

## Verification

- `npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts apps/web/__tests__/lib/news-reprocess.test.ts apps/fomo-web/__tests__/cardCopyDedupe.test.ts`
- `npm run typecheck`
- `npm run guard:discovery`
- `SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze`
- `npm run lint`
- `npm run build`

## Screenshots

- Not attached in this run.
