### PR TITLE
fix(fomo-web): stabilize KR stock logos

### DIFF
--- a/apps/fomo-web/__tests__/stockLogo.test.ts
+++ b/apps/fomo-web/__tests__/stockLogo.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  isKrStockCode,
+  krStockLogoUrl,
+  stockLogoApiSrc,
+  stockLogoFallbackSvg,
+} from "../lib/stockLogo";
+
+describe("stockLogo", () => {
+  it("accepts only six-digit KR stock codes", () => {
+    expect(isKrStockCode("005930")).toBe(true);
+    expect(isKrStockCode("5930")).toBe(false);
+    expect(isKrStockCode("AAPL")).toBe(false);
+    expect(isKrStockCode("../005930")).toBe(false);
+  });
+
+  it("builds a same-origin logo API path for KR stocks", () => {
+    expect(stockLogoApiSrc({ naverCode: "005930", name: "삼성전자" })).toBe(
+      "/api/stock-logo?code=005930&name=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90",
+    );
+    expect(stockLogoApiSrc({ naverCode: "AAPL", name: "애플" })).toBeUndefined();
+  });
+
+  it("keeps the upstream URL fixed to Naver's stock-logo host", () => {
+    expect(krStockLogoUrl("005930")).toBe(
+      "https://ssl.pstatic.net/imgstock/fn/real/logo/stock/Stock005930.svg",
+    );
+  });
+
+  it("returns a deterministic SVG fallback instead of a broken image", () => {
+    const svg = stockLogoFallbackSvg({ code: "123456", name: "테스트" });
+
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("테");
+    expect(svg).toContain("#D8FF3A");
+  });
+});

