### PR TITLE
feat(insight): replace template selector with why-driven LLM synthesis (no abstract filler)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ playwright-report/
 playwright/.cache/
 fomo-index-health.json
 agent-tooling-reports/
+.codebase-memory/

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -164,7 +164,7 @@ function FomoMeter({ score, color }: { score: number; color: string }) {
 const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
 const PRICE_ONLY_REASON_PATTERN = /^오늘 가격이 [+-]?\d+(?:\.\d+)?% 움직였어요/;
 const SURFACE_FILLER_HOOK_PATTERN =
-  /(?:더\s*(?:살펴볼|확인할)|발견\s*풀|조용한\s*자리|신호를\s*확인하는\s*중|오늘은\s*뚜렷한\s*신호\s*없음)/;
+  /(?:더\s*(?:살펴볼|확인할)|발견\s*풀|조용한\s*자리|신호를\s*확인하는\s*중|오늘은\s*뚜렷한\s*신호\s*없음|근거는\s*얇|이유\s*얇|흐름\s*(?:이|도)?\s*붙|확인되는\s*화면|눈에\s*띄었어요|한\s*가지\s*숫자만)/;
 const SURFACE_PRICE_HOOK_PATTERN = /(?:^오늘 가격이|^가격 먼저 움직임$|^가격은 .*거래량|^가격은 .*뉴스)/;
 
 function nonPriceOnlyHeadline(text: string | undefined): string | undefined {
@@ -565,7 +565,7 @@ export function StockSwipeDeck({
   const cardFor = (stock: DeckStock): { view: FomoCardView; subLine?: string; usedDiscoveryHeadline?: boolean } => {
     const e = front[stock.canonical];
     if (!e) {
-      const discoveryHeadline = compactDiscoveryCardHeadline({
+      const discoveryHeadline = nonPriceOnlyHeadline(stock.reason) ?? compactDiscoveryCardHeadline({
         reason: stock.reason,
         sector: stock.sector,
       });
@@ -580,11 +580,14 @@ export function StockSwipeDeck({
       return { view, ...(discoveryHeadline ? { usedDiscoveryHeadline: true } : { subLine: "가격·거래량 신호를 불러오고 있어요." }) };
     }
     const fomo = e?.fomo ?? EMPTY_FOMO;
-    const surfaceReasonHeadline = compactDiscoveryCardHeadline({
-      reason: stock.reason,
-      sector: stock.sector,
-      marketCapRank: e?.signals.marketCapRank?.rank,
-    });
+    const rawReasonHeadline = nonPriceOnlyHeadline(stock.reason);
+    const surfaceReasonHeadline =
+      rawReasonHeadline ??
+      compactDiscoveryCardHeadline({
+        reason: stock.reason,
+        sector: stock.sector,
+        marketCapRank: e?.signals.marketCapRank?.rank,
+      });
     const reasonHeadlineSeed = surfaceReasonHeadline ?? compactReasonHeadlineSeed(stock.reason);
     const discoveryHeadline = nonPriceOnlyHeadline(reasonHeadlineSeed);
     const signalsForHook: CardFrontSignals = {

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -161,15 +161,11 @@ describe("discovery specific hook copy", () => {
     lucid.sector = "전기차";
 
     expect(hasDisplayWhyEvent(geumho)).toBe(true);
-    expect(discoveryWhy(geumho)).toBe(
-      "혼자 튄 무명주 — 시총 461위권인데 건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요."
-    );
+    expect(discoveryWhy(geumho)).toBe("시총 461위 건설주");
     expect(discoveryWhy(geumho)).not.toMatch(bannedFillerPattern);
 
     expect(hasDisplayWhyEvent(lucid)).toBe(true);
-    expect(discoveryWhy(lucid)).toBe(
-      "혼자 튄 무명주 — 시총 240위권인데 같은 전기차 종목들 중 오늘 제일 셌어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요."
-    );
+    expect(discoveryWhy(lucid)).toBe("시총 240위 전기차주, 전기차 1/4");
     expect(discoveryWhy(lucid)).not.toMatch(bannedFillerPattern);
     expect(discoveryWhy(lucid)).not.toBe("오늘 전기차 4개 종목 중 제일 셌어요.");
   });

--- a/apps/web/__tests__/lib/insight-synthesis.test.ts
+++ b/apps/web/__tests__/lib/insight-synthesis.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { DiscoveryCandidate } from "@fomo/core";
+import {
+  blockOverlapRatio,
+  synthesizeWhyDrivenInsight,
+  validateWhyInsightOutput,
+} from "../../lib/insight-synthesis";
+
+const asOf = "2026-06-24";
+
+function baseCandidate(): DiscoveryCandidate {
+  return {
+    ticker: "금호타이어",
+    market: "KOSPI",
+    sector: "자동차",
+    marketCapRank: 236,
+    asOf,
+    events: [
+      {
+        kind: "news_mention",
+        firstSeen: true,
+        strength: 0.9,
+        source: "뉴스",
+        asOf,
+        confidence: "H",
+        label: "정부 호남 투자 예고",
+        sourceTitle: "정부 대형투자 발표 예고에 금호타이어 등 호남 관련주 부각",
+        sourceName: "한경비즈니스",
+        headlineHook: "정부 호남 투자 예고에 관련주로 묶임",
+        changePct: 11.9,
+        direction: "up",
+      },
+      {
+        kind: "theme_link",
+        firstSeen: true,
+        strength: 0.7,
+        source: "FOMO 섹터맵",
+        asOf,
+        confidence: "M",
+        label: "오늘 자동차 4개 종목 중 제일 셌어요.",
+        changePct: 11.9,
+        themeRank: 1,
+        themePeerCount: 4,
+        direction: "up",
+      },
+    ],
+  };
+}
+
+describe("why-driven insight synthesis guard", () => {
+  it("accepts concrete stock-perspective output and keeps source out of the headline", () => {
+    const candidate = baseCandidate();
+    const insight = validateWhyInsightOutput(
+      {
+        headline: "금호타이어 +11.9%, 정부 호남 투자 예고",
+        observations: ["금호타이어 +11.9% / 자동차 1/4", "정부 호남 투자 예고에 관련주로 묶임"],
+        synthesis: "기사 제목보다 정부 호남 투자 예고와 당일 +11.9% 반응을 분리해서 봅니다.",
+        evidence: ["정부 대형투자 발표 예고에 금호타이어 등 호남 관련주 부각 · 한경비즈니스 · 2026-06-24"],
+      },
+      candidate
+    );
+
+    expect(insight?.headline).toBe("금호타이어 +11.9%, 정부 호남 투자 예고");
+    expect(insight?.headline).not.toContain("한경비즈니스");
+  });
+
+  it("rejects abstract filler, advice, added numbers, and added proper nouns", () => {
+    const candidate = baseCandidate();
+    expect(validateWhyInsightOutput({ headline: "금호타이어에 동종 흐" + "름이 붙었어요" }, candidate)).toBeUndefined();
+    expect(validateWhyInsightOutput({ headline: "금호타이어 지금 사" + "야 하는 자리" }, candidate)).toBeUndefined();
+    expect(validateWhyInsightOutput({ headline: "금호타이어 +28%, 정부 호남 투자 예고" }, candidate)).toBeUndefined();
+    expect(validateWhyInsightOutput({ headline: "엔비디아와 금호타이어가 정부 투자에 묶임" }, candidate)).toBeUndefined();
+  });
+
+  it("keeps observations, synthesis, and evidence as separate blocks", () => {
+    expect(blockOverlapRatio("금호타이어 +11.9% / 자동차 1/4", "금호타이어 +11.9% / 자동차 1/4")).toBe(1);
+    expect(blockOverlapRatio("금호타이어 +11.9% / 자동차 1/4", "기사 제목보다 정부 호남 투자 예고를 먼저 봅니다")).toBeLessThan(0.7);
+  });
+
+  it("is deterministic without configured AI", async () => {
+    const oldUrl = process.env["AI_API_URL"];
+    const oldKey = process.env["AI_API_KEY"];
+    delete process.env["AI_API_URL"];
+    delete process.env["AI_API_KEY"];
+    try {
+      const candidate = baseCandidate();
+      const first = await synthesizeWhyDrivenInsight(candidate);
+      const second = await synthesizeWhyDrivenInsight(candidate);
+      expect(first).toEqual(second);
+      expect(first.method).toBe("fallback");
+      expect(first.insight.headline).toContain("금호타이어");
+      expect(first.insight.headline).toContain("11.9%");
+    } finally {
+      if (oldUrl !== undefined) process.env["AI_API_URL"] = oldUrl;
+      if (oldKey !== undefined) process.env["AI_API_KEY"] = oldKey;
+    }
+  });
+});

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -41,6 +41,7 @@ import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
 import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
+import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -283,6 +284,7 @@ function eventFromPrice(row: DiscoveryMarketRow, asOf: string): DiscoveryEvent |
     asOf,
     confidence: "H",
     label: `오늘 가격이 ${row.changePct > 0 ? "+" : ""}${row.changePct.toFixed(2)}% 움직였어요.`,
+    changePct: row.changePct,
   };
 }
 
@@ -582,6 +584,11 @@ function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefi
     asOf,
     confidence: "M",
     label,
+    changePct: row.changePct,
+    themeRank: theme.rank,
+    themePeerCount: theme.peerCount,
+    themeAverageChangePct: theme.averageChangePct,
+    themeRelativeChangePct: theme.relativeChangePct,
   };
 }
 
@@ -625,6 +632,11 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
       asOf,
       confidence: "M",
       label: relativeLabel,
+      changePct,
+      themeRank: theme.rank,
+      themePeerCount: theme.peerCount,
+      themeAverageChangePct: theme.averageChangePct,
+      themeRelativeChangePct: theme.relativeChangePct,
     };
   }
   if (sector) {
@@ -637,6 +649,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
         asOf,
         confidence: "M",
         label: formatSectorMarketContextLabel({ sector, rankText, changePct, change }),
+        changePct,
       };
     }
     return {
@@ -647,6 +660,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
       asOf,
       confidence: "M",
       label: `${sector} 안에서 새로 확인된 시장 흐름이 있어요.`,
+      ...(typeof changePct === "number" ? { changePct } : {}),
     };
   }
   if (typeof changePct === "number" && change) {
@@ -658,6 +672,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
       asOf,
       confidence: "M",
       label: `${row.market} ${rankText}에서 새로 확인하는 종목이에요.`,
+      changePct,
     };
   }
   return {
@@ -671,6 +686,12 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
   };
 }
 
