### PR TITLE
fix(discovery): hydrate live flow events for supply-axis cards

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -40,6 +40,7 @@ import { fetchStockDaily } from "./stock-front";
 import { computeStockAttentionSignals, type StockAttentionSignal } from "./stock-signal-coverage";
 import { resolveCardHeadline, type CardHeadline } from "./card-headline";
 import { selectDominantAxis } from "./card-axis";
+import { fetchSupplyDemand } from "./supply-demand";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
 import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
@@ -59,6 +60,10 @@ const DISCOVERY_RECOVERY_MIN_CARDS = 12;
 const DISCOVERY_RECOVERY_FAMOUS_FRONT_CUTOFF = 30;
 const TARGETED_MATERIAL_DEFAULT_ENABLED = process.env.DISCOVERY_TARGETED_MATERIAL !== "0";
 const DISCOVERY_FLOW_CACHE_ENABLED = process.env.DISCOVERY_FLOW_CACHE !== "0";
+const DISCOVERY_LIVE_FLOW_ENABLED = process.env.DISCOVERY_LIVE_FLOW !== "0";
+const DISCOVERY_LIVE_FLOW_LIMIT = Math.max(0, Math.min(96, Number(process.env.DISCOVERY_LIVE_FLOW_LIMIT ?? 72) || 72));
+const DISCOVERY_LIVE_FLOW_CONCURRENCY = Math.max(1, Math.min(8, Number(process.env.DISCOVERY_LIVE_FLOW_CONCURRENCY ?? 4) || 4));
+const DISCOVERY_LIVE_FLOW_TIMEOUT_MS = Math.max(2_000, Math.min(12_000, Number(process.env.DISCOVERY_LIVE_FLOW_TIMEOUT_MS ?? 8_000) || 8_000));
 const THEME_BUNDLE_MAX_CARDS = 2;
 const THEME_BUNDLE_MIN_ITEMS = 2;
 const THEME_BUNDLE_MAX_ITEMS = 4;
@@ -847,11 +852,50 @@ function eventFromFlowHistory(history: readonly InvestorFlow[]): DiscoveryEvent 
     source: "KRX 수급",
     asOf: history[0]?.date ?? todayKst(),
     confidence: "H",
-    label: `${actor} ${n}일째 사는 중이에요.`,
+    label: `${actor} ${n}일 연속 순매수 중이에요.`,
     flowActor: useForeign ? "foreign" : "institution",
     flowDays: n,
     ...(typeof latestNet === "number" && latestNet > 0 ? { flowAmountText: flowSharesText(latestNet) } : {}),
   };
+}
+
+function hasFlowEvent(events: readonly DiscoveryEvent[]): boolean {
+  return events.some((event) => event.kind === "flow_entry");
+}
+
+function hasMaterialEvent(events: readonly DiscoveryEvent[]): boolean {
+  return events.some((event) => event.kind === "disclosure" || event.kind === "news_mention");
+}
+
+async function hydrateLiveFlowEvents(byTicker: Map<string, { row: DiscoveryMarketRow; events: DiscoveryEvent[] }>): Promise<void> {
+  if (!DISCOVERY_LIVE_FLOW_ENABLED || DISCOVERY_LIVE_FLOW_LIMIT <= 0) return;
+  const targets = [...byTicker.entries()]
+    .filter(([, value]) => value.row.country === "KR" && !!value.row.naverCode && !hasFlowEvent(value.events))
+    .sort((a, b) => {
+      const aMaterial = Number(hasMaterialEvent(a[1].events));
+      const bMaterial = Number(hasMaterialEvent(b[1].events));
+      const aStrength = Math.max(0, ...a[1].events.map((event) => event.strength));
+      const bStrength = Math.max(0, ...b[1].events.map((event) => event.strength));
+      const aMove = Math.abs(a[1].row.changePct ?? 0);
+      const bMove = Math.abs(b[1].row.changePct ?? 0);
+      return bMaterial - aMaterial || bStrength - aStrength || bMove - aMove || a[0].localeCompare(b[0]);
+    })
+    .slice(0, DISCOVERY_LIVE_FLOW_LIMIT);
+
+  const live = await mapLimit(targets, DISCOVERY_LIVE_FLOW_CONCURRENCY, async ([ticker, value]) => {
+    const code = value.row.naverCode;
+    if (!code) return null;
+    const history = await fetchSupplyDemand(code, DISCOVERY_LIVE_FLOW_TIMEOUT_MS);
+    const event = eventFromFlowHistory(history);
+    return event ? { ticker, event } : null;
+  });
+
+  for (const result of live) {
+    if (result.status !== "fulfilled" || !result.value) continue;
+    const current = byTicker.get(result.value.ticker);
+    if (!current || hasFlowEvent(current.events)) continue;
+    byTicker.set(result.value.ticker, { ...current, events: [...current.events, result.value.event] });
+  }
 }
 
 function volumeRatioFromVolumes(volumes: readonly number[]): number | undefined {
@@ -1642,6 +1686,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       byTicker.set(ticker, { ...current, events: [...current.events, event] });
     }
   }
