### PR TITLE
fix(fomo-web): 메인 카드 height 축소 — 하단 버튼 가시성 확보

### DIFF
--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -842,7 +842,7 @@ export function StockSwipeDeck({
 
   return (
     <div className="w-full">
-      <div className="relative mx-auto h-[60svh] min-h-[460px] max-h-[580px] w-full select-none sm:min-h-[500px]">
+      <div className="relative mx-auto h-[52svh] min-h-[380px] max-h-[520px] w-full select-none sm:min-h-[420px]">
         {/* 다음 카드 — 뒤에 살짝 드러나는 스택(틴더식 peek). 위 카드가 불투명이라 body 통과 비침은 없음. */}
         {stocks.length > 1 && (
           <div


### PR DESCRIPTION
## 무엇
발견 덱 메인 카드가 세로 공간을 과하게 차지해 하단 액션 버튼(되돌리기·패스·슈퍼관심·관심)이 한 화면에서 잘림. **카드 컨테이너 height 값만** 축소.

```
- h-[60svh] min-h-[460px] max-h-[580px] sm:min-h-[500px]
+ h-[52svh] min-h-[380px] max-h-[520px] sm:min-h-[420px]
```

- 1파일 1라인 변경. 카드 내용·로직·버튼·정렬·수집 전부 무변경.
- 콘텐츠 높이(로고/가격/점수/칩/헤드라인/스파크라인 ~360px)보다 min-h가 커서 안전.

## 검증
- typecheck 통과
- 실제 카드 레이아웃은 이 PR의 Vercel 프리뷰에서 확인(버튼 한 화면 노출)

## 머지 순서
진행 중 PR #747 머지 이후 rebase·호환성 확인 후 머지(배포)할 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)