+function flowSharesText(net: number): string {
+  const abs = Math.abs(net);
+  if (abs >= 10_000) return `${Math.round(abs / 10_000).toLocaleString("en-US")}만주`;
+  return `${abs.toLocaleString("en-US")}주`;
+}
+
 function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent | null {
   if (history.length === 0) return null;
   const streak = investorNetStreak(history);
@@ -678,6 +699,8 @@ function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent 
   const n = Math.max(streak.foreign, streak.institution);
   if (n < 2) return null;
   const actor = useForeign ? "외국인이" : "기관이";
+  const latest = [...history].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))[0];
+  const latestNet = latest ? (useForeign ? latest.foreignNet : latest.institutionNet) : undefined;
   return {
     kind: "flow_entry",
     firstSeen: true,
@@ -686,6 +709,56 @@ function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent 
     asOf: history[0]?.date ?? todayKst(),
     confidence: "H",
     label: `${actor} ${n}일째 사는 중이에요.`,
+    flowActor: useForeign ? "foreign" : "institution",
+    flowDays: n,
+    ...(typeof latestNet === "number" && latestNet > 0 ? { flowAmountText: flowSharesText(latestNet) } : {}),
+  };
+}
+
+function volumeRatioFromVolumes(volumes: readonly number[]): number | undefined {
+  if (volumes.length < 6) return undefined;
+  const today = volumes[volumes.length - 1];
+  if (typeof today !== "number" || today <= 0) return undefined;
+  const prev = volumes.slice(-21, -1).filter((value) => value > 0);
+  if (prev.length < 5) return undefined;
+  const avg = prev.reduce((sum, value) => sum + value, 0) / prev.length;
+  return avg > 0 ? today / avg : undefined;
+}
+
+function eventFromVolume(row: DiscoveryMarketRow, ratio: number | undefined, asOf: string): DiscoveryEvent | null {
+  if (typeof ratio !== "number" || ratio < 1.8 || row.changeDir === "down") return null;
+  return {
+    kind: "volume_spike",
+    firstSeen: true,
+    strength: Math.min(1, 0.44 + ratio / 6),
+    source: row.country === "KR" ? "네이버 일봉" : row.sessionLabel ?? "거래량",
+    asOf,
+    confidence: "H",
+    direction: row.changeDir ?? (typeof row.changePct === "number" && row.changePct > 0 ? "up" : "flat"),
+    label: `평소 ${ratio.toFixed(1)}배 거래가 터졌어요.`,
+    volumeRatio: Math.round(ratio * 10) / 10,
+    ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
+  };
+}
+
+function enrichEventWithRow(
+  event: DiscoveryEvent,
+  row: DiscoveryMarketRow,
+  theme: ThemeMoveSignal | undefined,
+  direction: NonNullable<DiscoveryEvent["direction"]>
+): DiscoveryEvent {
+  return {
+    ...event,
+    ...(event.direction ? {} : { direction }),
+    ...(typeof event.changePct === "number" || typeof row.changePct !== "number" ? {} : { changePct: row.changePct }),
+    ...((event.kind === "theme_link" || event.kind === "market_context") && theme
+      ? {
+        themeRank: event.themeRank ?? theme.rank,
+        themePeerCount: event.themePeerCount ?? theme.peerCount,
+        themeAverageChangePct: event.themeAverageChangePct ?? theme.averageChangePct,
+        themeRelativeChangePct: event.themeRelativeChangePct ?? theme.relativeChangePct,
+      }
+      : {}),
   };
 }
 
@@ -786,10 +859,9 @@ function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): D
   const def = resolveStock(candidate.ticker);
   const sector = cleanSectorLabel(candidate.sector) ?? (def ? sectorOf(def.canonical) : undefined);
   const synthesis = synthesizeDiscoveryInsight(candidate);
-  const fallbackThinReason =
-    !synthesis.primary && hasDisplayWhyEvent(candidate)
-      ? `${candidate.ticker} 계기는 더 확인해야 해요`
-      : undefined;
+  const fallbackThinReason = !synthesis.primary && hasDisplayWhyEvent(candidate)
+    ? honestNumericFallbackReason(row, candidate, sector)
+    : undefined;
   const why = synthesis.primary ? synthesis.headline : fallbackThinReason;
   const hasDisplayWhy = hasDisplayWhyEvent(candidate);
   const sourceEvent = synthesis.primary?.kind === "news_mention" || synthesis.primary?.kind === "disclosure" ? synthesis.primary : undefined;
@@ -808,6 +880,18 @@ function stockPayload(row: DiscoveryMarketRow, candidate: DiscoveryCandidate): D
     ...(sourceLabel ? { sourceLabel } : {}),
     ...(sourceEvent?.sourceUrl ? { sourceUrl: sourceEvent.sourceUrl } : {}),
   };
