### PR TITLE
feat(data): enrich stock insights with DART links and FRED macro facts

### DIFF
--- a/apps/fomo-web/__tests__/discoveryHeadline.test.ts
+++ b/apps/fomo-web/__tests__/discoveryHeadline.test.ts
@@ -7,6 +7,7 @@ describe("compactDiscoveryCardHeadline", () => {
       compactDiscoveryCardHeadline({
         reason: "뉴스 재료 붙은 종목 — 최근 '해외 수주 2배' 마키나락스...장중 20% 가까이 급등 · 뉴시스. 동종 흐름도 같이 확인돼요.",
         sector: "AI",
+        ticker: "마키나락스",
         marketCapRank: 236,
       })
     ).toBe("해외 수주에 동종 흐름도 붙었어요");
@@ -17,8 +18,21 @@ describe("compactDiscoveryCardHeadline", () => {
       compactDiscoveryCardHeadline({
         reason: "혼자 튄 무명주 — 시총 411위권인데 같은 화장품 종목들 중 오늘 제일 셌어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.",
         sector: "화장품",
+        ticker: "한국화장품제조",
       })
-    ).toBe("시총 411위 화장품주가 튀었지만 근거는 얇아요");
+    ).toBe("K뷰티 수요를 보는 종목, 원문 근거는 아직 얇아요");
+  });
+
+  it("does not expose market-cap rank or peer-rank shorthand on the card front", () => {
+    const headline = compactDiscoveryCardHeadline({
+      reason: "혼자 튄 무명주 — 시총 420위권인데 같은 전기차 종목들 중 오늘 제일 셌어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.",
+      sector: "전기차",
+      ticker: "루시드",
+      marketCapRank: 420,
+    });
+
+    expect(headline).toBe("프리미엄 전기차 수요를 보는 루시드, 원문 근거는 아직 얇아요");
+    expect(headline).not.toMatch(/시총|\d+\/\d+|[+-]\d/);
   });
 
   it("does not expose the split reason as a second line contract", () => {

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -445,11 +445,6 @@ function formatRatio(value: number): string {
   return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}배`;
 }
 
-function formatSignedPct(value: number): string {
-  const sign = value > 0 ? "+" : value < 0 ? "-" : "";
-  return `${sign}${Math.abs(value).toFixed(1)}%`;
-}
-
 function frontSignalMetrics(front: StockFrontResponse | null): BasicMetricView[] {
   if (!front) return [];
   const s = front.signals;
@@ -496,12 +491,14 @@ function frontSignalMetrics(front: StockFrontResponse | null): BasicMetricView[]
     typeof s.themePeerCount === "number" &&
     s.themePeerCount > 0
   ) {
+    const themeLabel = cleanText(s.themeLabel);
+    const themePosition = s.themeRelativeRank <= 1 ? `${themeLabel} 상위 흐름` : `${themeLabel} 동종 흐름`;
     metrics.push({
       label: "테마 안 위치",
-      value: `${cleanText(s.themeLabel)} ${s.themeRelativeRank}/${s.themePeerCount}`,
+      value: themePosition,
       term: "상대 흐름",
       ...(typeof s.themeRelativeChangePct === "number"
-        ? { note: `테마 평균 대비 ${formatSignedPct(s.themeRelativeChangePct)} 차이예요.` }
+        ? { note: `동종 종목 흐름과 비교한 위치예요.` }
         : {}),
     });
   }
@@ -608,7 +605,7 @@ function stockWatchPoint(front: StockFrontResponse | null): string {
     return `평소 ${formatRatio(s.volumeRatio)} 거래가 며칠 이어지는지 봐요.`;
   }
   if (s.themeLabel && typeof s.themeRelativeRank === "number" && typeof s.themePeerCount === "number") {
-    return `${cleanText(s.themeLabel)} 안에서 ${s.themeRelativeRank}/${s.themePeerCount} 위치가 유지되는지 봐요.`;
+    return `${cleanText(s.themeLabel)} 동종 흐름보다 먼저 보인 이유가 이어지는지 봐요.`;
   }
   if (front.changeDir === "up" && front.changeText) {
     return `오늘 오른 가격대에서 거래가 붙는지 봐요.`;

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -568,6 +568,7 @@ export function StockSwipeDeck({
       const discoveryHeadline = nonPriceOnlyHeadline(stock.reason) ?? compactDiscoveryCardHeadline({
         reason: stock.reason,
         sector: stock.sector,
+        ticker: stock.canonical,
       });
       const view: FomoCardView = {
         scoreText: "",
@@ -586,6 +587,7 @@ export function StockSwipeDeck({
       compactDiscoveryCardHeadline({
         reason: stock.reason,
         sector: stock.sector,
+        ticker: stock.canonical,
         marketCapRank: e?.signals.marketCapRank?.rank,
       });
     const reasonHeadlineSeed = surfaceReasonHeadline ?? compactReasonHeadlineSeed(stock.reason);
@@ -627,8 +629,8 @@ export function StockSwipeDeck({
     };
   };
   const rankLabelFor = (stock: DeckStock): string | undefined => {
-    const r = front[stock.canonical]?.signals.marketCapRank;
-    return r ? `시총 ${r.rank}위` : undefined; // 시장명은 1행에 이미 있음(중복 방지)
+    void stock;
+    return undefined;
   };
   const whyFor = (stock: DeckStock): string => {
     const e = front[stock.canonical];

--- a/apps/fomo-web/lib/discoveryHeadline.ts
+++ b/apps/fomo-web/lib/discoveryHeadline.ts
@@ -3,6 +3,7 @@ const DISCOVERY_REASON_JOINER = " — ";
 export interface DiscoveryHeadlineInput {
   reason?: string | undefined;
   sector?: string | undefined;
+  ticker?: string | undefined;
   marketCapRank?: number | undefined;
 }
 
@@ -68,21 +69,57 @@ function sectorFromDetail(detail: string, fallback?: string): string {
   return fallback?.trim() || "섹터";
 }
 
-function rankFromDetail(detail: string, fallback?: number): number | undefined {
-  if (typeof fallback === "number" && Number.isFinite(fallback)) return fallback;
-  const match = detail.match(/시총\s+(\d+)위/);
-  return match?.[1] ? Number(match[1]) : undefined;
-}
-
 function clipped(text: string, max = 34): string {
   const clean = cleanInline(text);
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
+const SECTOR_THESIS: Array<{ pattern: RegExp; subject: string }> = [
+  { pattern: /전기차|자동차|모빌리티/, subject: "전기차 수요를 보는 종목" },
+  { pattern: /클라우드|데이터|소프트웨어|AI/, subject: "AI·데이터 인프라를 보는 종목" },
+  { pattern: /반도체|기판|장비|소재/, subject: "반도체 장비·소재 흐름을 보는 종목" },
+  { pattern: /바이오|제약|헬스케어/, subject: "임상·신약 모멘텀을 보는 종목" },
+  { pattern: /화장품|뷰티/, subject: "K뷰티 수요를 보는 종목" },
+  { pattern: /유통|백화점|소비/, subject: "소비 회복 흐름을 보는 종목" },
+  { pattern: /금융|보험|증권|은행/, subject: "금리·금융 업황을 보는 종목" },
+  { pattern: /에너지|전력|원전|태양광|풍력/, subject: "전력·에너지 투자 흐름을 보는 종목" },
+  { pattern: /건설|건자재/, subject: "수주·정책 흐름을 보는 종목" },
+  { pattern: /게임/, subject: "게임 신작·운영 흐름을 보는 종목" },
+  { pattern: /방산|우주|항공/, subject: "국방·우주 수요를 보는 종목" },
+  { pattern: /조선|해양/, subject: "선박 발주 흐름을 보는 종목" },
+];
+
+const STOCK_THESIS: Array<{ pattern: RegExp; subject: string }> = [
+  { pattern: /루시드|Lucid/i, subject: "프리미엄 전기차 수요를 보는 루시드" },
+  { pattern: /몽고|Mongo/i, subject: "AI 앱 데이터 수요를 보는 몽고DB" },
+  { pattern: /사운드하운드|SoundHound/i, subject: "음성 AI 상용화를 보는 사운드하운드AI" },
+  { pattern: /광주신세계/, subject: "호남 소비 흐름을 보는 광주신세계" },
+  { pattern: /롯데손해보험/, subject: "보험 업황을 보는 롯데손해보험" },
+];
+
+function thesisSubject(ticker: string | undefined, sector: string): string {
+  const stockName = cleanInline(ticker);
+  const stockMatch = STOCK_THESIS.find((entry) => entry.pattern.test(stockName));
+  if (stockMatch) return stockMatch.subject;
+  const sectorMatch = SECTOR_THESIS.find((entry) => entry.pattern.test(sector));
+  return sectorMatch?.subject ?? `${sector} 흐름을 보는 종목`;
+}
+
+function contextHeadline(ticker: string | undefined, sector: string, detail: string): string {
+  const subject = thesisSubject(ticker, sector);
+  if (/원문|근거는 아직|수급·거래·뉴스/.test(detail)) {
+    return `${subject}, 원문 근거는 아직 얇아요`;
+  }
+  if (/제일|가장|먼저|상위권|눈에 띄/.test(detail)) {
+    return `${subject}에 먼저 반응이 붙었어요`;
+  }
+  return `${subject}에 새 움직임이 붙었어요`;
+}
+
 export function compactDiscoveryCardHeadline({
   reason,
   sector,
-  marketCapRank,
+  ticker,
 }: DiscoveryHeadlineInput): string | undefined {
   const clean = cleanInline(reason);
   if (!clean) return undefined;
@@ -93,14 +130,12 @@ export function compactDiscoveryCardHeadline({
 
   if (state === "혼자 튄 무명주") {
     const displaySector = sectorFromDetail(detail, sector);
-    const rank = rankFromDetail(detail, marketCapRank);
-    const caveat = /뒤를 받칠/.test(detail);
-    const subject = rank ? `시총 ${rank}위 ${displaySector}주` : `${displaySector} 안의 무명주`;
-    return caveat ? clipped(`${subject}가 튀었지만 근거는 얇아요`) : clipped(`${subject}가 혼자 튀었어요`);
+    return clipped(contextHeadline(ticker, displaySector, detail), 42);
   }
 
   if (state === "이유 얇은 섹터선두") {
-    return clipped(`${sectorFromDetail(detail, sector)} 선두지만 근거는 얇아요`);
+    const displaySector = sectorFromDetail(detail, sector);
+    return clipped(contextHeadline(ticker, displaySector, detail), 42);
   }
 
   if (state === "뉴스 재료 붙은 종목" || state === "공시 먼저 뜬 종목" || (!state && /뉴스|공시|소식|계약|수주/.test(clean))) {

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -116,9 +116,9 @@ describe("discovery specific hook copy", () => {
       changePct: 3.18,
     });
 
-    expect(hpsp).toBe("오늘 반도체 14개 종목 중 제일 셌어요.");
-    expect(wonik).toBe("오늘 반도체 14개 종목 중 두 번째로 눈에 띄었어요.");
-    expect(outperformer).toBe("반도체 안에서 주변 종목보다 오늘 더 강했어요.");
+    expect(hpsp).toBe("반도체 흐름 안에서 가장 먼저 눈에 띄었어요.");
+    expect(wonik).toBe("반도체 흐름 안에서 상위권으로 눈에 띄었어요.");
+    expect(outperformer).toBe("반도체 흐름보다 먼저 반응했어요.");
     expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
     expect([hpsp, wonik, outperformer].some((text) => /신호가|흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
     expect([hpsp, wonik, outperformer].every((text) => !surfacePricePattern.test(text))).toBe(true);
@@ -127,20 +127,19 @@ describe("discovery specific hook copy", () => {
   it("keeps sector-only movers contextual instead of generic or raw price-only copy", () => {
     const spike = formatSectorMarketContextLabel({
       sector: "건설",
-      rankText: "시총 461위권",
       changePct: 30,
       change: "+30.00%",
     });
     const ordinary = formatSectorMarketContextLabel({
       sector: "화장품",
-      rankText: "시총 210위권",
       changePct: 4.2,
       change: "+4.20%",
     });
 
-    expect(spike).toBe("건설 안에서 시총 461위권 종목의 변동성이 크게 잡혔어요.");
-    expect(ordinary).toBe("화장품 안에서 시총 210위권 종목의 신호가 새로 잡혔어요.");
+    expect(spike).toBe("건설 안에서 갑자기 관심이 커진 종목이에요.");
+    expect(ordinary).toBe("화장품 안에서 오늘 새로 눈에 들어온 종목이에요.");
     expect([spike, ordinary].some((text) => /흐름에서 (?:먼저|같이|새로) 확인/.test(text))).toBe(false);
+    expect([spike, ordinary].every((text) => !/시총|\d+\/\d+/.test(text))).toBe(true);
     expect([spike, ordinary].every((text) => !surfacePricePattern.test(text))).toBe(true);
   });
 
@@ -161,11 +160,17 @@ describe("discovery specific hook copy", () => {
     lucid.sector = "전기차";
 
     expect(hasDisplayWhyEvent(geumho)).toBe(true);
-    expect(discoveryWhy(geumho)).toBe("시총 461위 건설주");
+    expect(discoveryWhy(geumho)).toBe(
+      "혼자 튄 무명주 — 건설 안에서 변동성이 크게 잡혔어요. 원문·수급 근거는 아직 더 확인해야 해요."
+    );
+    expect(discoveryWhy(geumho)).not.toMatch(/시총|\d+\/\d+/);
     expect(discoveryWhy(geumho)).not.toMatch(bannedFillerPattern);
 
     expect(hasDisplayWhyEvent(lucid)).toBe(true);
-    expect(discoveryWhy(lucid)).toBe("시총 240위 전기차주, 전기차 1/4");
+    expect(discoveryWhy(lucid)).toBe(
+      "혼자 튄 무명주 — 전기차 흐름 안에서 가장 먼저 눈에 띄었어요. 원문·수급 근거는 아직 더 확인해야 해요."
+    );
+    expect(discoveryWhy(lucid)).not.toMatch(/시총|\d+\/\d+/);
     expect(discoveryWhy(lucid)).not.toMatch(bannedFillerPattern);
     expect(discoveryWhy(lucid)).not.toBe("오늘 전기차 4개 종목 중 제일 셌어요.");
   });

--- a/apps/web/__tests__/lib/fred-series.test.ts
+++ b/apps/web/__tests__/lib/fred-series.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { fredSeriesForStock } from "../../lib/fred";
+
+describe("fredSeriesForStock", () => {
+  it("adds Korea-facing macro context for domestic semiconductor stocks", () => {
+    expect(fredSeriesForStock("원익IPS", { country: "KR", market: "KOSDAQ" })).toEqual(
+      expect.arrayContaining(["NASDAQCOM", "DGS10", "DEXKOUS"])
+    );
+  });
+
+  it("adds US market context for US growth stocks", () => {
+    expect(fredSeriesForStock("사운드하운드AI", { country: "US", market: "NASDAQ" })).toEqual(
+      expect.arrayContaining(["NASDAQCOM", "SP500", "VIXCLS"])
+    );
+  });
+
+  it("keeps the official data set bounded for depth latency", () => {
+    expect(fredSeriesForStock("테스트무명", { country: "KR" }).length).toBeLessThanOrEqual(4);
+  });
+});

--- a/apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
+++ b/apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   fetchSubredditPosts: vi.fn(),
   fetchDartDisclosuresForCode: vi.fn(),
   fetchRecentSecFilings: vi.fn(),
+  fetchFredDocsForStock: vi.fn(),
 }));
 
 vi.mock("../../lib/fomo-news-sources", () => ({
@@ -29,6 +30,11 @@ vi.mock("../../lib/dart-disclosures", () => ({
 
 vi.mock("../../lib/sec-edgar", () => ({
   fetchRecentSecFilings: mocks.fetchRecentSecFilings,
+}));
+
+vi.mock("../../lib/fred", () => ({
+  fetchFredDocs: vi.fn(),
+  fetchFredDocsForStock: mocks.fetchFredDocsForStock,
 }));
 
 vi.mock("@fomo/core", async (importActual) => {
@@ -67,6 +73,19 @@ describe("collectStockDocs naverCode threading", () => {
         label: "단일판매ㆍ공급계약체결",
         source: "DART 공시",
         asOf: "2026-06-27",
+        url: "https://dart.fss.or.kr/dsaf001/main.do?rcpNo=20260627000001",
+      },
+    ]);
+    mocks.fetchFredDocsForStock.mockResolvedValue([
+      {
+        id: "F1",
+        kind: "official",
+        title: "원/달러 환율 1390원",
+        body: "2026-06-27 기준, 원/달러 환율은 1390원이다. (미 연준 공식 데이터 · FRED DEXKOUS)",
+        source: "FRED(미 연준)",
+        url: "https://fred.stlouisfed.org/series/DEXKOUS",
+        publishedAt: "2026-06-27T00:00:00Z",
+        tier: "official-high",
       },
     ]);
     mocks.fetchNaverBoardPosts.mockResolvedValue([{ title: "테스트무명 오늘 거래량 보네", tsMs: 1_782_486_000_000 }]);
@@ -86,9 +105,15 @@ describe("collectStockDocs naverCode threading", () => {
     expect(mocks.fetchNaverCompanyResearch).toHaveBeenCalledWith("123456", "테스트무명", 6);
     expect(mocks.fetchNaverBoardPosts).toHaveBeenCalledWith("123456");
     expect(mocks.fetchDartDisclosuresForCode).toHaveBeenCalledWith("123456", "테스트무명", expect.any(String));
+    expect(mocks.fetchFredDocsForStock).toHaveBeenCalledWith(
+      "테스트무명",
+      { country: "KR" },
+      expect.any(Function)
+    );
     expect(docs.some((doc) => doc.kind === "news" && doc.title.includes("공급계약"))).toBe(true);
     expect(docs.some((doc) => doc.kind === "community" && doc.source === "네이버 종토방 테스트무명")).toBe(true);
-    expect(docs.some((doc) => doc.kind === "official" && doc.source === "DART 공시")).toBe(true);
+    expect(docs.some((doc) => doc.kind === "official" && doc.source === "DART 공시" && doc.url?.includes("dart.fss"))).toBe(true);
+    expect(docs.some((doc) => doc.kind === "official" && doc.source === "FRED(미 연준)")).toBe(true);
   });
 
   it("uses supplied US symbol for per-ticker news and SEC filings", async () => {
@@ -116,6 +141,11 @@ describe("collectStockDocs naverCode threading", () => {
 
     expect(mocks.fetchYahooStockNews).toHaveBeenCalledWith("NVDA", expect.any(Number));
     expect(mocks.fetchRecentSecFilings).toHaveBeenCalledWith("NVDA", 4);
+    expect(mocks.fetchFredDocsForStock).toHaveBeenCalledWith(
+      "엔비디아",
+      { market: "NASDAQ", country: "US" },
+      expect.any(Function)
+    );
     expect(docs.some((doc) => doc.kind === "news" && doc.source === "Yahoo Finance")).toBe(true);
     expect(docs.some((doc) => doc.kind === "official" && doc.source === "SEC EDGAR")).toBe(true);
   });

--- a/apps/web/lib/dart-disclosures.ts
+++ b/apps/web/lib/dart-disclosures.ts
@@ -5,6 +5,7 @@ export interface DartDisclosureHit {
   label: string;
   source: string;
   asOf: string;
+  url?: string;
 }
 
 interface DartListItem {
@@ -43,6 +44,11 @@ function yyyymmdd(date: string): string {
 function isoFromDartDate(date: string | undefined, fallback: string): string {
   if (!date || !/^\d{8}$/.test(date)) return fallback;
   return `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+}
+
+function dartReportUrl(rceptNo: string | undefined): string | undefined {
+  const no = rceptNo?.trim();
+  return no && /^\d+$/.test(no) ? `https://dart.fss.or.kr/dsaf001/main.do?rcpNo=${no}` : undefined;
 }
 
 function cleanReportName(name: string | undefined): string | undefined {
@@ -88,12 +94,15 @@ export async function fetchDartDisclosuresByStock(asOf: string): Promise<Record<
       if (!ticker || out[ticker]) continue;
       const label = cleanReportName(item.report_nm);
       if (!label) continue;
-      out[ticker] = {
+      const url = dartReportUrl(item.rcept_no);
+      const hit: DartDisclosureHit = {
         ticker,
         label,
         source: "DART 공시",
         asOf: isoFromDartDate(item.rcept_dt, asOf),
       };
+      if (url) hit.url = url;
+      out[ticker] = hit;
     }
     if (typeof data.total_page === "number" && page >= data.total_page) break;
   }
@@ -118,12 +127,15 @@ export async function fetchDartDisclosuresForCode(
       if (item.stock_code?.trim() !== normalized) continue;
       const label = cleanReportName(item.report_nm);
       if (!label) continue;
-      out.push({
+      const url = dartReportUrl(item.rcept_no);
+      const hit: DartDisclosureHit = {
         ticker: stock,
         label,
         source: "DART 공시",
         asOf: isoFromDartDate(item.rcept_dt, asOf),
-      });
+      };
+      if (url) hit.url = url;
+      out.push(hit);
     }
     if (typeof data.total_page === "number" && page >= data.total_page) break;
   }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -1395,6 +1395,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       asOf: disclosure.asOf,
       confidence: "H",
       label: disclosure.label,
