### PR TITLE
feat(discovery): deterministic card axis selection

### DIFF
--- a/apps/web/__tests__/lib/card-axis.test.ts
+++ b/apps/web/__tests__/lib/card-axis.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { DiscoveryCandidate, DiscoveryEvent } from "@fomo/core";
+import { axisStrength, formatAxisMetric, selectDominantAxis } from "../../lib/card-axis";
+
+const asOf = "2026-06-30";
+
+function candidate(events: DiscoveryEvent[]): DiscoveryCandidate {
+  return {
+    ticker: "테스트",
+    market: "KOSPI",
+    country: "KR",
+    sector: "바이오",
+    events,
+    asOf,
+  };
+}
+
+const materialEvent: DiscoveryEvent = {
+  kind: "news_mention",
+  firstSeen: true,
+  strength: 0.9,
+  source: "뉴스",
+  asOf,
+  confidence: "H",
+  label: "심근세포 정제 특허 확보",
+  sourceTitle: "티앤알바이오팹, 심근세포 정제 특허 확보",
+  sourceName: "한국경제",
+};
+
+function priceMove(changePct: number): DiscoveryEvent {
+  return {
+    kind: "price_move",
+    firstSeen: true,
+    strength: 0.6,
+    source: "market",
+    asOf,
+    confidence: "M",
+    changePct,
+  };
+}
+
+function flowEntry(flowDays: number, flowAmountText?: string): DiscoveryEvent {
+  return {
+    kind: "flow_entry",
+    firstSeen: true,
+    strength: 0.8,
+    source: "supply",
+    asOf,
+    confidence: "M",
+    label: "기관 순매수",
+    flowActor: "institution",
+    flowDays,
+    ...(flowAmountText ? { flowAmountText } : {}),
+  };
+}
+
+describe("selectDominantAxis", () => {
+  it("selects price when price movement clears the threshold and beats supply", () => {
+    const selected = selectDominantAxis(candidate([{ ...materialEvent, changePct: 12.4 }, priceMove(12.4)]));
+
+    expect(selected).toBe("price");
+  });
+
+  it("selects supply when flow streak clears the threshold and is at least as strong as price", () => {
+    const selected = selectDominantAxis(candidate([{ ...materialEvent, changePct: 4.2 }, priceMove(4.2), flowEntry(4, "18억원")]));
+
+    expect(selected).toBe("supply");
+    expect(formatAxisMetric(candidate([flowEntry(4, "18억원")]), "supply")).toBe("기관 4일 연속 순매수 18억원");
+  });
+
+  it("uses supply as the deterministic tie-break over price", () => {
+    const selected = selectDominantAxis(candidate([{ ...materialEvent, changePct: 9 }, priceMove(9), flowEntry(3)]));
+
+    const strength = axisStrength(candidate([priceMove(9), flowEntry(3)]));
+    expect(strength.price).toBeCloseTo(0.6);
+    expect(strength.supply).toBeCloseTo(0.6);
+    expect(selected).toBe("supply");
+  });
+
+  it("falls back to material when price and supply are both weak", () => {
+    const selected = selectDominantAxis(candidate([{ ...materialEvent, changePct: 2.1 }, priceMove(2.1), flowEntry(1)]));
+
+    expect(selected).toBe("material");
+  });
+
+  it("is deterministic for the same input", () => {
+    const input = candidate([{ ...materialEvent, changePct: 8.1 }, priceMove(8.1), flowEntry(2)]);
+    const results = Array.from({ length: 10 }, () => selectDominantAxis(input));
+
+    expect(new Set(results)).toEqual(new Set(["price"]));
+  });
+});

