### PR TITLE
feat(fomo-web): 차트·상세페이지 로딩에 Flicker 스피너 적용

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -27,6 +27,7 @@ import {
   type StockFrontResponse,
 } from "@/lib/fomoApi";
 import { isWatched, toggleWatch } from "@/lib/watchlist";
+import { FlickerSpinner } from "@/components/FlickerSpinner";
 
 /**
  * 키워드 뎁스 페이지 — 카드/히스토리에서 공용. KEYWORD_CARD_FEED_DEV_SPEC v3 §3.
@@ -155,10 +156,9 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
             </div>
 
             {loading ? (
-              <div className="mt-3 space-y-2" aria-busy="true">
+              <div className="mt-3 flex flex-col items-center gap-2 py-5" aria-busy="true">
+                <FlickerSpinner size={32} />
                 <p className="text-sm leading-6 text-muted">원문을 정리하는 중이에요…</p>
-                <div className="h-16 animate-pulse rounded-lg border border-hairline bg-surface" />
-                <div className="h-16 animate-pulse rounded-lg border border-hairline bg-surface" />
               </div>
             ) : hasInsight ? (
             <>
@@ -946,9 +946,8 @@ function StockDepthLoadingBlock() {
       <p className="mt-2 text-sm leading-6 text-muted">
         가격·차트·원문 근거를 한 번에 맞춰 불러오고 있어요.
       </p>
-      <div className="mt-4 space-y-2">
-        <div className="h-3 w-5/6 animate-pulse rounded-full bg-white/10" />
-        <div className="h-3 w-2/3 animate-pulse rounded-full bg-white/10" />
+      <div className="mt-5 flex justify-center">
+        <FlickerSpinner size={36} />
       </div>
     </section>
   );

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -22,6 +22,7 @@ import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
 import { isKrStockCode, stockLogoApiSrcForStock } from "@/lib/stockLogo";
 import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
+import { FlickerSpinner } from "@/components/FlickerSpinner";
 
 /**
  * 공통 종목 무한 스와이프 덱.
@@ -139,7 +140,8 @@ function Sparkline({ series }: { series: number[] }) {
 function ChartSlot({ series, supported }: { series?: number[] | undefined; supported: boolean }) {
   if (series && series.length >= 2) return <Sparkline series={series} />;
   return (
-    <div className="mt-2 flex h-8 w-full shrink-0 items-center justify-center rounded-lg border border-hairline bg-white/[0.03]">
+    <div className="mt-2 flex h-8 w-full shrink-0 items-center justify-center gap-1.5 rounded-lg border border-hairline bg-white/[0.03]">
+      {supported && <FlickerSpinner size={14} />}
       <span className="font-pixel text-[10px] text-muted">
         {supported ? "차트 불러오는 중" : "차트 데이터 없음"}
       </span>


### PR DESCRIPTION
## 무엇
지난번 만든 `FlickerSpinner`(ripple)가 실제 로딩 자리에 안 쓰이고 스켈레톤/텍스트만 돌던 곳을 통일.

- **차트 로딩** — `ChartSlot`의 "차트 불러오는 중"에 스피너 추가
- **상세페이지 메인 로딩** — `StockDepthLoadingBlock` 펄스바 → 스피너
- **상세 '원문 정리' 로딩** — 펄스박스 → 스피너 + 텍스트

"차트 데이터 없음"(빈 상태)은 로딩이 아니라 텍스트 유지. 로직·데이터·카드 내용 무변경.

## 검증
- typecheck 통과 (스피너 컴포넌트는 이전 PR에서 렌더 검증 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)