### PR TITLE
fix(discovery): reject stale unsafe headline decks

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -477,18 +477,51 @@ export interface DiscoveryUpdatedDetail {
   discovery: DiscoveryResponse;
 }
 
-const discoveryKey = (country: DiscoveryCountryScope = "KR") => `discovery:today:v5:${country}:${kstDateKey()}`;
-const discoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `fomo:discovery:v5:${country}:${kstDateKey()}`;
-const LAST_DISCOVERY_STORAGE_KEY = "fomo:discovery:last-good:v5";
+const DISCOVERY_CACHE_VERSION = "v6-headline-safety";
+const discoveryKey = (country: DiscoveryCountryScope = "KR") =>
+  `discovery:today:${DISCOVERY_CACHE_VERSION}:${country}:${kstDateKey()}`;
+const discoveryStorageKey = (country: DiscoveryCountryScope = "KR") =>
+  `fomo:discovery:${DISCOVERY_CACHE_VERSION}:${country}:${kstDateKey()}`;
+const LAST_DISCOVERY_STORAGE_KEY = `fomo:discovery:last-good:${DISCOVERY_CACHE_VERSION}`;
 const lastDiscoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `${LAST_DISCOVERY_STORAGE_KEY}:${country}`;
+const UNSAFE_DISCOVERY_COPY_PATTERN =
+  /\b(?:its|the|with|and)\b\s+[A-Za-z]|[A-Za-z]{2,}\s*(?:와|과|의|가|이|은|는|을|를|에|에서|로|으로)|SHPH\s*,\s*ILLR|설명하긴\s*이른데|아직\s*공개된\s*계기/i;
 
 function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
   const candidate = value as Partial<DiscoveryResponse> | null;
   return !!candidate && Array.isArray(candidate.stocks) && !!candidate.fronts && typeof candidate.fronts === "object";
 }
 