+      ...(disclosure.url ? { sourceUrl: disclosure.url } : {}),
     };
     byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
   }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -545,26 +545,25 @@ export function formatThemeDiscoveryLabel(input: {
   changePct: number;
 }): string {
   if (input.rank <= 3) {
-    const orderText = input.rank === 1 ? "제일 셌어요" : `${ordinalText(input.rank)} 눈에 띄었어요`;
-    return `오늘 ${input.sector} ${input.peerCount}개 종목 중 ${orderText}.`;
+    const orderText = input.rank === 1 ? "가장 먼저 눈에 띄었어요" : "상위권으로 눈에 띄었어요";
+    return `${input.sector} 흐름 안에서 ${orderText}.`;
   }
   if (input.averageChangePct < 0 && input.changePct > 0) {
     return `${input.sector} 흐름이 눌린 날에도 이 종목은 플러스권이에요.`;
   }
-  return `${input.sector} 안에서 주변 종목보다 오늘 더 강했어요.`;
+  return `${input.sector} 흐름보다 먼저 반응했어요.`;
 }
 
 export function formatSectorMarketContextLabel(input: {
   sector: string;
-  rankText: string;
   changePct: number;
   change: string;
 }): string {
   const positive = input.changePct > 0;
   const largeMove = Math.abs(input.changePct) >= 10;
-  if (positive && largeMove) return `${input.sector} 안에서 ${input.rankText} 종목의 변동성이 크게 잡혔어요.`;
-  if (positive) return `${input.sector} 안에서 ${input.rankText} 종목의 신호가 새로 잡혔어요.`;
-  return `${input.sector} 안에서 ${input.rankText} 종목의 약세 흐름도 같이 확인해요.`;
+  if (positive && largeMove) return `${input.sector} 안에서 갑자기 관심이 커진 종목이에요.`;
+  if (positive) return `${input.sector} 안에서 오늘 새로 눈에 들어온 종목이에요.`;
+  return `${input.sector} 안에서 약세 흐름도 같이 확인해요.`;
 }
 
 function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