+  await hydrateLiveFlowEvents(byTicker);
 
   for (const [ticker, current] of byTicker.entries()) {
     if (current.row.country !== "KR") continue;

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -562,13 +562,13 @@ function whyFactFor(event: DiscoveryEvent, candidate: DiscoveryCandidate): WhyFa
     const days = flowDaysOf(event);
     if (!actor || !days) return undefined;
     const amount = event.flowAmountText ? ` ${event.flowAmountText}` : "";
-    const headline = `${actor} ${days}일째${amount} 담는 ${ticker}`;
+    const headline = `${actor} ${days}일 연속 순매수${amount} — ${ticker}`;
     return {
       headline,
       state: "수급",
       observation: `${actor} ${days}일 연속 순매수${event.flowAmountText ? ` / ${event.flowAmountText}` : ""}.`,
       synthesis: `핵심 숫자는 ${actor} ${days}일 연속 수급입니다. 장마감 확정 자료라 장중 추정과 분리해서 봅니다.`,
-      evidence: `${event.source} · ${event.asOf.slice(0, 10)} · ${actor} ${days}일`,
+      evidence: `${event.source} · ${event.asOf.slice(0, 10)} · ${actor} ${days}일 연속 순매수`,
     };
   }
 

--- a/scripts/diag-headline-provenance.ts
+++ b/scripts/diag-headline-provenance.ts
@@ -17,8 +17,16 @@ import type { DiscoveryCountryScope } from "../apps/web/lib/market-source-types"
 
 type HeadlinePath = "raw_title" | "abstract_template" | "why_synthesis" | "fallback_no_event";
 type HeadlineMethod = "ai" | "rule" | "fallback" | "none";
