### PR TITLE
fix(discovery): route US material headlines through synthesis

### DIFF
--- a/apps/web/__tests__/lib/card-headline.test.ts
+++ b/apps/web/__tests__/lib/card-headline.test.ts
@@ -108,4 +108,38 @@ describe("resolveCardHeadline", () => {
       method: "none",
     });
   });
+
+  it("does not let English US source titles reach the card surface", async () => {
+    const title = "D-Wave Quantum Announces New Partnership With Aerospace Customer";
+    const event: DiscoveryEvent = {
+      ...baseEvent,
+      label: title,
+      sourceTitle: title,
+      sourceName: "Yahoo Finance",
+      sourceUrl: "https://example.com/dwave",
+    };
+    const usCandidate: DiscoveryCandidate = {
+      ticker: "디웨이브퀀텀",
+      market: "NYSE",
+      country: "US",
+      sector: "양자",
+      events: [event],
+      asOf: "2026-06-29",
+    };
+
+    const result = await resolveCardHeadline({
+      candidate: usCandidate,
+      synthesis: synthesis({
+        headline: title,
+        tone: "material",
+        primary: event,
+      }),
+      synthesisMethod: "ai",
+      sourceLabel: `${title} · Yahoo Finance`,
+    });
+
+    expect(result.text).toBe("Aerospace 고객과 제휴 발표");
+    expect(result.text).not.toContain("D-Wave");
+    expect(result.provenance).toBe("rule");
+  });
 });

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -63,12 +63,12 @@ describe("discovery material news filter", () => {
     expect(cleanMaterialTitle("장중 시황, 반도체주 차익 실현")).toBeUndefined();
   });
 
