### PR TITLE
fix(discovery): recover US material cards without lowering quality

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -52,6 +52,8 @@ const PAGE_SIZE = 100;
 const PAGES_PER_MARKET = 10;
 const SPARKLINE_CONCURRENCY = 8;
 const DISCOVERY_DECK_CARD_COUNT = 50;
+const US_DISCOVERY_DECK_CARD_COUNT = 50;
+const US_TARGETED_MATERIAL_CANDIDATE_LIMIT = 64;
 const DISCOVERY_RECOVERY_MIN_CARDS = 12;
 const DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF = 30;
 const TARGETED_MATERIAL_DEFAULT_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
@@ -171,6 +173,16 @@ function todayKst(): string {
 
 function discoveryAsOf(scope: DiscoveryCountryScope): string {
   return scope === "US" ? latestUsSessionAsOf().date : todayKst();
+}
+
+function discoveryDeckCardCount(scope: DiscoveryCountryScope): number {
+  return scope === "US" ? US_DISCOVERY_DECK_CARD_COUNT : DISCOVERY_DECK_CARD_COUNT;
+}
+
+function targetedMaterialCandidateLimit(scope: DiscoveryCountryScope, requested: number | undefined): number {
+  const base = requested ?? TARGETED_MATERIAL_CANDIDATE_LIMIT;
+  const scopedMax = scope === "US" ? Math.min(TARGETED_MATERIAL_CANDIDATE_LIMIT, US_TARGETED_MATERIAL_CANDIDATE_LIMIT) : TARGETED_MATERIAL_CANDIDATE_LIMIT;
+  return Math.max(0, Math.min(scopedMax, base));
 }
 
 function numberFromText(value: string | undefined): number | undefined {
@@ -1536,8 +1548,9 @@ function interleaveThemeBundles(
 export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOptions = {}): Promise<DiscoveryResponse> {
   const scope = options.country ?? "KR";
   const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
+  const deckCardCount = discoveryDeckCardCount(scope);
   const targetedMaterialLimit = targetedMaterialEnabled
-    ? Math.max(0, Math.min(TARGETED_MATERIAL_CANDIDATE_LIMIT, options.targetedMaterialLimit ?? TARGETED_MATERIAL_CANDIDATE_LIMIT))
+    ? targetedMaterialCandidateLimit(scope, options.targetedMaterialLimit)
     : 0;
   const asOf = discoveryAsOf(scope);
   const [rows, attentionMap] = await Promise.all([
@@ -1669,11 +1682,11 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   logDiscoverySignalCoverage("before-rank", candidates);
   const rowsByTicker = new Map([...byTicker.entries()].map(([ticker, value]) => [ticker, value.row]));
   let ranked = pushFamousCandidatesOutOfFrontBand(recoverDiscoveryCandidates(
-    rankDiscoveryCandidates(candidates, { maxCandidates: DISCOVERY_DECK_CARD_COUNT }),
+    rankDiscoveryCandidates(candidates, { maxCandidates: deckCardCount }),
     candidates,
-    DISCOVERY_DECK_CARD_COUNT
+    deckCardCount
   ));
-  if (targetedMaterialLimit > 0) {
+  if (targetedMaterialLimit > 0 && scope !== "US") {
     ranked = await hydrateFrontBandMaterial(ranked, rowsByTicker, asOf);
   }
   ranked = await hydrateReachedNewsHooks(ranked, rowsByTicker, asOf);
@@ -1681,7 +1694,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   const stocks: DiscoveryStockPayload[] = [];
 
   const dailyRows = await mapLimit(
-    ranked.slice(0, DISCOVERY_DECK_CARD_COUNT),
+    ranked.slice(0, deckCardCount),
     SPARKLINE_CONCURRENCY,
     async (candidate) => ({
       ticker: candidate.ticker,
@@ -1711,7 +1724,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     const front = frontSeed(row, candidate, attention, themeSignals.get(candidate.ticker), sparklineByTicker.get(candidate.ticker) ?? []);
     const stock = await stockPayload(row, candidate, front);
     const headline = stock.headline?.trim();
-    if (stock.headlineProvenance?.provenance === "suppressed" || !headline) continue;
+    if (stock.headlineProvenance?.provenance === "suppressed" || !headline) {
+      continue;
+    }
     const isUsStock = row.country === "US" || candidate.country === "US" || stock.country === "US";
     if (isUsStock) {
       const headlineEvent = stock.headlineProvenance?.eventRef;
@@ -1742,7 +1757,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     stocks,
     cards: interleaveThemeBundles(stocks, bundleCards),
     fronts,
-    confidence: stocks.length >= DISCOVERY_DECK_CARD_COUNT ? "H" : stocks.length >= 30 ? "M" : "L",
+    confidence: stocks.length >= deckCardCount ? "H" : stocks.length >= Math.min(30, Math.ceil(deckCardCount * 0.75)) ? "M" : "L",
     source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "시장 시세·공시·수급 캐시",
   };
 }

--- a/apps/web/lib/news-reprocess.ts
+++ b/apps/web/lib/news-reprocess.ts
@@ -383,6 +383,24 @@ function candidateHooks(input: NewsHookInput, title: string): string[] {
   if (/trainium/i.test(title)) hooks.push("트레이니움 칩 판매 이슈");
   if (/sub[-\s]?1nm\s+chip/i.test(title)) hooks.push("서브 1나노 칩 공개");
   if (/bitcoin\s+sales?|sale\s+of\s+bitcoin|sell\s+bitcoin/i.test(title)) hooks.push("비트코인 매각 프레임워크 공개");
+  if (/new\s+billion[-\s]?dollar\s+deal|billion[-\s]?dollar\s+deal|inks?\s+new\s+billion/i.test(title)) {
+    hooks.push("십억달러 규모 계약 체결");
+  }
+  if (/ai\s+sales\s+doubling|sales\s+doubling/i.test(title)) {
+    hooks.push("AI 매출 두 배 성장");
+  }
+  if (/monthly\s+sales\s+rise|monthly\s+sales\s+increase|sales\s+rise/i.test(title)) {
+    hooks.push("월간 매출 증가");
+  }
+  if (/licensing\s+strategy.*reactor\s+rollout|reactor\s+rollout/i.test(title)) {
+    hooks.push("원전 인허가 전략 공개");
+  }
+  if (/full\s+stack\s+ai\s+infrastructure\s+provider|ai\s+infrastructure\s+provider/i.test(title)) {
+    hooks.push("AI 인프라 전략 공개");
+  }
+  if (/new\s+nvidia\s+partnership|nvidia\s+partnership/i.test(title)) {
+    hooks.push("엔비디아 파트너십 이슈");
+  }
   if (/antitrust\s+lawsuit|price[-\s]?fixing|price[-\s]?gouging/i.test(title)) {
     hooks.push("가격담합 소송 제기");
   }


### PR DESCRIPTION
## Summary
- Keeps the existing strict headline quality gate, but expands the US reached deck to inspect enough material-backed candidates.
- Adds rule support for additional real US material patterns: Rocket Lab billion-dollar deal, Arista AI sales doubling, TSMC monthly sales rise, Oklo reactor licensing strategy, Arm AI infrastructure strategy, Palantir/Nvidia partnership.
- Avoids duplicate US front-band hydration so the US request does not re-fetch the same material path and keeps production latency under control.

## Verification
- `npm run diag:headline -- --country=US`
  - cards: 20
  - raw_title: 0%, abstract_template: 0%, fallback_no_event: 0%
  - why_synthesis: 100%, hasEvent: 100%, concrete: 100%
  - soWhat: 90%, trimmed: 0%, latinMixed: 0%
- `npm run diag:headline -- --country=KR`
  - cards: 48
  - raw_title: 0%, abstract_template: 0%, fallback_no_event: 0%
  - why_synthesis: 100%, hasEvent: 100%, concrete: 100%
- `npm run test -- news-reprocess copy-guards card-headline`
- `npm run typecheck`
- `npm run build:fomo-web`
- `npm run guard:discovery`

## Notes
- SpaceX is not directly listed, so this keeps public-market space exposure through listed tickers such as Rocket Lab while preserving the material-only card rule.