-type ProvenanceEventKind = "news_mention" | "disclosure" | "volume_spike" | "price_move" | "market_context" | "theme_link" | "none";
-type HeadlineTrack = "A_material" | "suppressed";
+type ProvenanceEventKind =
+  | "news_mention"
+  | "disclosure"
+  | "flow_entry"
+  | "volume_spike"
+  | "price_move"
+  | "market_context"
+  | "theme_link"
+  | "none";
+type HeadlineTrack = "A_material" | "B_supply" | "suppressed";
 type HeadlineAxis = "price" | "supply" | "material" | "unknown";
 
 interface Args {
@@ -127,6 +135,7 @@ function classifyEventKind(stock: DiscoveryStockPayload, front: DiscoveryFrontSe
   if (
     explicitKind === "news_mention" ||
     explicitKind === "disclosure" ||
+    explicitKind === "flow_entry" ||
     explicitKind === "volume_spike" ||
     explicitKind === "price_move" ||
     explicitKind === "market_context" ||
@@ -152,6 +161,7 @@ function classifyEventKind(stock: DiscoveryStockPayload, front: DiscoveryFrontSe
     .join(" ");
   if (DISCLOSURE_PATTERN.test(haystack)) return "disclosure";
   if (NEWS_PATTERN.test(haystack) || !!stock.sourceUrl || !!stock.sourceLabel || !!front?.signals.newsEventLabel) return "news_mention";
+  if (/(?:외국인|기관|개인|수급).{0,20}(?:\d+일|연속|순매수)|순매수/.test(haystack)) return "flow_entry";
   if (VOLUME_PATTERN.test(haystack)) return "volume_spike";
   return "none";
 }
@@ -171,6 +181,7 @@ function classifyPath(stock: DiscoveryStockPayload, headline: string, eventKind:
 function classifyTrack(path: HeadlinePath, eventKind: ProvenanceEventKind): HeadlineTrack {
   if (path === "fallback_no_event") return "suppressed";
   if (eventKind === "news_mention" || eventKind === "disclosure") return "A_material";
+  if (eventKind === "flow_entry") return "B_supply";
   return "suppressed";
 }
 
@@ -250,6 +261,7 @@ function buildReport(payload: DiscoveryResponse, args: Args): HeadlineProvenance
   };
   const trackCounts: Record<HeadlineTrack, number> = {
     A_material: 0,
+    B_supply: 0,
     suppressed: 0,
   };
   const methodCounts: Record<HeadlineMethod, number> = {
@@ -267,6 +279,7 @@ function buildReport(payload: DiscoveryResponse, args: Args): HeadlineProvenance
   const eventCounts: Record<ProvenanceEventKind, number> = {
     news_mention: 0,
     disclosure: 0,
+    flow_entry: 0,
     volume_spike: 0,
     price_move: 0,
     market_context: 0,

--- a/scripts/discovery-regression-gate.ts
+++ b/scripts/discovery-regression-gate.ts
@@ -106,7 +106,7 @@ export function evaluateDiscoveryPayload(
       add("hook.price_only", `앞단 ${index + 1}번 카드 '${name}'가 가격-only 또는 움직임 재진술 문장입니다.`, hook);
     }
 
-    if (FORBIDDEN_ADVICE_PATTERN.test(allCopy)) {
+    if (FORBIDDEN_ADVICE_PATTERN.test(neutralizeSupplyFactTerms(allCopy))) {
       add("copy.forbidden_advice", `앞단 ${index + 1}번 카드 '${name}'에 금칙어가 있습니다.`, allCopy);
     }
   }
@@ -141,6 +141,10 @@ function visibleHook(stock: DiscoveryGateStock): string {
 
 function visibleCopy(stock: DiscoveryGateStock): string {
   return [stock.reason, stock.whyShown, stock.headline, stock.axisHook?.hookText].filter(Boolean).join(" ").trim();
+}
+
+function neutralizeSupplyFactTerms(text: string): string {
+  return text.replace(/순매수|순매도/g, "수급");
 }
 
 function duplicateVisibleHooks(stocks: readonly DiscoveryGateStock[]): Array<[string, number]> {


### PR DESCRIPTION
## Summary
- Hydrates live KR supply-demand data for reached discovery candidates so the deterministic supply axis can actually surface in the deck.
- Changes flow copy from vague buying language to factual `N일 연속 순매수` wording.
- Updates headline diagnostics and discovery guard so `flow_entry`/supply-track cards are measured, while factual `순매수` is not misclassified as investment advice.

## Why this was still invisible
- The axis selector had landed, but the live deck had no `flow_entry` events for it to choose from.
- After this change, diagnostics show flow events are present before and after ranking.

## Verification
- `npm run test -- card-axis card-headline insight-synthesis` ✅
- `npm run typecheck` ✅
- `npm run build:web` ✅
- `npm run build:fomo-web` ✅
- `npm run diag:headline -- --country=KR` ✅
  - before-rank flow: 39
  - after-rank flow: 20
  - final cards: 47
  - track: B_supply 11 / 47 (23%)
  - axis: supply 11 / 47 (23%)
  - sample: `기관 10일 연속 순매수 1만주 — 우양에이치씨`
- `npm run guard:discovery` ✅