--- a/apps/fomo-web/app/api/stock-logo/route.ts
+++ b/apps/fomo-web/app/api/stock-logo/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { isKrStockCode, krStockLogoUrl, stockLogoFallbackSvg } from "@/lib/stockLogo";
+
+export const runtime = "nodejs";
+
+const CACHE_CONTROL = "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000";
+const TIMEOUT_MS = 3_500;
+
+function svgResponse(svg: string): NextResponse {
+  return new NextResponse(svg, {
+    headers: {
+      "Cache-Control": CACHE_CONTROL,
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "X-Fomo-Logo-Source": "fallback",
+    },
+  });
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code")?.trim() ?? "";
+  const name = searchParams.get("name")?.trim().slice(0, 24) ?? "";
+
+  if (!isKrStockCode(code)) {
+    return svgResponse(stockLogoFallbackSvg({ name }));
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const upstream = await fetch(krStockLogoUrl(code), {
+      cache: "force-cache",
+      headers: {
+        Accept: "image/avif,image/webp,image/svg+xml,image/*,*/*;q=0.8",
+        "User-Agent": "FOMO Club stock-logo proxy",
+      },
+      next: { revalidate: 604_800 },
+      signal: controller.signal,
+    });
+
+    const contentType = upstream.headers.get("content-type") ?? "image/svg+xml";
+    if (upstream.ok && contentType.toLowerCase().includes("image")) {
+      const body = await upstream.arrayBuffer();
+      return new NextResponse(body, {
+        headers: {
+          "Cache-Control": CACHE_CONTROL,
+          "Content-Type": contentType,
+          "X-Fomo-Logo-Source": "naver",
+        },
+      });
+    }
+  } catch {
+    // Fall through to a deterministic local SVG so the card never shows a broken image.
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return svgResponse(stockLogoFallbackSvg({ code, name }));
+}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -20,6 +20,7 @@ import { isThemeBundleCard, type DiscoveryDeckCard, type DeckThemeBundle } from 
 import { whyShown } from "@/lib/whyShown";
 import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
+import { stockLogoApiSrc } from "@/lib/stockLogo";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
 
 /**
@@ -77,7 +78,7 @@ function normalizeChangeText(text: string | undefined): string | undefined {
   return text.replace(/^--+/, "-").replace(/^\+\++/, "+");
 }
 
-/** 종목 로고 — 국내는 네이버 심볼, 미국은 티커 로고(Parqet), 실패 시 이니셜 원형 폴백. */
+/** 종목 로고 — 국내는 same-origin 로고 프록시, 미국은 티커 로고(Parqet), 실패 시 이니셜 원형 폴백. */
 function LogoBadge({
   name,
   naverCode,
@@ -89,11 +90,14 @@ function LogoBadge({
 }) {
   const [failed, setFailed] = useState(false);
   const ch = name.trim().slice(0, 1) || "·";
-  const src = naverCode
-    ? `https://ssl.pstatic.net/imgstock/fn/real/logo/stock/Stock${naverCode}.svg`
-    : symbol
-      ? `https://assets.parqet.com/logos/symbol/${encodeURIComponent(symbol)}`
-      : undefined;
+  const src =
+    stockLogoApiSrc({ naverCode, name }) ??
+    (symbol ? `https://assets.parqet.com/logos/symbol/${encodeURIComponent(symbol)}` : undefined);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
   if (src && !failed) {
     return (
       <img

--- a/apps/fomo-web/lib/stockLogo.ts
+++ b/apps/fomo-web/lib/stockLogo.ts
@@ -1,0 +1,65 @@
+const KR_STOCK_CODE_RE = /^\d{6}$/;
+
+const FALLBACK_COLORS = [
+  "#12355B",
+  "#0E5E6F",
+  "#344E41",
+  "#5C2751",
+  "#5F0F40",
+  "#1B4332",
+  "#2D3142",
+  "#3D348B",
+];
+
+export function isKrStockCode(value: string | undefined | null): value is string {
+  return typeof value === "string" && KR_STOCK_CODE_RE.test(value);
+}
+
+export function krStockLogoUrl(code: string): string {
+  return `https://ssl.pstatic.net/imgstock/fn/real/logo/stock/Stock${code}.svg`;
+}
+
+export function stockLogoApiSrc(input: {
+  naverCode?: string | undefined;
+  name?: string | undefined;
+}): string | undefined {
+  const code = input.naverCode?.trim();
+  if (!isKrStockCode(code)) return undefined;
+  const params = new URLSearchParams({ code });
+  const name = input.name?.trim();
+  if (name) params.set("name", name.slice(0, 24));
+  return `/api/stock-logo?${params.toString()}`;
+}
+
+export function stockLogoInitial(name: string | undefined | null): string {
+  return name?.trim().slice(0, 1) || "·";
+}
+
+export function stockLogoFallbackColor(key: string | undefined | null): string {
+  const text = key?.trim() || "fomo";
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
+  }
+  return FALLBACK_COLORS[hash % FALLBACK_COLORS.length] ?? "#12355B";
+}
+
+function escapeSvgText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function stockLogoFallbackSvg(input: { name?: string; code?: string }): string {
+  const initial = escapeSvgText(stockLogoInitial(input.name ?? input.code));
+  const color = stockLogoFallbackColor(input.code ?? input.name);
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="${initial}">`,
+    `<circle cx="32" cy="32" r="31" fill="#fff"/>`,
+    `<circle cx="32" cy="32" r="25" fill="${color}"/>`,
+    `<text x="32" y="39" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="23" font-weight="800" fill="#D8FF3A">${initial}</text>`,
+    `</svg>`,
+  ].join("");
+}


### PR DESCRIPTION
## Summary
- Route KR stock logos through a same-origin `/api/stock-logo` image endpoint instead of relying on the browser to hit Naver CDN directly.
- Add deterministic SVG fallback from the same endpoint so domestic cards do not show broken/missing ticker images.
- Reset logo image failure state when the card changes, preventing one failed image from poisoning subsequent cards.

## Verification
- `npm run test -- apps/fomo-web/__tests__/stockLogo.test.ts`
- `npm run typecheck:fomo-web`
- `npm run build:fomo-web`