### PR TITLE
[Auto] #761 — fix(keywords): 세션 풀러 포화(EMAXCONNSESSION) 시 스냅샷 쓰기 백오프 재시도 + 종료 시 커넥션 반납

### DIFF
--- a/apps/web/lib/keyword-snapshot.ts
+++ b/apps/web/lib/keyword-snapshot.ts
@@ -52,21 +52,45 @@ export async function readLatestKeywordSnapshot(date: string): Promise<KeywordSn
   }
 }
 
+/**
+ * 일시적 커넥션 포화 오류 여부. Supabase 세션 풀러가 꽉 차면
+ * `FATAL: ... max clients reached in session mode`(EMAXCONNSESSION) 나 P2024 를 던진다.
+ * 다른 클라이언트가 커넥션을 반납하면 재시도로 회복 가능 — 영구 실패와 구분한다.
+ */
+function isTransientConnectionError(err: unknown): boolean {
+  const code = (err as { code?: string })?.code;
+  if (code === "P2024") return true; // Prisma: Timed out fetching a connection from the pool
+  const msg = (err as Error)?.message ?? "";
+  return /EMAXCONNSESSION|max clients reached|too many connections|Timed out fetching a connection/i.test(msg);
+}
+
 /** 스냅샷 upsert(날짜 unique). cron 전용. 실패 시 throw — 스크립트가 비정상 종료로 가시화. */
 export async function writeKeywordSnapshot(
   date: string,
   snapshot: Omit<KeywordSnapshot, "date">
 ): Promise<void> {
-  await prisma.keywordCardSnapshot.upsert({
-    where: { date },
-    create: {
-      date,
-      cards: snapshot.cards as unknown as object,
-      confidence: snapshot.confidence,
-    },
-    update: {
-      cards: snapshot.cards as unknown as object,
-      confidence: snapshot.confidence,
-    },
-  });
+  const data = {
+    cards: snapshot.cards as unknown as object,
+    confidence: snapshot.confidence,
+  };
+  // 일시적 풀러 포화는 짧은 백오프로 재시도. 소진 후에도 실패면 throw(정직한 숫자: 누락을 숨기지 않음).
+  const maxAttempts = 4;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await prisma.keywordCardSnapshot.upsert({
+        where: { date },
+        create: { date, ...data },
+        update: data,
+      });
+      return;
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientConnectionError(err)) throw err;
+      const delayMs = 500 * 2 ** (attempt - 1); // 0.5s, 1s, 2s
+      console.warn(
+        `[keyword-snapshot] write transient error (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms:`,
+        (err as Error)?.message
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
 }

--- a/keyword-cards-health.json
+++ b/keyword-cards-health.json
@@ -1,0 +1,5 @@
+{
+  "date": "2026-07-01",
+  "count": 20,
+  "confidence": "low"
+}

--- a/scripts/keywords-generate.ts
+++ b/scripts/keywords-generate.ts
@@ -39,9 +39,23 @@ async function main() {
   console.log(`[keywords:generate] 스냅샷 저장 완료: ${date}`);
 }
 
+// 세션 모드 풀러 커넥션을 즉시 반납해 동시 실행 간 풀 포화를 줄인다(EMAXCONNSESSION 완화).
+async function disconnect() {
+  try {
+    const { prisma } = await import("../apps/web/lib/prisma");
+    await prisma.$disconnect();
+  } catch (err) {
+    console.warn("[keywords:generate] disconnect 실패", err instanceof Error ? err.message : String(err));
+  }
+}
+
 main()
-  .then(() => process.exit(0))
-  .catch((err) => {
+  .then(async () => {
+    await disconnect();
+    process.exit(0);
+  })
+  .catch(async (err) => {
     console.error("[keywords:generate] 실패", err);
+    await disconnect();
     process.exit(1);
   });


### PR DESCRIPTION
## 프로젝트 task #761 자동 구현

Closes #761

- 에이전트: Claude Code (구독 인증)
- 검증: ✅ lint/typecheck 통과(자가수정 포함).
- 작업: fix(keywords): 세션 풀러 포화(EMAXCONNSESSION) 시 스냅샷 쓰기 백오프 재시도 + 종료 시 커넥션 반납
- 자동 구현 가드: max_turns=30, timeout=25m, changed_files=2/12, added_lines=52/900
- 허용 경로: .github,apps/web,scripts,packages/fomo-core,packages/shared


