### PR TITLE
fix(fomo-web): restore KR stock logos from discovery symbols

### DIFF
--- a/apps/fomo-web/__tests__/discoveryDeck.test.ts
+++ b/apps/fomo-web/__tests__/discoveryDeck.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AxisSignal, HookAxis, KeywordCard, MultiAxisHookSelection, SectorStock, StockSector } from "@fomo/core";
-import { applyAxisSnapshotToStocks, buildTodayDiscoveryStocks, MAX_DISCOVERY_STOCKS } from "../lib/discoveryDeck";
+import { applyAxisSnapshotToStocks, buildTodayDiscoveryStocks, MAX_DISCOVERY_STOCKS, normalizeDiscoveryDeckCards } from "../lib/discoveryDeck";
 
 const storage = new Map<string, string>();
 
@@ -35,6 +35,22 @@ function pools(count: number) {
 }
 
 describe("buildTodayDiscoveryStocks", () => {
+  it("restores KR naverCode from a six-digit discovery symbol", () => {
+    const result = normalizeDiscoveryDeckCards([
+      {
+        kind: "stock",
+        canonical: "엠게임",
+        market: "KOSDAQ",
+        country: "KR",
+        sector: "게임",
+        symbol: "058630",
+        marquee: false,
+      },
+    ]);
+
+    expect(result[0]).toMatchObject({ canonical: "엠게임", naverCode: "058630" });
+  });
+
   it("dedupes canonical stocks and caps the discovery deck", () => {
     const cards = [
       {

--- a/apps/fomo-web/__tests__/stockLogo.test.ts
+++ b/apps/fomo-web/__tests__/stockLogo.test.ts
@@ -3,6 +3,7 @@ import {
   isKrStockCode,
   krStockLogoUrl,
   stockLogoApiSrc,
+  stockLogoApiSrcForStock,
   stockLogoFallbackSvg,
 } from "../lib/stockLogo";
 
@@ -19,6 +20,13 @@ describe("stockLogo", () => {
       "/api/stock-logo?code=005930&name=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90",
     );
     expect(stockLogoApiSrc({ naverCode: "AAPL", name: "애플" })).toBeUndefined();
+  });
+
+  it("uses a six-digit symbol as the KR logo code when naverCode is missing", () => {
+    expect(stockLogoApiSrcForStock({ symbol: "058630", name: "엠게임" })).toBe(
+      "/api/stock-logo?code=058630&name=%EC%97%A0%EA%B2%8C%EC%9E%84",
+    );
+    expect(stockLogoApiSrcForStock({ symbol: "LCID", name: "루시드" })).toBeUndefined();
   });
 
   it("keeps the upstream URL fixed to Naver's stock-logo host", () => {

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -20,7 +20,7 @@ import { isThemeBundleCard, type DiscoveryDeckCard, type DeckThemeBundle } from 
 import { whyShown } from "@/lib/whyShown";
 import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
-import { stockLogoApiSrc } from "@/lib/stockLogo";
+import { isKrStockCode, stockLogoApiSrcForStock } from "@/lib/stockLogo";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
 
 /**
@@ -90,9 +90,10 @@ function LogoBadge({
 }) {
   const [failed, setFailed] = useState(false);
   const ch = name.trim().slice(0, 1) || "·";
+  const usSymbol = symbol && !isKrStockCode(symbol.trim()) ? symbol : undefined;
   const src =
-    stockLogoApiSrc({ naverCode, name }) ??
-    (symbol ? `https://assets.parqet.com/logos/symbol/${encodeURIComponent(symbol)}` : undefined);
+    stockLogoApiSrcForStock({ naverCode, symbol, name }) ??
+    (usSymbol ? `https://assets.parqet.com/logos/symbol/${encodeURIComponent(usSymbol)}` : undefined);
 
   useEffect(() => {
     setFailed(false);

--- a/apps/fomo-web/components/TodayDiscoveryDeck.tsx
+++ b/apps/fomo-web/components/TodayDiscoveryDeck.tsx
@@ -10,7 +10,7 @@ import {
   type DiscoveryUpdatedDetail,
 } from "@/lib/fomoApi";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
-import { MIN_DISCOVERY_STOCKS, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
+import { MIN_DISCOVERY_STOCKS, normalizeDiscoveryDeckCards, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
 
 interface TodayDiscoveryDeckProps {
@@ -53,7 +53,8 @@ export function TodayDiscoveryDeck({ loggedIn, onRequireLogin }: TodayDiscoveryD
   useEffect(() => {
     let alive = true;
     const applyDiscovery = (discovery: DiscoveryResponse) => {
-      const cards = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
+      const rawCards = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
+      const cards = normalizeDiscoveryDeckCards(rawCards);
       if (cards.length === 0) {
         setState({ kind: "error" });
         return;

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -14,6 +14,7 @@ import {
 } from "@fomo/core";
 import { getWatchlist } from "./watchlist";
 import { recentSeenStocks, stockInteractionSummary, stockInterestScore } from "./stockInterest";
+import { normalizeKrStockCode } from "./stockLogo";
 
 export const MAX_DISCOVERY_STOCKS = 60;
 export const MIN_DISCOVERY_STOCKS = 30;
@@ -83,6 +84,29 @@ export type DiscoveryDeckCard = DeckStock | DeckThemeBundle;
 
 export function isThemeBundleCard(card: DiscoveryDeckCard): card is DeckThemeBundle {
   return card.kind === "theme_bundle";
+}
+
+function normalizeDeckStockIdentifiers(stock: DeckStock): DeckStock {
+  if (stock.country !== "KR") return stock;
+  const naverCode = normalizeKrStockCode(stock.naverCode) ?? normalizeKrStockCode(stock.symbol);
+  return naverCode ? { ...stock, naverCode } : stock;
+}
+
+function normalizeThemeBundleIdentifiers(bundle: DeckThemeBundle): DeckThemeBundle {
+  return {
+    ...bundle,
+    items: bundle.items.map((item) => {
+      if (item.country !== "KR") return item;
+      const naverCode = normalizeKrStockCode(item.naverCode) ?? normalizeKrStockCode(item.symbol);
+      return naverCode ? { ...item, naverCode } : item;
+    }),
+  };
+}
+
+export function normalizeDiscoveryDeckCards(cards: readonly DiscoveryDeckCard[]): DiscoveryDeckCard[] {
+  return cards.map((card) =>
+    isThemeBundleCard(card) ? normalizeThemeBundleIdentifiers(card) : normalizeDeckStockIdentifiers(card)
+  );
 }
 
 export interface AxisSnapshotLike {

--- a/apps/fomo-web/lib/stockLogo.ts
+++ b/apps/fomo-web/lib/stockLogo.ts
@@ -15,6 +15,11 @@ export function isKrStockCode(value: string | undefined | null): value is string
   return typeof value === "string" && KR_STOCK_CODE_RE.test(value);
 }
 
+export function normalizeKrStockCode(value: string | undefined | null): string | undefined {
+  const code = value?.trim();
+  return isKrStockCode(code) ? code : undefined;
+}
+
 export function krStockLogoUrl(code: string): string {
   return `https://ssl.pstatic.net/imgstock/fn/real/logo/stock/Stock${code}.svg`;
 }
@@ -23,12 +28,21 @@ export function stockLogoApiSrc(input: {
   naverCode?: string | undefined;
   name?: string | undefined;
 }): string | undefined {
-  const code = input.naverCode?.trim();
-  if (!isKrStockCode(code)) return undefined;
+  const code = normalizeKrStockCode(input.naverCode);
+  if (!code) return undefined;
   const params = new URLSearchParams({ code });
   const name = input.name?.trim();
   if (name) params.set("name", name.slice(0, 24));
   return `/api/stock-logo?${params.toString()}`;
+}
+
+export function stockLogoApiSrcForStock(input: {
+  naverCode?: string | undefined;
+  symbol?: string | undefined;
+  name?: string | undefined;
+}): string | undefined {
+  const code = normalizeKrStockCode(input.naverCode) ?? normalizeKrStockCode(input.symbol);
+  return stockLogoApiSrc({ naverCode: code, name: input.name });
 }
 
 export function stockLogoInitial(name: string | undefined | null): string {


### PR DESCRIPTION
## Summary
- restore domestic stock logo URLs when discovery payloads carry only a six-digit KR symbol and no naverCode
- prevent six-digit KR symbols from falling through to the US Parqet logo endpoint
- normalize KR discovery cards and theme-bundle items before rendering

## Root Cause
Some KR discovery cards arrived with symbol populated as the six-digit stock code while naverCode was missing. The card UI only used naverCode for the Naver logo proxy, then treated symbol as a US-style ticker fallback, so many domestic cards fell back to initials instead of logos.

## Verification
- npm run test -- stockLogo discoveryDeck
- npm run typecheck
- npm run build:fomo-web