--- a/apps/web/__tests__/lib/card-headline.test.ts
+++ b/apps/web/__tests__/lib/card-headline.test.ts
@@ -60,7 +60,10 @@ describe("resolveCardHeadline", () => {
     };
 
     const result = await resolveCardHeadline({
-      candidate: candidate([event, priceEvent]),
+      candidate: {
+        ...candidate([event, priceEvent]),
+        dominantAxis: "price",
+      },
       synthesis: synthesis({
         headline: title,
         tone: "material",

--- a/apps/web/__tests__/lib/insight-synthesis.test.ts
+++ b/apps/web/__tests__/lib/insight-synthesis.test.ts
@@ -144,4 +144,53 @@ describe("why-driven insight synthesis guard", () => {
       if (oldKey !== undefined) process.env["AI_API_KEY"] = oldKey;
     }
   });
+
+  it("uses the code-selected supply axis without falling back to the price template", async () => {
+    const oldUrl = process.env["AI_API_URL"];
+    const oldKey = process.env["AI_API_KEY"];
+    delete process.env["AI_API_URL"];
+    delete process.env["AI_API_KEY"];
+    try {
+      const candidate: DiscoveryCandidate = {
+        ...baseCandidate(),
+        dominantAxis: "supply",
+        events: [
+          {
+            kind: "news_mention",
+            firstSeen: true,
+            strength: 0.9,
+            source: "뉴스",
+            asOf,
+            confidence: "H",
+            label: "심근세포 정제 특허 확보",
+            sourceTitle: "티앤알바이오팹, 심근세포 정제 특허 확보",
+            sourceName: "한국경제",
+            changePct: 11.9,
+          },
+          {
+            kind: "flow_entry",
+            firstSeen: true,
+            strength: 0.8,
+            source: "수급",
+            asOf,
+            confidence: "M",
+            label: "기관 순매수",
+            flowActor: "institution",
+            flowDays: 5,
+            flowAmountText: "42억원",
+          },
+        ],
+      };
+
+      const result = await synthesizeWhyDrivenInsight(candidate);
+
+      expect(result.method).toBe("fallback");
+      expect(result.insight.headline).toContain("심근세포 정제 특허");
+      expect(result.insight.headline).toContain("기관 5일 연속 순매수");
+      expect(result.insight.headline).not.toContain("+12%");
+    } finally {
+      if (oldUrl !== undefined) process.env["AI_API_URL"] = oldUrl;
+      if (oldKey !== undefined) process.env["AI_API_KEY"] = oldKey;
+    }
+  });
 });

--- a/apps/web/lib/card-axis.ts
+++ b/apps/web/lib/card-axis.ts
@@ -1,0 +1,104 @@
+import type { DiscoveryCandidate, DiscoveryEvent } from "@fomo/core";
+
+export type CardAxis = "price" | "supply" | "material";
+
+export const CARD_AXIS_PRICE_TOP_PCT = 15;
+export const CARD_AXIS_PRICE_MIN_PCT = 7;
+export const CARD_AXIS_SUPPLY_MIN_DAYS = 3;
+export const CARD_AXIS_SUPPLY_TOP_DAYS = 5;
+export const CARD_AXIS_SUPPLY_AMOUNT_BONUS = 0.2;
+
+export interface CardAxisStrength {
+  price: number;
+  supply: number;
+  material: number;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function eventChangePct(event: DiscoveryEvent): number {
+  return typeof event.changePct === "number" && Number.isFinite(event.changePct) ? event.changePct : 0;
+}
+
+export function strongestChangePct(candidate: DiscoveryCandidate): number | undefined {
+  const values = candidate.events
+    .map((event) => eventChangePct(event))
+    .filter((value) => value !== 0)
+    .sort((a, b) => Math.abs(b) - Math.abs(a));
+  return values[0];
+}
+
+export function strongestFlowEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
+  return candidate.events
+    .filter((event) => event.kind === "flow_entry" && typeof event.flowDays === "number" && event.flowDays > 0)
+    .sort((a, b) => {
+      const days = (b.flowDays ?? 0) - (a.flowDays ?? 0);
+      if (days !== 0) return days;
+      const bAmount = b.flowAmountText ? 1 : 0;
+      const aAmount = a.flowAmountText ? 1 : 0;
+      return bAmount - aAmount;
+    })[0];
+}
+
+export function axisStrength(candidate: DiscoveryCandidate): CardAxisStrength {
+  const maxAbsChange = Math.abs(strongestChangePct(candidate) ?? 0);
+  const flow = strongestFlowEvent(candidate);
+  const flowDays = flow?.flowDays ?? 0;
+  const material = Math.max(
+    0,
+    ...candidate.events
+      .filter((event) => event.kind === "news_mention" || event.kind === "disclosure")
+      .map((event) => (Number.isFinite(event.strength) ? event.strength : 0))
+  );
+  return {
+    price: clamp01(maxAbsChange / CARD_AXIS_PRICE_TOP_PCT),
+    supply: clamp01(flowDays / CARD_AXIS_SUPPLY_TOP_DAYS + (flow?.flowAmountText ? CARD_AXIS_SUPPLY_AMOUNT_BONUS : 0)),
+    material: clamp01(material),
+  };
+}
+
+export function selectDominantAxis(candidate: DiscoveryCandidate): CardAxis {
+  const strength = axisStrength(candidate);
+  const maxAbsChange = Math.abs(strongestChangePct(candidate) ?? 0);
+  const flowDays = strongestFlowEvent(candidate)?.flowDays ?? 0;
+
+  if (flowDays >= CARD_AXIS_SUPPLY_MIN_DAYS && strength.supply >= strength.price) {
+    return "supply";
+  }
+  if (maxAbsChange >= CARD_AXIS_PRICE_MIN_PCT && strength.price >= strength.supply) {
+    return "price";
+  }
+  return "material";
+}
+
+export function resolvedCardAxis(candidate: DiscoveryCandidate): CardAxis {
+  return candidate.dominantAxis ?? selectDominantAxis(candidate);
+}
+
+function flowActorLabel(actor: DiscoveryEvent["flowActor"]): string {
+  if (actor === "foreign") return "외국인";
+  if (actor === "institution") return "기관";
+  return "수급";
+}
+
+export function formatAxisMetric(candidate: DiscoveryCandidate, axis: CardAxis): string | undefined {
+  if (axis === "price") {
+    const change = strongestChangePct(candidate);
+    if (typeof change !== "number") return undefined;
+    const rounded = Math.abs(change) >= 10 ? change.toFixed(0) : change.toFixed(1);
+    return `${change > 0 ? "+" : ""}${rounded.replace(/\.0$/, "")}%`;
+  }
+
+  if (axis === "supply") {
+    const flow = strongestFlowEvent(candidate);
+    if (!flow || !flow.flowDays || flow.flowDays < CARD_AXIS_SUPPLY_MIN_DAYS) return undefined;
+    const actor = flowActorLabel(flow.flowActor);
+    const amount = flow.flowAmountText ? ` ${flow.flowAmountText}` : "";
+    return `${actor} ${flow.flowDays}일 연속 순매수${amount}`;
+  }
+
+  return undefined;
+}

--- a/apps/web/lib/card-headline.ts
+++ b/apps/web/lib/card-headline.ts
@@ -15,6 +15,7 @@ import {
 } from "./copy-guards";
 import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
 import { ruleReprocessNewsHook } from "./news-reprocess";
+import { resolvedCardAxis, type CardAxis } from "./card-axis";
 
 export type CardHeadlineProvenance = "synthesis" | "rule" | "suppressed";
 export type CardHeadlineMethod = "ai" | "rule" | "none";
@@ -23,6 +24,7 @@ export interface CardHeadline {
   text: string;
   provenance: CardHeadlineProvenance;
   method: CardHeadlineMethod;
+  axis?: CardAxis;
   eventRef?: {
     kind: DiscoveryEvent["kind"];
     source?: string;
@@ -105,14 +107,17 @@ function eventSourceText(event: DiscoveryEvent | undefined): string | undefined 
 function isUsableHeadline(
   text: string | undefined,
   sourceText: string | undefined,
-  rawTitle: string | undefined
+  rawTitle: string | undefined,
+  axis: CardAxis
 ): text is string {
   const clean = cleanInline(text);
   if (!clean || EMPTY_PATTERN.test(clean)) return false;
   if (hasExcessiveLatinHeadline(clean) || hasEnglishFragmentHeadline(clean)) return false;
   if (hasForbiddenCopy(clean) || isAbstractTemplate(clean)) return false;
   if (isRawTitleCopy(clean, rawTitle ?? sourceText)) return false;
-  if (!SURFACE_METRIC_PATTERN.test(clean)) return false;
+  if (axis === "price" && !/[+\-]\d+(?:\.\d+)?%/.test(clean)) return false;
+  if (axis === "supply" && !/(?:외국인|기관|개인|수급).{0,16}(?:\d+일|연속|순매수)|순매수/.test(clean)) return false;
+  if (axis !== "material" && !SURFACE_METRIC_PATTERN.test(clean)) return false;
   const hasSourceConcrete = sourceText ? hasConcreteSourceValue(clean, sourceText) : false;
   if (!hasSourceConcrete && !MATERIAL_CONTEXT_PATTERN.test(clean)) return false;
   return true;
@@ -140,6 +145,7 @@ function ruleHeadlineFromMaterial(
   sourceTitle: string | undefined
 ): string | undefined {
   if (!isMaterialEvent(primary)) return undefined;
+  if (resolvedCardAxis(candidate) !== "price") return undefined;
   const title = sourceTitle ?? eventSourceTitle(primary);
   if (!title) return undefined;
   return ruleReprocessNewsHook({
@@ -175,6 +181,7 @@ async function resolveSynthesis(input: ResolveCardHeadlineInput): Promise<{
 
 export async function resolveCardHeadline(input: ResolveCardHeadlineInput): Promise<CardHeadline> {
   const { synthesis, method } = await resolveSynthesis(input);
+  const axis = resolvedCardAxis(input.candidate);
   const primary = synthesis.primary;
   const materialEvent = materialEventFrom(input.candidate, primary);
   const rawTitle =
@@ -184,33 +191,36 @@ export async function resolveCardHeadline(input: ResolveCardHeadlineInput): Prom
   const reasonParts = splitReasonDetail(input.reason);
   const reasonDetail = reasonParts.detail ?? input.reason;
 
-  if (isUsableHeadline(synthesis.headline, sourceText, rawTitle)) {
+  if (isUsableHeadline(synthesis.headline, sourceText, rawTitle, axis)) {
     const eventRef = eventRefFrom(primary ?? materialEvent);
     return {
       text: cleanInline(synthesis.headline),
       provenance: "synthesis",
       method,
+      axis,
       ...(eventRef ? { eventRef } : {}),
     };
   }
 
   const materialHeadline = ruleHeadlineFromMaterial(input.candidate, materialEvent, rawTitle);
-  if (isUsableHeadline(materialHeadline, sourceText, rawTitle)) {
+  if (isUsableHeadline(materialHeadline, sourceText, rawTitle, axis)) {
     const eventRef = eventRefFrom(materialEvent ?? primary);
     return {
       text: cleanInline(materialHeadline),
       provenance: "rule",
       method: "rule",
+      axis,
       ...(eventRef ? { eventRef } : {}),
     };
   }
 
-  if (isUsableHeadline(reasonDetail, sourceText, rawTitle) && !WHAT_ONLY_PATTERN.test(reasonDetail ?? "")) {
+  if (isUsableHeadline(reasonDetail, sourceText, rawTitle, axis) && !WHAT_ONLY_PATTERN.test(reasonDetail ?? "")) {
     const eventRef = eventRefFrom(primary ?? materialEvent);
     return {
       text: cleanInline(reasonDetail),
       provenance: "rule",
       method: "rule",
+      axis,
       ...(eventRef ? { eventRef } : {}),
     };
   }
@@ -220,6 +230,7 @@ export async function resolveCardHeadline(input: ResolveCardHeadlineInput): Prom
     text: "",
     provenance: "suppressed",
     method: "none",
+    axis,
     ...(eventRef ? { eventRef } : {}),
   };
 }

--- a/apps/web/lib/copy-guards.ts
+++ b/apps/web/lib/copy-guards.ts
@@ -117,6 +117,10 @@ export function isAbstractTemplate(text: string | undefined): boolean {
   return !!clean && ABSTRACT_TEMPLATE_BLOCKLIST.some((pattern) => pattern.test(clean));
 }
 
+export function neutralizeSupplyFactTerms(text: string | undefined): string {
+  return cleanInline(text).replace(/순매수|순매도/g, "수급");
+}
+
 function koreanTokens(text: string): string[] {
   return [...text.matchAll(/[가-힣A-Za-z0-9][가-힣A-Za-z0-9&().+-]{1,}/g)]
     .map((match) => match[0]!)
@@ -306,5 +310,10 @@ export function hasEnglishFragmentHeadline(text: string | undefined): boolean {
 
 export function hasForbiddenCopy(text: string | undefined): boolean {
   const clean = cleanInline(text);
-  return FORBIDDEN_COPY.test(clean) || SOURCE_NAME_PATTERN.test(clean) || isAbstractTemplate(clean) || hasEnglishFragmentHeadline(clean);
+  return (
+    FORBIDDEN_COPY.test(neutralizeSupplyFactTerms(clean)) ||
+    SOURCE_NAME_PATTERN.test(clean) ||
+    isAbstractTemplate(clean) ||
+    hasEnglishFragmentHeadline(clean)
+  );
 }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -39,6 +39,7 @@ import { fetchRecentSecFilings } from "./sec-edgar";
 import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
 import { resolveCardHeadline, type CardHeadline } from "./card-headline";
+import { selectDominantAxis } from "./card-axis";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
 import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
@@ -1058,10 +1059,14 @@ function headlineCandidate(
   const events = candidate.events.map((event) =>
     attachMaterialEventIndicators(withRuleHeadlineHook(event, candidate.ticker, sector, row, candidate.asOf), indicators)
   );
-  return {
+  const resolved: DiscoveryCandidate = {
     ...rest,
     ...(sector ? { sector } : {}),
     events,
+  };
+  return {
+    ...resolved,
+    dominantAxis: selectDominantAxis(resolved),
   };
 }
 

--- a/apps/web/lib/insight-synthesis.ts
+++ b/apps/web/lib/insight-synthesis.ts
@@ -12,7 +12,9 @@ import {
   hasForbiddenCopy,
   isAbstractTemplate,
   isRawTitleCopy,
+  neutralizeSupplyFactTerms,
 } from "./copy-guards";
+import { formatAxisMetric, resolvedCardAxis, type CardAxis } from "./card-axis";
 import { ruleReprocessNewsHook } from "./news-reprocess";
 
 export interface WhySynthesisResult {
@@ -151,6 +153,7 @@ function inputText(candidate: DiscoveryCandidate): string {
     candidate.market,
     candidate.marketCapRank,
     candidate.asOf,
+    candidate.dominantAxis,
     ...candidate.events.flatMap((event) => [
       event.label,
       event.headlineHook,
@@ -161,6 +164,7 @@ function inputText(candidate: DiscoveryCandidate): string {
       event.asOf,
       event.changePct,
       event.volumeRatio,
+      event.flowActor,
       event.flowDays,
       event.flowAmountText,
       event.themeRank,
@@ -290,36 +294,8 @@ function translatedProperNounIsBacked(text: string, candidate: DiscoveryCandidat
   return TRANSLATED_PROPER_NOUNS.some(([ko, source]) => ko.test(text) && source.test(input));
 }
 
-function formatSignedPercent(value: number): string {
-  const rounded = Math.abs(value) >= 10 ? value.toFixed(0) : value.toFixed(1);
-  return `${value > 0 ? "+" : ""}${rounded.replace(/\.0$/, "")}%`;
-}
-
-function formatVolumeRatio(value: number): string {
-  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
-  return `거래량 ${rounded.replace(/\.0$/, "")}배`;
-}
-
-function strongestMetric(candidate: DiscoveryCandidate): string | undefined {
-  const metricEvents = candidate.events
-    .map((event) => {
-      const change = typeof event.changePct === "number" && Number.isFinite(event.changePct) ? Math.abs(event.changePct) : 0;
-      const volume = typeof event.volumeRatio === "number" && Number.isFinite(event.volumeRatio) ? event.volumeRatio : 0;
-      const relative =
-        typeof event.themeRelativeChangePct === "number" && Number.isFinite(event.themeRelativeChangePct)
-          ? Math.abs(event.themeRelativeChangePct)
-          : 0;
-      return { event, score: Math.max(change / 6, volume / 3, relative / 3) };
-    })
-    .sort((a, b) => b.score - a.score);
-  const event = metricEvents[0]?.event;
-  if (!event) return undefined;
-  if (typeof event.volumeRatio === "number" && event.volumeRatio >= 2.5) return formatVolumeRatio(event.volumeRatio);
-  if (typeof event.changePct === "number" && Math.abs(event.changePct) >= 1) return formatSignedPercent(event.changePct);
-  if (event.flowAmountText) return event.flowAmountText;
-  if (typeof event.themeRelativeChangePct === "number" && Math.abs(event.themeRelativeChangePct) >= 1) {
-    return `동종 평균보다 ${formatSignedPercent(event.themeRelativeChangePct)}p`;
-  }
+function metricForAxis(candidate: DiscoveryCandidate, axis: CardAxis): string | undefined {
+  if (axis === "price" || axis === "supply") return formatAxisMetric(candidate, axis);
   return undefined;
 }
 
@@ -356,6 +332,13 @@ function hasMetricContext(headline: string): boolean {
   return /[+\-]\d+(?:\.\d+)?%|거래량\s*\d+(?:\.\d+)?배|외국인|기관|순매수|순매도|동종 평균보다|억|조|달러/.test(headline);
 }
 
+function hasAxisContext(headline: string, candidate: DiscoveryCandidate): boolean {
+  const axis = resolvedCardAxis(candidate);
+  if (axis === "price") return /[+\-]\d+(?:\.\d+)?%/.test(headline);
+  if (axis === "supply") return /(?:외국인|기관|개인|수급).{0,16}(?:\d+일|연속|순매수)|순매수/.test(headline);
+  return true;
+}
+
 function hasMaterialContext(headline: string, candidate: DiscoveryCandidate): boolean {
   const event = materialEvent(candidate);
   if (!event) return false;
@@ -366,7 +349,9 @@ function hasMaterialContext(headline: string, candidate: DiscoveryCandidate): bo
 }
 
 function hasSoWhatHeadline(headline: string, candidate: DiscoveryCandidate): boolean {
-  return hasMaterialContext(headline, candidate) && hasMetricContext(headline);
+  const axis = resolvedCardAxis(candidate);
+  if (axis === "material") return hasMaterialContext(headline, candidate);
+  return hasMaterialContext(headline, candidate) && hasMetricContext(headline) && hasAxisContext(headline, candidate);
 }
 
 function hasBrokenEnding(headline: string): boolean {
@@ -382,10 +367,15 @@ function isRawCopyFromAnySource(headline: string, candidate: DiscoveryCandidate)
 
 function buildSoWhatFallback(candidate: DiscoveryCandidate, fallback: DiscoveryInsightSynthesis): DiscoveryInsightSynthesis | undefined {
   const event = materialEvent(candidate);
-  const phrase = ruleMaterialPhrase(candidate, event) ?? materialPhrase(event);
-  const metric = strongestMetric(candidate);
-  if (!event || !phrase || !metric) return undefined;
-  const headline = cleanInline(hasMetricContext(phrase) ? phrase : `${phrase}에 ${metric}`);
+  const axis = resolvedCardAxis(candidate);
+  const phrase =
+    axis === "price"
+      ? ruleMaterialPhrase(candidate, event) ?? materialPhrase(event)
+      : materialPhrase(event) ?? ruleMaterialPhrase(candidate, event)?.replace(/\s*에\s*[+\-]?\d+(?:\.\d+)?%$/, "");
+  const metric = metricForAxis(candidate, axis);
+  if (!event || !phrase) return undefined;
+  if (axis !== "material" && !metric) return undefined;
+  const headline = cleanInline(axis === "material" || hasMetricContext(phrase) ? phrase : `${phrase}에 ${metric}`);
   const evidence = [
     [event.sourceTitle ?? event.label, event.sourceName ?? event.source, event.asOf].map(cleanInline).filter(Boolean).join(" · "),
   ].filter(Boolean);
@@ -393,8 +383,13 @@ function buildSoWhatFallback(candidate: DiscoveryCandidate, fallback: DiscoveryI
     ...fallback,
     primary: event,
     headline,
-    observations: [`재료: ${phrase}`, `지표: ${metric}`],
-    synthesis: "재료 확인과 시장 반응이 같은 날 겹친 카드예요.",
+    observations: axis === "material" ? [`재료: ${phrase}`] : [`재료: ${phrase}`, `축: ${axis}`, `지표: ${metric}`],
+    synthesis:
+      axis === "supply"
+        ? "공개된 사건과 기관·외국인 수급 흐름을 같은 날 나눠 보는 카드예요."
+        : axis === "price"
+          ? "공개된 사건과 당일 가격 반응을 같은 날 나눠 보는 카드예요."
+          : "공개된 사건 자체를 먼저 보는 카드예요.",
     evidence: evidence.length > 0 ? evidence : fallback.evidence,
   };
   return whyInsightRejectionReasons(insight, candidate).length === 0 ? insight : undefined;
@@ -453,7 +448,7 @@ export function whyInsightRejectionReasons(
   if (isRawCopyFromAnySource(insight.headline, candidate)) reasons.push("raw-copy");
   if (hasBrokenEnding(insight.headline)) reasons.push("broken-ending");
   if (!hasSoWhatHeadline(insight.headline, candidate)) reasons.push("no-so-what");
-  if (ADVICE_PATTERN.test(fullText)) reasons.push("advice");
+  if (ADVICE_PATTERN.test(neutralizeSupplyFactTerms(fullText))) reasons.push("advice");
   if (ABSTRACT_PATTERN.test(fullText) || hasAbstractDiscoveryFiller(fullText)) reasons.push("abstract");
   if (hasSourceLeak(insight.headline, candidate)) reasons.push("source-leak");
   if (hasAddedNumber(fullText, candidate)) reasons.push("added-number");
@@ -479,6 +474,7 @@ function cacheKey(candidate: DiscoveryCandidate): string {
     market: candidate.market,
     marketCapRank: candidate.marketCapRank,
     asOf: candidate.asOf.slice(0, 10),
+    dominantAxis: resolvedCardAxis(candidate),
     events: candidate.events.map((event) => ({
       kind: event.kind,
       label: event.label,
@@ -517,12 +513,16 @@ function systemPrompt(): string {
     "출력 헤드라인은 100% 한국어다. 영어 단어를 한국어 조사에 섞지 마라('Aerospace 고객과', 'its NVIDIA와' 금지).",
     "회사명은 한국어 표기로 쓴다(NVIDIA→엔비디아, Tesla→테슬라). 한국어 표기가 없는 소형주는 회사명을 생략하고 사건만 쓴다.",
     "영문 약어·관사('its', 'the', 'with', 'and', 'HpO')를 그대로 남기지 마라.",
-    "헤드라인 = [재료: 무엇이 일어났나] + [가장 두드러진 지표 1개]를 동시성으로 결합한 한 줄이다.",
-    "지표는 입력 JSON의 changePct·volumeRatio·flowAmountText·themeRelativeChangePct 중 가장 강한 1개만 쓴다.",
+    "입력 JSON의 dominantAxis는 코드가 결정론으로 고른 축이다. 축을 바꾸거나 섞지 마라.",
+    "dominantAxis=price이면 헤드라인 = [재료: 무엇이 일어났나] + [당일 등락률]을 동시성으로 결합한 한 줄이다.",
+    "dominantAxis=supply이면 헤드라인 = [재료: 무엇이 일어났나] + [기관/외국인 N일 연속 순매수]를 동시성으로 결합한 한 줄이다. 등락률은 쓰지 마라.",
+    "dominantAxis=material이면 헤드라인 = [재료: 무엇이 일어났나]만 쓴다. 약한 가격·수급 지표를 억지로 붙이지 마라.",
     "동시성 표현('~에', '~당일', '~소식에')만 쓴다. 인과어('때문에', '덕분에') 금지.",
     "제목을 자르거나 복붙하지 마라. 입력에 없는 숫자·고유명사 금지. 글자를 어절 중간에서 끊지 마라('특허 확' 금지).",
     "예측·기대·전망·수혜·유망 등 미래 단정 금지. 사실과 해석까지만 쓴다.",
-    "좋은 예: '엔비디아와 제품 협력 소식에 +34%', '심근세포 정제 특허 확보 당일 +16%', '유럽 리테일 파트너십 공시에 거래량 3배'.",
+    "좋은 예(price): '엔비디아와 제품 협력 소식에 +34%', '심근세포 정제 특허 확보 당일 +16%'.",
+    "좋은 예(supply): '심근세포 정제 특허 확보에 기관 5일 연속 순매수', '공급계약 발표에 외국인 32만주 순매수'.",
+    "좋은 예(material): '유럽 리테일 파트너십 공시'.",
     "나쁜 예: 'its NVIDIA와 제품 협력', 'Aerospace 고객과 제휴 발표', '특허 확', '제휴 소식이 나왔어요', '수혜 기대'.",
     `${banned.join(", ")} 금지.`,
     "투자 조언과 방향 예측 금지. 사실과 해석까지만 쓴다.",
@@ -552,6 +552,7 @@ async function aiSynthesize(candidate: DiscoveryCandidate, fallback: DiscoveryIn
           market: candidate.market,
           marketCapRank: candidate.marketCapRank,
           asOf: candidate.asOf,
+          dominantAxis: resolvedCardAxis(candidate),
           events: candidate.events.map((event) => ({
             kind: event.kind,
             label: event.label,

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -56,6 +56,7 @@ export interface DiscoveryCandidate {
   reason?: string;
   marquee?: boolean;
   marketCapRank?: number;
+  dominantAxis?: "price" | "supply" | "material";
   synthesizedInsight?: DiscoveryInsightSynthesis;
 }
 

--- a/scripts/diag-headline-provenance.ts
+++ b/scripts/diag-headline-provenance.ts
@@ -19,6 +19,7 @@ type HeadlinePath = "raw_title" | "abstract_template" | "why_synthesis" | "fallb
 type HeadlineMethod = "ai" | "rule" | "fallback" | "none";
 type ProvenanceEventKind = "news_mention" | "disclosure" | "volume_spike" | "price_move" | "market_context" | "theme_link" | "none";
 type HeadlineTrack = "A_material" | "suppressed";
+type HeadlineAxis = "price" | "supply" | "material" | "unknown";
 
 interface Args {
   country: DiscoveryCountryScope;
@@ -33,6 +34,7 @@ interface HeadlineProvenanceRow {
   headline: string;
   path: HeadlinePath;
   track: HeadlineTrack;
+  axis: HeadlineAxis;
   method: HeadlineMethod;
   hasEvent: boolean;
   eventKind: ProvenanceEventKind;
@@ -53,6 +55,7 @@ interface HeadlineProvenanceReport {
   distributions: {
     path: Record<HeadlinePath, number>;
     track: Record<HeadlineTrack, number>;
+    axis: Record<HeadlineAxis, number>;
     method: Record<HeadlineMethod, number>;
     eventKind: Record<ProvenanceEventKind, number>;
     hasEvent: {
@@ -226,6 +229,7 @@ function buildReport(payload: DiscoveryResponse, args: Args): HeadlineProvenance
       headline,
       path,
       track,
+      axis: stock.headlineProvenance?.axis ?? "unknown",
       method: classifyMethod(stock, path, headline),
       hasEvent: eventKind !== "none",
       eventKind,
@@ -253,6 +257,12 @@ function buildReport(payload: DiscoveryResponse, args: Args): HeadlineProvenance
     rule: 0,
     fallback: 0,
     none: 0,
+  };
+  const axisCounts: Record<HeadlineAxis, number> = {
+    price: 0,
+    supply: 0,
+    material: 0,
+    unknown: 0,
   };
   const eventCounts: Record<ProvenanceEventKind, number> = {
     news_mention: 0,
@@ -286,6 +296,7 @@ function buildReport(payload: DiscoveryResponse, args: Args): HeadlineProvenance
   rows.forEach((row) => {
     increment(pathCounts, row.path);
     increment(trackCounts, row.track);
+    increment(axisCounts, row.axis);
     increment(methodCounts, row.method);
     increment(eventCounts, row.eventKind);
     if (row.hasEvent) {
@@ -324,6 +335,7 @@ function buildReport(payload: DiscoveryResponse, args: Args): HeadlineProvenance
     distributions: {
       path: pathCounts,
       track: trackCounts,
+      axis: axisCounts,
       method: methodCounts,
       eventKind: eventCounts,
       hasEvent: hasEventCounts,
@@ -355,6 +367,12 @@ function printReport(report: HeadlineProvenanceReport): void {
   console.log("- method");
   (Object.keys(report.distributions.method) as HeadlineMethod[]).forEach((key) => {
     const value = report.distributions.method[key];
+    const pct = report.total > 0 ? Math.round((value / report.total) * 100) : 0;
+    console.log(`  - ${key}: ${value} (${pct}%)`);
+  });
+  console.log("- axis");
+  (Object.keys(report.distributions.axis) as HeadlineAxis[]).forEach((key) => {
+    const value = report.distributions.axis[key];
     const pct = report.total > 0 ? Math.round((value / report.total) * 100) : 0;
     console.log(`  - ${key}: ${value} (${pct}%)`);
   });
@@ -396,7 +414,7 @@ function printReport(report: HeadlineProvenanceReport): void {
   });
   console.log("\nTop samples");
   report.cards.slice(0, 12).forEach((row) => {
-    console.log(`${String(row.index).padStart(2, "0")}. ${row.ticker} [${row.track}/${row.path}/${row.eventKind}] ${row.headline}`);
+    console.log(`${String(row.index).padStart(2, "0")}. ${row.ticker} [${row.axis}/${row.track}/${row.path}/${row.eventKind}] ${row.headline}`);
   });
 }
 


### PR DESCRIPTION
## Summary
- Add deterministic card-axis selection for discovery headlines: price / supply / material.
- Attach the selected `dominantAxis` to discovery candidates before headline synthesis.
- Keep price-axis behavior as the existing material + percent pattern.
- Make supply-axis headlines require real `flow_entry` data and render institution/foreign consecutive net-buy facts.
- Extend headline provenance diagnostics with axis distribution.

## Verification
- `npm run test -- card-axis card-headline insight-synthesis` passed.
- `npm run typecheck` passed.
- `npm run build:web` passed.
- `npm run build:fomo-web` passed.
- `npm run guard:discovery` passed.
- `npm run diag:headline -- --country=KR` passed.

## KR diag snapshot
- path: raw_title 0%, abstract_template 0%, why_synthesis 100%, fallback_no_event 0%.
- axis: price 13 / material 34 / supply 0 on local data.

## Note
The supply-axis engine and tests are implemented, but the current local discovery run produced `flow_entry: 0` because `SupplyDemandDaily` history is unavailable in this environment (`DATABASE_URL` gated). No supply facts are fabricated. Once flow history is populated, cards with `flowDays >= 3` deterministically choose the supply axis.
