### PR TITLE
fix(discovery): block US raw headline leaks

### DIFF
--- a/apps/web/__tests__/lib/copy-guards.test.ts
+++ b/apps/web/__tests__/lib/copy-guards.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { hasEnglishFragmentHeadline } from "../../lib/copy-guards";
+
+describe("headline latin fragment guard", () => {
+  it("blocks English fragments mixed into Korean card headlines", () => {
+    expect(hasEnglishFragmentHeadline("its NVIDIA와 제품 협력")).toBe(true);
+    expect(hasEnglishFragmentHeadline("Can와 파트너십 체결")).toBe(true);
+    expect(hasEnglishFragmentHeadline("SHPH, ILLR, IVF: Why These Stocks Posted Double-Digit Gains")).toBe(true);
+  });
+
+  it("allows Koreanized company names and known technical acronyms", () => {
+    expect(hasEnglishFragmentHeadline("엔비디아와 제품 협력에 +34%")).toBe(false);
+    expect(hasEnglishFragmentHeadline("AI 모델 출시")).toBe(false);
+    expect(hasEnglishFragmentHeadline("SEC 8-K 주요 공시 제출")).toBe(false);
+  });
+});

--- a/apps/web/__tests__/lib/discovery-supply-material.test.ts
+++ b/apps/web/__tests__/lib/discovery-supply-material.test.ts
@@ -80,6 +80,10 @@ describe("discovery material news filter", () => {
     expect(cleanUsMaterialTitle("The $7 Trillion AI Boom Is Running Out of Power")).toBeUndefined();
     expect(cleanUsMaterialTitle("OpenAI IPO Fears Hit Oracle and Other Stocks Exposed to the AI Trade")).toBeUndefined();
     expect(cleanUsMaterialTitle("Moderna, Nvidia, Sandisk, Palantir, ON Semi, and More Stocks That Moved Today")).toBeUndefined();
+    expect(cleanUsMaterialTitle("SHPH, ILLR, IVF: Why These Stocks Posted Double-Digit Gains After-Hours Today")).toBeUndefined();
+    expect(cleanUsMaterialTitle("NN, Inc. Awarded Contract From its NVIDIA Product Partner")).toBe(
+      "NN, Inc. Awarded Contract From its NVIDIA Product Partner"
+    );
     expect(cleanUsMaterialTitle("Sandisk Stock Limps Along. The Micron Earnings Afterglow Is Gone")).toBeUndefined();
   });
 });

--- a/apps/web/__tests__/lib/news-reprocess.test.ts
+++ b/apps/web/__tests__/lib/news-reprocess.test.ts
@@ -61,6 +61,31 @@ describe("news hook reprocessing", () => {
     ).toBe("1분기 실적 발표에 +11%");
   });
 