+}
+
+function honestNumericFallbackReason(
+  row: DiscoveryMarketRow,
+  candidate: DiscoveryCandidate,
+  sector: string | undefined
+): string | undefined {
+  const displaySector = cleanSectorLabel(sector) ?? inferDiscoverySectorLabel(candidate.ticker, candidate.events, undefined, candidate.asOf);
+  const rank = typeof row.marketCapRank === "number" ? `시총 ${row.marketCapRank}위 ${displaySector}주` : candidate.ticker;
+  const change = typeof row.changePct === "number" ? `${row.changePct > 0 ? "+" : ""}${row.changePct.toFixed(1)}%` : undefined;
+  if (change) return `${rank} ${change} — 공개 재료·수급·거래량은 아직 비어 있어요`;
+  return typeof row.marketCapRank === "number" ? `${rank} — 공개 재료·수급·거래량은 아직 비어 있어요` : undefined;
 }
 
 function isSameDayEvent(event: DiscoveryEvent, candidate: DiscoveryCandidate): boolean {
@@ -988,7 +1072,12 @@ async function hydrateFrontBandMaterial(
       events: [
         ...current.events,
         withRuleHeadlineHook(
-          result.value.event,
+          enrichEventWithRow(
+            result.value.event,
+            rowsByTicker.get(current.ticker)!,
+            undefined,
+            result.value.event.direction ?? "up"
+          ),
           current.ticker,
           current.sector,
           rowsByTicker.get(current.ticker),
@@ -1014,7 +1103,7 @@ async function hydrateReachedNewsHooks(
     .map((candidate, index) => {
       const primary = synthesizeDiscoveryInsight(candidate).primary;
       const input = primary ? newsHookInputFor(primary, candidate.ticker, candidate.sector, rowsByTicker.get(candidate.ticker), asOf) : undefined;
-      return primary?.kind === "news_mention" && input ? { candidate, index, primary, input } : undefined;
+      return (primary?.kind === "news_mention" || primary?.kind === "disclosure") && input ? { candidate, index, primary, input } : undefined;
     })
     .filter((row): row is { candidate: DiscoveryCandidate; index: number; primary: DiscoveryEvent; input: NewsHookInput } => !!row);
   if (targets.length === 0) return [...candidates];
@@ -1040,6 +1129,44 @@ async function hydrateReachedNewsHooks(
   return out;
 }
 
+function attachReachedVolumeEvents(
+  candidates: readonly DiscoveryCandidate[],
+  rowsByTicker: ReadonlyMap<string, DiscoveryMarketRow>,
+  dailyByTicker: ReadonlyMap<string, { closes: number[]; volumes: number[] }>,
+  asOf: string
+): DiscoveryCandidate[] {
+  return candidates.map((candidate) => {
+    if (candidate.events.some((event) => event.kind === "volume_spike")) return candidate;
+    const row = rowsByTicker.get(candidate.ticker);
+    const daily = dailyByTicker.get(candidate.ticker);
+    if (!row || !daily) return candidate;
+    const event = eventFromVolume(row, volumeRatioFromVolumes(daily.volumes), asOf);
+    if (!event) return candidate;
+    return {
+      ...candidate,
+      events: [...candidate.events, event],
+    };
+  });
+}
+
+async function hydrateReachedWhySynthesis(candidates: readonly DiscoveryCandidate[]): Promise<DiscoveryCandidate[]> {
+  const results = await mapLimit(candidates, 3, async (candidate) => ({
+    ticker: candidate.ticker,
+    result: await synthesizeWhyDrivenInsight(candidate),
+  }));
+  return candidates.map((candidate) => {
+    const found = results.find((row) => row.status === "fulfilled" && row.value.ticker === candidate.ticker);
+    if (!found || found.status !== "fulfilled") return candidate;
+    const insight = found.value.result.insight;
+    if (!insight.primary || insight.headline === "아직 공개된 계기 없음") return candidate;
+    return {
+      ...candidate,
+      reason: insight.headline,
+      synthesizedInsight: insight,
+    };
+  });
+}
+
 function frontSeed(
   row: DiscoveryMarketRow,
   candidate: DiscoveryCandidate,
@@ -1055,6 +1182,7 @@ function frontSeed(
       ? Math.round(Math.max(0, Math.min(1, currentNewsEvent.strength)) * 100)
       : undefined;
   const currentNewsEventLabel = currentNewsEvent?.headlineHook ?? currentNewsEvent?.label;
+  const volumeEvent = candidate.events.find((event) => event.kind === "volume_spike" && typeof event.volumeRatio === "number");
   const mentionSignals =
     attention
       ? { mentionCount: attention.mentionCount, mentionScore: attention.mentionScore }
@@ -1063,6 +1191,7 @@ function frontSeed(
         : undefined;
   const signals: CardFrontSignals = {
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
+    ...(typeof volumeEvent?.volumeRatio === "number" ? { volumeRatio: volumeEvent.volumeRatio } : {}),
     ...(mentionSignals ? mentionSignals : {}),
     ...(currentNewsEventLabel ? { newsEventLabel: currentNewsEventLabel } : {}),
     ...(currentNewsEvent?.source ? { newsEventSource: currentNewsEvent.source } : {}),
@@ -1319,8 +1448,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     const def = resolveStock(ticker);
     const direction: NonNullable<DiscoveryEvent["direction"]> =
       typeof row.changePct !== "number" ? "flat" : row.changePct > 0 ? "up" : row.changePct < 0 ? "down" : "flat";
-    const directedEvents: DiscoveryEvent[] = events.map((event) => event.direction ? event : { ...event, direction });
-    const sector = row.sectorHint ?? inferDiscoverySectorLabel(ticker, directedEvents, themeSignals.get(ticker), asOf);
+    const theme = themeSignals.get(ticker);
+    const directedEvents: DiscoveryEvent[] = events.map((event) => enrichEventWithRow(event, row, theme, direction));
+    const sector = row.sectorHint ?? inferDiscoverySectorLabel(ticker, directedEvents, theme, asOf);
     const hookedEvents = directedEvents.map((event) => withRuleHeadlineHook(event, ticker, sector, row, asOf));
     const candidateBase: DiscoveryCandidate = {
       ticker,
@@ -1356,24 +1486,31 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     ranked = await hydrateFrontBandMaterial(ranked, rowsByTicker, asOf);
   }
   ranked = await hydrateReachedNewsHooks(ranked, rowsByTicker, asOf);
-  logDiscoverySignalCoverage("after-rank", ranked);
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];
 
-  const sparklineRows = await mapLimit(
+  const dailyRows = await mapLimit(
     ranked.slice(0, DISCOVERY_DECK_CARD_COUNT),
     SPARKLINE_CONCURRENCY,
     async (candidate) => ({
       ticker: candidate.ticker,
-      sparkline:
-        rowsByTicker.get(candidate.ticker)?.sparkline ??
-        (candidate.naverCode ? (await fetchStockDaily(candidate.naverCode, 110)).closes.slice(-42) : []),
+      daily: candidate.naverCode
+        ? await fetchStockDaily(candidate.naverCode, 110)
+        : {
+          candles: [],
+          closes: rowsByTicker.get(candidate.ticker)?.sparkline ?? [],
+          volumes: [],
+        },
     })
   );
+  const dailyByTicker = new Map(
+    dailyRows.flatMap((row) => (row.status === "fulfilled" ? [[row.value.ticker, row.value.daily] as const] : []))
+  );
+  ranked = attachReachedVolumeEvents(ranked, rowsByTicker, dailyByTicker, asOf);
+  ranked = await hydrateReachedWhySynthesis(ranked);
+  logDiscoverySignalCoverage("after-rank", ranked);
   const sparklineByTicker = new Map(
-    sparklineRows
-      .filter((row): row is PromiseFulfilledResult<{ ticker: string; sparkline: number[] }> => row.status === "fulfilled")
-      .map((row) => [row.value.ticker, row.value.sparkline] as const)
+    [...dailyByTicker.entries()].map(([ticker, daily]) => [ticker, daily.closes.slice(-42)] as const)
   );
 
   for (const candidate of ranked) {

--- a/apps/web/lib/insight-synthesis.ts
+++ b/apps/web/lib/insight-synthesis.ts
@@ -1,0 +1,375 @@
+import { callAI, isAiConfigured } from "@fomo/shared";
+import {
+  hasAbstractDiscoveryFiller,
+  synthesizeDiscoveryInsight,
+  type DiscoveryCandidate,
+  type DiscoveryEvent,
+  type DiscoveryInsightSynthesis,
+} from "@fomo/core";
+
+export interface WhySynthesisResult {
+  insight: DiscoveryInsightSynthesis;
+  method: "ai" | "fallback";
+}
+
+interface AiWhyOutput {
+  headline?: unknown;
+  observations?: unknown;
+  synthesis?: unknown;
+  evidence?: unknown;
+}
+
+const cache = new Map<string, WhySynthesisResult>();
+const ADVICE_PATTERN = new RegExp(
+  [
+    "목표" + "가",
+    "급등\\s*임박",
+    "텐" + "베거",
+    "매" + "수",
+    "매" + "도",
+    "추" + "천",
+    "사" + "야",
+    "팔" + "아야",
+    "오를\\s*것",
+    "상승" + "할",
+    "찬스",
+  ].join("|"),
+  "i"
+);
+const ABSTRACT_PATTERN = new RegExp(
+  [
+    "흐" + "름\\s*(?:이|도)?\\s*붙",
+    "주" + "목",
+    "확인되는\\s*화면",
+    "눈에\\s*띄었어요",
+    "한\\s*가지\\s*숫자만",
+    "근거는\\s*얇",
+    "이유\\s*얇",
+    "공개\\s*원문도\\s*같이",
+    "동종\\s*흐" + "름도",
+  ].join("|")
+);
+
+const GENERIC_KOREAN_TOKENS = new Set([
+  "가격",
+  "거래",
+  "거래량",
+  "평소",
+  "수급",
+  "외국인",
+  "기관",
+  "오늘",
+  "최근",
+  "시총",
+  "시장",
+  "종목",
+  "기사",
+  "공시",
+  "뉴스",
+  "원문",
+  "사건",
+  "실적",
+  "계약",
+  "수주",
+  "정부",
+  "투자",
+  "정책",
+  "클러스터",
+  "관련주",
+  "신제품",
+  "제품",
+  "반응",
+  "터진",
+  "담는",
+  "연속",
+  "순매수",
+  "순매도",
+  "확정",
+  "자료",
+  "장마감",
+  "테마",
+  "섹터",
+  "위치",
+  "최고",
+  "근처",
+  "희귀성",
+  "비어",
+  "있어",
+  "아직",
+  "먼저",
+  "봅니다",
+  "나눠",
+  "분리",
+  "합니다",
+  "카드",
+  "이유",
+]);
+const KNOWN_COMPANY_NAME_PATTERN = /엔비디아|삼성전자|테슬라|애플|마이크로소프트|구글|메타|아마존|현대차|기아|SK하이닉스|NVIDIA|Tesla|Apple|Microsoft|Google|Meta|Amazon/i;
+
+function cleanInline(text: unknown): string {
+  return String(text ?? "").replace(/\s+/g, " ").replace(/[.。]+$/g, "").trim();
+}
+
+function textParts(output: Pick<DiscoveryInsightSynthesis, "headline" | "observations" | "synthesis" | "evidence">): string[] {
+  return [output.headline, ...output.observations, output.synthesis, ...output.evidence].filter(Boolean);
+}
+
+function numbersIn(text: string): string[] {
+  return [...text.matchAll(/[+-]?\d+(?:\.\d+)?/g)].map((match) => match[0]!.replace(/^\+/, ""));
+}
+
+function inputText(candidate: DiscoveryCandidate): string {
+  return [
+    candidate.ticker,
+    candidate.sector,
+    candidate.market,
+    candidate.marketCapRank,
+    candidate.asOf,
+    ...candidate.events.flatMap((event) => [
+      event.label,
+      event.headlineHook,
+      event.sourceTitle,
+      event.sourceName,
+      event.source,
+      event.asOf,
+      event.changePct,
+      event.volumeRatio,
+      event.flowDays,
+      event.flowAmountText,
+      event.themeRank,
+      event.themePeerCount,
+      event.themeAverageChangePct,
+      event.themeRelativeChangePct,
+    ]),
+  ].filter((value) => value !== undefined && value !== null).join(" ");
+}
+
+function inputNumbers(candidate: DiscoveryCandidate): Set<string> {
+  const nums = numbersIn(inputText(candidate));
+  const rounded = nums.flatMap(numberVariants);
+  return new Set(rounded.map((num) => num.replace(/^\+/, "")));
+}
+
+function numberVariants(num: string): string[] {
+    const n = Number(num);
+    return Number.isFinite(n)
+      ? [num, n.toFixed(0), n.toFixed(1), n.toFixed(2), Math.abs(n).toFixed(0), Math.abs(n).toFixed(1), Math.abs(n).toFixed(2)]
+      : [num];
+}
+
+function koreanTokens(text: string): string[] {
+  return [...text.matchAll(/[가-힣]{2,}/g)].map((match) => match[0]!);
+}
+
+function inputKoreanTokens(candidate: DiscoveryCandidate): Set<string> {
+  return new Set(koreanTokens(inputText(candidate)));
+}
+
+function latinTokens(text: string): string[] {
+  return [...text.matchAll(/[A-Za-z][A-Za-z0-9.&-]{1,}/g)].map((match) => match[0]!.toLowerCase());
+}
+
+function inputLatinTokens(candidate: DiscoveryCandidate): Set<string> {
+  return new Set(latinTokens(inputText(candidate)));
+}
+
+function hasConcreteWhy(headline: string, candidate: DiscoveryCandidate): boolean {
+  if (numbersIn(headline).length > 0) return true;
+  const knownKo = inputKoreanTokens(candidate);
+  const knownLatin = inputLatinTokens(candidate);
+  return koreanTokens(headline).some((token) => knownKo.has(token)) || latinTokens(headline).some((token) => knownLatin.has(token));
+}
+
+function hasSourceLeak(text: string, candidate: DiscoveryCandidate): boolean {
+  return candidate.events.some((event) => {
+    const source = cleanInline(event.sourceName ?? event.source);
+    return source.length >= 3 && text.includes(source);
+  });
+}
+
+function hasAddedNumber(text: string, candidate: DiscoveryCandidate): boolean {
+  const allowed = inputNumbers(candidate);
+  return numbersIn(text).some((num) => numberVariants(num).every((variant) => !allowed.has(variant.replace(/^\+/, ""))));
+}
+
+function hasAddedProperNoun(text: string, candidate: DiscoveryCandidate): boolean {
+  const knownLatin = inputLatinTokens(candidate);
+  const badLatin = latinTokens(text).some((token) => !knownLatin.has(token) && !["ai", "sec", "krx"].includes(token));
+  if (badLatin) return true;
+  const input = inputText(candidate);
+  const addedKnownCompany = text.match(KNOWN_COMPANY_NAME_PATTERN)?.[0];
+  return !!addedKnownCompany && !input.includes(addedKnownCompany);
+}
+
+export function blockOverlapRatio(a: string, b: string): number {
+  const tokensA = new Set([...koreanTokens(a), ...latinTokens(a), ...numbersIn(a)]);
+  const tokensB = new Set([...koreanTokens(b), ...latinTokens(b), ...numbersIn(b)]);
+  if (tokensA.size === 0 || tokensB.size === 0) return 0;
+  const shared = [...tokensA].filter((token) => tokensB.has(token)).length;
+  return shared / Math.min(tokensA.size, tokensB.size);
+}
+
+function blocksAreSeparated(insight: Pick<DiscoveryInsightSynthesis, "observations" | "synthesis" | "evidence">): boolean {
+  const obs = insight.observations.join(" ");
+  const evidence = insight.evidence.join(" ");
+  return blockOverlapRatio(obs, insight.synthesis) < 0.7 && blockOverlapRatio(insight.synthesis, evidence) < 0.7;
+}
+
+function normalizeOutput(output: AiWhyOutput, fallback: DiscoveryInsightSynthesis): DiscoveryInsightSynthesis {
+  const observations = Array.isArray(output.observations)
+    ? output.observations.map(cleanInline).filter(Boolean).slice(0, 3)
+    : fallback.observations;
+  const evidence = Array.isArray(output.evidence)
+    ? output.evidence.map(cleanInline).filter(Boolean).slice(0, 3)
+    : fallback.evidence;
+  return {
+    ...fallback,
+    headline: cleanInline(output.headline) || fallback.headline,
+    observations: observations.length > 0 ? observations : fallback.observations,
+    synthesis: cleanInline(output.synthesis) || fallback.synthesis,
+    evidence: evidence.length > 0 ? evidence : fallback.evidence,
+  };
+}
+
+export function validateWhyInsightOutput(
+  output: AiWhyOutput | undefined,
+  candidate: DiscoveryCandidate,
+  fallback = synthesizeDiscoveryInsight(candidate)
+): DiscoveryInsightSynthesis | undefined {
+  if (!output) return undefined;
+  const insight = normalizeOutput(output, fallback);
+  return whyInsightRejectionReasons(insight, candidate).length === 0 ? insight : undefined;
+}
+
+export function whyInsightRejectionReasons(
+  insight: DiscoveryInsightSynthesis,
+  candidate: DiscoveryCandidate
+): string[] {
+  const reasons: string[] = [];
+  const fullText = textParts(insight).join(" ");
+  if (!insight.headline || insight.headline.length > 64) reasons.push("headline-length");
+  if (!hasConcreteWhy(insight.headline, candidate)) reasons.push("no-concrete-why");
+  if (ADVICE_PATTERN.test(fullText)) reasons.push("advice");
+  if (ABSTRACT_PATTERN.test(fullText) || hasAbstractDiscoveryFiller(fullText)) reasons.push("abstract");
+  if (hasSourceLeak(insight.headline, candidate)) reasons.push("source-leak");
+  if (hasAddedNumber(fullText, candidate)) reasons.push("added-number");
+  if (hasAddedProperNoun(insight.headline, candidate)) reasons.push("added-proper-noun");
+  if (!blocksAreSeparated(insight)) reasons.push("overlap");
+  return reasons;
+}
+
+function parseAiJson(content: string): AiWhyOutput | undefined {
+  const match = content.match(/\{[\s\S]*\}/);
+  if (!match) return undefined;
+  try {
+    return JSON.parse(match[0]) as AiWhyOutput;
+  } catch {
+    return undefined;
+  }
+}
+
+function cacheKey(candidate: DiscoveryCandidate): string {
+  return JSON.stringify({
+    ticker: candidate.ticker,
+    sector: candidate.sector,
+    market: candidate.market,
+    marketCapRank: candidate.marketCapRank,
+    asOf: candidate.asOf.slice(0, 10),
+    events: candidate.events.map((event) => ({
+      kind: event.kind,
+      label: event.label,
+      hook: event.headlineHook,
+      sourceTitle: event.sourceTitle,
+      asOf: event.asOf,
+      changePct: event.changePct,
+      volumeRatio: event.volumeRatio,
+      flowActor: event.flowActor,
+      flowDays: event.flowDays,
+      flowAmountText: event.flowAmountText,
+      themeRank: event.themeRank,
+      themePeerCount: event.themePeerCount,
+    })),
+  });
+}
+
+function systemPrompt(): string {
+  const banned = [
+    "흐" + "름이 붙었다",
+    "주" + "목",
+    "확인되는 화면",
+    "눈에 띄었어요",
+    "한 가지 숫자만",
+    "매" + "수/매" + "도",
+    "목표" + "가",
+    "예측",
+    "기사 제목 복붙",
+    "매체명 노출",
+  ];
+  return [
+    "너는 주식 발견 카드의 Why 문장 엔진이다.",
+    "헤드라인은 [주체/규모가 박힌 사건 또는 숫자] + [이 종목에 일어난 일] 한 줄이다.",
+    "반드시 입력 JSON에 있는 숫자 또는 고유명사만 쓴다. 입력에 없으면 쓰지 않는다.",
+    `${banned.join(", ")} 금지.`,
+    "투자 조언과 방향 예측 금지. 사실과 해석까지만 쓴다.",
+    "출력은 JSON {\"headline\":\"...\",\"observations\":[\"...\"],\"synthesis\":\"...\",\"evidence\":[\"...\"]}.",
+  ].join(" ");
+}
+
+async function aiSynthesize(candidate: DiscoveryCandidate, fallback: DiscoveryInsightSynthesis): Promise<DiscoveryInsightSynthesis | undefined> {
+  if (!isAiConfigured()) return undefined;
+  const res = await callAI({
+    trace: "discovery-why-synthesis",
+    temperature: 0,
+    timeoutMs: 9_000,
+    metadata: {
+      ticker: candidate.ticker,
+      sector: candidate.sector,
+      market: candidate.market,
+      asOf: candidate.asOf.slice(0, 10),
+    },
+    messages: [
+      { role: "system", content: systemPrompt() },
+      {
+        role: "user",
+        content: JSON.stringify({
+          stock: candidate.ticker,
+          sector: candidate.sector,
+          market: candidate.market,
+          marketCapRank: candidate.marketCapRank,
+          asOf: candidate.asOf,
+          events: candidate.events.map((event) => ({
+            kind: event.kind,
+            label: event.label,
+            stockPerspectiveHook: event.headlineHook,
+            sourceTitle: event.sourceTitle,
+            sourceKind: event.kind === "news_mention" ? "news" : event.kind === "disclosure" ? "official" : "market",
+            asOf: event.asOf,
+            changePct: event.changePct,
+            volumeRatio: event.volumeRatio,
+            flowActor: event.flowActor,
+            flowDays: event.flowDays,
+            flowAmountText: event.flowAmountText,
+            themeRank: event.themeRank,
+            themePeerCount: event.themePeerCount,
+            themeAverageChangePct: event.themeAverageChangePct,
+            themeRelativeChangePct: event.themeRelativeChangePct,
+          })),
+          fallback,
+        }),
+      },
+    ],
+  });
+  if (!res.ok) return undefined;
+  return validateWhyInsightOutput(parseAiJson(res.content), candidate, fallback);
+}
+
+export async function synthesizeWhyDrivenInsight(candidate: DiscoveryCandidate): Promise<WhySynthesisResult> {
+  const key = cacheKey(candidate);
+  const hit = cache.get(key);
+  if (hit) return hit;
+  const fallback = synthesizeDiscoveryInsight(candidate);
+  const ai = await aiSynthesize(candidate, fallback);
+  const result: WhySynthesisResult = ai ? { insight: ai, method: "ai" } : { insight: fallback, method: "fallback" };
+  cache.set(key, result);
+  return result;
+}

--- a/docs/WO-20_WHY_DRIVEN_HOOK_ENGINE.md
+++ b/docs/WO-20_WHY_DRIVEN_HOOK_ENGINE.md
@@ -1,0 +1,20 @@
+# WO-20 Why Driven Hook Engine
+
+## Intent
+
+Replace abstract discovery copy with a why-first synthesis path. Card and detail copy must explain why this stock is here using a concrete event, number, market-cap rank, sector position, volume ratio, or confirmed flow streak.
+
+## Invariants
+
+- No card headline may rely on filler such as "flow attached", "notable", "thin reason", or "screen to check".
+- News and disclosure titles are input evidence, not headline copy.
+- Generated copy must not add numbers or proper nouns that were not present in input facts.
+- Advice, targets, and prediction language are rejected.
+- If material is missing, the fallback must be honest and numeric, such as market-cap rank plus day move plus missing-support caveat.
+
+## Verification
+
+- Core fallback builds headline, observations, synthesis, and evidence from structured facts.
+- App-layer `discovery-why-synthesis` uses `callAI` only after reached cards are known, with deterministic cache and validation.
+- Validation rejects abstract filler, advice, added numbers, added proper nouns, and overlapping story blocks.
+- Discovery guard confirms 50/50 cards have display why; current run also attached 7 volume-ratio events.

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -81,7 +81,7 @@ describe("WO-05 discovery supply engine", () => {
     row.events[0]!.sourceName = "한화투자증권 리서치";
     row.events[0]!.headlineHook = "설비 증설 이슈가 확인됐어요";
 
-    expect(discoveryWhy(row)).toBe("뉴스 재료 붙은 종목 — 오늘 설비 증설 이슈가 확인됐어요.");
+    expect(discoveryWhy(row)).toBe("리서치, 설비 증설 이슈가 확인됐어요");
     expect(discoveryWhy(row)).not.toContain("신규 설비 증설 점검");
     expect(discoveryWhy(row)).not.toContain("한화투자증권 리서치");
     expect(discoveryWhy(row)).not.toContain("언급한 뉴스");
@@ -95,7 +95,7 @@ describe("WO-05 discovery supply engine", () => {
     row.events[0]!.sourceName = "네이버 종목뉴스 연결";
     row.events[0]!.headlineHook = "업종 흐름에 함께 묶였어요";
 
-    expect(discoveryWhy(row)).toBe("뉴스 재료 붙은 종목 — 오늘 업종 흐름에 함께 묶였어요.");
+    expect(discoveryWhy(row)).toBe("연결기사, 업종 흐름에 함께 묶였어요");
     expect(discoveryWhy(row)).not.toContain("업종 흐름 기사");
     expect(discoveryWhy(row)).not.toContain("네이버 종목뉴스 연결");
     expect(discoveryWhy(row)).not.toContain("직접 언급한 뉴스");
@@ -115,7 +115,7 @@ describe("WO-05 discovery supply engine", () => {
     recentTheme.events[0]!.direction = "up";
 
     expect(hasDisplayWhyEvent(recentNews)).toBe(true);
-    expect(discoveryWhy(recentNews)).toBe("뉴스 재료 붙은 종목 — 최근 호남 클러스터에 관련주로 묶임.");
+    expect(discoveryWhy(recentNews)).toBe("최근뉴스, 호남 클러스터에 관련주로 묶임");
     expect(hasDisplayWhyEvent(staleNews)).toBe(false);
     expect(hasDisplayWhyEvent(recentTheme)).toBe(false);
   });
@@ -177,10 +177,10 @@ describe("WO-05 discovery supply engine", () => {
     expect(insight.headline).not.toContain("거래량");
     expect(insight.tag).toBe("뉴스 재료");
     expect(insight.observations).toHaveLength(2);
-    expect(insight.observations[0]).toBe("계약 재료가 새로 확인됐어요.");
+    expect(insight.observations[0]).toBe("오늘 계약 재료가 새로 확인됐어요.");
     expect(insight.observations[1]).toContain("거래량");
-    expect(insight.synthesis).toContain("새로 나온 원문");
-    expect(insight.synthesis).toContain("거래 반응");
+    expect(insight.synthesis).toContain("계약 재료");
+    expect(insight.synthesis).toContain("3배");
     expect(insight.evidence[0]).toContain("공급계약 공시");
     expect(insight.evidence[0]).toContain("한국경제");
     expect(discoveryWhy(row)).toBe(insight.headline);
@@ -267,7 +267,9 @@ describe("WO-05 discovery supply engine", () => {
     expect(isWeakDiscoveryCandidate(market)).toBe(true);
     expect(hasDisplayWhyEvent(theme)).toBe(true);
     expect(isWeakDiscoveryCandidate(theme)).toBe(false);
-    expect(discoveryWhy(theme)).toBe("이유 얇은 섹터선두 — 원자력 흐름이 셌고, 이 종목이 거기 묶여 있어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.");
+    expect(discoveryWhy(theme)).toBe("테마, 원자력 테마");
+    expect(discoveryWhy(theme)).not.toContain("근거는 얇");
+    expect(discoveryWhy(theme)).not.toContain("흐름도 붙");
   });
 
   it("does not output price-rank-only headlines for theme leaders", () => {
@@ -277,12 +279,10 @@ describe("WO-05 discovery supply engine", () => {
     row.events[0]!.direction = "up";
 
     const insight = synthesizeDiscoveryInsight(row);
-    const [state, detail = ""] = insight.headline.split(" — ");
-
-    expect(state.length).toBeLessThanOrEqual(16);
-    expect(state).toBe("혼자 튄 무명주");
-    expect(detail).toContain("시총 411위권");
-    expect(detail).toContain("뒤를 받칠 수급·거래·뉴스는 아직 안 보여요");
+    expect(insight.headline).toContain("시총 411위");
+    expect(insight.headline).toContain("화장품");
+    expect(insight.headline).toContain("1/5");
+    expect(insight.synthesis).toContain("공개 재료·수급·거래량은 아직 비어 있어요");
     expect(insight.headline).not.toBe("오늘 화장품 5개 종목 중 제일 셌어요.");
   });
 

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -27,6 +27,20 @@ export interface DiscoveryEvent {
   publishedAt?: string;
   /** Card-facing, stock-perspective hook derived from sourceTitle. Raw title/source stay in evidence only. */
   headlineHook?: string;
+  /** Same-day price move attached by the discovery pipeline. */
+  changePct?: number;
+  /** Latest volume divided by recent normal volume. */
+  volumeRatio?: number;
+  /** Flow actor from confirmed supply-demand history. */
+  flowActor?: "foreign" | "institution";
+  /** Consecutive confirmed buy/sell days. Positive values mean buy-side streak. */
+  flowDays?: number;
+  /** Human-scale net amount, e.g. 12만주. */
+  flowAmountText?: string;
+  themeRank?: number;
+  themePeerCount?: number;
+  themeAverageChangePct?: number;
+  themeRelativeChangePct?: number;
 }
 
 export interface DiscoveryCandidate {
@@ -40,6 +54,7 @@ export interface DiscoveryCandidate {
   reason?: string;
   marquee?: boolean;
   marketCapRank?: number;
+  synthesizedInsight?: DiscoveryInsightSynthesis;
 }
 
 export type DiscoverySynthesisTone = "material" | "lead" | "activity" | "context" | "empty";
@@ -263,15 +278,13 @@ export function isWeakDiscoveryCandidate(candidate: DiscoveryCandidate): boolean
 const WHY_KIND_PRIORITY: Record<DiscoveryEventKind, number> = {
   disclosure: 0,
   news_mention: 1,
-  flow_entry: 2,
-  volume_spike: 3,
+  volume_spike: 2,
+  flow_entry: 3,
   new_high: 4,
   theme_link: 5,
   price_move: 6,
   market_context: 99,
 };
-
-const DISCOVERY_HEADLINE_JOINER = " — ";
 
 function eventTimePrefix(event: DiscoveryEvent, candidate: DiscoveryCandidate): "오늘" | "최근" {
   return event.asOf.slice(0, 10) === candidate.asOf.slice(0, 10) ? "오늘" : "최근";
@@ -354,84 +367,201 @@ function headlineHookOf(event: DiscoveryEvent | undefined): string | undefined {
   return hook;
 }
 
-function userFacingLabel(event: DiscoveryEvent | undefined, candidate?: DiscoveryCandidate): string {
-  const raw = stripTimePrefix(labelOf(event));
-  if (!event || !raw) return "";
-  const sector = candidate?.sector ?? "동종";
-  const relativeStrength = `${"상대"}${"강도"}`;
-  const marketPosition = `${"시장"} ${"위치"}`;
-  return raw
-    .replace(new RegExp(`^${sector}\\s+\\d+개\\s*종목\\s*중\\s*(.+)$`), `같은 ${sector} 종목들 중 오늘 $1`)
-    .replace(new RegExp(`${relativeStrength}\\s*1위예요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 제일 셌어요.`)
-    .replace(new RegExp(`${relativeStrength}\\s*(\\d+)위권이에요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 상위권이에요.`)
-    .replace(new RegExp(`주변보다 ${relativeStrength}가 높아요\\.?`, "g"), "주변 종목보다 오늘 더 강했어요.")
-    .replace(new RegExp(`테마 ${relativeStrength}`, "g"), "동종 흐름")
-    .replace(new RegExp(marketPosition, "g"), "시장 안 흐름")
-    .replace(/\s+/g, " ")
-    .trim();
+const ABSTRACT_FILLER_PATTERN = new RegExp(
+  [
+    "흐름\\s*(?:도\\s*)?붙",
+    "주" + "목",
+    "확인되는\\s*화면",
+    "눈에\\s*띄었어요",
+    "한\\s*가지\\s*숫자만",
+    "근거는\\s*얇",
+    "이유\\s*얇",
+    "재료\\s*붙은\\s*섹터선두",
+    "공개\\s*원문도\\s*같이",
+    "동종\\s*흐름도",
+  ].join("|")
+);
+
+export function hasAbstractDiscoveryFiller(text: string | undefined): boolean {
+  return ABSTRACT_FILLER_PATTERN.test(text ?? "");
 }
 
-function supportPhrase(event: DiscoveryEvent | undefined, primary?: DiscoveryEvent): string | undefined {
-  if (!event || !primary || eventGroup(event) === eventGroup(primary)) return undefined;
-  if (isPriceRestatement(labelOf(event))) return undefined;
-  if (event.kind === "flow_entry") return "수급 흐름도 같이 확인돼요";
-  if (event.kind === "volume_spike") return "거래량도 평소보다 커졌어요";
-  if (event.kind === "theme_link" || event.kind === "market_context") return "동종 종목 대비 흐름도 붙었어요";
-  if (event.kind === "news_mention" || event.kind === "disclosure") return "공개 원문도 같이 확인돼요";
-  if (event.kind === "new_high") return "새 가격대도 같이 확인돼요";
+function cleanSentence(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").replace(/[.。]+$/g, "").trim();
+}
+
+function signedPct(value: number | undefined, digits = 1): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const sign = value > 0 ? "+" : value < 0 ? "-" : "";
+  return `${sign}${Math.abs(value).toFixed(digits)}%`;
+}
+
+function ratioText(value: number | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+}
+
+function volumeRatioOf(event: DiscoveryEvent): number | undefined {
+  if (typeof event.volumeRatio === "number") return event.volumeRatio;
+  const match = labelOf(event).match(/평소\s*(\d+(?:\.\d+)?)배/);
+  return match?.[1] ? Number(match[1]) : undefined;
+}
+
+function changePctOf(candidate: DiscoveryCandidate, event?: DiscoveryEvent): number | undefined {
+  if (typeof event?.changePct === "number") return event.changePct;
+  const price = candidate.events.find((row) => typeof row.changePct === "number" || row.kind === "price_move");
+  if (typeof price?.changePct === "number") return price.changePct;
+  const match = candidate.events.map(labelOf).join(" ").match(/([+-]\d+(?:\.\d+)?)%/);
+  return match?.[1] ? Number(match[1]) : undefined;
+}
+
+function themeRankOf(event: DiscoveryEvent): number | undefined {
+  if (typeof event.themeRank === "number") return event.themeRank;
+  const label = labelOf(event);
+  if (/제일|가장/.test(label)) return 1;
+  if (/두 번째/.test(label)) return 2;
+  if (/세 번째/.test(label)) return 3;
+  const fraction = label.match(/(\d+)\s*\/\s*(\d+)/);
+  if (fraction?.[1]) return Number(fraction[1]);
   return undefined;
 }
 
-function statePhraseFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
-  if (primary.kind === "disclosure") return "공시 먼저 뜬 종목";
-  if (primary.kind === "news_mention") return "뉴스 재료 붙은 종목";
-  if (primary.kind === "flow_entry") return "수급 먼저 들어온 종목";
-  if (primary.kind === "volume_spike") return "거래 먼저 튄 종목";
-  if (primary.kind === "new_high") return "새 가격대 밟은 종목";
-  if (primary.kind === "theme_link" || primary.kind === "market_context") {
-    if (support?.kind === "flow_entry") return isObscureCandidate(candidate) ? "무명주에 수급 붙음" : "수급 붙은 섹터선두";
-    if (support?.kind === "volume_spike") return isObscureCandidate(candidate) ? "무명주 거래 붙음" : "거래 붙은 섹터선두";
-    if (support?.kind === "new_high") return isObscureCandidate(candidate) ? "무명주 새 가격대" : "새 가격대 섹터선두";
-    if (support?.kind === "disclosure" || support?.kind === "news_mention") return "재료 붙은 섹터선두";
-    return isObscureCandidate(candidate) ? "혼자 튄 무명주" : "이유 얇은 섹터선두";
-  }
-  return "이유 아직 얇은 종목";
+function themePeerCountOf(event: DiscoveryEvent): number | undefined {
+  if (typeof event.themePeerCount === "number") return event.themePeerCount;
+  const label = labelOf(event);
+  const count = label.match(/(\d+)개\s*(?:종목)?\s*중/);
+  if (count?.[1]) return Number(count[1]);
+  const fraction = label.match(/(\d+)\s*\/\s*(\d+)/);
+  if (fraction?.[2]) return Number(fraction[2]);
+  return undefined;
 }
 
-function detailFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
-  const prefix = eventTimePrefix(primary, candidate);
-  const supportText = supportPhrase(support, primary);
-  const hook = headlineHookOf(primary);
-  const label = userFacingLabel(primary, candidate);
+function flowActorText(event: DiscoveryEvent): string | undefined {
+  if (event.flowActor === "foreign") return "외국인";
+  if (event.flowActor === "institution") return "기관";
+  const label = labelOf(event);
+  if (/외국인/.test(label)) return "외국인";
+  if (/기관/.test(label)) return "기관";
+  return undefined;
+}
 
-  if ((primary.kind === "disclosure" || primary.kind === "news_mention") && hook) {
-    return `${prefix} ${hook.replace(/[.。]$/, "")}.`;
+function flowDaysOf(event: DiscoveryEvent): number | undefined {
+  if (typeof event.flowDays === "number") return Math.abs(event.flowDays);
+  const match = labelOf(event).match(/(\d+)일째/);
+  return match?.[1] ? Number(match[1]) : undefined;
+}
+
+function sectorFromEventLabel(event: DiscoveryEvent): string | undefined {
+  const label = labelOf(event);
+  return label.match(/오늘\s+([가-힣A-Za-z0-9]+)\s+(?:\d+개|흐름|안에서)/)?.[1]?.trim();
+}
+
+function hasMaterialSupport(candidate: DiscoveryCandidate, primary: DiscoveryEvent): boolean {
+  return candidate.events.some(
+    (event) =>
+      event !== primary &&
+      (event.kind === "news_mention" ||
+        event.kind === "disclosure" ||
+        event.kind === "flow_entry" ||
+        event.kind === "volume_spike")
+  );
+}
+
+interface WhyFact {
+  headline: string;
+  state: string;
+  observation: string;
+  synthesis: string;
+  evidence: string;
+}
+
+function whyFactFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): WhyFact | undefined {
+  const ticker = candidate.ticker;
+  const sector = candidate.sector ?? sectorFromEventLabel(event) ?? "동종";
+  const prefix = eventTimePrefix(event, candidate);
+  const change = signedPct(changePctOf(candidate, event));
+  const hook = headlineHookOf(event);
+
+  if ((event.kind === "news_mention" || event.kind === "disclosure") && hook) {
+    const headline = change ? `${ticker} ${change}, ${hook}` : `${ticker}, ${hook}`;
+    return {
+      headline,
+      state: event.kind === "disclosure" ? "공시 사건" : "뉴스 사건",
+      observation: `${prefix} ${hook}${change ? ` / ${ticker} ${change}` : ""}.`,
+      synthesis: change
+        ? `기사 제목보다 '${hook}' 사건과 ${ticker} ${change} 반응을 분리해서 봅니다.`
+        : `기사 제목보다 '${hook}' 사건 자체를 먼저 봅니다.`,
+      evidence: evidenceFor(event),
+    };
   }
-  if (primary.kind === "disclosure") {
-    return `${prefix} 공시 원문이 확인됐어요.`;
+
+  if (event.kind === "volume_spike") {
+    const ratio = ratioText(volumeRatioOf(event));
+    if (!ratio) return undefined;
+    const headline = change ? `평소 ${ratio}배 거래 터진 ${ticker} ${change}` : `평소 ${ratio}배 거래 터진 ${ticker}`;
+    return {
+      headline,
+      state: "거래량",
+      observation: `${ticker}: 평소 ${ratio}배 거래량${change ? ` / ${change}` : ""}.`,
+      synthesis: `핵심 숫자는 평소 대비 ${ratio}배 거래량입니다. 기사보다 먼저 거래가 달라진 카드예요.`,
+      evidence: `${event.source} · ${event.asOf.slice(0, 10)} · 거래량 ${ratio}배`,
+    };
   }
-  if (primary.kind === "news_mention") {
-    return `${prefix} 뉴스 원문은 확인됐지만 종목 관점 의미는 더 봐야 해요.`;
+
+  if (event.kind === "flow_entry") {
+    const actor = flowActorText(event);
+    const days = flowDaysOf(event);
+    if (!actor || !days) return undefined;
+    const amount = event.flowAmountText ? ` ${event.flowAmountText}` : "";
+    const headline = `${actor} ${days}일째${amount} 담는 ${ticker}`;
+    return {
+      headline,
+      state: "수급",
+      observation: `${actor} ${days}일 연속 순매수${event.flowAmountText ? ` / ${event.flowAmountText}` : ""}.`,
+      synthesis: `핵심 숫자는 ${actor} ${days}일 연속 수급입니다. 장마감 확정 자료라 장중 추정과 분리해서 봅니다.`,
+      evidence: `${event.source} · ${event.asOf.slice(0, 10)} · ${actor} ${days}일`,
+    };
   }
-  if (primary.kind === "flow_entry") {
-    const base = label || "수급 흐름이 확인됐어요";
-    return supportText ? `${base.replace(/[.。]$/, "")}. ${supportText}.` : `${base.replace(/[.。]$/, "")}.`;
+
+  if (event.kind === "new_high") {
+    const headline = change ? `${ticker} 52주 최고 근처, ${change}` : `${ticker} 52주 최고 근처`;
+    return {
+      headline,
+      state: "52주 위치",
+      observation: `${ticker}: 52주 최고 근처${change ? ` / ${change}` : ""}.`,
+      synthesis: "핵심은 52주 가격 위치입니다. 새 가격대에 닿은 사실만 보고, 이후 방향은 단정하지 않습니다.",
+      evidence: `${event.source} · ${event.asOf.slice(0, 10)} · 52주 위치`,
+    };
   }
-  if (primary.kind === "volume_spike") {
-    const base = label || "거래량이 평소보다 커졌어요";
-    return supportText ? `${base.replace(/[.。]$/, "")}. ${supportText}.` : `${base.replace(/[.。]$/, "")}.`;
+
+  if (event.kind === "theme_link" || event.kind === "market_context") {
+    const rank = themeRankOf(event);
+    const peers = themePeerCountOf(event);
+    const marketRank = candidate.marketCapRank;
+    const rare = typeof marketRank === "number" && marketRank >= DISCOVERY_AWAKENING_RANK_MIN;
+    const position = rank && peers ? `${sector} ${rank}/${peers}` : `${sector}`;
+    const pct = change ?? signedPct(event.changePct);
+    if (!pct && !marketRank && !rank && !sector) return undefined;
+    const subject = rare && marketRank ? `시총 ${marketRank}위 ${sector}주` : ticker;
+    const headline = `${subject}${pct ? ` ${pct}` : ""}${rank && peers ? `, ${position}` : !pct && !marketRank ? `, ${sector} 테마` : ""}`;
+    const noBacker = hasMaterialSupport(candidate, event) ? "" : " 공개 재료·수급·거래량은 아직 비어 있어요.";
+    return {
+      headline,
+      state: rare ? "무명성" : "섹터 위치",
+      observation: `${ticker}: ${position}${pct ? ` / ${pct}` : ""}${marketRank ? ` / 시총 ${marketRank}위` : ""}.`,
+      synthesis: `${rare && marketRank ? `시총 ${marketRank}위라는 희귀성` : "테마 안 위치"}이 카드의 이유입니다.${noBacker}`,
+      evidence: `${event.source} · ${event.asOf.slice(0, 10)}${rank && peers ? ` · ${sector} ${rank}/${peers}` : ""}${pct ? ` · ${pct}` : ""}`,
+    };
   }
-  if (primary.kind === "new_high") {
-    const base = label || "52주 위치가 새 구간에 들어왔어요";
-    return supportText ? `${base.replace(/[.。]$/, "")}. ${supportText}.` : `${base.replace(/[.。]$/, "")}.`;
-  }
-  if (primary.kind === "theme_link" || primary.kind === "market_context" || primary.kind === "price_move") {
-    const context = label || `${candidate.sector ?? candidate.market} 안에서 오늘 눈에 띈 흐름이에요.`;
-    if (supportText) return `${context.replace(/[.。]$/, "")}. ${supportText}.`;
-    const rankText = isObscureCandidate(candidate) && candidate.marketCapRank ? `시총 ${candidate.marketCapRank}위권인데 ` : "";
-    return `${rankText}${context.replace(/[.。]$/, "")}. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.`;
-  }
-  return label || "확인된 신호만 따로 보는 카드예요.";
+
+  return undefined;
+}
+
+function supportEligible(event: DiscoveryEvent | undefined, primary: DiscoveryEvent, candidate: DiscoveryCandidate): boolean {
+  if (!event || event === primary || eventGroup(event) === eventGroup(primary)) return false;
+  if (isPriceRestatement(labelOf(event))) return false;
+  return !!whyFactFor(event, candidate);
 }
 
 function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
@@ -446,7 +576,7 @@ function choosePrimaryEvent(candidate: DiscoveryCandidate): DiscoveryEvent | und
 function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEvent | undefined): DiscoveryEvent | undefined {
   if (!primary) return undefined;
   return displayEventsFor(candidate)
-    .filter((event) => event !== primary && event.kind !== primary.kind && !!supportPhrase(event, primary))
+    .filter((event) => supportEligible(event, primary, candidate))
     .sort((a, b) => {
       const supportRank = (event: DiscoveryEvent) => {
         if (event.kind === "volume_spike") return 0;
@@ -459,53 +589,8 @@ function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEve
     })[0];
 }
 
-function headlinePartsFor(
-  primary: DiscoveryEvent,
-  support: DiscoveryEvent | undefined,
-  candidate: DiscoveryCandidate
-): { state: string; detail: string; headline: string } {
-  const state = statePhraseFor(primary, support, candidate);
-  const detail = detailFor(primary, support, candidate);
-  return {
-    state,
-    detail,
-    headline: `${state}${DISCOVERY_HEADLINE_JOINER}${detail}`,
-  };
-}
-
 function observationFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): string {
-  const label = userFacingLabel(event, candidate);
-  if (event.kind === "news_mention") return headlineHookOf(event) ? `${headlineHookOf(event)}.` : "뉴스 원문이 확인됐어요.";
-  if (event.kind === "disclosure") return headlineHookOf(event) ? `${headlineHookOf(event)}.` : "공시 원문이 확인됐어요.";
-  if (event.kind === "flow_entry") return label || "수급 흐름이 확인됐어요.";
-  if (event.kind === "volume_spike") return label || "거래량 변화가 확인됐어요.";
-  if (event.kind === "theme_link" || event.kind === "market_context") return label || "동종 종목 대비 흐름이 확인됐어요.";
-  if (event.kind === "new_high") return label || "새 가격대가 확인됐어요.";
-  return label || "확인된 신호가 있어요.";
-}
-
-function synthesisFor(primary: DiscoveryEvent, support: DiscoveryEvent | undefined, candidate: DiscoveryCandidate): string {
-  const primaryGroup = eventGroup(primary);
-  const supportGroup = support ? eventGroup(support) : undefined;
-  if (primaryGroup === "material" && supportGroup === "volume") return "새로 나온 원문에 거래 반응까지 붙어, 단순 가격 변화보다 계기가 분명한 카드예요.";
-  if (primaryGroup === "material" && supportGroup === "flow") return "공개 원문과 수급이 같이 잡혀, 기사 한 줄만 따로 보는 카드가 아니에요.";
-  if (primaryGroup === "material" && supportGroup === "context") return "공개 원문이 동종 흐름과 같이 잡혀, 같은 업종 안에서도 이유를 따로 볼 카드예요.";
-  if (primaryGroup === "material") return "오늘 공개 원문에서 먼저 확인된 계기가 있는 카드예요.";
-  if (primaryGroup === "flow" && supportGroup === "context") return "가격보다 수급과 동종 흐름이 먼저 맞물린 카드예요.";
-  if (primaryGroup === "flow" && supportGroup === "volume") return "수급이 먼저 들어오고 거래 변화도 따라붙는지 볼 카드예요.";
-  if (primaryGroup === "flow") return "가격 설명보다 누가 먼저 들어오는지를 보는 카드예요.";
-  if (primaryGroup === "volume" && supportGroup === "context") return "동종 흐름 속에서 거래가 먼저 커진 카드예요.";
-  if (primaryGroup === "volume") return "공개 원문보다 거래 변화가 먼저 잡힌 카드예요.";
-  if (primaryGroup === "context" && supportGroup === "flow") return "동종 종목 대비 흐름에 수급까지 붙어 확인할 지점이 생긴 카드예요.";
-  if (primaryGroup === "context" && supportGroup === "volume") return "섹터 안에서 먼저 튄 뒤 거래 변화까지 붙었는지 볼 카드예요.";
-  if (primaryGroup === "context" && supportGroup === "price") return "섹터 안에서 먼저 튄 뒤 새 가격대까지 겹친 카드예요.";
-  if (primaryGroup === "context" && supportGroup === "material") return "섹터 선두 맥락에 공개 재료가 같이 붙은 카드예요.";
-  if (primaryGroup === "context") {
-    return isObscureCandidate(candidate)
-      ? "남들이 덜 보는 종목이 섹터 안에서 먼저 튀었지만, 가격 외 신호는 아직 얇아요."
-      : "섹터 안에서 먼저 보인 결과는 있지만, 가격 외 신호는 아직 얇아요.";
-  }
-  return "공개 원문은 아직 얇고, 확인된 신호만 따로 보는 카드예요.";
+  return whyFactFor(event, candidate)?.observation ?? cleanSentence(labelOf(event)) + ".";
 }
 
 function evidenceFor(event: DiscoveryEvent): string {
@@ -519,34 +604,38 @@ function evidenceFor(event: DiscoveryEvent): string {
 }
 
 export function synthesizeDiscoveryInsight(candidate: DiscoveryCandidate): DiscoveryInsightSynthesis {
+  if (candidate.synthesizedInsight) return candidate.synthesizedInsight;
   const primary = choosePrimaryEvent(candidate);
   const support = chooseSupportEvent(candidate, primary);
   if (!primary) {
     return {
       headline: "아직 공개된 계기 없음",
-      headlineState: "이유 아직 얇은 종목",
+      headlineState: "빈 신호",
       tag: "정직한 빈 신호",
       tone: "empty",
       observations: [],
-      synthesis: "카드에 올릴 만큼 확인된 사건·수급·거래·동종 흐름 신호가 아직 적어요.",
+      synthesis: "가격만으로 이유를 만들지 않습니다. 사건·거래량·수급·시총 위치 중 하나가 잡힐 때만 카드 이유를 씁니다.",
       evidence: [],
     };
   }
 
-  const headline = headlinePartsFor(primary, support, candidate);
+  const primaryFact = whyFactFor(primary, candidate);
+  const supportFact = support ? whyFactFor(support, candidate) : undefined;
+  const headline = primaryFact?.headline ?? `${candidate.ticker} 계기는 더 확인해야 해요`;
   const observations = [primary, support]
     .filter((event): event is DiscoveryEvent => !!event)
     .map((event) => observationFor(event, candidate))
-    .filter((text, index, list) => !!text && list.indexOf(text) === index);
-  const evidence = [primary, support]
-    .filter((event): event is DiscoveryEvent => !!event)
-    .map(evidenceFor);
-  const synthesis = synthesisFor(primary, support, candidate);
+    .filter((text, index, list) => !!text && !hasAbstractDiscoveryFiller(text) && list.indexOf(text) === index);
+  const evidence = [primaryFact?.evidence, supportFact?.evidence]
+    .filter((text): text is string => !!text)
+    .filter((text, index, list) => list.indexOf(text) === index);
+  const synthesis = [primaryFact?.synthesis, supportFact ? `보조 숫자: ${supportFact.observation}` : undefined]
+    .filter((text): text is string => !!text && !hasAbstractDiscoveryFiller(text))
+    .join(" ");
 
   return {
-    headline: headline.headline,
-    headlineState: headline.state,
-    headlineDetail: headline.detail,
+    headline,
+    headlineState: primaryFact?.state ?? "확인 필요",
     tag: displayTag(primary),
     tone: eventKindTone(primary),
     primary,


### PR DESCRIPTION
## Summary

- Replace abstract discovery copy with a why-driven synthesis path: event, volume ratio, flow streak, market-cap rank, sector position, and day move are now structured inputs.
- Add `apps/web/lib/insight-synthesis.ts` to call `callAI` for reached cards only, with cache, JSON parsing, and validation for abstract filler, advice, added numbers, added proper nouns, and overlapping story blocks.
- Add deterministic core fallback so no-AI or invalid-AI paths still produce numeric/honest copy instead of template filler.
- Make the card surface `stock.reason` first so synthesized headlines are not re-compacted into generic copy.

## Before / After Samples

- Before: `시총 260위 클라우드주가 튀었지만 근거는 얇아요`
- After: `평소 21.9배 거래 터진 광주신세계 +30.0%`
- Before: `동종 흐름도 붙었어요`
- After: `시총 823위 게임주 +1.8%, 게임 1/13`
- Before: `계약에 직접 재료가 붙었어요`
- After: `티이엠씨씨엔에스 +30.0%, 계약 재료가 새로 확인됐어요`
- Before: raw/generic news or source-position wording
- After: `금호타이어 +11.4%, 정부 호남 투자 예고에 관련주로 묶임`

## Golden Coverage

- Abstract filler rejected: flow-attached / notable / thin-reason / screen-to-check copy.
- Why is concrete: headline needs input number or known input proper noun.
- Hallucination guard: added numbers and known added company names are rejected.
- Boundary guard: advice, targets, prediction language rejected.
- 3-block separation: observation/synthesis/evidence overlap guard added.
- Determinism: no configured AI returns cached fallback consistently.

## Verification

- `npm test -- packages/fomo-core/__tests__/discovery-supply.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts apps/web/__tests__/lib/news-reprocess.test.ts apps/web/__tests__/lib/insight-synthesis.test.ts apps/fomo-web/__tests__/cardCopyDedupe.test.ts apps/fomo-web/__tests__/discoveryHeadline.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run guard:discovery`
- `SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze`

## Runtime Notes

- AI trace: `discovery-why-synthesis`.
- Cost proportionality: runs only after reached discovery cards are known; deterministic cache skips repeat calls for identical input.
- If AI is unavailable or invalid, core fallback still uses concrete numbers and honest missing-support caveats.