-  it("turns concrete US catalyst titles into material hooks instead of generic foreign-news labels", () => {
+  it("keeps concrete US catalyst titles as synthesis input instead of generic foreign-news labels", () => {
     expect(cleanUsMaterialTitle("SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance")).toBe(
-      "SoundHound AI, 실적·가이던스 소식이 나왔어요."
+      "SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance"
     );
     expect(cleanUsMaterialTitle("D-Wave Quantum Announces New Partnership With Aerospace Customer")).toBe(
-      "D-Wave Quantum, 고객·파트너십 소식이 나왔어요."
+      "D-Wave Quantum Announces New Partnership With Aerospace Customer"
     );
     expect(cleanUsMaterialTitle("Analyst raises price target on Micron shares")).toBeUndefined();
     expect(cleanUsMaterialTitle("D-Wave Quantum (QBTS) Is Down 11.3% After U.S. Quantum Orders And Funding News")).toBeUndefined();

--- a/apps/web/__tests__/lib/insight-synthesis.test.ts
+++ b/apps/web/__tests__/lib/insight-synthesis.test.ts
@@ -72,6 +72,53 @@ describe("why-driven insight synthesis guard", () => {
     expect(validateWhyInsightOutput({ headline: "엔비디아와 금호타이어가 정부 투자에 묶임" }, candidate)).toBeUndefined();
   });
 
+  it("rejects English US headlines and accepts Korean concrete synthesis from English quarter text", () => {
+    const candidate: DiscoveryCandidate = {
+      ticker: "사운드하운드AI",
+      market: "NASDAQ",
+      country: "US",
+      sector: "AI",
+      asOf,
+      events: [
+        {
+          kind: "news_mention",
+          firstSeen: true,
+          strength: 0.9,
+          source: "news",
+          asOf,
+          confidence: "H",
+          label: "SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance",
+          sourceTitle: "SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance",
+          sourceName: "Yahoo Finance",
+        },
+      ],
+    };
+
+    expect(
+      validateWhyInsightOutput(
+        {
+          headline: "SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance",
+          observations: ["SoundHound AI first quarter revenue growth"],
+          synthesis: "First quarter revenue and guidance are both mentioned in the same article.",
+          evidence: ["SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance · Yahoo Finance · 2026-06-24"],
+        },
+        candidate
+      )
+    ).toBeUndefined();
+
+    const insight = validateWhyInsightOutput(
+      {
+        headline: "1분기 매출 성장·가이던스 상향",
+        observations: ["영문 원문에 first quarter revenue growth와 guidance raise가 함께 언급됨"],
+        synthesis: "실적과 전망 조정이 같은 기사 안에서 함께 확인된 재료예요",
+        evidence: ["SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance · Yahoo Finance · 2026-06-24"],
+      },
+      candidate
+    );
+
+    expect(insight?.headline).toBe("1분기 매출 성장·가이던스 상향");
+  });
+
   it("keeps observations, synthesis, and evidence as separate blocks", () => {
     expect(blockOverlapRatio("금호타이어 +11.9% / 자동차 1/4", "금호타이어 +11.9% / 자동차 1/4")).toBe(1);
     expect(blockOverlapRatio("금호타이어 +11.9% / 자동차 1/4", "기사 제목보다 정부 호남 투자 예고를 먼저 봅니다")).toBeLessThan(0.7);

--- a/apps/web/__tests__/lib/news-reprocess.test.ts
+++ b/apps/web/__tests__/lib/news-reprocess.test.ts
@@ -44,10 +44,27 @@ describe("news hook reprocessing", () => {
     expect(ruleReprocessNewsHook({ ...base, title: "소식이 나왔어요." })).toBeUndefined();
   });
 
+  it("turns concrete US material titles into Korean rule hooks", () => {
+    expect(
+      ruleReprocessNewsHook({
+        ...base,
+        stock: "디웨이브퀀텀",
+        title: "D-Wave Quantum Announces New Partnership With Aerospace Customer",
+      })
+    ).toBe("Aerospace 고객과 제휴 발표");
+    expect(
+      ruleReprocessNewsHook({
+        ...base,
+        title: "SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance",
+      })
+    ).toBe("1분기 실적 발표");
+  });
+
   it("rejects abstract template fillers instead of letting them reach the card", () => {
     expect(validateReprocessedNewsHook("계약 재료가 새로 확인됐어요", base)).toBeUndefined();
     expect(validateReprocessedNewsHook("직접 재료가 붙었어요", base)).toBeUndefined();
     expect(validateReprocessedNewsHook("소식에 반응", base)).toBeUndefined();
+    expect(validateReprocessedNewsHook("NIO Stock Eyes June Delivery", base)).toBeUndefined();
   });
 
   it("rejects source names, raw-title paste, forbidden advice, and added numbers", () => {

--- a/apps/web/lib/card-headline.ts
+++ b/apps/web/lib/card-headline.ts
@@ -7,6 +7,7 @@ import {
 import {
   cleanInline,
   hasConcreteSourceValue,
+  hasExcessiveLatinHeadline,
   hasForbiddenCopy,
   isAbstractTemplate,
   isRawTitleCopy,
@@ -91,6 +92,7 @@ function eventSourceTitle(event: DiscoveryEvent | undefined): string | undefined
 function isUsableHeadline(text: string | undefined, sourceTitle: string | undefined): text is string {
   const clean = cleanInline(text);
   if (!clean || EMPTY_PATTERN.test(clean)) return false;
+  if (hasExcessiveLatinHeadline(clean)) return false;
   if (hasForbiddenCopy(clean) || isAbstractTemplate(clean)) return false;
   if (isRawTitleCopy(clean, sourceTitle)) return false;
   if (sourceTitle && !hasConcreteSourceValue(clean, sourceTitle)) return false;

--- a/apps/web/lib/copy-guards.ts
+++ b/apps/web/lib/copy-guards.ts
@@ -46,6 +46,50 @@ export function numbersIn(text: string | undefined): string[] {
     .filter(Boolean);
 }
 
+export function englishQuarterNumbers(text: string | undefined): string[] {
+  const quarterMap: Record<string, string> = {
+    first: "1",
+    second: "2",
+    third: "3",
+    fourth: "4",
+  };
+  return [...cleanInline(text).matchAll(/\b(first|second|third|fourth)\s+quarter\b/gi)]
+    .map((match) => quarterMap[match[1]!.toLowerCase()])
+    .filter((value): value is string => Boolean(value));
+}
+
+export function englishMonthNumbers(text: string | undefined): string[] {
+  const monthMap: Record<string, string> = {
+    january: "1",
+    jan: "1",
+    february: "2",
+    feb: "2",
+    march: "3",
+    mar: "3",
+    april: "4",
+    apr: "4",
+    may: "5",
+    june: "6",
+    jun: "6",
+    july: "7",
+    jul: "7",
+    august: "8",
+    aug: "8",
+    september: "9",
+    sep: "9",
+    sept: "9",
+    october: "10",
+    oct: "10",
+    november: "11",
+    nov: "11",
+    december: "12",
+    dec: "12",
+  };
+  return [...cleanInline(text).matchAll(/\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b/gi)]
+    .map((match) => monthMap[match[1]!.toLowerCase()])
+    .filter((value): value is string => Boolean(value));
+}
+
 export function numberVariants(value: string): string[] {
   const n = Number(value.replace(/^\+/, ""));
   if (!Number.isFinite(n)) return [value];
@@ -131,7 +175,11 @@ function concreteCandidates(title: string): string[] {
       /([가-힣A-Za-z0-9&().+-]{2,24})\s*(?:공급계약|계약|수주|발표|체결|확보|개발|출시|승인|허가|실적|가이던스|인수전|클러스터|투자|파트너십|제휴)/g
     ),
   ].map((match) => match[1]!);
-  return [...quoted, ...amounts, ...latin, ...korean, ...nounBeforeEvent].map(cleanInline).filter((token) => token.length >= 2);
+  const englishQuarter = englishQuarterNumbers(clean).map((value) => `${value}분기`);
+  const englishMonth = englishMonthNumbers(clean).map((value) => `${value}월`);
+  return [...quoted, ...amounts, ...latin, ...korean, ...nounBeforeEvent, ...englishQuarter, ...englishMonth]
+    .map(cleanInline)
+    .filter((token) => token.length >= 2);
 }
 
 export function hasConcreteSourceValue(hook: string | undefined, sourceTitle: string | undefined): boolean {
@@ -139,10 +187,47 @@ export function hasConcreteSourceValue(hook: string | undefined, sourceTitle: st
   const cleanTitle = cleanInline(sourceTitle);
   if (!cleanHook || !cleanTitle) return false;
   const titleNumbers = new Set(numbersIn(cleanTitle).flatMap(numberVariants).map((num) => num.replace(/^\+/, "")));
+  englishQuarterNumbers(cleanTitle).forEach((num) => {
+    numberVariants(num).forEach((variant) => titleNumbers.add(variant.replace(/^\+/, "")));
+  });
+  englishMonthNumbers(cleanTitle).forEach((num) => {
+    numberVariants(num).forEach((variant) => titleNumbers.add(variant.replace(/^\+/, "")));
+  });
   if (numbersIn(cleanHook).some((num) => numberVariants(num).some((variant) => titleNumbers.has(variant.replace(/^\+/, ""))))) {
     return true;
   }
+  const normalizedHook = cleanHook.toLowerCase();
+  const normalizedTitle = cleanTitle.toLowerCase();
+  const knownTranslations: Array<[string, string]> = [
+    ["엔비디아", "nvidia"],
+    ["미 육군", "army"],
+    ["반도체 제조 시스템", "chipmaking systems"],
+    ["반도체 제조 시스템", "chipmaking system"],
+    ["미국 항공우주", "aerospace"],
+  ];
+  if (
+    knownTranslations.some(
+      ([ko, en]) => normalizedHook.includes(ko.toLowerCase()) && normalizedTitle.includes(en.toLowerCase())
+    )
+  ) {
+    return true;
+  }
   return concreteCandidates(cleanTitle).some((token) => cleanHook.includes(token));
+}
+
+export function hasExcessiveLatinHeadline(text: string | undefined): boolean {
+  const clean = cleanInline(text);
+  if (!clean) return false;
+  const latinWords = clean.match(/[A-Za-z][A-Za-z0-9&'().-]*/g) ?? [];
+  if (latinWords.length === 0) return false;
+  const meaningfulLatin = latinWords.filter((word) => !/^(?:AI|GPU|CPU|SEC|KRX|DART|KOSPI|KOSDAQ|NYSE|NASDAQ|ETF|IPO|ESS)$/i.test(word));
+  const latinChars = meaningfulLatin.join("").length;
+  const koChars = (clean.match(/[가-힣]/g) ?? []).length;
+  const totalLetters = latinChars + koChars;
+  if (latinChars >= 12 && koChars === 0) return true;
+  if (meaningfulLatin.length >= 4 && koChars < 4) return true;
+  if (meaningfulLatin.length <= 2 && koChars >= 3) return false;
+  return totalLetters > 0 && latinChars / totalLetters >= 0.4 && koChars < 8;
 }
 
 export function hasForbiddenCopy(text: string | undefined): boolean {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -41,6 +41,7 @@ import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock
 import { resolveCardHeadline, type CardHeadline } from "./card-headline";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
+import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
 import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
 import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
 import { isAbstractTemplate } from "./copy-guards";
@@ -68,7 +69,7 @@ const MATERIAL_NEWS_NOISE =
 const MATERIAL_NEWS_CATALYST =
   /공시|계약|공급계약|수주|납품|실적|매출|영업이익|순이익|가이던스|전망치|컨센서스|어닝|흑자|적자|턴어라운드|임상|허가|승인|FDA|품목허가|신약|치료제|기술이전|라이선스|증설|공장|양산|수율|수주잔고|M&A|인수|합병|지분|투자|유상증자|무상증자|자사주|배당|분할|상장|정부|정책|규제|지원|보조금|관세|제재|신제품|출시|개발|특허|공급|독점|선정|채택|수출|수입|국책|프로젝트|수혜|클러스터|산단|거점|밸류체인|관련주|부각|모멘텀|호재|주목|협력|제휴/i;
 const US_MATERIAL_NEWS_NOISE =
-  /price\s?target|target price|analyst|rating|upgrade|downgrade|initiates?|maintains?|reiterates?|buybacks?\s+explained|history of|buy,\s*sell,\s*or\s*hold|should you buy|stock to buy|better buy|which .* stock|what investors should know|motley fool|zacks|benzinga|investorplace|approach with caution|missing link|strain inside|what you|can it|market rotation|running out of power|internet.?s .+ odd duck|all-time low|gaining ground|more significant dip|boom is|fears hit|gains as market dips|limps along|afterglow is gone|and more stocks|more stocks that|stocks that|stock market today|market roundup|why .* stock (?:is )?(?:up|down|rising|falling)|\b(?:is|are|was|were)?\s*(?:up|down|higher|lower|gains?|loses?|rises?|falls?)\s+\d+(?:\.\d+)?%|\b(?:is|are|was|were)\s+(?:up|down|higher|lower)\b|shares? (?:rise|fall|slip|jump|gain|lose) after hours/i;
+  /price\s?target|target price|\braises?\s+PT\b|\bPT\s+on\b|analyst|rating|upgrade|downgrade|initiates?|maintains?|reiterates?|buybacks?\s+explained|history of|buy,\s*sell,\s*or\s*hold|should you buy|stock to buy|better buy|which .* stock|what investors should know|\b[A-Z]{1,6}\s+investors?\b|investors?\s+(?:have|can|should|alert|deadline|opportunity|reminder|notice)|shareholders?|class action|lawsuit|law firm|securities fraud|motley fool|zacks|benzinga|investorplace|approach with caution|missing link|strain inside|what you|can it|market rotation|running out of power|internet.?s .+ odd duck|all-time low|gaining ground|more significant dip|boom is|fears hit|gains as market dips|limps along|afterglow is gone|and more stocks|more stocks that|stocks that|stock market today|market roundup|why .* stock (?:is )?(?:up|down|rising|falling)|\b(?:is|are|was|were)?\s*(?:up|down|higher|lower|gains?|loses?|rises?|falls?)\s+\d+(?:\.\d+)?%|\b(?:is|are|was|were)\s+(?:up|down|higher|lower)\b|shares? (?:rise|fall|slip|jump|gain|lose) after hours/i;
 const US_MATERIAL_NEWS_CATALYST =
   /earnings|results|revenue|profit|margin|guidance|forecast|quarter|q[1-4]|contract|deal|order|supply|supplier|customer|partnership|launch|unveil|product|chip|gpu|ai|data center|approval|fda|trial|drug|sec|8-k|10-q|filing|acquisition|merger|stake|investment|buyback authorization|dividend/i;
 const DISCOVERY_SOURCE_LABEL = TARGETED_MATERIAL_DEFAULT_ENABLED
@@ -306,7 +307,7 @@ export function cleanMaterialTitle(title: string): string | undefined {
   return isFrontHookSafe(`${compact} 소식이 나왔어요.`) ? compact : undefined;
 }
 
-export function cleanUsMaterialTitle(title: string, subjectHint?: string): string | undefined {
+export function cleanUsMaterialTitle(title: string): string | undefined {
   const cleaned = decodeHtmlEntities(title)
     .replace(/^\s*(?:\[[^\]]+\]|【[^】]+】|\([^)]*\))\s*/g, "")
     .replace(/[“”"]/g, "")
@@ -318,7 +319,7 @@ export function cleanUsMaterialTitle(title: string, subjectHint?: string): strin
   }
   if (!US_MATERIAL_NEWS_CATALYST.test(cleaned)) return undefined;
   if (/[\[\]{}<>]/.test(cleaned)) return undefined;
-  return translateUsMaterialTitle(cleaned, subjectHint);
+  return cleaned;
 }
 
 function isPrimaryStockArticle(canonical: string, article: RawArticle): boolean {
@@ -343,39 +344,93 @@ function pickTargetedMaterialArticle(canonical: string, articles: readonly RawAr
   );
 }
 
-function usSubject(title: string): string | undefined {
-  const match = title.match(/^([A-Z][A-Za-z0-9 .&'-]{1,42}?)(?:\s+\([A-Z.]+\))?\s+(?:Reports|Raises|Announces|Unveils|Launches|Introduces|Signs|Secures|Expands|Files|Receives|Wins|Posts|Beats)\b/i);
-  return match?.[1]?.trim().replace(/\s+/g, " ");
+const US_ARTICLE_ALIAS_OVERRIDES: Record<string, string[]> = {
+  AMD: ["Advanced Micro Devices"],
+  ARM: ["Arm Holdings"],
+  APP: ["AppLovin"],
+  AVGO: ["Broadcom"],
+  BBAI: ["BigBear.ai", "BigBear AI"],
+  BE: ["Bloom Energy"],
+  COIN: ["Coinbase"],
+  CRWD: ["CrowdStrike"],
+  DDOG: ["Datadog"],
+  DUOL: ["Duolingo"],
+  GEV: ["GE Vernova"],
+  HOOD: ["Robinhood"],
+  IONQ: ["IonQ"],
+  LCID: ["Lucid", "Lucid Group"],
+  MDB: ["MongoDB"],
+  MRVL: ["Marvell"],
+  MU: ["Micron"],
+  NIO: ["NIO"],
+  NVDA: ["Nvidia", "NVIDIA"],
+  PLTR: ["Palantir"],
+  QBTS: ["D-Wave", "D-Wave Quantum"],
+  RGTI: ["Rigetti"],
+  RIVN: ["Rivian"],
+  RKLB: ["Rocket Lab"],
+  SMCI: ["Super Micro", "Supermicro"],
+  SOFI: ["SoFi"],
+  SOUN: ["SoundHound", "SoundHound AI"],
+  SQ: ["Block"],
+  TSM: ["Taiwan Semiconductor", "TSMC"],
+  TSLA: ["Tesla"],
+  UPST: ["Upstart"],
+  VRT: ["Vertiv"],
+  VST: ["Vistra"],
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function translateUsMaterialTitle(title: string, subjectHint?: string): string | undefined {
-  const subject = subjectHint?.trim() || usSubject(title);
-  if (!subject) return undefined;
-  const lower = title.toLowerCase();
-  let detail: string | undefined;
-  if (/revenue|earnings|results|guidance|forecast|margin|profit/.test(lower)) {
-    detail = "실적·가이던스 소식";
-  } else if (/partnership|customer|deal|contract|order|supply|supplier/.test(lower)) {
-    detail = "고객·파트너십 소식";
-  } else if (/sec|8-k|10-q|filing/.test(lower)) {
-    detail = "SEC 공시";
-  } else if (/approval|fda|trial|drug/.test(lower)) {
-    detail = "신약·허가 소식";
-  } else if (/acquisition|merger|stake|investment/.test(lower)) {
-    detail = "인수·투자 소식";
-  } else if (/launch|unveil|introduce|product|chip|gpu|ai|data center|solution/.test(lower)) {
-    detail = "제품·AI 인프라 소식";
-  } else if (/delivery|deliveries/.test(lower)) {
-    detail = "인도량 확인 이슈";
-  } else if (/funding|securitization|liquidity/.test(lower)) {
-    detail = "자금조달·유동화 이슈";
-  } else if (/nuclear|reactor|reactors/.test(lower)) {
-    detail = "원전 설계·개발 이슈";
+function usAliasesForRow(row: DiscoveryMarketRow): string[] {
+  const symbol = row.symbol.trim().toUpperCase();
+  const symbolDef = US_DISCOVERY_SYMBOLS.find((item) => item.symbol === symbol || item.canonical === row.canonical);
+  return [
+    symbol,
+    row.canonical,
+    ...(symbolDef ? [symbolDef.canonical] : []),
+    ...(US_ARTICLE_ALIAS_OVERRIDES[symbol] ?? []),
+  ]
+    .map((alias) => alias.trim())
+    .filter((alias, index, all) => alias.length >= 2 && all.indexOf(alias) === index);
+}
+
+function usAliasMatchScore(text: string, aliases: readonly string[]): number {
+  const clean = decodeHtmlEntities(text).replace(/\s+/g, " ").trim();
+  if (!clean) return 0;
+  let score = 0;
+  for (const alias of aliases) {
+    if (/^[A-Z0-9.]{1,6}$/.test(alias)) {
+      const pattern = new RegExp(`(?:^|[^A-Za-z0-9])${escapeRegExp(alias)}(?:$|[^A-Za-z0-9])`, "i");
+      if (pattern.test(clean)) score = Math.max(score, 5);
+      continue;
+    }
+    if (/^[가-힣]/.test(alias)) {
+      if (clean.includes(alias)) score = Math.max(score, 3);
+      continue;
+    }
+    const pattern = new RegExp(`(?:^|[^A-Za-z0-9])${escapeRegExp(alias)}(?:$|[^A-Za-z0-9])`, "i");
+    if (pattern.test(clean)) score = Math.max(score, Math.min(8, Math.max(4, alias.length / 4)));
   }
-  if (!detail) return undefined;
-  const particle = /(공시|이슈)$/.test(detail) ? "가" : "이";
-  const translated = `${subject}, ${detail}${particle} 나왔어요.`;
-  return isFrontHookSafe(translated) ? translated : undefined;
+  return score;
+}
+
+function usArticleMatchScore(row: DiscoveryMarketRow, article: RawArticle): number {
+  if (!cleanUsMaterialTitle(article.title)) return 0;
+  const aliases = usAliasesForRow(row);
+  const titleScore = usAliasMatchScore(article.title, aliases);
+  const summaryScore = article.summary ? usAliasMatchScore(article.summary, aliases) : 0;
+  if (titleScore <= 0 && summaryScore <= 0) return 0;
+  return titleScore * 3 + summaryScore;
+}
+
+function pickUsTargetedMaterialArticle(row: DiscoveryMarketRow, articles: readonly RawArticle[]): RawArticle | undefined {
+  return articles
+    .map((article) => ({ article, score: usArticleMatchScore(row, article) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)[0]?.article;
 }
 
 function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
@@ -414,8 +469,8 @@ function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEv
   };
 }
 
-function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string, subjectHint?: string): DiscoveryEvent | null {
-  const label = cleanUsMaterialTitle(article.title, subjectHint);
+function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
+  const label = cleanUsMaterialTitle(article.title);
   if (!label) return null;
   const sourceName = article.source || sourceFallback;
   const sourceTitle = decodeHtmlEntities(article.title).replace(/\s+/g, " ").trim();
@@ -505,11 +560,8 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
         sourceName: filing.source,
       };
     }
-    const stockNews =
-      newsResult.status === "fulfilled"
-        ? newsResult.value.find((article) => materialEventFromUsArticle(article, asOf, "Yahoo Finance", row.canonical) !== null)
-        : undefined;
-    return stockNews ? materialEventFromUsArticle(stockNews, asOf, "Yahoo Finance", row.canonical) : null;
+    const stockNews = newsResult.status === "fulfilled" ? pickUsTargetedMaterialArticle(row, newsResult.value) : undefined;
+    return stockNews ? materialEventFromUsArticle(stockNews, asOf, "Yahoo Finance") : null;
   }
   if (!row.naverCode || !/^\d{6}$/.test(row.naverCode)) return null;
   const disclosure = (await fetchDartDisclosuresForCode(row.naverCode, row.canonical, asOf).catch(
@@ -899,6 +951,20 @@ function frontMaterialReason(front: DiscoveryFrontSeed | undefined): { reason: s
   return undefined;
 }
 
+function headlineCandidate(
+  row: DiscoveryMarketRow,
+  candidate: DiscoveryCandidate,
+  sector: string | undefined
+): DiscoveryCandidate {
+  const { synthesizedInsight: _previousSynthesis, ...rest } = candidate;
+  const events = candidate.events.map((event) => withRuleHeadlineHook(event, candidate.ticker, sector, row, candidate.asOf));
+  return {
+    ...rest,
+    ...(sector ? { sector } : {}),
+    events,
+  };
+}
+
 async function stockPayload(
   row: DiscoveryMarketRow,
   candidate: DiscoveryCandidate,
@@ -906,7 +972,9 @@ async function stockPayload(
 ): Promise<DiscoveryStockPayload> {
   const def = resolveStock(candidate.ticker);
   const sector = cleanSectorLabel(candidate.sector) ?? (def ? sectorOf(def.canonical) : undefined);
-  const synthesis = synthesizeDiscoveryInsight(candidate);
+  const resolvedCandidate = headlineCandidate(row, candidate, sector);
+  const whyDriven = await synthesizeWhyDrivenInsight(resolvedCandidate);
+  const synthesis = whyDriven.insight;
   const frontReason = frontMaterialReason(front);
   const synthesizedWhy = synthesis.headline;
   const why = isConcreteMaterialReason(synthesizedWhy) ? synthesizedWhy : frontReason?.reason ?? synthesizedWhy;
@@ -915,7 +983,9 @@ async function stockPayload(
   const sourceName = (sourceEvent?.sourceName ?? sourceEvent?.source)?.trim();
   const sourceLabel = sourceTitle ? `${sourceTitle}${sourceName ? ` · ${sourceName}` : ""}` : sourceName ?? frontReason?.sourceLabel;
   const headline = await resolveCardHeadline({
-    candidate,
+    candidate: resolvedCandidate,
+    synthesis,
+    synthesisMethod: whyDriven.method === "ai" ? "ai" : "rule",
     reason: why,
     ...(sourceLabel ? { sourceLabel } : {}),
   });
@@ -1554,6 +1624,14 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     const stock = await stockPayload(row, candidate, front);
     const headline = stock.headline?.trim();
     if (stock.headlineProvenance?.provenance === "suppressed" || !headline) continue;
+    const isUsStock = row.country === "US" || candidate.country === "US" || stock.country === "US";
+    if (isUsStock) {
+      const headlineEvent = stock.headlineProvenance?.eventRef;
+      const headlineEventKind = headlineEvent?.kind;
+      const hasSurfaceMaterial = headlineEventKind === "news_mention" || headlineEventKind === "disclosure";
+      const hasGroundedMaterial = Boolean(stock.sourceLabel && (stock.sourceUrl || headlineEvent?.url));
+      if (!hasSurfaceMaterial || !hasGroundedMaterial) continue;
+    }
     stocks.push(stock);
     fronts[candidate.ticker] = front;
   }

--- a/apps/web/lib/insight-synthesis.ts
+++ b/apps/web/lib/insight-synthesis.ts
@@ -6,6 +6,7 @@ import {
   type DiscoveryEvent,
   type DiscoveryInsightSynthesis,
 } from "@fomo/core";
+import { hasExcessiveLatinHeadline, hasForbiddenCopy, isAbstractTemplate } from "./copy-guards";
 
 export interface WhySynthesisResult {
   insight: DiscoveryInsightSynthesis;
@@ -118,6 +119,18 @@ function numbersIn(text: string): string[] {
   return [...text.matchAll(/[+-]?\d+(?:\.\d+)?/g)].map((match) => match[0]!.replace(/^\+/, ""));
 }
 
+function englishQuarterNumbers(text: string): string[] {
+  const quarterMap: Record<string, string> = {
+    first: "1",
+    second: "2",
+    third: "3",
+    fourth: "4",
+  };
+  return [...text.matchAll(/\b(first|second|third|fourth)\s+quarter\b/gi)]
+    .map((match) => quarterMap[match[1]!.toLowerCase()])
+    .filter((value): value is string => Boolean(value));
+}
+
 function inputText(candidate: DiscoveryCandidate): string {
   return [
     candidate.ticker,
@@ -145,7 +158,8 @@ function inputText(candidate: DiscoveryCandidate): string {
 }
 
 function inputNumbers(candidate: DiscoveryCandidate): Set<string> {
-  const nums = numbersIn(inputText(candidate));
+  const input = inputText(candidate);
+  const nums = [...numbersIn(input), ...englishQuarterNumbers(input)];
   const rounded = nums.flatMap(numberVariants);
   return new Set(rounded.map((num) => num.replace(/^\+/, "")));
 }
@@ -249,6 +263,8 @@ export function whyInsightRejectionReasons(
   const fullText = textParts(insight).join(" ");
   if (!insight.headline || insight.headline.length > 64) reasons.push("headline-length");
   if (!hasConcreteWhy(insight.headline, candidate)) reasons.push("no-concrete-why");
+  if (hasExcessiveLatinHeadline(insight.headline)) reasons.push("latin-headline");
+  if (hasForbiddenCopy(insight.headline) || isAbstractTemplate(insight.headline)) reasons.push("headline-guard");
   if (ADVICE_PATTERN.test(fullText)) reasons.push("advice");
   if (ABSTRACT_PATTERN.test(fullText) || hasAbstractDiscoveryFiller(fullText)) reasons.push("abstract");
   if (hasSourceLeak(insight.headline, candidate)) reasons.push("source-leak");
@@ -307,8 +323,13 @@ function systemPrompt(): string {
   ];
   return [
     "너는 주식 발견 카드의 Why 문장 엔진이다.",
+    "입력이 영어 미국 종목 뉴스/공시여도 출력 헤드라인은 반드시 한국어로 쓴다.",
     "헤드라인은 [주체/규모가 박힌 사건 또는 숫자] + [이 종목에 일어난 일] 한 줄이다.",
+    "원문에서 무엇을·누구와·얼마·언제 중 확인 가능한 구체값을 최소 1개 포함한다.",
     "반드시 입력 JSON에 있는 숫자 또는 고유명사만 쓴다. 입력에 없으면 쓰지 않는다.",
+    "영문 기사 제목을 그대로 번역하거나 복붙하지 말고, 종목 보유자 관점의 한국어 한 줄로 압축한다.",
+    "좋은 예: '1분기 매출 성장·가이던스 상향', 'Aerospace 고객과 제휴 발표', '8-K 중요계약 공시 확인'.",
+    "나쁜 예: 'partnership news announced', '제휴 소식이 나왔어요', 'D-Wave Quantum Announces New Partnership With Aerospace Customer'.",
     `${banned.join(", ")} 금지.`,
     "투자 조언과 방향 예측 금지. 사실과 해석까지만 쓴다.",
     "출력은 JSON {\"headline\":\"...\",\"observations\":[\"...\"],\"synthesis\":\"...\",\"evidence\":[\"...\"]}.",

--- a/apps/web/lib/news-reprocess.ts
+++ b/apps/web/lib/news-reprocess.ts
@@ -1,7 +1,10 @@
 import { callAI, isAiConfigured } from "@fomo/shared";
 import {
   cleanInline,
+  englishMonthNumbers,
+  englishQuarterNumbers,
   hasConcreteSourceValue,
+  hasExcessiveLatinHeadline,
   hasForbiddenCopy,
   isAbstractTemplate,
   isRawTitleCopy,
@@ -34,9 +37,16 @@ function cacheKey(input: NewsHookInput): string {
 export function validateReprocessedNewsHook(hook: string | undefined, input: NewsHookInput): string | undefined {
   const clean = cleanInline(hook);
   if (!clean || clean.length > 44) return undefined;
+  if (hasExcessiveLatinHeadline(clean)) return undefined;
   if (hasForbiddenCopy(clean) || SOURCE_NAME_PATTERN.test(clean) || isAbstractTemplate(clean)) return undefined;
   if (isRawTitleCopy(clean, input.title)) return undefined;
   const allowedNumbers = new Set(numbersIn(input.title).flatMap(numberVariants));
+  englishQuarterNumbers(input.title).forEach((num) => {
+    numberVariants(num).forEach((value) => allowedNumbers.add(value));
+  });
+  englishMonthNumbers(input.title).forEach((num) => {
+    numberVariants(num).forEach((value) => allowedNumbers.add(value));
+  });
   if (typeof input.changePct === "number" && Number.isFinite(input.changePct)) {
     numberVariants(String(Math.abs(input.changePct))).forEach((value) => allowedNumbers.add(value));
   }
@@ -63,8 +73,8 @@ function pickCounterparty(title: string): string | undefined {
   if (pair?.[1] && pair[2]) return `${pair[1]}·${pair[2]}`;
   const ko = title.match(/([가-힣A-Za-z0-9&().+-]{2,24})(?:와|과|와의|과의)\s*(?:공급계약|계약|제휴|협력|파트너십|인수전|수주)/);
   if (ko?.[1]) return ko[1].trim();
-  const en = title.match(/\b(?:with|from|by)\s+([A-Z][A-Za-z0-9&().+-]{1,24})/);
-  return en?.[1]?.trim();
+  const en = title.match(/\b(?:with|from|by|for)\s+([A-Z][A-Za-z0-9&().+-]{1,24}(?:\s+[A-Z][A-Za-z0-9&().+-]{1,24}){0,1})/i);
+  return cleanEnglishPhrase(en?.[1]);
 }
 
 function pickProduct(title: string): string | undefined {
@@ -76,6 +86,84 @@ function pickProduct(title: string): string | undefined {
     .replace(/\s*(?:공급|수주|계약)$/i, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function pickQuarterLabel(title: string): string | undefined {
+  const q = title.match(/\bQ([1-4])\b/i)?.[1] ?? englishQuarterNumbers(title)[0];
+  return q ? `${q}분기` : undefined;
+}
+
+function pickMonthLabel(title: string): string | undefined {
+  const month = englishMonthNumbers(title)[0];
+  return month ? `${month}월` : undefined;
+}
+
+function cleanEnglishPhrase(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (/\baerospace\s+customer\b/i.test(value)) return "Aerospace 고객";
+  const cleaned = value
+    .replace(/\b(?:Inc|Corp|Corporation|Co|Company|Ltd|PLC|LLC|Holdings?|Group|The)\b\.?/gi, "")
+    .replace(
+      /\b(?:new|major|strategic|global|retail|media|data|hub|customer|customers|partnership|deal|contract|order|key|as|role|seat)\b/gi,
+      ""
+    )
+    .replace(/\b(?:with|from|by|for|of)\b/gi, "")
+    .replace(/^\d+[-\s]*/, "")
+    .replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned || cleaned.length < 2) return undefined;
+  return localizeEnglishPhrase(cleaned.split(/\s+/).slice(0, 3).join(" "));
+}
+
+function localizeEnglishPhrase(value: string): string {
+  const clean = value.replace(/\s+/g, " ").trim();
+  const normalized = clean.toLowerCase();
+  const exact: Record<string, string> = {
+    aerospace: "Aerospace",
+    "aerospace customer": "Aerospace 고객",
+    army: "미 육군",
+    "army role": "미 육군",
+    nvidia: "엔비디아",
+    "chipmaking systems": "반도체 제조 시스템",
+    "chipmaking system": "반도체 제조 시스템",
+    "seat es8": "ES8",
+    "5-seat es8": "ES8",
+  };
+  return exact[normalized] ?? clean;
+}
+
+function phraseAfterVerb(title: string, verbs: string): string | undefined {
+  const match = title.match(new RegExp(`\\b(?:${verbs})\\s+(?:a\\s+|an\\s+|the\\s+|new\\s+|suite\\s+of\\s+new\\s+)?([^:;,.()]{2,64})`, "i"));
+  return cleanEnglishPhrase(match?.[1]);
+}
+
+function phraseBeforeKeyword(title: string, keyword: string): string | undefined {
+  const match = title.match(new RegExp(`([A-Z][A-Za-z0-9&().+-]{1,24}(?:\\s+[A-Z][A-Za-z0-9&().+-]{1,24}){0,2})\\s+${keyword}`, "i"));
+  return cleanEnglishPhrase(match?.[1]);
+}
+
+function pickBacklog(title: string): string | undefined {
+  const match = title.match(/\$?\s?(\d+(?:\.\d+)?)\s*(Billion|Million)\s+Backlog/i);
+  if (!match?.[1] || !match[2]) return undefined;
+  return `${match[1]} ${match[2]} 수주잔고`;
+}
+
+function pickDeliveryProduct(title: string): string | undefined {
+  const quoted = pickQuoted(title);
+  if (quoted) return cleanEnglishPhrase(quoted);
+  const beforePreorder = title.match(/([A-Z][A-Za-z0-9&().+-]{1,24}(?:\s+[A-Z0-9][A-Za-z0-9&().+-]{1,24}){0,2})\s+Preorders?/i)?.[1];
+  if (beforePreorder) return cleanEnglishPhrase(beforePreorder);
+  const beforeLaunch = title.match(/([A-Z][A-Za-z0-9&().+-]{1,24}(?:\s+[A-Z0-9][A-Za-z0-9&().+-]{1,24}){0,2})\s+(?:Launch|Launches|Launches? Ahead|Debut)/i)?.[1];
+  return cleanEnglishPhrase(beforeLaunch);
+}
+
+function withAndParticle(value: string): string {
+  const last = value.trim().at(-1);
+  if (!last) return value;
+  const code = last.charCodeAt(0);
+  if (code < 0xac00 || code > 0xd7a3) return `${value}와`;
+  return (code - 0xac00) % 28 === 0 ? `${value}와` : `${value}과`;
 }
 
 function compactTitlePhrase(title: string): string | undefined {
@@ -115,13 +203,35 @@ function candidateHooks(input: NewsHookInput, title: string): string[] {
   const counterparty = pickCounterparty(title);
   const product = pickProduct(title);
   const filing = pickFiling(title);
+  const quarter = pickQuarterLabel(title);
+  const month = pickMonthLabel(title);
   const hooks: string[] = [];
+
+  if (counterparty && /launch(?:es|ed)?|introduc|unveil|product|platform|solution/i.test(title)) {
+    hooks.push(`${withAndParticle(counterparty)} 제품 협력`);
+  }
+
+  if (/deliver(?:y|ies|ed)|preorders?|launch(?:es|ed)?|debut/i.test(title)) {
+    const deliveryProduct = pickDeliveryProduct(title) ?? product;
+    if (/preorders?/i.test(title) && month && deliveryProduct) hooks.push(`${deliveryProduct} ${month} 출시 전 사전예약`);
+    if (/preorders?/i.test(title) && deliveryProduct) hooks.push(`${deliveryProduct} 사전예약 시작`);
+    if (/deliver/i.test(title) && quarter) hooks.push(`${quarter} 인도량 발표`);
+    if (/deliver/i.test(title) && month) hooks.push(`${month} 인도량 발표`);
+    if (/launch|debut/i.test(title) && month && deliveryProduct) hooks.push(`${deliveryProduct} ${month} 출시 일정`);
+  }
 
   if (/정부|국책|투자|클러스터|산단|호남/.test(title) && /관련주|부각|묶|투자/.test(title)) {
     if (/호남/.test(title)) hooks.push("호남 투자 발표에 관련주로 언급");
     if (amount) hooks.push(`${amount} 투자 발표에 관련주로 언급`);
   }
-  if (/공급계약|계약|수주|contract|deal|order|supply/.test(lower)) {
+  if (/partnership|collaboration|deal/.test(lower) && counterparty) {
+    hooks.push(`${withAndParticle(counterparty)} 제휴 발표`);
+  }
+  if (/공급계약|계약|수주|contract|order|supply/.test(lower)) {
+    const securedCounterparty = phraseAfterVerb(title, "secures?|wins?|lands?|receives?|signs?");
+    const backlog = pickBacklog(title);
+    if (backlog) hooks.push(`${backlog} 확보`);
+    if (securedCounterparty && /contract|order|supply/i.test(title)) hooks.push(`${securedCounterparty} 공급계약 체결`);
     if (amount && product) hooks.push(`${amount} ${product} 공급계약 체결`);
     if (amount) hooks.push(`${amount} 공급계약 체결`);
     if (counterparty) hooks.push(`${counterparty} 공급계약 체결`);
@@ -138,18 +248,27 @@ function candidateHooks(input: NewsHookInput, title: string): string[] {
     if (amount) hooks.push(`${amount} 매각 이슈`);
   }
   if (/제품|신제품|AI 인프라|data center|solution|launch|unveil|introduce|product/.test(lower)) {
-    if (counterparty) hooks.push(`${counterparty}와 제품 협력`);
+    const launched = phraseAfterVerb(title, "launches?|introduces?|unveils?|extends?|debuts?|announces?");
+    if (launched && /extend/i.test(title)) hooks.push(`${launched} 제품 확장`);
+    if (launched && !/extend/i.test(title)) hooks.push(`${launched} 제품 공개`);
+    if (counterparty) hooks.push(`${withAndParticle(counterparty)} 제품 협력`);
     if (product) hooks.push(`${product} 공개`);
   }
   const compactPhrase = compactTitlePhrase(title);
   if (compactPhrase) hooks.push(compactPhrase);
   if (/실적|가이던스|매출|revenue|earnings|results|guidance|forecast/.test(lower)) {
     if (amount) hooks.push(`${amount} 실적 발표`);
-    if (/1Q|1분기/i.test(title)) hooks.push("1분기 실적 발표");
-    if (/2Q|2분기/i.test(title)) hooks.push("2분기 실적 발표");
+    if (quarter) hooks.push(`${quarter} 실적 발표`);
   }
   if (/파트너십|제휴|협력|고객|partnership|customer/.test(lower)) {
-    if (counterparty) hooks.push(`${counterparty}와 제휴 발표`);
+    if (counterparty) hooks.push(`${withAndParticle(counterparty)} 제휴 발표`);
+    const partnershipCounterparty =
+      phraseAfterVerb(title, "partners?\\s+with") ??
+      (counterparty ? undefined : phraseBeforeKeyword(title, "partnership")) ??
+      phraseAfterVerb(title, "lands?|announces?");
+    if (partnershipCounterparty && partnershipCounterparty !== counterparty) {
+      hooks.push(`${withAndParticle(partnershipCounterparty)} 파트너십 체결`);
+    }
     if (product) hooks.push(`${product} 협력 발표`);
   }
   if (/SEC|8-K|10-Q|10-K|filing|공시/i.test(title) && filing) {
@@ -251,12 +370,17 @@ function systemPrompt(): string {
   const banned = ["매" + "수/매" + "도", "목표" + "가", "예측", "과장", "매체명", "기사 제목 복붙"];
   return [
     "너는 주식 발견 카드의 뉴스 제목을 종목 관점 한 줄로 압축한다.",
+    "입력이 영문 미국 종목 뉴스/공시여도 출력은 반드시 한국어다.",
     "제목에 있는 사실만 사용한다.",
     "무엇을·누구와·얼마·언제 중 확인 가능한 구체값을 최소 1개 포함한다.",
     "계약/수주/실적/공시/뉴스/소식/재료 같은 카테고리 명사만으로 끝내지 않는다.",
     "상대방·금액·제품·수치 중 하나가 없으면 빈 hook을 반환한다.",
+    "영문 기사 제목을 그대로 번역하지 말고 종목 보유자 관점으로 압축한다.",
     "좋은 예: 원문 '티이엠씨씨엔에스, 180억원 반도체 장비 공급계약 체결' -> '180억원 반도체 장비 공급계약 체결'.",
-    "나쁜 예: '계약 재료가 새로 확인됐어요', '직접 재료가 붙었어요', '소식에 반응'.",
+    "좋은 예: 원문 'D-Wave Quantum Announces New Partnership With Aerospace Customer' -> 'Aerospace 고객과 제휴 발표'.",
+    "좋은 예: 원문 'SoundHound AI Reports First Quarter Revenue Growth and Raises Guidance' -> '1분기 매출 성장·가이던스 상향'.",
+    "나쁜 예: 'NIO Stock Eyes June Delivery', '팔란티어 제휴 발표', '아이온큐 공개'.",
+    "나쁜 예: 카테고리만 말하는 추상 문장, 원문 사건 없이 반응만 말하는 문장.",
     `${banned.join(", ")} 금지.`,
     "결과는 한국어 44자 이하 JSON {\"hook\":\"...\"}.",
     "연결을 못 만들면 {\"hook\":\"\"}.",

--- a/apps/web/lib/us-symbols.ts
+++ b/apps/web/lib/us-symbols.ts
@@ -35,7 +35,7 @@ export const US_DISCOVERY_SYMBOLS: UsDiscoverySymbol[] = [
   { canonical: "디웨이브퀀텀", symbol: "QBTS", market: "NYSE", sector: "양자", fameRank: 650 },
   { canonical: "사운드하운드AI", symbol: "SOUN", market: "NASDAQ", sector: "AI", fameRank: 540 },
   { canonical: "빅베어AI", symbol: "BBAI", market: "NYSE", sector: "AI", fameRank: 690 },
-  { canonical: "세레브라스", symbol: "CRWV", market: "NASDAQ", sector: "AI", fameRank: 430 },
+  { canonical: "코어위브", symbol: "CRWV", market: "NASDAQ", sector: "AI", fameRank: 430 },
   { canonical: "아스테라랩스", symbol: "ALAB", market: "NASDAQ", sector: "반도체", fameRank: 310 },
   { canonical: "램리서치", symbol: "LRCX", market: "NASDAQ", sector: "반도체", fameRank: 80 },
   { canonical: "어플라이드머티어리얼즈", symbol: "AMAT", market: "NASDAQ", sector: "반도체", fameRank: 75 },

--- a/generated/headline-provenance-baseline.json
+++ b/generated/headline-provenance-baseline.json
@@ -1,6 +1,6 @@
 {
   "KR": {
-    "generatedAt": "2026-06-29T07:04:08.575Z",
+    "generatedAt": "2026-06-29T10:26:05.693Z",
     "asOf": "2026-06-29",
     "country": "KR",
     "limit": 50,
@@ -62,6 +62,19 @@
       },
       {
         "index": 3,
+        "ticker": "애경케미칼",
+        "country": "KR",
+        "headline": "첨단·친환경 소재 투자 확대",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "애경케미칼, 첨단·친환경 소재 투자 확대…TPC·하드카본 사업 강화 · 한국경제"
+      },
+      {
+        "index": 4,
         "ticker": "한섬",
         "country": "KR",
         "headline": "오프라인 채널 중심 회복세",
@@ -74,7 +87,7 @@
         "sourceLabel": "한섬, 오프라인 채널 중심 회복세...백화점 호황에 덩달아 수혜 · 블로터"
       },
       {
-        "index": 4,
+        "index": 5,
         "ticker": "부광약품",
         "country": "KR",
         "headline": "한국유니온제약 인수 후 첫 협업",
@@ -87,7 +100,7 @@
         "sourceLabel": "부광약품, 한국유니온제약 인수 후 첫 협업…위탁생산 본격화 · 이데일리"
       },
       {
-        "index": 5,
+        "index": 6,
         "ticker": "DB증권",
         "country": "KR",
         "headline": "2분기 영업이익 5868억 달성 기대",
@@ -100,7 +113,20 @@
         "sourceLabel": "DB증권 삼성바이오, 2분기 영업이익 5868억 달성 기대 · 동행미디어 시대"
       },
       {
-        "index": 6,
+        "index": 7,
+        "ticker": "금호건설",
+        "country": "KR",
+        "headline": "금호전기·건설, 호남 반도체 클러스터에 '상한가'",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "땡큐, 삼전·SK…금호전기·건설, 호남 반도체 클러스터에 '상한가' · 뉴시스"
+      },
+      {
+        "index": 8,
         "ticker": "광동제약",
         "country": "KR",
         "headline": "‘광동 V라인 슬림핏’ 출시",
@@ -113,7 +139,7 @@
         "sourceLabel": "광동제약, ‘광동 V라인 슬림핏’ 출시 · 스포츠동아"
       },
       {
-        "index": 7,
+        "index": 9,
         "ticker": "남양유업",
         "country": "KR",
         "headline": "흑자 후 전략 전환",
@@ -126,7 +152,7 @@
         "sourceLabel": "남양유업, 급식·수출로 몸집 키운다…흑자 후 전략 전환 · 동행미디어 시대"
       },
       {
-        "index": 8,
+        "index": 10,
         "ticker": "한양증권",
         "country": "KR",
         "headline": "500억 규모 유상증자",
@@ -139,7 +165,7 @@
         "sourceLabel": "한양증권, 500억 규모 유상증자 결정…중형 증권사로 도약 · 머니투데이"
       },
       {
-        "index": 9,
+        "index": 11,
         "ticker": "DS단석",
         "country": "KR",
         "headline": "VMR 첫 상용제품 글로벌 공개",
@@ -152,7 +178,7 @@
         "sourceLabel": "DS단석, VMR 첫 상용제품 글로벌 공급…도시광산 사업 본격화 · 조선비즈"
       },
       {
-        "index": 10,
+        "index": 12,
         "ticker": "SJG세종",
         "country": "KR",
         "headline": "모비어스 RCPS 부담",
@@ -165,7 +191,7 @@
         "sourceLabel": "SJG세종, 모비어스 RCPS 부담 ...'중복상장' 논란 잠재울까 · 블로터"
       },
       {
-        "index": 11,
+        "index": 13,
         "ticker": "자이에스앤디",
         "country": "KR",
         "headline": "주택 공급계약 체결",
@@ -178,20 +204,20 @@
         "sourceLabel": "자이에스앤디는, 주택 수주 1조 돌파…브랜드 저력 통했다 · 한국경제"
       },
       {
-        "index": 12,
-        "ticker": "엠로",
+        "index": 14,
+        "ticker": "석경에이티",
         "country": "KR",
-        "headline": "코오롱인더스트리 구매 지원",
+        "headline": "자사주 취득 신탁 공급계약 체결",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "엠로, 코오롱인더스트리 AI 기반 구매 지원 · 뉴스1"
+        "sourceLabel": "석경에이티, 5억 규모 자사주 취득 신탁계약 체결 · 이데일리"
       },
       {
-        "index": 13,
+        "index": 15,
         "ticker": "셀바스AI",
         "country": "KR",
         "headline": "인터엠디 협력 발표",
@@ -204,7 +230,7 @@
         "sourceLabel": "셀바스AI, 의료진 전용 플랫폼 '인터엠디'와 협력…메디보이스 채널 · 머니투데이"
       },
       {
-        "index": 14,
+        "index": 16,
         "ticker": "쓰리빌리언",
         "country": "KR",
         "headline": "AI 신약 개발",
@@ -217,7 +243,7 @@
         "sourceLabel": "AI 신약개발 바이오텍 도약 쓰리빌리언, 유전체 데이터로 승부수 · 파이낸셜뉴스"
       },
       {
-        "index": 15,
+        "index": 17,
         "ticker": "나이벡",
         "country": "KR",
         "headline": "바이오 USA서 NP-201 글로벌 임상 데이터 발표",
@@ -230,7 +256,7 @@
         "sourceLabel": "나이벡, 바이오 USA서 NP-201 글로벌 임상 전략 및 후속 파이프라인 성 · 한국경제"
       },
       {
-        "index": 16,
+        "index": 18,
         "ticker": "스맥",
         "country": "KR",
         "headline": "파시니와 손잡고 휴머노이드 자율가공 개발",
@@ -243,7 +269,7 @@
         "sourceLabel": "스맥, 中 파시니와 손잡고 휴머노이드 자율가공 개발…피지컬 AI 제조 · 이데일리"
       },
       {
-        "index": 17,
+        "index": 19,
         "ticker": "아이엘",
         "country": "KR",
         "headline": "휴머노이드 로봇 렌탈 서비스 출시",
@@ -256,7 +282,7 @@
         "sourceLabel": "아이엘로보틱스, 휴머노이드 로봇 렌탈 서비스 출시 · 이데일리"
       },
       {
-        "index": 18,
+        "index": 20,
         "ticker": "자람테크놀로지",
         "country": "KR",
         "headline": "XGS-PON ASIC 첫 양산 PO 공급계약 체결",
@@ -269,7 +295,7 @@
         "sourceLabel": "자람테크놀로지, XGS-PON ASIC 첫 양산 PO 수주…개발 넘어 양산 매출 · 이데일리"
       },
       {
-        "index": 19,
+        "index": 21,
         "ticker": "나노엔텍",
         "country": "KR",
         "headline": "카이트파마에 자동화 세포분석 로봇 공급",
@@ -282,20 +308,20 @@
         "sourceLabel": "나노엔텍, 길리어드 자회사 카이트파마에 자동화 세포분석 로봇 공급 · 이데일리"
       },
       {
-        "index": 20,
+        "index": 22,
         "ticker": "녹십자웰빙",
         "country": "KR",
-        "headline": "국내 독점 상업화 권리 확보",
+        "headline": "라지엘서 국소비만 신약 판권 확보",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "GC녹십자웰빙, '차세대 지방분해주사' 국내 독점 상업화 권리 확보 · 전자신문"
+        "sourceLabel": "녹십자웰빙, 美 라지엘서 국소비만 신약 판권 확보 · 한국경제"
       },
       {
-        "index": 21,
+        "index": 23,
         "ticker": "AP위성",
         "country": "KR",
         "headline": "'적자전환' , 400억 CB '20% 할증' 발행",
@@ -308,7 +334,20 @@
         "sourceLabel": "'적자전환' AP위성, 400억 CB '20% 할증' 발행…신사업 기대감 · 머니투데이"
       },
       {
-        "index": 22,
+        "index": 24,
+        "ticker": "씨앤지하이테크",
+        "country": "KR",
+        "headline": "반도체 제조장비 공급 공급계약 체결",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "씨앤지하이테크, 204억 규모 반도체 제조장비 공급 계약 · 아시아경제"
+      },
+      {
+        "index": 25,
         "ticker": "플리토",
         "country": "KR",
         "headline": "대 AI 데이터 공급계약 체결",
@@ -321,7 +360,7 @@
         "sourceLabel": "플리토, 300억대 AI 데이터 계약 확보…3분기만에 작년 수출액 추월 · 블로터"
       },
       {
-        "index": 23,
+        "index": 26,
         "ticker": "박셀바이오",
         "country": "KR",
         "headline": "첨생법 NK세포 치료 ‘저위험’ 조정",
@@ -334,7 +373,20 @@
         "sourceLabel": "첨생법 NK세포 치료 ‘저위험’ 조정…박셀바이오 최대 수혜 기대 · 이데일리"
       },
       {
-        "index": 24,
+        "index": 27,
+        "ticker": "KCC건설",
+        "country": "KR",
+        "headline": "입주민 통합 주거 서비스 '스윗온' 출시",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "KCC건설, 입주민 통합 주거 서비스 '스윗온' 출시 · 파이낸셜뉴스"
+      },
+      {
+        "index": 28,
         "ticker": "DMS",
         "country": "KR",
         "headline": "디스플레이패널 장비 공급 공급계약 체결",
@@ -347,7 +399,7 @@
         "sourceLabel": "DMS, 677억 규모 디스플레이패널 장비 공급 계약 · 뉴시스"
       },
       {
-        "index": 25,
+        "index": 29,
         "ticker": "웨이비스",
         "country": "KR",
         "headline": "AX 원스톱 바우처 지원",
@@ -360,7 +412,7 @@
         "sourceLabel": "웨이비스, 26억 규모 'AX 원스톱 바우처 지원사업' 주관 선정 · 뉴시스"
       },
       {
-        "index": 26,
+        "index": 30,
         "ticker": "지니언스",
         "country": "KR",
         "headline": "K-시큐리티 수출 경쟁력",
@@ -373,7 +425,7 @@
         "sourceLabel": "실전에서 검증된 K-시큐리티, 방산과 결합해 수출 경쟁력 높여야 · 디지털데일리"
       },
       {
-        "index": 27,
+        "index": 31,
         "ticker": "노머스",
         "country": "KR",
         "headline": "8억원 자사주 취득 신탁",
@@ -386,7 +438,7 @@
         "sourceLabel": "노머스, 8억원 규모 자사주 소각 결정 · 이데일리"
       },
       {
-        "index": 28,
+        "index": 32,
         "ticker": "엑셈",
         "country": "KR",
         "headline": "AI 기반 SQL 튜닝 서비스 출시",
@@ -399,7 +451,7 @@
         "sourceLabel": "엑셈, AI 기반 SQL 튜닝 서비스 출시 예정 · 한국경제TV"
       },
       {
-        "index": 29,
+        "index": 33,
         "ticker": "남화토건",
         "country": "KR",
         "headline": "호남 투자 발표에 관련주로 언급",
@@ -412,20 +464,20 @@
         "sourceLabel": "호남이면 일단 ‘상한가’ 친다?…반도체 ‘메가프로젝트’ 투자 앞두 · 서울경제"
       },
       {
-        "index": 30,
+        "index": 34,
         "ticker": "그래디언트",
         "country": "KR",
-        "headline": "'내 배당금이 5배로'",
+        "headline": "100억원 자사주 취득 신탁",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "'내 배당금이 5배로'…비과세 특별배당 쏜 이 회사 · 한국경제"
+        "sourceLabel": "그래디언트, 특별배당·100억원 자사주 매입 추진 · 이데일리"
       },
       {
-        "index": 31,
+        "index": 35,
         "ticker": "티앤알바이오팹",
         "country": "KR",
         "headline": "심장질환 치료용 고순도 심근세포 정제 기술 특허 확",
@@ -438,7 +490,7 @@
         "sourceLabel": "티앤알바이오팹, 심장질환 치료용 고순도 심근세포 정제 기술 특허 확 · 머니투데이"
       },
       {
-        "index": 32,
+        "index": 36,
         "ticker": "한성크린텍",
         "country": "KR",
         "headline": "호남 투자 발표에 관련주로 언급",
@@ -451,7 +503,7 @@
         "sourceLabel": "한성크린텍, 호남 반도체 공장 추진 등 AI 반도체 투자 확대 수혜 기대 · 아시아경제"
       },
       {
-        "index": 33,
+        "index": 37,
         "ticker": "한컴위드",
         "country": "KR",
         "headline": "30% 실적 발표",
@@ -464,7 +516,7 @@
         "sourceLabel": "한컴위드, 한컴 지분 30% 눈앞…연결 편입 땐 매출 1조 그룹으로 · 머니투데이"
       },
       {
-        "index": 34,
+        "index": 38,
         "ticker": "아우토크립트",
         "country": "KR",
         "headline": "'국토교통 R&D 우수성과 20선' 선정",
@@ -477,7 +529,7 @@
         "sourceLabel": "아우토크립트, '국토교통 R&D 우수성과 20선' 선정 · 머니투데이"
       },
       {
-        "index": 35,
+        "index": 39,
         "ticker": "포바이포",
         "country": "KR",
         "headline": "AI 픽셀 데스크톱 버전 출시",
@@ -490,7 +542,7 @@
         "sourceLabel": "포바이포, AI 픽셀 데스크톱 버전 출시 · 아시아경제"
       },
       {
-        "index": 36,
+        "index": 40,
         "ticker": "서한",
         "country": "KR",
         "headline": "호남권 반도체 클러스터 추진",
@@ -503,7 +555,7 @@
         "sourceLabel": "'호남권 반도체 클러스터' 추진에 이인선·이상휘 국회의원, 청와대에 · 대구MBC"
       },
       {
-        "index": 37,
+        "index": 41,
         "ticker": "엠오티",
         "country": "KR",
         "headline": "자사주 취득 신탁 공급계약 체결",
@@ -516,7 +568,7 @@
         "sourceLabel": "엠오티, 30억 규모 자사주 취득 신탁계약 · 뉴시스"
       },
       {
-        "index": 38,
+        "index": 42,
         "ticker": "특수건설",
         "country": "KR",
         "headline": "384억원 도로시설개량공사 공급계약 체결",
@@ -529,7 +581,20 @@
         "sourceLabel": "특수건설, 384억원 규모 도로시설개량공사 계약 · 이데일리"
       },
       {
-        "index": 39,
+        "index": 43,
+        "ticker": "JW중외제약",
+        "country": "KR",
+        "headline": "준수율 3년 상승",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "JW중외제약, 준수율 3년 상승…내부통제는 과제 · 블로터"
+      },
+      {
+        "index": 44,
         "ticker": "에이직랜드",
         "country": "KR",
         "headline": "SK하이닉스 차세대 eSSD 공급계약 체결",
@@ -542,7 +607,7 @@
         "sourceLabel": "에이직랜드, SK하이닉스 차세대 eSSD 개발 참여…319억 계약 · 아이뉴스24"
       },
       {
-        "index": 40,
+        "index": 45,
         "ticker": "롯데손해보험",
         "country": "KR",
         "headline": "'인수전 기대감'에 상한가 마감",
@@ -555,85 +620,46 @@
         "sourceLabel": "롯데손해보험, 새 주인 찾나?…'인수전 기대감'에 상한가 마감 · SBS Biz"
       },
       {
-        "index": 41,
+        "index": 46,
         "ticker": "아이에스동서",
         "country": "KR",
-        "headline": "‘펜타힐즈W 1단지’, 오늘 특별공급 청약 접수",
+        "headline": "29일 특별공급",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "아이에스동서 ‘펜타힐즈W 1단지’, 오늘 특별공급 청약 접수 · 한국경제TV"
-      },
-      {
-        "index": 42,
-        "ticker": "SK케미칼",
-        "country": "KR",
-        "headline": "J2H와 MASH 치료제 공동 개발",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "SK케미칼, J2H와 MASH 치료제 공동개발 의향서 체결 · 서울경제"
-      },
-      {
-        "index": 43,
-        "ticker": "영풍",
-        "country": "KR",
-        "headline": "후보에 박유경 전 APG 본부장 선정",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "영풍·MBK, 고려아연 사외이사 후보에 박유경 전 APG 본부장 선정 · 지디넷코리아"
-      },
-      {
-        "index": 44,
-        "ticker": "롯데웰푸드",
-        "country": "KR",
-        "headline": "마가렛트와 복호두 만났다",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "마가렛트와 복호두 만났다…롯데웰푸드, 디저트 협업 신제품 · 노컷뉴스"
-      },
-      {
-        "index": 45,
-        "ticker": "지엔씨에너지",
-        "country": "KR",
-        "headline": "와 맞손...AIDC 전력 공급",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "LGU+, 지엔씨에너지와 맞손...AIDC 전력 공급 안정성 높인다 · 서울경제"
-      },
-      {
-        "index": 46,
-        "ticker": "한일시멘트",
-        "country": "KR",
-        "headline": "중대재해 예방 안전 세미나 협력 발표",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "한일시멘트, 노사·협력사 합동 '중대재해 예방 안전 세미나' 개최 · 머니투데이"
+        "sourceLabel": "펜타힐즈W 1단지, 29일 특별공급 시작…본격 청약 일정 돌입 · 이코노미스트"
       },
       {
         "index": 47,
+        "ticker": "셀트리온",
+        "country": "KR",
+        "headline": "美정부 임상시험계획·1상 절차 간소화 임상 데이터 발표",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "'美정부 임상시험계획·1상 절차 간소화'...셀트리온, 신약 20종 가동 · 이데일리"
+      },
+      {
+        "index": 48,
+        "ticker": "올릭스",
+        "country": "KR",
+        "headline": "와 뷰티 협력",
+        "path": "why_synthesis",
+        "method": "rule",
+        "hasEvent": true,
+        "eventKind": "news_mention",
+        "concrete": true,
+        "insightTag": "뉴스 재료",
+        "sourceLabel": "로레알, 올릭스와 뷰티 협력 강화 · 한국경제"
+      },
+      {
+        "index": 49,
         "ticker": "서진시스템",
         "country": "KR",
         "headline": "삼성SDI와 북미 ESS용 배터리 인클로저 임가공 공급계약 체결",
@@ -646,78 +672,52 @@
         "sourceLabel": "서진시스템, 삼성SDI와 북미 ESS용 배터리 인클로저 임가공계약 체결 · 머니투데이"
       },
       {
-        "index": 48,
+        "index": 50,
         "ticker": "HD한국조선해양",
         "country": "KR",
-        "headline": "70척분 공급 공급계약 체결",
+        "headline": "LNG 연료공급용 고압펌프 ‘국산화’ 성공",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "HD한국조선해양, LNG추진선 고압펌프 국산화… 70척분 공급 계약 확보 · 동아일보"
-      },
-      {
-        "index": 49,
-        "ticker": "카카오",
-        "country": "KR",
-        "headline": "최대 실적에도 52주 신저가 찍은 의 역설",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "최대 실적에도 52주 신저가 찍은 카카오의 역설… 경영 · 조선비즈"
-      },
-      {
-        "index": 50,
-        "ticker": "크래프톤",
-        "country": "KR",
-        "headline": "프로젝트 제타 글로벌 테스트",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "크래프톤 신작 '프로젝트 제타', 오는 28일까지 첫 글로벌 커뮤니티 테 · OSEN"
+        "sourceLabel": "HD한국조선해양, LNG 연료공급용 고압펌프 ‘국산화’ 성공 · 문화일보"
       }
     ]
   },
   "US": {
-    "generatedAt": "2026-06-29T07:04:50.878Z",
+    "generatedAt": "2026-06-29T10:25:19.210Z",
     "asOf": "2026-06-29",
     "country": "US",
     "limit": 50,
-    "total": 35,
+    "total": 5,
     "distributions": {
       "path": {
         "raw_title": 0,
         "abstract_template": 0,
-        "why_synthesis": 30,
-        "fallback_no_event": 5
+        "why_synthesis": 5,
+        "fallback_no_event": 0
       },
       "method": {
         "ai": 0,
-        "rule": 35,
+        "rule": 5,
         "fallback": 0,
         "none": 0
       },
       "eventKind": {
-        "news_mention": 23,
-        "disclosure": 7,
+        "news_mention": 5,
+        "disclosure": 0,
         "volume_spike": 0,
-        "none": 5
+        "none": 0
       },
       "hasEvent": {
-        "true": 30,
-        "false": 5
+        "true": 5,
+        "false": 0
       },
       "concrete": {
-        "true": 30,
-        "false": 5
+        "true": 5,
+        "false": 0
       }
     },
     "cards": [
@@ -725,33 +725,20 @@
         "index": 1,
         "ticker": "니오",
         "country": "US",
-        "headline": "NIO Stock Eyes June Delivery",
+        "headline": "ES8 7월 출시 전 사전예약",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "NIO Stock Eyes June Delivery Test: Deutsche Bank Tracker Shows Nio Orders Beating Tesla In China · Yahoo Finance"
+        "sourceLabel": "NIO Stock Rises Overnight: 5-Seat ES8 Preorders Open Ahead Of July Launch, Nio Day Bidding Heats Up · Yahoo Finance"
       },
       {
         "index": 2,
-        "ticker": "업스타트",
-        "country": "US",
-        "headline": "Renewed Funding And",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Renewed Funding And Securitization Might Change The Case For Investing In Upstart Holdings (UPST) · Yahoo Finance"
-      },
-      {
-        "index": 3,
         "ticker": "어펌",
         "country": "US",
-        "headline": "How Affirm’s Backcountry",
+        "headline": "Backcountry와 파트너십 체결",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
@@ -761,36 +748,10 @@
         "sourceLabel": "How Affirm’s Backcountry Partnership Expands Its Outdoor Footprint And Diversification Narrative At AFRM · Yahoo Finance"
       },
       {
-        "index": 4,
-        "ticker": "리비안",
-        "country": "US",
-        "headline": "More Layoffs, Acquisitions, and",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "More Layoffs, Acquisitions, and SpaceX Becomes AI Company · Yahoo Finance"
-      },
-      {
-        "index": 5,
-        "ticker": "레딧",
-        "country": "US",
-        "headline": "They Asked Millennials How They",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "They Asked Millennials How They Are Preparing 'The Old Folks' In Their Lives For A 22% Cut To Social Security? 'We Must Help Them Prepare Now' · Yahoo Finance"
-      },
-      {
-        "index": 6,
+        "index": 3,
         "ticker": "스노우플레이크",
         "country": "US",
-        "headline": "Snowflake (SNOW) Lands Unlimitail",
+        "headline": "Unlimitail와 파트너십 체결",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
@@ -800,205 +761,23 @@
         "sourceLabel": "Snowflake (SNOW) Lands Unlimitail Retail Media Data Hub Partnership · Yahoo Finance"
       },
       {
-        "index": 7,
-        "ticker": "데이터독",
-        "country": "US",
-        "headline": "WDAY, ADBE, CRM: Software Stocks",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "NOW, WDAY, ADBE, CRM: Software Stocks On The Rebound As OpenAI Threat Weakens · Yahoo Finance"
-      },
-      {
-        "index": 8,
-        "ticker": "아이온큐",
-        "country": "US",
-        "headline": "IonQ (IONQ) 공개",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "IonQ (IONQ) Launches Clavis XG Multiplex For Quantum Security On Metro Fiber · Yahoo Finance"
-      },
-      {
-        "index": 9,
-        "ticker": "오클로",
-        "country": "US",
-        "headline": "Oklo Is Using AI to Design",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Oklo Is Using AI to Design Nuclear Reactors Faster. Here's Why OKLO Stock Deserves a Second Look. · Yahoo Finance"
-      },
-      {
-        "index": 10,
-        "ticker": "로빈후드",
-        "country": "US",
-        "headline": "More Layoffs, Acquisitions, and",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "More Layoffs, Acquisitions, and SpaceX Becomes AI Company · Yahoo Finance"
-      },
-      {
-        "index": 11,
-        "ticker": "코인베이스",
-        "country": "US",
-        "headline": "Bitcoin Has Had a Terrible 2026",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Bitcoin Has Had a Terrible 2026. What Can Make the Second Half of the Year Better? · Yahoo Finance"
-      },
-      {
-        "index": 12,
-        "ticker": "크라우드스트라이크",
-        "country": "US",
-        "headline": "CrowdStrike (CRWD) Extends Falcon",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "CrowdStrike (CRWD) Extends Falcon AIDR to Create Unified AI Security Control Plane · Yahoo Finance"
-      },
-      {
-        "index": 13,
-        "ticker": "웨스턴디지털",
-        "country": "US",
-        "headline": "Western Digital (WDC) Stock",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Western Digital (WDC) Stock Rallies As Micron’s $100 Billion AI Deals Lift Storage Demand · Yahoo Finance"
-      },
-      {
-        "index": 14,
-        "ticker": "슈퍼마이크로",
-        "country": "US",
-        "headline": "Odine Partners with Supermicro",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Odine Partners with Supermicro (SMCI) to Accelerate AI Infrastructure Development in Türkiye · Yahoo Finance"
-      },
-      {
-        "index": 15,
-        "ticker": "비스트라",
-        "country": "US",
-        "headline": "The Ultimate AI Power Supercycle",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "The Ultimate AI Power Supercycle Winner: NextEra Energy or Vistra Stock? · Yahoo Finance"
-      },
-      {
-        "index": 16,
+        "index": 4,
         "ticker": "마벨테크놀로지",
         "country": "US",
-        "headline": "Is Broadcom (AVGO) One of the",
+        "headline": "엔비디아와 제휴 발표",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
         "eventKind": "news_mention",
         "concrete": true,
         "insightTag": "뉴스 재료",
-        "sourceLabel": "Is Broadcom (AVGO) One of the Best Trending AI Stocks to Watch in 2026? · Yahoo Finance"
+        "sourceLabel": "Marvell Technology (NasdaqGS:MRVL) Expands AI Push With Nvidia Deal And Two Acquisitions · Yahoo Finance"
       },
       {
-        "index": 17,
-        "ticker": "버티브",
-        "country": "US",
-        "headline": "Vertiv (VRT) Expands AI Cooling",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Vertiv (VRT) Expands AI Cooling Reach With ThermoKey And Strategic Thermal Labs · Yahoo Finance"
-      },
-      {
-        "index": 18,
-        "ticker": "마이크론",
-        "country": "US",
-        "headline": "Why Retail Traders Couldn’t Take",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Why Retail Traders Couldn’t Take Their Eyes Off These Stocks Last Week: AAPL, MU, MSFT, INFQ, RKLB · Yahoo Finance"
-      },
-      {
-        "index": 19,
-        "ticker": "콘스텔레이션에너지",
-        "country": "US",
-        "headline": "AI’s Energy Crunch Has Investors",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "AI’s Energy Crunch Has Investors Searching for Next IPO Winners · Yahoo Finance"
-      },
-      {
-        "index": 20,
-        "ticker": "팔란티어",
-        "country": "US",
-        "headline": "Palantir와 제휴 발표",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Zeta Global (ZETA) Enters into a Strategic Partnership with Palantir Technologies · Yahoo Finance"
-      },
-      {
-        "index": 21,
-        "ticker": "램리서치",
-        "country": "US",
-        "headline": "What Lam Research Stock Gave Up",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "What Lam Research Stock Gave Up To Become An AI Giant · Yahoo Finance"
-      },
-      {
-        "index": 22,
+        "index": 5,
         "ticker": "어플라이드머티어리얼즈",
         "country": "US",
-        "headline": "Applied Materials (AMAT) 공개",
+        "headline": "반도체 제조 시스템 제품 공개",
         "path": "why_synthesis",
         "method": "rule",
         "hasEvent": true,
@@ -1006,170 +785,6 @@
         "concrete": true,
         "insightTag": "뉴스 재료",
         "sourceLabel": "Applied Materials (AMAT) Introduces Suite of New Chipmaking Systems · Yahoo Finance"
-      },
-      {
-        "index": 23,
-        "ticker": "이튼",
-        "country": "US",
-        "headline": "Data Center Delays Create",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Data Center Delays Create Opportunity in These 3 Stocks · Yahoo Finance"
-      },
-      {
-        "index": 24,
-        "ticker": "테슬라",
-        "country": "US",
-        "headline": "Tesla Reports Q2 Deliveries in a",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Tesla Reports Q2 Deliveries in a Matter of Days. Here's the Number That Matters. · Yahoo Finance"
-      },
-      {
-        "index": 25,
-        "ticker": "마이크로소프트",
-        "country": "US",
-        "headline": "CrowdStrike (CRWD) Extends Falcon",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "disclosure",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "CrowdStrike (CRWD) Extends Falcon AIDR to Create Unified AI Security Control Plane · Yahoo Finance"
-      },
-      {
-        "index": 26,
-        "ticker": "애플",
-        "country": "US",
-        "headline": "AAPL Stock Rises Overnight: After",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "AAPL Stock Rises Overnight: After Price Hikes, Apple Reportedly Seeks US Approval To Buy Chinese Memory Chips · Yahoo Finance"
-      },
-      {
-        "index": 27,
-        "ticker": "AMD",
-        "country": "US",
-        "headline": "Taiwan Semiconductor",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Taiwan Semiconductor Manufacturing Company (TSM)’s Monthly Sales Rise · Yahoo Finance"
-      },
-      {
-        "index": 28,
-        "ticker": "TSMC",
-        "country": "US",
-        "headline": "India See Top Firms Lose Market",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "China, India See Top Firms Lose Market Cap Share in AI Lag · Yahoo Finance"
-      },
-      {
-        "index": 29,
-        "ticker": "브로드컴",
-        "country": "US",
-        "headline": "Broadcom Inc. (AVGO) is Avoiding",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Broadcom Inc. (AVGO) is Avoiding Acquisitions in Favor of AI Organic Development · Yahoo Finance"
-      },
-      {
-        "index": 30,
-        "ticker": "엔비디아",
-        "country": "US",
-        "headline": "Prediction: This Artificial",
-        "path": "why_synthesis",
-        "method": "rule",
-        "hasEvent": true,
-        "eventKind": "news_mention",
-        "concrete": true,
-        "insightTag": "뉴스 재료",
-        "sourceLabel": "Prediction: This Artificial Intelligence (AI) Semiconductor Stock Will Join the $1 Trillion Club by 2028 · Yahoo Finance"
-      },
-      {
-        "index": 31,
-        "ticker": "몽고DB",
-        "country": "US",
-        "headline": "Is MongoDB (MDB) One Of The Tech",
-        "path": "fallback_no_event",
-        "method": "rule",
-        "hasEvent": false,
-        "eventKind": "none",
-        "concrete": false,
-        "insightTag": "정직한 빈 신호"
-      },
-      {
-        "index": 32,
-        "ticker": "사운드하운드AI",
-        "country": "US",
-        "headline": "Roadzen Named Deep Learning",
-        "path": "fallback_no_event",
-        "method": "rule",
-        "hasEvent": false,
-        "eventKind": "none",
-        "concrete": false,
-        "insightTag": "정직한 빈 신호"
-      },
-      {
-        "index": 33,
-        "ticker": "빅베어AI",
-        "country": "US",
-        "headline": "Is BigBear.ai Becoming a",
-        "path": "fallback_no_event",
-        "method": "rule",
-        "hasEvent": false,
-        "eventKind": "none",
-        "concrete": false,
-        "insightTag": "정직한 빈 신호"
-      },
-      {
-        "index": 34,
-        "ticker": "GE버노바",
-        "country": "US",
-        "headline": "Microsoft Solves AI’s Biggest",
-        "path": "fallback_no_event",
-        "method": "rule",
-        "hasEvent": false,
-        "eventKind": "none",
-        "concrete": false,
-        "insightTag": "정직한 빈 신호"
-      },
-      {
-        "index": 35,
-        "ticker": "아스테라랩스",
-        "country": "US",
-        "headline": "Stifel Raises Texas Instruments",
-        "path": "fallback_no_event",
-        "method": "rule",
-        "hasEvent": false,
-        "eventKind": "none",
-        "concrete": false,
-        "insightTag": "정직한 빈 신호"
       }
     ]
   }

--- a/scripts/diag-headline-provenance.ts
+++ b/scripts/diag-headline-provenance.ts
@@ -6,7 +6,7 @@ import {
   type DiscoveryResponse,
   type DiscoveryStockPayload,
 } from "../apps/web/lib/discovery-supply";
-import { hasConcreteSourceValue, isAbstractTemplate, isRawTitleCopy } from "../apps/web/lib/copy-guards";
+import { hasConcreteSourceValue, hasExcessiveLatinHeadline, isAbstractTemplate, isRawTitleCopy } from "../apps/web/lib/copy-guards";
 import type { DiscoveryCountryScope } from "../apps/web/lib/market-source-types";
 
 type HeadlinePath = "raw_title" | "abstract_template" | "why_synthesis" | "fallback_no_event";
@@ -91,12 +91,26 @@ function finalVisibleHeadline(stock: DiscoveryStockPayload): string {
 
 function sourceTitleFrom(stock: DiscoveryStockPayload): string | undefined {
   const label = cleanInline(stock.sourceLabel);
-  if (!label) return undefined;
-  return label.split(/\s+·\s+/)[0]?.trim();
+  if (label) return label.split(/\s+·\s+/)[0]?.trim();
+  return cleanInline(stock.headlineProvenance?.eventRef?.title) || undefined;
 }
 
 function classifyEventKind(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined, headline: string): ProvenanceEventKind {
-  const haystack = [headline, stock.reason, stock.whyShown, stock.insightTag, stock.sourceLabel, stock.sourceUrl, front?.signals.newsEventLabel, front?.signals.newsEventSource]
+  const explicitKind = stock.headlineProvenance?.eventRef?.kind;
+  if (explicitKind === "news_mention" || explicitKind === "disclosure") return explicitKind;
+  const haystack = [
+    headline,
+    stock.reason,
+    stock.whyShown,
+    stock.insightTag,
+    stock.sourceLabel,
+    stock.sourceUrl,
+    stock.headlineProvenance?.eventRef?.source,
+    stock.headlineProvenance?.eventRef?.title,
+    stock.headlineProvenance?.eventRef?.url,
+    front?.signals.newsEventLabel,
+    front?.signals.newsEventSource,
+  ]
     .map(cleanInline)
     .filter(Boolean)
     .join(" ");
@@ -111,6 +125,7 @@ function classifyPath(stock: DiscoveryStockPayload, headline: string, eventKind:
     return "fallback_no_event";
   }
   const title = sourceTitleFrom(stock);
+  if (hasExcessiveLatinHeadline(headline)) return "raw_title";
   if (title && isRawTitleCopy(headline, title)) return "raw_title";
   if (ABSTRACT_TEMPLATE_PATTERN.test(headline) || ADDITIONAL_ABSTRACT_TEMPLATE_PATTERN.test(headline) || isAbstractTemplate(headline)) return "abstract_template";
   if (eventKind === "none") return "fallback_no_event";
@@ -131,6 +146,7 @@ function increment<T extends string>(bucket: Record<T, number>, key: T): void {
 }
 
 function isConcreteHeadline(stock: DiscoveryStockPayload, headline: string): boolean {
+  if (hasExcessiveLatinHeadline(headline)) return false;
   const sourceTitle = sourceTitleFrom(stock);
   if (sourceTitle && hasConcreteSourceValue(headline, sourceTitle)) return true;
   return /\d/.test(headline) || /[A-Z]{2,}|[가-힣A-Za-z0-9]+(?:와|과)\s*[가-힣A-Za-z0-9]+/.test(headline);


### PR DESCRIPTION
## Summary
- Routes US card headlines through the same synthesized headline path used by KR instead of the old dictionary/English-title surface path.
- Blocks English sentence leakage with a Latin-ratio guard and keeps US source titles only as evidence/source metadata.
- Replaces first-match Yahoo article selection with ticker/company alias scoring, then suppresses US cards without grounded news/disclosure material.

## Diagnostics
- US diag: 5 cards, raw_title 0%, abstract_template 0%, why_synthesis 100%, fallback_no_event 0%, hasEvent true 100%, concrete true 100%.
- KR diag regression: 50 cards, raw_title 0%, abstract_template 0%, why_synthesis 100%, fallback_no_event 0%, hasEvent true 100%, concrete true 100%.

US samples:
1. 니오 — ES8 7월 출시 전 사전예약
2. 어펌 — Backcountry와 파트너십 체결
3. 스노우플레이크 — Unlimitail와 파트너십 체결
4. 마벨테크놀로지 — 엔비디아와 제휴 발표
5. 어플라이드머티어리얼즈 — 반도체 제조 시스템 제품 공개

## Verification
- npm run test -- news-reprocess card-headline copy-guards us-material insight-synthesis
- npm run test -- discovery-supply
- npm run diag:headline -- --country=US
- npm run diag:headline -- --country=KR
- npm run typecheck
- npm run build:web
- npm run build:fomo-web
- npm run guard:discovery
- SPEC_ANALYZE_GUARD_DISCOVERY_RAN=true npm run spec:analyze (passes with coverage warning; this PR body includes the WO/check coverage)
- git diff --check
- surface banned-copy grep: 0 matches