### PR TITLE
fix(discovery): make hook copy user-facing

### DIFF
--- a/apps/fomo-web/__tests__/discoveryHeadline.test.ts
+++ b/apps/fomo-web/__tests__/discoveryHeadline.test.ts
@@ -2,25 +2,32 @@ import { describe, expect, it } from "vitest";
 import { compactDiscoveryCardHeadline, splitDiscoveryReason } from "../lib/discoveryHeadline";
 
 describe("compactDiscoveryCardHeadline", () => {
+  const bannedSurfaceCopy =
+    /혼자\s*튄|무명주|흐름\s+흐름|흐름\s*안에서|먼저\s*반응|눈에\s*띄|원문\s*근거|보는\s*종목|움직였어요|강하게\s*움직|상위권으로\s*움직|더\s*강하게\s*움직/;
+
   it("turns material detail into one card-front sentence instead of a label plus prose", () => {
-    expect(
-      compactDiscoveryCardHeadline({
-        reason: "뉴스 재료 붙은 종목 — 최근 '해외 수주 2배' 마키나락스...장중 20% 가까이 급등 · 뉴시스. 동종 흐름도 같이 확인돼요.",
-        sector: "AI",
-        ticker: "마키나락스",
-        marketCapRank: 236,
-      })
-    ).toBe("해외 수주에 동종 흐름도 붙었어요");
+    const headline = compactDiscoveryCardHeadline({
+      reason: "뉴스 재료 붙은 종목 — 최근 '해외 수주 2배' 마키나락스...장중 20% 가까이 급등 · 뉴시스. 동종 흐름도 같이 확인돼요.",
+      sector: "AI",
+      ticker: "마키나락스",
+      marketCapRank: 236,
+    });
+
+    expect(headline).toContain("해외 수주 2배");
+    expect(headline).toContain("마키나락스");
+    expect(headline).not.toMatch(bannedSurfaceCopy);
   });
 
   it("keeps obscure theme leaders honest in one sentence", () => {
-    expect(
+    const headline =
       compactDiscoveryCardHeadline({
         reason: "혼자 튄 무명주 — 시총 411위권인데 같은 화장품 종목들 중 오늘 제일 셌어요. 뒤를 받칠 수급·거래·뉴스는 아직 안 보여요.",
         sector: "화장품",
         ticker: "한국화장품제조",
-      })
-    ).toBe("K뷰티 수요를 보는 종목, 원문 근거는 아직 얇아요");
+      }) ?? "";
+
+    expect(headline).toBe("같은 화장품 종목들 중 오늘 변동성이 가장 컸어요");
+    expect(headline).not.toMatch(bannedSurfaceCopy);
   });
 
   it("does not expose market-cap rank or peer-rank shorthand on the card front", () => {
@@ -31,14 +38,15 @@ describe("compactDiscoveryCardHeadline", () => {
       marketCapRank: 420,
     });
 
-    expect(headline).toBe("프리미엄 전기차 수요를 보는 루시드, 원문 근거는 아직 얇아요");
+    expect(headline).toBe("같은 전기차 종목들 중 오늘 변동성이 가장 컸어요");
     expect(headline).not.toMatch(/시총|\d+\/\d+|[+-]\d/);
+    expect(headline).not.toMatch(bannedSurfaceCopy);
   });
 
   it("does not expose the split reason as a second line contract", () => {
     const parts = splitDiscoveryReason("뉴스 재료 붙은 종목 — 오늘 공급계약 공시 · 한국경제.");
 
     expect(parts.state).toBe("뉴스 재료 붙은 종목");
-    expect(compactDiscoveryCardHeadline({ reason: `${parts.state} — ${parts.detail}` })).toBe("계약에 직접 재료가 붙었어요");
+    expect(compactDiscoveryCardHeadline({ reason: `${parts.state} — ${parts.detail}` })).toContain("공급계약");
   });
 });

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -605,7 +605,7 @@ function stockWatchPoint(front: StockFrontResponse | null): string {
     return `평소 ${formatRatio(s.volumeRatio)} 거래가 며칠 이어지는지 봐요.`;
   }
   if (s.themeLabel && typeof s.themeRelativeRank === "number" && typeof s.themePeerCount === "number") {
-    return `${cleanText(s.themeLabel)} 동종 흐름보다 먼저 보인 이유가 이어지는지 봐요.`;
+    return `${cleanText(s.themeLabel)} 종목들 중 달랐던 거래·수급이 이어지는지 봐요.`;
   }
   if (front.changeDir === "up" && front.changeText) {
     return `오늘 오른 가격대에서 거래가 붙는지 봐요.`;
@@ -888,11 +888,11 @@ function StockSynthesisBlock({
   const support = primary ? observations.find((p) => !copyRestates(p.text, primary.text)) : undefined;
   const contextSynthesis =
     contextParts.state === "혼자 튄 무명주"
-      ? "남들이 덜 보는 종목이 섹터 안에서 먼저 튀었지만, 가격 외 신호는 아직 얇아요."
+      ? "같은 종목군과 다른 변동성이 잡힌 이유를 먼저 확인하는 화면이에요."
       : contextParts.state === "이유 얇은 섹터선두"
-        ? "섹터 안에서 먼저 보인 결과는 있지만, 가격 외 신호는 아직 얇아요."
+        ? "같은 종목군 안에서 오늘 변동성이 컸던 이유를 먼저 확인하는 화면이에요."
         : contextParts.state
-          ? `${contextParts.state}이라서 먼저 확인하는 화면이에요.`
+          ? `${contextParts.state} 근거를 먼저 확인하는 화면이에요.`
           : undefined;
   const synthesis =
     contextSynthesis ??

--- a/apps/fomo-web/lib/discoveryHeadline.ts
+++ b/apps/fomo-web/lib/discoveryHeadline.ts
@@ -37,11 +37,44 @@ function stripSourceAndTime(text: string): string {
     .trim();
 }
 
+const BAD_SURFACE_COPY_PATTERN =
+  /혼자\s*튄|무명주|흐름\s+흐름|흐름\s*안에서|흐름보다\s*먼저\s*반응|먼저\s*반응|눈에\s*띄|원문\s*근거|근거는\s*아직|더\s*살펴볼|더\s*확인할|보는\s*종목/;
+
+function normalizeSurfaceCopy(text: string, sector?: string, ticker?: string): string {
+  const displaySector = cleanInline(sector) || "동종";
+  const displayTicker = cleanInline(ticker);
+  return stripSourceAndTime(
+    text
+      .replace(/뒤를\s*받칠\s*수급·거래·뉴스는\s*아직\s*안\s*보여요\.?/g, "")
+      .replace(/원문·수급\s*근거는\s*아직\s*더\s*확인해야\s*해요\.?/g, "")
+      .replace(/뉴스·공시·수급\s*근거는\s*아직\s*확인되지\s*않았어요\.?/g, "")
+      .replace(/\s*·\s*(?:뉴시스|연합뉴스|한국경제|매일경제|Reuters|Bloomberg|CNBC|Yahoo Finance|SEC|DART|공시)[^.。]*[.。]?/gi, ".")
+  )
+    .replace(/^혼자\s*튄\s*무명주\s*[—-]\s*/g, "")
+    .replace(/시총\s*\d+위권인데\s*/g, "")
+    .replace(/시총\s*상위권인데\s*/g, "")
+    .replace(/흐름\s+흐름/g, "흐름")
+    .replace(/([가-힣A-Za-z0-9]+)\s*흐름\s*안에서\s*가장\s*먼저\s*눈에\s*띄었어요\.?/g, "같은 $1 종목들 중 오늘 변동성이 가장 컸어요")
+    .replace(/([가-힣A-Za-z0-9]+)\s*흐름\s*안에서\s*상위권으로\s*눈에\s*띄었어요\.?/g, "같은 $1 종목들 중 오늘 변동성이 상위권이에요")
+    .replace(/([가-힣A-Za-z0-9]+)\s*흐름보다\s*먼저\s*반응했어요\.?/g, "같은 $1 종목들보다 오늘 변동성이 더 컸어요")
+    .replace(/([가-힣A-Za-z0-9]+)\s*안에서\s*변동성이\s*크게\s*잡혔어요\.?/g, "$1 종목 중 오늘 변동성이 크게 잡혔어요")
+    .replace(/같은\s+(.+?)\s+종목들\s+중\s+오늘\s+제일\s+셌어요/g, "같은 $1 종목들 중 오늘 변동성이 가장 컸어요")
+    .replace(/같은\s+(.+?)\s+종목들\s+중\s+오늘\s+가장\s+셌어요/g, "같은 $1 종목들 중 오늘 변동성이 가장 컸어요")
+    .replace(/상대강도/g, "동종 비교")
+    .replace(/시장\s*위치/g, "시장 안 비교")
+    .replace(/테마\s*동종 비교/g, "동종 비교")
+    .replace(/^\s*[—-]\s*/g, "")
+    .replace(/[.。]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim() || (displayTicker ? `${displayTicker}에서 오늘 확인할 변화가 잡혔어요` : `같은 ${displaySector} 종목들과 다른 변동성이 잡혔어요`);
+}
+
 function topicFromMaterial(detail: string): string {
   const title = stripSourceAndTime(detail);
   const lower = title.toLowerCase();
   if (/해외\s*수주/.test(title)) return "해외 수주";
-  if (/공급계약|계약|contract|deal|order/.test(lower)) return "계약";
+  if (/공급계약/.test(title)) return "공급계약";
+  if (/계약|contract|deal|order/.test(lower)) return "계약";
   if (/수주/.test(title)) return "수주";
   if (/실적|가이던스|매출|earnings|revenue|guidance|results/.test(lower)) return "실적";
   if (/sec|공시|filing|8-k|10-q/.test(lower)) return "공시";
@@ -57,7 +90,7 @@ function topicFromMaterial(detail: string): string {
 function supportFromDetail(detail: string): string {
   if (/수급|외국인|기관|순매수|사는 중/.test(detail)) return "수급도 붙었어요";
   if (/거래량|거래가|거래도/.test(detail)) return "거래도 붙었어요";
-  if (/동종|섹터|흐름|종목들 중/.test(detail)) return "동종 흐름도 붙었어요";
+  if (/동종|섹터|종목들 중/.test(detail)) return "동종 종목 비교도 붙었어요";
   return "직접 재료가 붙었어요";
 }
 
@@ -74,48 +107,6 @@ function clipped(text: string, max = 34): string {
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 
-const SECTOR_THESIS: Array<{ pattern: RegExp; subject: string }> = [
-  { pattern: /전기차|자동차|모빌리티/, subject: "전기차 수요를 보는 종목" },
-  { pattern: /클라우드|데이터|소프트웨어|AI/, subject: "AI·데이터 인프라를 보는 종목" },
-  { pattern: /반도체|기판|장비|소재/, subject: "반도체 장비·소재 흐름을 보는 종목" },
-  { pattern: /바이오|제약|헬스케어/, subject: "임상·신약 모멘텀을 보는 종목" },
-  { pattern: /화장품|뷰티/, subject: "K뷰티 수요를 보는 종목" },
-  { pattern: /유통|백화점|소비/, subject: "소비 회복 흐름을 보는 종목" },
-  { pattern: /금융|보험|증권|은행/, subject: "금리·금융 업황을 보는 종목" },
-  { pattern: /에너지|전력|원전|태양광|풍력/, subject: "전력·에너지 투자 흐름을 보는 종목" },
-  { pattern: /건설|건자재/, subject: "수주·정책 흐름을 보는 종목" },
-  { pattern: /게임/, subject: "게임 신작·운영 흐름을 보는 종목" },
-  { pattern: /방산|우주|항공/, subject: "국방·우주 수요를 보는 종목" },
-  { pattern: /조선|해양/, subject: "선박 발주 흐름을 보는 종목" },
-];
-
-const STOCK_THESIS: Array<{ pattern: RegExp; subject: string }> = [
-  { pattern: /루시드|Lucid/i, subject: "프리미엄 전기차 수요를 보는 루시드" },
-  { pattern: /몽고|Mongo/i, subject: "AI 앱 데이터 수요를 보는 몽고DB" },
-  { pattern: /사운드하운드|SoundHound/i, subject: "음성 AI 상용화를 보는 사운드하운드AI" },
-  { pattern: /광주신세계/, subject: "호남 소비 흐름을 보는 광주신세계" },
-  { pattern: /롯데손해보험/, subject: "보험 업황을 보는 롯데손해보험" },
-];
-
-function thesisSubject(ticker: string | undefined, sector: string): string {
-  const stockName = cleanInline(ticker);
-  const stockMatch = STOCK_THESIS.find((entry) => entry.pattern.test(stockName));
-  if (stockMatch) return stockMatch.subject;
-  const sectorMatch = SECTOR_THESIS.find((entry) => entry.pattern.test(sector));
-  return sectorMatch?.subject ?? `${sector} 흐름을 보는 종목`;
-}
-
-function contextHeadline(ticker: string | undefined, sector: string, detail: string): string {
-  const subject = thesisSubject(ticker, sector);
-  if (/원문|근거는 아직|수급·거래·뉴스/.test(detail)) {
-    return `${subject}, 원문 근거는 아직 얇아요`;
-  }
-  if (/제일|가장|먼저|상위권|눈에 띄/.test(detail)) {
-    return `${subject}에 먼저 반응이 붙었어요`;
-  }
-  return `${subject}에 새 움직임이 붙었어요`;
-}
-
 export function compactDiscoveryCardHeadline({
   reason,
   sector,
@@ -129,16 +120,16 @@ export function compactDiscoveryCardHeadline({
   const detail = parts.detail ?? clean;
 
   if (state === "혼자 튄 무명주") {
-    const displaySector = sectorFromDetail(detail, sector);
-    return clipped(contextHeadline(ticker, displaySector, detail), 42);
+    return clipped(normalizeSurfaceCopy(detail, sectorFromDetail(detail, sector), ticker), 42);
   }
 
   if (state === "이유 얇은 섹터선두") {
-    const displaySector = sectorFromDetail(detail, sector);
-    return clipped(contextHeadline(ticker, displaySector, detail), 42);
+    return clipped(normalizeSurfaceCopy(detail, sectorFromDetail(detail, sector), ticker), 42);
   }
 
   if (state === "뉴스 재료 붙은 종목" || state === "공시 먼저 뜬 종목" || (!state && /뉴스|공시|소식|계약|수주/.test(clean))) {
+    const material = normalizeSurfaceCopy(detail, sector, ticker);
+    if (material && !BAD_SURFACE_COPY_PATTERN.test(material) && material.length > 8) return clipped(material, 44);
     const topic = topicFromMaterial(detail);
     const support = supportFromDetail(detail);
     return topic === "뉴스" ? support : `${topic}에 ${support}`;
@@ -152,6 +143,9 @@ export function compactDiscoveryCardHeadline({
 
   if (state?.includes("거래")) return "거래가 먼저 커진 종목이에요";
   if (state?.includes("새 가격대")) return "새 가격대까지 밟은 종목이에요";
+
+  const normalized = normalizeSurfaceCopy(detail, sector, ticker);
+  if (normalized && !BAD_SURFACE_COPY_PATTERN.test(normalized)) return clipped(normalized, 44);
 
   return undefined;
 }

--- a/apps/fomo-web/lib/whyShown.ts
+++ b/apps/fomo-web/lib/whyShown.ts
@@ -65,7 +65,7 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
     signals.themeAverageChangePct >= 2 &&
     signals.themeRelativeChangePct <= -3
   ) {
-    return `같은 ${signals.themeLabel ?? stock.sector} 흐름은 평균적으로 움직였는데, 이 종목은 아직 덜 움직여서 보여줘요.`;
+    return `같은 ${signals.themeLabel ?? stock.sector} 종목들과 다른 변동성이 잡혀서 보여줘요.`;
   }
   if (
     typeof signals?.themeRelativeRank === "number" &&
@@ -73,7 +73,7 @@ export function whyShown({ stock, fomoLabel, signals, nowMs = Date.now() }: WhyS
     typeof signals.changePct === "number" &&
     signals.changePct > 0
   ) {
-    return `${signals.themeLabel ?? stock.sector} 흐름 안에서 오늘 가장 앞에서 움직여서 보여줘요.`;
+    return `같은 ${signals.themeLabel ?? stock.sector} 종목들보다 오늘 변동성이 더 커서 보여줘요.`;
   }
   if (isDown && (mentionStrong || volumeStrong)) {
     return "강세 카드가 아니라, 하락 중에도 거래·언급이 몰린 이유를 확인하는 카드예요.";

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -87,8 +87,24 @@ describe("discovery material news filter", () => {
 describe("discovery specific hook copy", () => {
   const surfacePricePattern = /(?:가격|[+-]\d+(?:\.\d+)?%|\d+(?:\.\d+)?포인트|섹터 평균|평균보다)/;
   const bannedFillerPattern = new RegExp(
-    [`더\\s*(?:살펴${"볼"}|확인${"할"})`, `조용한\\s*자${"리"}`, `발견\\s*풀`].join("|")
+    [
+      `더\\s*(?:살펴${"볼"}|확인${"할"})`,
+      `조용한\\s*자${"리"}`,
+      `발견\\s*풀`,
+      `혼자\\s*튄`,
+      `무명주`,
+      `흐름\\s+흐름`,
+      `흐름\\s*안에서`,
+      `먼저\\s*반응`,
+      `눈에\\s*띄`,
+      `보는\\s*종목`,
+      `원문\\s*근거`,
+      `강하게\\s*움직`,
+      `상위권으로\\s*움직`,
+      `더\\s*강하게\\s*움직`,
+    ].join("|")
   );
+  const bannedSurfaceMovementPattern = /움직였어요|강하게\s*움직|상위권으로\s*움직|더\s*강하게\s*움직/;
 
   it("keeps same-sector leaders specific instead of collapsing to one generic sentence", () => {
     const hpsp = formatThemeDiscoveryLabel({
@@ -116,12 +132,13 @@ describe("discovery specific hook copy", () => {
       changePct: 3.18,
     });
 
-    expect(hpsp).toBe("반도체 흐름 안에서 가장 먼저 눈에 띄었어요.");
-    expect(wonik).toBe("반도체 흐름 안에서 상위권으로 눈에 띄었어요.");
-    expect(outperformer).toBe("반도체 흐름보다 먼저 반응했어요.");
+    expect(hpsp).toBe("같은 반도체 종목들 중 오늘 변동성이 가장 컸어요.");
+    expect(wonik).toBe("같은 반도체 종목들 중 오늘 변동성이 상위권이에요.");
+    expect(outperformer).toBe("같은 반도체 종목들보다 오늘 변동성이 더 컸어요.");
     expect(new Set([hpsp, wonik, outperformer]).size).toBe(3);
     expect([hpsp, wonik, outperformer].some((text) => /신호가|흐름에서 (?:먼저|같이) 확인/.test(text))).toBe(false);
     expect([hpsp, wonik, outperformer].every((text) => !surfacePricePattern.test(text))).toBe(true);
+    expect([hpsp, wonik, outperformer].every((text) => !bannedSurfaceMovementPattern.test(text))).toBe(true);
   });
 
   it("keeps sector-only movers contextual instead of generic or raw price-only copy", () => {
@@ -136,11 +153,12 @@ describe("discovery specific hook copy", () => {
       change: "+4.20%",
     });
 
-    expect(spike).toBe("건설 안에서 갑자기 관심이 커진 종목이에요.");
-    expect(ordinary).toBe("화장품 안에서 오늘 새로 눈에 들어온 종목이에요.");
+    expect(spike).toBe("건설 종목 중 오늘 거래와 변동성이 크게 잡혔어요.");
+    expect(ordinary).toBe("화장품 종목 중 오늘 변화가 잡혔어요.");
     expect([spike, ordinary].some((text) => /흐름에서 (?:먼저|같이|새로) 확인/.test(text))).toBe(false);
     expect([spike, ordinary].every((text) => !/시총|\d+\/\d+/.test(text))).toBe(true);
     expect([spike, ordinary].every((text) => !surfacePricePattern.test(text))).toBe(true);
+    expect([spike, ordinary].every((text) => !bannedSurfaceMovementPattern.test(text))).toBe(true);
   });
 
   it("uses the same concrete context signal for headline and reason instead of filler copy", () => {
@@ -160,18 +178,16 @@ describe("discovery specific hook copy", () => {
     lucid.sector = "전기차";
 
     expect(hasDisplayWhyEvent(geumho)).toBe(true);
-    expect(discoveryWhy(geumho)).toBe(
-      "혼자 튄 무명주 — 건설 안에서 변동성이 크게 잡혔어요. 원문·수급 근거는 아직 더 확인해야 해요."
-    );
+    expect(discoveryWhy(geumho)).toBe("건설 종목 중 오늘 변동성이 크게 잡혔어요");
     expect(discoveryWhy(geumho)).not.toMatch(/시총|\d+\/\d+/);
     expect(discoveryWhy(geumho)).not.toMatch(bannedFillerPattern);
+    expect(discoveryWhy(geumho)).not.toMatch(bannedSurfaceMovementPattern);
 
     expect(hasDisplayWhyEvent(lucid)).toBe(true);
-    expect(discoveryWhy(lucid)).toBe(
-      "혼자 튄 무명주 — 전기차 흐름 안에서 가장 먼저 눈에 띄었어요. 원문·수급 근거는 아직 더 확인해야 해요."
-    );
+    expect(discoveryWhy(lucid)).toBe("같은 전기차 종목들 중 오늘 변동성이 가장 컸어요");
     expect(discoveryWhy(lucid)).not.toMatch(/시총|\d+\/\d+/);
     expect(discoveryWhy(lucid)).not.toMatch(bannedFillerPattern);
+    expect(discoveryWhy(lucid)).not.toMatch(bannedSurfaceMovementPattern);
     expect(discoveryWhy(lucid)).not.toBe("오늘 전기차 4개 종목 중 제일 셌어요.");
   });
 

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -545,13 +545,13 @@ export function formatThemeDiscoveryLabel(input: {
   changePct: number;
 }): string {
   if (input.rank <= 3) {
-    const orderText = input.rank === 1 ? "가장 먼저 눈에 띄었어요" : "상위권으로 눈에 띄었어요";
-    return `${input.sector} 흐름 안에서 ${orderText}.`;
+    const orderText = input.rank === 1 ? "변동성이 가장 컸어요" : "변동성이 상위권이에요";
+    return `같은 ${input.sector} 종목들 중 오늘 ${orderText}.`;
   }
   if (input.averageChangePct < 0 && input.changePct > 0) {
-    return `${input.sector} 흐름이 눌린 날에도 이 종목은 플러스권이에요.`;
+    return `같은 ${input.sector} 종목들이 약한 날에도 이 종목은 플러스권이에요.`;
   }
-  return `${input.sector} 흐름보다 먼저 반응했어요.`;
+  return `같은 ${input.sector} 종목들보다 오늘 변동성이 더 컸어요.`;
 }
 
 export function formatSectorMarketContextLabel(input: {
@@ -561,9 +561,9 @@ export function formatSectorMarketContextLabel(input: {
 }): string {
   const positive = input.changePct > 0;
   const largeMove = Math.abs(input.changePct) >= 10;
-  if (positive && largeMove) return `${input.sector} 안에서 갑자기 관심이 커진 종목이에요.`;
-  if (positive) return `${input.sector} 안에서 오늘 새로 눈에 들어온 종목이에요.`;
-  return `${input.sector} 안에서 약세 흐름도 같이 확인해요.`;
+  if (positive && largeMove) return `${input.sector} 종목 중 오늘 거래와 변동성이 크게 잡혔어요.`;
+  if (positive) return `${input.sector} 종목 중 오늘 변화가 잡혔어요.`;
+  return `${input.sector} 종목 중 약세 신호가 같이 잡혔어요.`;
 }
 
 function eventFromTheme(row: DiscoveryMarketRow, theme: ThemeMoveSignal | undefined, asOf: string): DiscoveryEvent | null {
@@ -720,7 +720,7 @@ function eventFromVolume(row: DiscoveryMarketRow, ratio: number | undefined, asO
     asOf,
     confidence: "H",
     direction: row.changeDir ?? (typeof row.changePct === "number" && row.changePct > 0 ? "up" : "flat"),
-    label: `평소 ${ratio.toFixed(1)}배 거래가 터졌어요.`,
+    label: `거래가 평소 ${ratio.toFixed(1)}배로 늘었어요.`,
     volumeRatio: Math.round(ratio * 10) / 10,
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
   };

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -193,7 +193,7 @@ function buildFeedPoints(
   }
   if (typeof signals.themeRelativeRank === "number" && signals.themeRelativeRank === 1 && typeof signals.changePct === "number" && signals.changePct > 0) {
     pushUnique(bull, {
-      text: `${signals.themeLabel ?? "같은 테마"} 흐름 안에서 가장 먼저 눈에 띄었어요.`,
+      text: `같은 ${signals.themeLabel ?? "테마"} 종목들 중 오늘 변동성이 가장 컸어요.`,
       source: "테마",
     });
   }

--- a/packages/fomo-core/__tests__/card-front-hook.test.ts
+++ b/packages/fomo-core/__tests__/card-front-hook.test.ts
@@ -234,7 +234,7 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
       },
     });
     expect(lagging.kind).toBe("relative");
-    expect(lagging.headline).toBe("AI 테마 흐름이 강한 날, 다른 속도로 움직였어요.");
+    expect(lagging.headline).toBe("AI 테마 안에서 다른 속도의 변동성이 잡혔어요.");
 
     const moving = computeFomoScore({ changePct: 7, mentionScore: 80 });
     const leading = selectFomoHook({
@@ -249,7 +249,7 @@ describe("selectFomoHook — 상태 배지와 분리된 종목별 헤드라인",
       },
     });
     expect(leading.kind).toBe("relative");
-    expect(leading.headline).toBe("오늘 AI 테마 흐름 안에서 가장 먼저 눈에 띄었어요.");
+    expect(leading.headline).toBe("같은 AI 테마 종목들 중 오늘 변동성이 가장 컸어요.");
   });
 
   it("뉴스 재료와 D-day seam — 데이터가 들어온 경우에만 재료 헤드라인을 고른다", () => {

--- a/packages/fomo-core/__tests__/discovery-supply.test.ts
+++ b/packages/fomo-core/__tests__/discovery-supply.test.ts
@@ -281,11 +281,13 @@ describe("WO-05 discovery supply engine", () => {
     row.events[0]!.direction = "up";
 
     const insight = synthesizeDiscoveryInsight(row);
-    expect(insight.headline).toContain("혼자 튄 무명주");
+    expect(insight.headline).toContain("같은 화장품 종목들");
+    expect(insight.headline).toContain("변동성이 가장 컸어요");
     expect(insight.headline).toContain("화장품");
     expect(insight.headline).not.toContain("시총 411위");
     expect(insight.headline).not.toMatch(/\d+\/\d+/);
-    expect(insight.synthesis).toContain("공개 재료·수급·거래량은 아직 비어 있어요");
+    expect(insight.synthesis).toContain("뉴스·공시·수급 근거는 아직 확인되지 않았어요");
+    expect(insight.headline).not.toMatch(/혼자 튄|무명주|흐름 안에서|먼저 반응|눈에 띄|움직였어요|강하게\s*움직/);
     expect(insight.headline).not.toBe("오늘 화장품 5개 종목 중 제일 셌어요.");
   });
 

--- a/packages/fomo-core/src/keyword-cards/card-front-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/card-front-hook.ts
@@ -520,7 +520,7 @@ function relativeCandidate(signals: CardFrontSignals): HookCandidate | null {
       kind: "relative",
       tier: "material",
       score: Math.min(0.86, 0.56 + Math.abs(delta) / 20),
-      headline: `오늘 ${label} 흐름 안에서 가장 먼저 눈에 띄었어요.`,
+      headline: `같은 ${label} 종목들 중 오늘 변동성이 가장 컸어요.`,
     };
   }
 
@@ -529,7 +529,7 @@ function relativeCandidate(signals: CardFrontSignals): HookCandidate | null {
       kind: "relative",
       tier: "material",
       score: Math.min(0.82, 0.54 + Math.abs(delta) / 22),
-      headline: `${label} 흐름이 강한 날, 다른 속도로 움직였어요.`,
+      headline: `${label} 안에서 다른 속도의 변동성이 잡혔어요.`,
     };
   }
 

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -390,18 +390,23 @@ function userFacingLabel(event: DiscoveryEvent | undefined, candidate?: Discover
   const raw = stripTimePrefix(labelOf(event));
   if (!event || !raw) return "";
   const sector = candidate?.sector ?? "동종";
+  const escapedSector = sector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const relativeStrength = `${"상대"}${"강도"}`;
   const marketPosition = `${"시장"} ${"위치"}`;
   return raw
     .replace(/시총\s*\d+위권\s*종목의\s*/g, "")
     .replace(/시총\s*상위권\s*종목의\s*/g, "")
-    .replace(new RegExp(`^${sector}\\s+\\d+개\\s*종목\\s*중\\s*(?:제일|가장)\\s*(?:셌어요|강했어요|먼저.+)\\.?$`), `${sector} 흐름 안에서 가장 먼저 눈에 띄었어요.`)
-    .replace(new RegExp(`^${sector}\\s+\\d+개\\s*종목\\s*중\\s*(.+)$`), `${sector} 흐름 안에서 상위권으로 눈에 띄었어요.`)
-    .replace(new RegExp(`${relativeStrength}\\s*1위예요\\.?`, "g"), `${sector} 흐름 안에서 가장 먼저 눈에 띄었어요.`)
-    .replace(new RegExp(`${relativeStrength}\\s*(\\d+)위권이에요\\.?`, "g"), `${sector} 흐름 안에서 상위권으로 눈에 띄었어요.`)
-    .replace(new RegExp(`주변보다 ${relativeStrength}가 높아요\\.?`, "g"), "주변 종목보다 오늘 더 강했어요.")
-    .replace(new RegExp(`테마 ${relativeStrength}`, "g"), "동종 흐름")
-    .replace(new RegExp(marketPosition, "g"), "시장 안 흐름")
+    .replace(new RegExp(`^${escapedSector}\\s+\\d+개\\s*종목\\s*중\\s*(?:제일|가장)\\s*(?:셌어요|강했어요|먼저.+)\\.?$`), `같은 ${sector} 종목들 중 오늘 변동성이 가장 컸어요.`)
+    .replace(new RegExp(`^${escapedSector}\\s+\\d+개\\s*종목\\s*중\\s*(.+)$`), `같은 ${sector} 종목들 중 오늘 변동성이 상위권이에요.`)
+    .replace(new RegExp(`${relativeStrength}\\s*1위예요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 변동성이 가장 컸어요.`)
+    .replace(new RegExp(`${relativeStrength}\\s*(\\d+)위권이에요\\.?`, "g"), `같은 ${sector} 종목들 중 오늘 변동성이 상위권이에요.`)
+    .replace(new RegExp(`주변보다 ${relativeStrength}가 높아요\\.?`, "g"), "주변 종목보다 오늘 변동성이 더 컸어요.")
+    .replace(new RegExp(`테마 ${relativeStrength}`, "g"), "동종 종목 비교")
+    .replace(new RegExp(marketPosition, "g"), "시장 안 비교")
+    .replace(new RegExp(`^${escapedSector}\\s+안에서\\s+변동성이\\s+크게\\s+잡혔어요\\.?$`), `${sector} 종목 중 오늘 변동성이 크게 잡혔어요.`)
+    .replace(/흐름\s+흐름/g, "흐름")
+    .replace(/흐름\s*안에서\s*가장\s*먼저\s*눈에\s*띄었어요\.?/g, "종목들 중 오늘 변동성이 가장 컸어요.")
+    .replace(/흐름보다\s*먼저\s*반응했어요\.?/g, "종목들보다 오늘 변동성이 더 컸어요.")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -519,12 +524,12 @@ function whyFactFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): WhyFa
   if (event.kind === "volume_spike") {
     const ratio = ratioText(volumeRatioOf(event));
     if (!ratio) return undefined;
-    const headline = change ? `평소 ${ratio}배 거래 터진 ${ticker} ${change}` : `평소 ${ratio}배 거래 터진 ${ticker}`;
+    const headline = `${ticker} 거래가 평소 ${ratio}배로 늘었어요`;
     return {
       headline,
       state: "거래량",
       observation: `${ticker}: 평소 ${ratio}배 거래량${change ? ` / ${change}` : ""}.`,
-      synthesis: `핵심 숫자는 평소 대비 ${ratio}배 거래량입니다. 기사보다 먼저 거래가 달라진 카드예요.`,
+      synthesis: `평소보다 거래가 크게 늘어, 가격만이 아니라 거래 쪽 변화도 같이 보는 카드예요.`,
       evidence: `${event.source} · ${event.asOf.slice(0, 10)} · 거래량 ${ratio}배`,
     };
   }
@@ -557,19 +562,21 @@ function whyFactFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): WhyFa
 
   if (event.kind === "theme_link" || event.kind === "market_context") {
     const marketRank = candidate.marketCapRank;
-    const rare = typeof marketRank === "number" && marketRank >= DISCOVERY_AWAKENING_RANK_MIN;
     const label = userFacingLabel(event, candidate);
-    const position = label || `${sector} 흐름 안에서 확인된 신호가 있어요.`;
+    const position =
+      label ||
+      (change
+        ? `${ticker}에서 같은 ${sector} 종목들과 다른 변동성이 잡혔어요.`
+        : `같은 ${sector} 종목들과 비교할 변화가 잡혔어요.`);
     const pct = change ?? signedPct(event.changePct);
     if (!pct && !marketRank && !label && !sector) return undefined;
-    const subject = rare ? "혼자 튄 무명주" : `${sector} 흐름`;
-    const headline = `${subject} — ${position.replace(/[.。]$/, "")}.${hasMaterialSupport(candidate, event) ? "" : " 원문·수급 근거는 아직 더 확인해야 해요."}`;
-    const noBacker = hasMaterialSupport(candidate, event) ? "" : " 공개 재료·수급·거래량은 아직 비어 있어요.";
+    const headline = position.replace(/[.。]$/, "");
+    const noBacker = hasMaterialSupport(candidate, event) ? "" : " 뉴스·공시·수급 근거는 아직 확인되지 않았어요.";
     return {
       headline,
-      state: rare ? "무명성" : "섹터 위치",
+      state: "동종 비교",
       observation: `${ticker}: ${position.replace(/[.。]$/, "")}${pct ? ` / ${pct}` : ""}.`,
-      synthesis: `${rare ? "대형주보다 덜 보던 종목에서 먼저 잡힌 흐름" : "동종 흐름 안에서 먼저 보인 변화"}이 카드의 이유입니다.${noBacker}`,
+      synthesis: `같은 ${sector} 종목들과 비교해 달라진 점이 카드의 이유입니다.${noBacker}`,
       evidence: `${event.source} · ${event.asOf.slice(0, 10)}${pct ? ` · ${pct}` : ""}`,
     };
   }

--- a/packages/fomo-core/src/keyword-cards/multi-axis-hook.ts
+++ b/packages/fomo-core/src/keyword-cards/multi-axis-hook.ts
@@ -180,8 +180,8 @@ function herdAxis(signals: CardFrontSignals, asOf: string): AxisSignal {
     return signal("herd", false, 0, "", []);
   }
   if (rank === 1 && pct > 0) {
-    return signal("herd", true, 0.76, `오늘 ${theme} 흐름 안에서 가장 먼저 눈에 띄었어요.`, [
-      { text: `${theme} 동종 흐름, 등락률 ${pctText(pct)}`, sourceKind: "market", source: "동종 흐름", asOf },
+    return signal("herd", true, 0.76, `같은 ${theme} 종목들 중 오늘 변동성이 가장 컸어요.`, [
+      { text: `${theme} 동종 종목 비교, 등락률 ${pctText(pct)}`, sourceKind: "market", source: "동종 비교", asOf },
     ]);
   }
   if (typeof avg === "number" && typeof delta === "number" && avg <= -2 && delta >= 3) {


### PR DESCRIPTION
## Summary
- 표면 훅에서 내부어/필러 문구를 정규화했습니다: 혼자 튄 무명주, 흐름 안에서, 먼저 반응, 눈에 띄, 보는 종목.
- 섹터/동종 비교 문장은 유저가 이해할 수 있는 거래·변동성 문장으로 바꿨습니다.
- 카드/상세 헤드라인 회귀 테스트와 discovery guard를 추가/갱신했습니다.

## Verification
- npm test -- apps/fomo-web/__tests__/discoveryHeadline.test.ts apps/web/__tests__/lib/discovery-supply-material.test.ts packages/fomo-core/__tests__/discovery-supply.test.ts packages/fomo-core/__tests__/card-front-hook.test.ts
- npm run typecheck
- npm run build:fomo-web
- npm run build:web
- npm run lint
- npm run guard:discovery
- SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze (warning-only: PR body includes coverage)