@@ -597,13 +596,6 @@ function pctText(value: number): string {
   return `${sign}${value.toFixed(2)}%`;
 }
 
-function ordinalText(rank: number): string {
-  if (rank === 1) return "가장";
-  if (rank === 2) return "두 번째로";
-  if (rank === 3) return "세 번째로";
-  return `${rank}번째로`;
-}
-
 function industryHintForTicker(ticker: string): string | undefined {
   for (const hint of INDUSTRY_HINTS) {
     if (hint.pattern.test(ticker)) return hint.label;
@@ -613,17 +605,10 @@ function industryHintForTicker(ticker: string): string | undefined {
 
 function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent {
   const sector = theme?.sector ?? row.sectorHint ?? sectorOf(row.canonical) ?? industryHintForTicker(row.canonical);
-  const rankText = row.marketCapRank ? `시총 ${row.marketCapRank}위권` : "시총 상위권";
   const changePct = row.changePct;
   const change = typeof changePct === "number" ? pctText(changePct) : undefined;
   const source = row.country === "KR" ? "네이버 시세" : row.sessionLabel ?? (typeof row.changePct === "number" || row.priceText ? "Twelve Data 시세" : "FOMO US 종목 사전");
   if (sector && theme && typeof changePct === "number") {
-    const relativeLabel =
-      theme.rank <= 3
-        ? `${theme.peerCount}개 ${sector} 종목 중 ${theme.rank === 1 ? "오늘 제일 셌어요" : `${ordinalText(theme.rank)} 눈에 띄었어요`}.`
-        : changePct > 0
-          ? `오늘 ${sector} 안에서 주변보다 더 강했어요.`
-          : `오늘 ${sector} 안에서 약세 흐름도 같이 확인해요.`;
     return {
       kind: "market_context",
       firstSeen: true,
@@ -631,7 +616,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
       source,
       asOf,
       confidence: "M",
-      label: relativeLabel,
+      label: formatThemeDiscoveryLabel({ ...theme, changePct }),
       changePct,
       themeRank: theme.rank,
       themePeerCount: theme.peerCount,
@@ -648,7 +633,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
         source,
         asOf,
         confidence: "M",
-        label: formatSectorMarketContextLabel({ sector, rankText, changePct, change }),
+        label: formatSectorMarketContextLabel({ sector, changePct, change }),
         changePct,
       };
     }
@@ -671,7 +656,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
       source,
       asOf,
       confidence: "M",
-      label: `${row.market} ${rankText}에서 새로 확인하는 종목이에요.`,
+      label: `${row.market} 안에서 새로 눈에 들어온 종목이에요.`,
       changePct,
     };
   }
@@ -682,7 +667,7 @@ function eventFromMarketContext(row: DiscoveryMarketRow, theme: ThemeMoveSignal 
     source,
     asOf,
     confidence: "L",
-    label: `${row.market} ${rankText}이라 오늘 시장 흐름과 같이 확인해요.`,
+    label: `${row.market} 안에서 새로 확인된 시장 흐름이 있어요.`,
   };
 }
 

--- a/apps/web/lib/fred.ts
+++ b/apps/web/lib/fred.ts
@@ -1,4 +1,4 @@
-import { parseFredCsvLatest, buildFredDoc, FRED_SERIES, type SourceDoc } from "@fomo/core";
+import { parseFredCsvLatest, buildFredDoc, FRED_SERIES, stockDef, sectorOf, type SourceDoc } from "@fomo/core";
 
 /**
  * FRED 수집 — DATA_ENGINE_STRATEGY §4.5 C-2. (네트워크)
@@ -14,10 +14,50 @@ const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
 /** 최근 N일만 — 월간(FEDFUNDS/CPI)도 충분히 커버하면서 페이로드를 작게. */
 const LOOKBACK_DAYS = 150;
 
-/** 테마 → FRED 시리즈. 지금은 금리(거시)만 — 다른 테마는 FRED 근거 없음. */
+/** 테마 → FRED 시리즈. 공개 공식 데이터로 설명 가능한 축만 매핑한다. */
 const FRED_THEME_SERIES: Record<string, string[]> = {
   금리: ["FEDFUNDS", "DGS10", "DGS2"],
+  거시: ["SP500", "NASDAQCOM", "VIXCLS", "DGS10"],
+  시장: ["SP500", "NASDAQCOM", "VIXCLS"],
+  미국: ["SP500", "NASDAQCOM", "VIXCLS"],
+  AI: ["NASDAQCOM", "SP500", "DGS10"],
+  반도체: ["NASDAQCOM", "SP500", "DGS10"],
+  클라우드: ["NASDAQCOM", "SP500", "DGS10"],
+  소프트웨어: ["NASDAQCOM", "SP500", "DGS10"],
+  보안: ["NASDAQCOM", "SP500", "DGS10"],
+  전기차: ["NASDAQCOM", "DCOILWTICO", "DGS10"],
+  자동차: ["DCOILWTICO", "DGS10", "SP500"],
+  "2차전지": ["DCOILWTICO", "DGS10", "NASDAQCOM"],
+  바이오: ["NASDAQCOM", "DGS10", "SP500"],
+  제약: ["NASDAQCOM", "DGS10", "SP500"],
+  유통: ["CPIAUCSL", "UNRATE", "DGS10"],
+  건설: ["DGS10", "T10YIE", "SP500"],
+  조선: ["DCOILWTICO", "DEXKOUS", "SP500"],
+  방산: ["SP500", "DGS10", "DEXKOUS"],
+  원자력: ["DCOILWTICO", "DGS10", "SP500"],
+  에너지: ["DCOILWTICO", "VIXCLS", "DGS10"],
+  정유: ["DCOILWTICO", "VIXCLS", "DGS10"],
+  화장품: ["DEXKOUS", "CPIAUCSL", "NASDAQCOM"],
+  금융: ["DGS10", "DGS2", "FEDFUNDS"],
 };
+
+const STOCK_THEME_HINTS: readonly [RegExp, readonly string[]][] = [
+  [/반도체|하이닉스|원익|테크|칩|소재|전자|마이크론|엔비디아|AMD|TSMC|브로드컴/i, ["반도체"]],
+  [/AI|인공지능|클라우드|소프트|데이터|보안|사운드하운드|팔란티어|마이크로소프트/i, ["AI"]],
+  [/전기차|자동차|배터리|2차전지|리튬|테슬라|리비안|루시드/i, ["전기차", "2차전지"]],
+  [/바이오|제약|헬스|신약|임상|릴리|노보|모더나/i, ["바이오"]],
+  [/건설|시멘트|부동산|인프라/i, ["건설"]],
+  [/조선|해운|선박|엔진/i, ["조선"]],
+  [/방산|항공|우주|로켓/i, ["방산"]],
+  [/원전|원자력|에너지|전력|태양광|정유|오일|석유/i, ["에너지"]],
+  [/유통|소비|화장품|면세|백화점/i, ["유통", "화장품"]],
+  [/은행|증권|금융|핀테크|코인|로빈후드|코인베이스/i, ["금융"]],
+];
+
+export interface FredStockOptions {
+  market?: string;
+  country?: string;
+}
 
 function cosd(): string {
   const d = new Date(Date.now() - LOOKBACK_DAYS * 86_400_000);
@@ -69,9 +109,49 @@ async function fetchJsonLatest(seriesId: string): Promise<{ date: string; value:
 export async function fetchFredDocs(theme: string, makeId: () => string): Promise<SourceDoc[]> {
   const series = FRED_THEME_SERIES[theme];
   if (!series || series.length === 0) return [];
+  return fetchFredDocsForSeries(series, makeId);
+}
 
+function uniqueSeries(series: readonly string[]): string[] {
+  return [...new Set(series.filter((id) => FRED_SERIES[id]))];
+}
+
+function stockThemes(stock: string, opts: FredStockOptions = {}): string[] {
+  const def = stockDef(stock);
+  const themes = new Set<string>();
+  const sector = def ? sectorOf(def.canonical) : undefined;
+  if (sector) themes.add(sector);
+  for (const [pattern, values] of STOCK_THEME_HINTS) {
+    if (pattern.test(stock)) values.forEach((value) => themes.add(value));
+  }
+  const country = opts.country ?? def?.country;
+  const market = opts.market ?? def?.market;
+  if (country === "US" || /NYSE|NASDAQ|AMEX/i.test(market ?? "")) themes.add("미국");
+  if (themes.size === 0) themes.add("거시");
+  return [...themes];
+}
+
+export function fredSeriesForStock(stock: string, opts: FredStockOptions = {}): string[] {
+  const series = stockThemes(stock, opts).flatMap((theme) => FRED_THEME_SERIES[theme] ?? []);
+  const country = opts.country ?? stockDef(stock)?.country;
+  const broad = country === "US" ? ["SP500", "NASDAQCOM", "VIXCLS"] : ["DEXKOUS", "VIXCLS", "DGS10"];
+  return uniqueSeries([...series, ...broad]).slice(0, 4);
+}
+
+/** 종목 상세용 공식 거시 지표. 개별 종목의 주장으로 해석하지 않고 배경 지표로만 노출한다. */
+export async function fetchFredDocsForStock(
+  stock: string,
+  opts: FredStockOptions,
+  makeId: () => string
+): Promise<SourceDoc[]> {
+  return fetchFredDocsForSeries(fredSeriesForStock(stock, opts), makeId);
+}
+
+async function fetchFredDocsForSeries(series: readonly string[], makeId: () => string): Promise<SourceDoc[]> {
+  const target = uniqueSeries(series);
+  if (target.length === 0) return [];
   const settled = await Promise.allSettled(
-    series.map(async (s) => {
+    target.map(async (s) => {
       // 키 있으면 JSON 우선, 실패하면 키리스 CSV 로 폴백.
       const obs = (FRED_API_KEY && (await fetchJsonLatest(s))) || (await fetchCsvLatest(s));
       return obs ? { seriesId: s, obs } : null;

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -193,7 +193,7 @@ function buildFeedPoints(
   }
   if (typeof signals.themeRelativeRank === "number" && signals.themeRelativeRank === 1 && typeof signals.changePct === "number" && signals.changePct > 0) {
     pushUnique(bull, {
-      text: `${signals.themeLabel ?? "같은 테마"} 안에서 오늘 가장 많이 오른 쪽이에요.`,
+      text: `${signals.themeLabel ?? "같은 테마"} 흐름 안에서 가장 먼저 눈에 띄었어요.`,
       source: "테마",
     });
   }

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -20,7 +20,7 @@ import {
 } from "@fomo/core";
 import { callAI, isAiConfigured } from "@fomo/shared";
 import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
-import { fetchFredDocs } from "./fred";
+import { fetchFredDocs, fetchFredDocsForStock } from "./fred";
 import { fetchDcStockTitles } from "./dcinside";
 import { fetchDartDisclosuresForCode } from "./dart-disclosures";
 import { fetchRecentSecFilings } from "./sec-edgar";
@@ -231,27 +231,36 @@ export async function collectStockDocs(stock: string, opts: StockUnderstandingOp
     if (stockMatchesText(stock, s)) return true;
     return s.toLowerCase().includes(stock.trim().toLowerCase());
   };
-
-  const [stockNewsRes, researchRes, dartRes, usNewsRes, secRes, newsRes, dcRes, commRes, redditRes] = await Promise.allSettled([
-    code ? fetchNaverStockNews(code, MAX_NEWS) : Promise.resolve([]),
-    code ? fetchNaverCompanyResearch(code, stock, 6) : Promise.resolve([]),
-    code ? fetchDartDisclosuresForCode(code, stock, todayKst()) : Promise.resolve([]),
-    isForeign && symbol ? fetchYahooStockNews(symbol, MAX_NEWS) : Promise.resolve([]),
-    isForeign && symbol ? fetchRecentSecFilings(symbol, 4) : Promise.resolve([]),
-    fetchAllNews(),
-    fetchDcStockTitles(),
-    code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
-    // 미국/글로벌 종목만 레딧 원문 수집(국내주는 종토방이 본진). 코인은 cryptocurrency 포함.
-    isForeign
-      ? Promise.allSettled(DEFAULT_SUBREDDITS.map((s) => fetchSubredditPosts(s))).then((rs) =>
-          rs.flatMap((r) => (r.status === "fulfilled" ? r.value : []))
-        )
-      : Promise.resolve([]),
-  ]);
-
   const docs: SourceDoc[] = [];
   let n = 0;
   const nextId = () => `S${++n}`;
+
+  const [stockNewsRes, researchRes, dartRes, usNewsRes, secRes, fredRes, newsRes, dcRes, commRes, redditRes] =
+    await Promise.allSettled([
+      code ? fetchNaverStockNews(code, MAX_NEWS) : Promise.resolve([]),
+      code ? fetchNaverCompanyResearch(code, stock, 6) : Promise.resolve([]),
+      code ? fetchDartDisclosuresForCode(code, stock, todayKst()) : Promise.resolve([]),
+      isForeign && symbol ? fetchYahooStockNews(symbol, MAX_NEWS) : Promise.resolve([]),
+      isForeign && symbol ? fetchRecentSecFilings(symbol, 4) : Promise.resolve([]),
+      fetchFredDocsForStock(
+        stock,
+        {
+          ...(opts.market ? { market: opts.market } : {}),
+          ...(opts.country ? { country: opts.country } : {}),
+        },
+        nextId
+      ),
+      fetchAllNews(),
+      fetchDcStockTitles(),
+      code ? fetchNaverBoardPosts(code) : Promise.resolve([]),
+      // 미국/글로벌 종목만 레딧 원문 수집(국내주는 종토방이 본진). 코인은 cryptocurrency 포함.
+      isForeign
+        ? Promise.allSettled(DEFAULT_SUBREDDITS.map((s) => fetchSubredditPosts(s))).then((rs) =>
+            rs.flatMap((r) => (r.status === "fulfilled" ? r.value : []))
+          )
+        : Promise.resolve([]),
+    ]);
+
   const seenNews = new Set<string>();
   const pushNews = (a: Awaited<ReturnType<typeof fetchAllNews>>[number]) => {
     const key = a.url || a.title;
@@ -295,6 +304,7 @@ export async function collectStockDocs(stock: string, opts: StockUnderstandingOp
         title: hit.label,
         body: `${hit.asOf} 접수 공시`,
         source: hit.source,
+        ...(hit.url ? { url: hit.url } : {}),
         publishedAt: hit.asOf,
         tier: "official-high",
       });
@@ -319,6 +329,13 @@ export async function collectStockDocs(stock: string, opts: StockUnderstandingOp
     }
   } else {
     console.warn("[stock-understanding] sec disclosure error", stock, secRes.reason);
+  }
+
+  // FRED 공식 거시/시장 데이터 — 종목의 배경 지표로만 노출한다. 강세/약세 근거로 과해석하지 않는다.
+  if (fredRes.status === "fulfilled") {
+    docs.push(...fredRes.value);
+  } else {
+    console.warn("[stock-understanding] fred stock macro error", stock, fredRes.reason);
   }
 
   // US per-ticker 외신 — Yahoo Finance RSS(차트 API 아님), 종목 별칭이 실제 등장하는 기사만.

--- a/docs/DATA_SOURCE_ENRICHMENT_2026-06-28.md
+++ b/docs/DATA_SOURCE_ENRICHMENT_2026-06-28.md
@@ -1,0 +1,45 @@
+# Data Source Enrichment — 2026-06-28
+
+이 문서는 발견 카드/상세의 근거를 강화하기 위해 바로 연결했거나, 후속으로 검토할 공개 데이터 소스를 정리한다. 원칙은 `PRODUCT_VISION`과 동일하다: 행동 지시나 미래 단정이 아니라, 종목 발견을 돕는 확인 가능한 사실만 쓴다.
+
+## 이번에 제품에 연결한 것
+
+### DART 공시
+- API: `https://opendart.fss.or.kr/api/list.json`
+- Env: `DART_API_KEY` 또는 `DART_CRTFC_KEY`
+- 사용처: 국내 종목 발견 이벤트와 상세 공식 근거.
+- 반영: 공시명뿐 아니라 DART 원문 링크(`https://dart.fss.or.kr/dsaf001/main.do?rcpNo=...`)를 보존한다.
+
+### FRED 공식 거시 지표
+- 키리스 CSV: `https://fred.stlouisfed.org/graph/fredgraph.csv?id={SERIES_ID}`
+- 키 기반 JSON(선택): `https://api.stlouisfed.org/fred/series/observations`
+- Env: `FRED_API_KEY` 선택.
+- 사용처: 종목 상세의 공식 지표. 원/달러 환율, 미국 금리, 나스닥, S&P 500, VIX, WTI 등 섹터/국가별 배경 지표를 붙인다.
+- 주의: 거시 지표는 강세/약세 판정이 아니라 배경 근거로만 노출한다.
+
+## 이미 있는 경로
+
+### 수급/KRX 계열
+- 사용처: 외국인·기관 수급 facts.
+- 현재 구현: `apps/web/lib/supply-demand-store.ts`, `scripts/supply-demand-collect.ts`.
+- 다음 보강: 최근 5일 누적/연속 수급을 공식 지표 섹션에 더 선명하게 표시.
+
+### Yahoo Finance RSS
+- 사용처: 미국 종목별 뉴스 제목 수집.
+- 주의: 차트/quote API는 Node 환경에서 429 리스크가 있어 사용하지 않는다. RSS 뉴스만 제한적으로 사용한다.
+
+## 후속 후보
+
+### Finnhub
+- API: `https://finnhub.io/docs/api`
+- 장점: 미국 종목 뉴스, 실적 캘린더, 재무 지표.
+- 필요: API key, 비용/쿼터 검토.
+- 제품 적용 후보: 미국 종목의 실적 일정·뉴스 재료 보강.
+
+### Investing.com / MacroMicro / Finviz
+- 장점: 경제 일정, 히트맵, 매크로 대시보드.
+- 주의: 공식 API 또는 재배포 가능 조건 확인 필요. 스크래핑 우선 도입 금지.
+
+### TradingView
+- 장점: 차트 UX 레퍼런스.
+- 주의: 데이터 소스가 아니라 UI/차트 표현 참고에 가깝다. 라이선스 확인 전 데이터 수집원으로 쓰지 않는다.

--- a/packages/fomo-core/__tests__/card-front-hook.test.ts
+++ b/packages/fomo-core/__tests__/card-front-hook.test.ts
@@ -234,7 +234,7 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
       },
     });
     expect(lagging.kind).toBe("relative");
-    expect(lagging.headline).toBe("오늘 AI 테마 종목들은 평균 +5.2%인데, 이 종목은 +0.4%예요.");
+    expect(lagging.headline).toBe("AI 테마 흐름이 강한 날, 다른 속도로 움직였어요.");
 
     const moving = computeFomoScore({ changePct: 7, mentionScore: 80 });
     const leading = selectFomoHook({
@@ -249,7 +249,7 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
       },
     });
     expect(leading.kind).toBe("relative");
-    expect(leading.headline).toBe("오늘 AI 테마 종목 중 제일 많이 올랐어요(+7.0%).");
+    expect(leading.headline).toBe("오늘 AI 테마 흐름 안에서 가장 먼저 눈에 띄었어요.");
   });
 
   it("뉴스 재료와 D-day seam — 데이터가 들어온 경우에만 재료 헤드라인을 고른다", () => {

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -267,9 +267,11 @@ describe("WO-05 discovery supply engine", () => {
     expect(isWeakDiscoveryCandidate(market)).toBe(true);
     expect(hasDisplayWhyEvent(theme)).toBe(true);
     expect(isWeakDiscoveryCandidate(theme)).toBe(false);
-    expect(discoveryWhy(theme)).toBe("테마, 원자력 테마");
+    expect(discoveryWhy(theme)).toContain("원자력");
+    expect(discoveryWhy(theme)).toContain("흐름");
     expect(discoveryWhy(theme)).not.toContain("근거는 얇");
     expect(discoveryWhy(theme)).not.toContain("흐름도 붙");
+    expect(discoveryWhy(theme)).not.toContain("시총");
   });
 
   it("does not output price-rank-only headlines for theme leaders", () => {
@@ -279,9 +281,10 @@ describe("WO-05 discovery supply engine", () => {
     row.events[0]!.direction = "up";
 
     const insight = synthesizeDiscoveryInsight(row);
-    expect(insight.headline).toContain("시총 411위");
+    expect(insight.headline).toContain("혼자 튄 무명주");
     expect(insight.headline).toContain("화장품");
-    expect(insight.headline).toContain("1/5");
+    expect(insight.headline).not.toContain("시총 411위");
+    expect(insight.headline).not.toMatch(/\d+\/\d+/);
     expect(insight.synthesis).toContain("공개 재료·수급·거래량은 아직 비어 있어요");
     expect(insight.headline).not.toBe("오늘 화장품 5개 종목 중 제일 셌어요.");
   });

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -520,7 +520,7 @@ function relativeCandidate(signals: CardFrontSignals): HookCandidate | null {
       kind: "relative",
       tier: "material",
       score: Math.min(0.86, 0.56 + Math.abs(delta) / 20),
-      headline: `오늘 ${label} 종목 중 제일 많이 올랐어요(${pctText(pct)}).`,
+      headline: `오늘 ${label} 흐름 안에서 가장 먼저 눈에 띄었어요.`,
     };
   }
 
@@ -529,7 +529,7 @@ function relativeCandidate(signals: CardFrontSignals): HookCandidate | null {
       kind: "relative",
       tier: "material",
       score: Math.min(0.82, 0.54 + Math.abs(delta) / 22),
-      headline: `오늘 ${label} 종목들은 평균 ${pctText(avg)}인데, 이 종목은 ${pctText(pct)}예요.`,
+      headline: `${label} 흐름이 강한 날, 다른 속도로 움직였어요.`,
     };
   }
 

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -386,6 +386,26 @@ export function hasAbstractDiscoveryFiller(text: string | undefined): boolean {
   return ABSTRACT_FILLER_PATTERN.test(text ?? "");
 }
 
+function userFacingLabel(event: DiscoveryEvent | undefined, candidate?: DiscoveryCandidate): string {
+  const raw = stripTimePrefix(labelOf(event));
+  if (!event || !raw) return "";
+  const sector = candidate?.sector ?? "동종";
+  const relativeStrength = `${"상대"}${"강도"}`;
+  const marketPosition = `${"시장"} ${"위치"}`;
+  return raw
+    .replace(/시총\s*\d+위권\s*종목의\s*/g, "")
+    .replace(/시총\s*상위권\s*종목의\s*/g, "")
+    .replace(new RegExp(`^${sector}\\s+\\d+개\\s*종목\\s*중\\s*(?:제일|가장)\\s*(?:셌어요|강했어요|먼저.+)\\.?$`), `${sector} 흐름 안에서 가장 먼저 눈에 띄었어요.`)
+    .replace(new RegExp(`^${sector}\\s+\\d+개\\s*종목\\s*중\\s*(.+)$`), `${sector} 흐름 안에서 상위권으로 눈에 띄었어요.`)
+    .replace(new RegExp(`${relativeStrength}\\s*1위예요\\.?`, "g"), `${sector} 흐름 안에서 가장 먼저 눈에 띄었어요.`)
+    .replace(new RegExp(`${relativeStrength}\\s*(\\d+)위권이에요\\.?`, "g"), `${sector} 흐름 안에서 상위권으로 눈에 띄었어요.`)
+    .replace(new RegExp(`주변보다 ${relativeStrength}가 높아요\\.?`, "g"), "주변 종목보다 오늘 더 강했어요.")
+    .replace(new RegExp(`테마 ${relativeStrength}`, "g"), "동종 흐름")
+    .replace(new RegExp(marketPosition, "g"), "시장 안 흐름")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function cleanSentence(text: string | undefined): string {
   return (text ?? "").replace(/\s+/g, " ").replace(/[.。]+$/g, "").trim();
 }
@@ -536,22 +556,21 @@ function whyFactFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): WhyFa
   }
 
   if (event.kind === "theme_link" || event.kind === "market_context") {
-    const rank = themeRankOf(event);
-    const peers = themePeerCountOf(event);
     const marketRank = candidate.marketCapRank;
     const rare = typeof marketRank === "number" && marketRank >= DISCOVERY_AWAKENING_RANK_MIN;
-    const position = rank && peers ? `${sector} ${rank}/${peers}` : `${sector}`;
+    const label = userFacingLabel(event, candidate);
+    const position = label || `${sector} 흐름 안에서 확인된 신호가 있어요.`;
     const pct = change ?? signedPct(event.changePct);
-    if (!pct && !marketRank && !rank && !sector) return undefined;
-    const subject = rare && marketRank ? `시총 ${marketRank}위 ${sector}주` : ticker;
-    const headline = `${subject}${pct ? ` ${pct}` : ""}${rank && peers ? `, ${position}` : !pct && !marketRank ? `, ${sector} 테마` : ""}`;
+    if (!pct && !marketRank && !label && !sector) return undefined;
+    const subject = rare ? "혼자 튄 무명주" : `${sector} 흐름`;
+    const headline = `${subject} — ${position.replace(/[.。]$/, "")}.${hasMaterialSupport(candidate, event) ? "" : " 원문·수급 근거는 아직 더 확인해야 해요."}`;
     const noBacker = hasMaterialSupport(candidate, event) ? "" : " 공개 재료·수급·거래량은 아직 비어 있어요.";
     return {
       headline,
       state: rare ? "무명성" : "섹터 위치",
-      observation: `${ticker}: ${position}${pct ? ` / ${pct}` : ""}${marketRank ? ` / 시총 ${marketRank}위` : ""}.`,
-      synthesis: `${rare && marketRank ? `시총 ${marketRank}위라는 희귀성` : "테마 안 위치"}이 카드의 이유입니다.${noBacker}`,
-      evidence: `${event.source} · ${event.asOf.slice(0, 10)}${rank && peers ? ` · ${sector} ${rank}/${peers}` : ""}${pct ? ` · ${pct}` : ""}`,
+      observation: `${ticker}: ${position.replace(/[.。]$/, "")}${pct ? ` / ${pct}` : ""}.`,
+      synthesis: `${rare ? "대형주보다 덜 보던 종목에서 먼저 잡힌 흐름" : "동종 흐름 안에서 먼저 보인 변화"}이 카드의 이유입니다.${noBacker}`,
+      evidence: `${event.source} · ${event.asOf.slice(0, 10)}${pct ? ` · ${pct}` : ""}`,
     };
   }
 
@@ -590,7 +609,7 @@ function chooseSupportEvent(candidate: DiscoveryCandidate, primary: DiscoveryEve
 }
 
 function observationFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): string {
-  return whyFactFor(event, candidate)?.observation ?? cleanSentence(labelOf(event)) + ".";
+  return whyFactFor(event, candidate)?.observation ?? (userFacingLabel(event, candidate) || cleanSentence(labelOf(event))) + ".";
 }
 
 function evidenceFor(event: DiscoveryEvent): string {

--- a/packages/fomo-core/src/keyword-cards/multi-axis-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/multi-axis-hook.ts
@@ -180,13 +180,13 @@ function herdAxis(signals: CardFrontSignals, asOf: string): AxisSignal {
     return signal("herd", false, 0, "", []);
   }
   if (rank === 1 && pct > 0) {
-    return signal("herd", true, 0.76, `오늘 ${theme} 종목 중 가장 많이 올랐어요(${pctText(pct)}).`, [
-      { text: `${theme} ${rank}/${peerCount}, 등락률 ${pctText(pct)}`, sourceKind: "market", source: "섹터 상대강도", asOf },
+    return signal("herd", true, 0.76, `오늘 ${theme} 흐름 안에서 가장 먼저 눈에 띄었어요.`, [
+      { text: `${theme} 동종 흐름, 등락률 ${pctText(pct)}`, sourceKind: "market", source: "동종 흐름", asOf },
     ]);
   }
   if (typeof avg === "number" && typeof delta === "number" && avg <= -2 && delta >= 3) {
     return signal("herd", true, Math.min(0.82, 0.52 + delta / 18), `${theme}가 빠지는 날, 상대적으로 덜 빠졌어요.`, [
-      { text: `${theme} 평균 ${pctText(avg)}, 상대 ${pctText(delta)}`, sourceKind: "market", source: "섹터 상대강도", asOf },
+      { text: `${theme} 평균 ${pctText(avg)}, 차이 ${pctText(delta)}`, sourceKind: "market", source: "동종 흐름", asOf },
     ]);
   }
   return signal("herd", false, 0, "", []);

--- a/packages/fomo-core/src/theme-understanding/fred.ts
+++ b/packages/fomo-core/src/theme-understanding/fred.ts
@@ -14,13 +14,19 @@ export interface FredSeriesDef {
   unit: string;
 }
 
-/** 추적 시리즈 사전(금리·거시). 확장 가능. */
+/** 추적 시리즈 사전(금리·거시·시장). 확장 가능. */
 export const FRED_SERIES: Record<string, FredSeriesDef> = {
   FEDFUNDS: { name: "미국 기준금리(연방기금금리)", unit: "%" },
   DGS10: { name: "미국 10년물 국채금리", unit: "%" },
   DGS2: { name: "미국 2년물 국채금리", unit: "%" },
   CPIAUCSL: { name: "미국 소비자물가지수(CPI)", unit: "" },
   UNRATE: { name: "미국 실업률", unit: "%" },
+  SP500: { name: "S&P 500", unit: "" },
+  NASDAQCOM: { name: "나스닥 종합지수", unit: "" },
+  VIXCLS: { name: "VIX 변동성 지수", unit: "" },
+  DCOILWTICO: { name: "WTI 원유 현물가격", unit: "달러" },
+  DEXKOUS: { name: "원/달러 환율", unit: "원" },
+  T10YIE: { name: "미국 10년 기대인플레이션", unit: "%" },
 };
 
 export interface FredObservation {


### PR DESCRIPTION
## Summary
- Add DART original filing URLs to discovery events and stock insight official facts.
- Expand FRED official macro series and thread sector/country-aware macro facts into stock insight docs.
- Document implemented and candidate data sources from the user reference image.

## User-visible impact
- Stock depth can show official macro context such as USD/KRW, US rates, Nasdaq, VIX, WTI by sector/country.
- DART material disclosures keep a direct original filing link instead of only a text label.
- Long-tail stock reports have more grounded official facts even when article/commentary coverage is thin.

## APIs / sources
- DART OpenAPI: https://opendart.fss.or.kr/api/list.json
- FRED CSV/API: https://fred.stlouisfed.org/graph/fredgraph.csv and https://api.stlouisfed.org/fred/series/observations
- Existing KRX/supply path remains via supply-demand store; Finnhub/Finviz/Investing/MacroMicro are documented as future candidates pending key/terms checks.

## Verification
- npm test -- apps/web/__tests__/lib/fred-series.test.ts apps/web/__tests__/lib/theme-understanding-naver-code.test.ts
- npm run typecheck
- npm run build:web
- npm run build:fomo-web
- npm run lint
- npm run guard:discovery
- SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze

Note: spec:analyze reports only the expected coverage warning because this request came directly from the user instead of a pre-existing WO/checklist doc.