+  it("localizes English counterparties instead of leaking fragments into Korean", () => {
+    const hook = ruleReprocessNewsHook({
+      ...base,
+      stock: "NN Inc.",
+      sector: "산업재",
+      title: "NN, Inc. Awarded Contract From its NVIDIA Product Partner",
+      changePct: 97.58,
+    });
+
+    expect(hook).toBeDefined();
+    expect(hook).toContain("엔비디아");
+    expect(hook).toContain("+98%");
+    expect(hook).not.toMatch(/\bits\b|NVIDIA|Can와/i);
+  });
+
+  it("rejects English stopword fragments as counterparties", () => {
+    expect(
+      ruleReprocessNewsHook({
+        ...base,
+        stock: "스노우플레이크",
+        title: "Snowflake (SNOW) Down 5.1% Since Last Earnings Report: Can It Rebound",
+      })
+    ).toBeUndefined();
+  });
+
   it("rejects abstract template fillers instead of letting them reach the card", () => {
     expect(validateReprocessedNewsHook("계약 재료가 새로 확인됐어요", base)).toBeUndefined();
     expect(validateReprocessedNewsHook("직접 재료가 붙었어요", base)).toBeUndefined();

--- a/apps/web/lib/copy-guards.ts
+++ b/apps/web/lib/copy-guards.ts
@@ -245,7 +245,10 @@ export function hasExcessiveLatinHeadline(text: string | undefined): boolean {
 }
 
 const LATIN_ALLOWED_TOKEN = /^(?:AI|GPU|CPU|SEC|KRX|DART|KOSPI|KOSDAQ|NYSE|NASDAQ|ETF|IPO|ESS|FDA|8-K|10-Q|10-K|SK)$/i;
-const ENGLISH_FRAGMENT_TOKEN = /^(?:its|the|with|and|for|from|by|of|to|in|on|as|a|an|inc|corp|co|company|holdings?|group|plc|llc)$/i;
+const ENGLISH_FRAGMENT_TOKEN =
+  /^(?:its|the|with|and|for|from|by|of|to|in|on|as|a|an|can|why|these|stocks?|stock|posted|double|digit|after|hours?|today|eyes?|june|delivery|deliveries|moved|more|market|inc|corp|co|company|holdings?|group|plc|llc)$/i;
+const LATIN_WITH_KOREAN_PARTICLE_PATTERN =
+  /\b([A-Za-z][A-Za-z0-9&'().-]*)\s*(?:와|과|의|가|이|은|는|을|를|에|에서|로|으로|도|만)/g;
 
 export function hasEnglishFragmentHeadline(text: string | undefined): boolean {
   const clean = cleanInline(text);
@@ -254,6 +257,10 @@ export function hasEnglishFragmentHeadline(text: string | undefined): boolean {
   if (latinWords.length === 0) return false;
   const koChars = (clean.match(/[가-힣]/g) ?? []).length;
   const meaningful = latinWords.filter((word) => !LATIN_ALLOWED_TOKEN.test(word));
+  for (const match of clean.matchAll(LATIN_WITH_KOREAN_PARTICLE_PATTERN)) {
+    const token = match[1];
+    if (token && !LATIN_ALLOWED_TOKEN.test(token)) return true;
+  }
   if (meaningful.some((word) => ENGLISH_FRAGMENT_TOKEN.test(word))) return true;
   if (koChars === 0 && meaningful.length > 0) return true;
   if (meaningful.length >= 2) return true;

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -317,6 +317,7 @@ export function cleanUsMaterialTitle(title: string): string | undefined {
   if (!cleaned || cleaned.length < 6 || MATERIAL_NEWS_NOISE.test(cleaned) || US_MATERIAL_NEWS_NOISE.test(cleaned)) {
     return undefined;
   }
+  if (isUsBundleArticleTitle(cleaned)) return undefined;
   if (!US_MATERIAL_NEWS_CATALYST.test(cleaned)) return undefined;
   if (/[\[\]{}<>]/.test(cleaned)) return undefined;
   return cleaned;
@@ -431,9 +432,13 @@ function isUsBundleArticleTitle(title: string | undefined): boolean {
   const clean = decodeHtmlEntities(title ?? "").replace(/\s+/g, " ").trim();
   if (!clean) return false;
   const beforeColon = clean.split(":")[0] ?? "";
-  const tickers = beforeColon.match(/\b[A-Z]{2,5}\b/g) ?? [];
+  if (/^[A-Z]{1,5}(?:\s*,\s*[A-Z]{1,5}){1,}\s*:/i.test(clean)) return true;
+  const tickers = beforeColon.match(/\b[A-Z]{1,5}\b/g) ?? [];
   if (tickers.length >= 2 && /,|and|&/i.test(beforeColon)) return true;
-  return /\bwhy\s+these\s+stocks\b/i.test(clean) && tickers.length >= 2;
+  if (/\b(?:why\s+these\s+stocks|these\s+stocks|stocks\s+posted|after[-\s]?hours?|more\s+stocks\s+that\s+moved|and\s+more\s+stocks)\b/i.test(clean)) {
+    return true;
+  }
+  return false;
 }
 
 function cleanMaterialSummary(summary: string | undefined): string | undefined {

--- a/apps/web/lib/news-reprocess.ts
+++ b/apps/web/lib/news-reprocess.ts
@@ -31,6 +31,8 @@ export interface NewsHookResult {
 
 const cache = new Map<string, NewsHookResult>();
 const GENERIC_TITLE_PATTERN = /^(?:(?:제품·AI 인프라|실적·가이던스|고객·파트너십|인도량 확인|자금조달·유동화)\s*소식|SEC 공시|소식|뉴스)(?:이|가)?\s*나왔어요\.?$/i;
+const US_MARKET_NOISE_PATTERN =
+  /\b(?:what\s+you\s+should\s+know|can\s+it\s+rebound|is\s+it\s+time\s+to|better\s+buy|price\s+target|stock\s+eyes|why\s+these\s+stocks|these\s+stocks|stocks\s+posted|after[-\s]?hours?)\b/i;
 
 function cacheKey(input: NewsHookInput): string {
   return [input.asOf.slice(0, 10), input.stock, input.sector ?? "", input.title, input.summary ?? "", input.changePct ?? "", input.source ?? ""].join("\u001f");
@@ -134,19 +136,54 @@ function pickMonthLabel(title: string): string | undefined {
 function cleanEnglishPhrase(value: string | undefined): string | undefined {
   if (!value) return undefined;
   if (/\baerospace\s+customer\b/i.test(value)) return "항공우주 고객";
+  const knownCompany = localizeKnownEnglishCompany(value);
+  if (knownCompany) return knownCompany;
   const cleaned = value
     .replace(/\b(?:Inc|Corp|Corporation|Co|Company|Ltd|PLC|LLC|Holdings?|Group|The)\b\.?/gi, "")
     .replace(
-      /\b(?:new|major|strategic|global|retail|media|data|hub|customer|customers|partnership|deal|contract|order|key|as|role|seat)\b/gi,
+      /\b(?:its|new|major|strategic|global|retail|media|data|hub|customer|customers|partnership|deal|contract|order|key|as|role|seat|can|why|these|stocks?|posted|double|digit|after|hours?|today|eyes?|june|delivery|deliveries|moved|more|market|is|are|was|were|has|had|have|will|could|should|rebound)\b/gi,
       ""
     )
-    .replace(/\b(?:with|from|by|for|of)\b/gi, "")
+    .replace(/\b(?:with|from|by|for|of|to|in|on|and)\b/gi, "")
     .replace(/^\d+[-\s]*/, "")
     .replace(/^[^A-Za-z0-9]+|[^A-Za-z0-9]+$/g, "")
     .replace(/\s+/g, " ")
     .trim();
   if (!cleaned || cleaned.length < 2) return undefined;
+  if (
+    /^(?:can|why|these|stocks?|stock|posted|double|digit|after|hours?|today|eyes?|june|delivery|deliveries|moved|more|market|rebound)$/i.test(
+      cleaned
+    )
+  ) {
+    return undefined;
+  }
   return localizeEnglishPhrase(cleaned.split(/\s+/).slice(0, 3).join(" "));
+}
+
+function localizeKnownEnglishCompany(value: string | undefined): string | undefined {
+  const clean = value ?? "";
+  const known: Array<[RegExp, string]> = [
+    [/\bNVIDIA\b/i, "엔비디아"],
+    [/\bTesla\b/i, "테슬라"],
+    [/\bStellantis\b/i, "스텔란티스"],
+    [/\bMicrosoft\b/i, "마이크로소프트"],
+    [/\bApple\b/i, "애플"],
+    [/\bAmazon\b/i, "아마존"],
+    [/\bAlphabet\b|\bGoogle\b/i, "구글"],
+    [/\bMeta\b/i, "메타"],
+    [/\bPalantir\b/i, "팔란티어"],
+    [/\bCrowdStrike\b/i, "크라우드스트라이크"],
+    [/\bServiceNow\b/i, "서비스나우"],
+    [/\bWorkday\b/i, "워크데이"],
+    [/\bOracle\b/i, "오라클"],
+    [/\bOpenAI\b/i, "오픈AI"],
+    [/\bAdvanced Micro Devices\b|\bAMD\b/i, "AMD"],
+    [/\bTaiwan Semiconductor\b|\bTSMC\b/i, "TSMC"],
+    [/\bLucid\b/i, "루시드"],
+    [/\bRivian\b/i, "리비안"],
+    [/\bNIO\b/i, "니오"],
+  ];
+  return known.find(([pattern]) => pattern.test(clean))?.[1];
 }
 
 function localizeEnglishPhrase(value: string): string {
@@ -160,6 +197,23 @@ function localizeEnglishPhrase(value: string): string {
     nvidia: "엔비디아",
     tesla: "테슬라",
     stellantis: "스텔란티스",
+    microsoft: "마이크로소프트",
+    apple: "애플",
+    amazon: "아마존",
+    alphabet: "구글",
+    google: "구글",
+    meta: "메타",
+    palantir: "팔란티어",
+    crowdstrike: "크라우드스트라이크",
+    servicenow: "서비스나우",
+    workday: "워크데이",
+    oracle: "오라클",
+    openai: "오픈AI",
+    "advanced micro devices": "AMD",
+    "taiwan semiconductor": "TSMC",
+    lucid: "루시드",
+    rivian: "리비안",
+    nio: "니오",
     "soundhound ai": "사운드하운드AI",
     "voice commerce platform": "음성 커머스 플랫폼",
     "chipmaking systems": "반도체 제조 시스템",
@@ -389,7 +443,7 @@ function pickLeadClause(title: string): string | undefined {
 
 export function ruleReprocessNewsHook(input: NewsHookInput): string | undefined {
   const title = cleanInline(stripStockName(input.title, input.stock));
-  if (!title || GENERIC_TITLE_PATTERN.test(title)) return undefined;
+  if (!title || GENERIC_TITLE_PATTERN.test(title) || US_MARKET_NOISE_PATTERN.test(title)) return undefined;
 
   for (const hook of candidateHooks(input, title)) {
     const normalized = normalizeHookPhrase(hook);


### PR DESCRIPTION
## Summary
- Block US raw English/fragments from reaching surface headlines, including cases like `its NVIDIA와` and `Can와`.
- Reject bundled Yahoo-style articles such as `SHPH, ILLR, IVF: Why These Stocks...` before they become single-stock material.
- Route acceptable US material through the same concrete Korean rule/synthesis guard path used by KR, with known US company names localized.

## Verification
- `npm run typecheck` ✅
- `npm run test -- copy-guards news-reprocess discovery-supply-material card-headline insight-synthesis` ✅ 5 files / 31 tests
- `npm run diag:headline -- --country=US` ✅ raw_title 0%, abstract_template 0%, fallback_no_event 0%, latinMixed 0%, hasEvent 100% (strictly matched material cards: 1)
- `npm run diag:headline -- --country=KR` ✅ raw_title 0%, abstract_template 0%, fallback_no_event 0%, latinMixed 0%, why_synthesis 100% (43 cards)

## Note
This intentionally suppresses loosely matched US material instead of filling with English/raw/bundled headlines. US card count is now strict; expanding it should come from better material coverage, not weaker matching.