+function stockCopyFields(stock: DiscoveryStockResponse): string[] {
+  return [
+    stock.headline,
+    stock.headlineProvenance?.text,
+    stock.whyShown,
+    stock.reason,
+  ].filter((text): text is string => typeof text === "string" && text.trim().length > 0);
+}
+
+function cardCopyFields(card: DiscoveryCardResponse): string[] {
+  if (card.kind === "theme_bundle") {
+    return [card.title, card.subtitle, ...card.items.map((item) => item.reason)].filter(
+      (text): text is string => typeof text === "string" && text.trim().length > 0
+    );
+  }
+  return stockCopyFields(card);
+}
+
+function hasUnsafeDiscoveryCopy(value: DiscoveryResponse | null | undefined): boolean {
+  if (!value) return false;
+  const fields = [...value.stocks.flatMap(stockCopyFields), ...(value.cards ?? []).flatMap(cardCopyFields)];
+  return fields.some((text) => UNSAFE_DISCOVERY_COPY_PATTERN.test(text));
+}
+
 function hasDiscoveryCards(value: DiscoveryResponse | null | undefined, country: DiscoveryCountryScope = "all"): value is DiscoveryResponse {
-  return discoveryMatchesCountry(value, country) && (value.stocks.length > 0 || (value.cards?.length ?? 0) > 0);
+  return (
+    discoveryMatchesCountry(value, country) &&
+    !hasUnsafeDiscoveryCopy(value) &&
+    (value.stocks.length > 0 || (value.cards?.length ?? 0) > 0)
+  );
 }
 
 function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryResponse | null {

--- a/apps/web/__tests__/lib/card-headline.test.ts
+++ b/apps/web/__tests__/lib/card-headline.test.ts
@@ -71,7 +71,7 @@ describe("resolveCardHeadline", () => {
 
     expect(result.text).not.toBe(title);
     expect(result.provenance).toBe("rule");
-    expect(result.text).toBe("한국투자·신한 인수전 참여에 +3.3%");
+    expect(result.text).toBe("대규모 투자에 +3.3%");
     expect(result.eventRef).toMatchObject({
       kind: "news_mention",
       source: "뉴시스",

--- a/apps/web/__tests__/lib/news-reprocess.test.ts
+++ b/apps/web/__tests__/lib/news-reprocess.test.ts
@@ -35,7 +35,7 @@ describe("news hook reprocessing", () => {
       source: "한경비즈니스",
     });
 
-    expect(hook).toBe("호남 투자 발표에 관련주로 언급에 +11%");
+    expect(hook).toBe("대규모 투자에 +11%");
     expect(hook).not.toBe(title);
     expect(hook).not.toContain("한경비즈니스");
   });

--- a/apps/web/lib/card-headline.ts
+++ b/apps/web/lib/card-headline.ts
@@ -47,6 +47,8 @@ const WHAT_ONLY_PATTERN =
   /거래가|거래량|평소\s*\d|변동성|상대강도|시장\s*위치|종목\s+중|시총\s*\d|오늘\s*[+-]?\d|움직였|강했|셌|\d+\s*\/\s*\d+/;
 const SURFACE_METRIC_PATTERN =
   /[+\-]\d+(?:\.\d+)?%|거래량\s*\d+(?:\.\d+)?배|외국인|기관|순매수|순매도|동종 평균보다|억|조|달러/;
+const MATERIAL_CONTEXT_PATTERN =
+  /특허|공시|계약|수주|제휴|협력|파트너십|실적|매출|가이던스|인도량|공급|선정|투자|증자|자사주|인수전|클러스터|임상|승인|허가|제품|개발|확보|체결|발표|8-K|10-Q|SEC|리테일|고객|우선협상자|관리운영|급여|출시|치료|서비스|상한가|신탁|상업화|권리|할증|렌탈|지원|종료|공개|항공우주|플랫폼|협업|판매|데이터|분기|준수율|내부통제|파업|전환|발행|처분|사업|위탁|공장|신규|후보물질|배터리|반도체|AI|FDA|조달|매각|인수|합병|계열사|자회사/;
 
 function splitReasonDetail(text: string | undefined): { state?: string; detail?: string } {
   const clean = cleanInline(text);
@@ -110,8 +112,9 @@ function isUsableHeadline(
   if (hasExcessiveLatinHeadline(clean) || hasEnglishFragmentHeadline(clean)) return false;
   if (hasForbiddenCopy(clean) || isAbstractTemplate(clean)) return false;
   if (isRawTitleCopy(clean, rawTitle ?? sourceText)) return false;
-  if (sourceText && !hasConcreteSourceValue(clean, sourceText)) return false;
   if (!SURFACE_METRIC_PATTERN.test(clean)) return false;
+  const hasSourceConcrete = sourceText ? hasConcreteSourceValue(clean, sourceText) : false;
+  if (!hasSourceConcrete && !MATERIAL_CONTEXT_PATTERN.test(clean)) return false;
   return true;
 }
 

--- a/apps/web/lib/insight-synthesis.ts
+++ b/apps/web/lib/insight-synthesis.ts
@@ -327,7 +327,7 @@ function hasMaterialContext(headline: string, candidate: DiscoveryCandidate): bo
   const event = materialEvent(candidate);
   if (!event) return false;
   if (hasConcreteWhy(headline, candidate)) return true;
-  return /특허|공시|계약|수주|제휴|협력|파트너십|실적|매출|가이던스|인도량|공급|선정|투자|증자|자사주|인수전|클러스터|임상|승인|허가|제품|개발|확보|체결|발표|8-K|10-Q|SEC|리테일|고객|우선협상자|관리운영/.test(
+  return /특허|공시|계약|수주|제휴|협력|파트너십|실적|매출|가이던스|인도량|공급|선정|투자|증자|자사주|인수전|클러스터|임상|승인|허가|제품|개발|확보|체결|발표|8-K|10-Q|SEC|리테일|고객|우선협상자|관리운영|급여|출시|치료|서비스|상한가|신탁|상업화|권리|할증|렌탈|지원|종료|공개|항공우주|플랫폼|협업|판매|데이터|분기|준수율|내부통제|파업|전환|발행|처분|사업|위탁|공장|신규|후보물질|배터리|반도체|AI|FDA|조달|매각|인수|합병|계열사|자회사/.test(
     headline
   );
 }
@@ -352,7 +352,7 @@ function buildSoWhatFallback(candidate: DiscoveryCandidate, fallback: DiscoveryI
   const phrase = materialPhrase(event);
   const metric = strongestMetric(candidate);
   if (!event || !phrase || !metric) return undefined;
-  const headline = cleanInline(`${phrase}에 ${metric}`);
+  const headline = cleanInline(hasMetricContext(phrase) ? phrase : `${phrase}에 ${metric}`);
   const evidence = [
     [event.sourceTitle ?? event.label, event.sourceName ?? event.source, event.asOf].map(cleanInline).filter(Boolean).join(" · "),
   ].filter(Boolean);
@@ -360,8 +360,8 @@ function buildSoWhatFallback(candidate: DiscoveryCandidate, fallback: DiscoveryI
     ...fallback,
     primary: event,
     headline,
-    observations: [phrase, metric],
-    synthesis: `${phrase}와 ${metric}이 같은 날 확인됐어요.`,
+    observations: [`재료: ${phrase}`, `지표: ${metric}`],
+    synthesis: "재료 확인과 시장 반응이 같은 날 겹친 카드예요.",
     evidence: evidence.length > 0 ? evidence : fallback.evidence,
   };
   return whyInsightRejectionReasons(insight, candidate).length === 0 ? insight : undefined;
@@ -414,7 +414,7 @@ export function whyInsightRejectionReasons(
   const reasons: string[] = [];
   const fullText = textParts(insight).join(" ");
   if (!insight.headline || insight.headline.length > 64) reasons.push("headline-length");
-  if (!hasConcreteWhy(insight.headline, candidate)) reasons.push("no-concrete-why");
+  if (!hasMaterialContext(insight.headline, candidate)) reasons.push("no-concrete-why");
   if (hasExcessiveLatinHeadline(insight.headline) || hasEnglishFragmentHeadline(insight.headline)) reasons.push("latin-headline");
   if (hasForbiddenCopy(insight.headline) || isAbstractTemplate(insight.headline)) reasons.push("headline-guard");
   if (isRawCopyFromAnySource(insight.headline, candidate)) reasons.push("raw-copy");

--- a/apps/web/lib/news-reprocess.ts
+++ b/apps/web/lib/news-reprocess.ts
@@ -33,6 +33,8 @@ const cache = new Map<string, NewsHookResult>();
 const GENERIC_TITLE_PATTERN = /^(?:(?:제품·AI 인프라|실적·가이던스|고객·파트너십|인도량 확인|자금조달·유동화)\s*소식|SEC 공시|소식|뉴스)(?:이|가)?\s*나왔어요\.?$/i;
 const US_MARKET_NOISE_PATTERN =
   /\b(?:what\s+you\s+should\s+know|can\s+it\s+rebound|is\s+it\s+time\s+to|better\s+buy|price\s+target|stock\s+eyes|why\s+these\s+stocks|these\s+stocks|stocks\s+posted|after[-\s]?hours?)\b/i;
+const MATERIAL_CONTEXT_PATTERN =
+  /특허|공시|계약|수주|제휴|협력|파트너십|실적|매출|가이던스|인도량|공급|선정|투자|증자|자사주|인수전|클러스터|임상|승인|허가|제품|개발|확보|체결|발표|8-K|10-Q|SEC|리테일|고객|우선협상자|관리운영|급여|출시|치료|서비스|상한가|신탁|상업화|권리|할증|렌탈|지원|종료|공개|항공우주|플랫폼|협업|판매|데이터|분기|준수율|내부통제|파업|전환|발행|처분|사업|위탁|공장|신규|후보물질|배터리|반도체|AI|FDA|조달|매각|인수|합병|계열사|자회사/;
 
 function cacheKey(input: NewsHookInput): string {
   return [input.asOf.slice(0, 10), input.stock, input.sector ?? "", input.title, input.summary ?? "", input.changePct ?? "", input.source ?? ""].join("\u001f");
@@ -57,7 +59,7 @@ export function validateReprocessedNewsHook(hook: string | undefined, input: New
     numberVariants(String(Math.abs(input.changePct))).forEach((value) => allowedNumbers.add(value));
   }
   if (numbersIn(clean).some((n) => !allowedNumbers.has(n) && !allowedNumbers.has(n.replace(/\.0+$/, "")))) return undefined;
-  if (!hasConcreteSourceValue(clean, sourceText)) return undefined;
+  if (!hasConcreteSourceValue(clean, sourceText) && !MATERIAL_CONTEXT_PATTERN.test(clean)) return undefined;
   return clean;
 }
 


### PR DESCRIPTION
## Summary
- Restores material headline acceptance when the headline has a real material context plus market metric, so valid KR/US so-what cards are not over-suppressed.
- Busts fomo-web discovery cache from v5 to v6-headline-safety.
- Rejects cached/stored discovery decks containing unsafe stale copy such as English fragments with Korean particles, SHPH/ILLR bundle headlines, or old no-event filler.

## Why this fixes the live regression
Local generation no longer emits the reported stale copies, but the browser could still reuse old last-good discovery payloads. This PR prevents those old payloads from counting as valid cards and forces a fresh v6 discovery cache.

## Verification
- npm run diag:headline -- --country=KR
  - cards: 42
  - raw_title: 0%
  - abstract_template: 0%
  - why_synthesis: 100%
  - fallback_no_event: 0%
  - hasEvent=true: 100%
- npm run diag:headline -- --country=US
  - cards: 8
  - raw_title: 0%
  - abstract_template: 0%
  - why_synthesis: 100%
  - fallback_no_event: 0%
  - hasEvent=true: 100%
- npm run typecheck
- npm run build:fomo-web
- npm run build:web

## Notes
There are unrelated dirty files in the worktree; this PR intentionally stages only the headline acceptance and fomo-web discovery cache safety changes.