### PR TITLE
feat(agent-ops): 이슈 생성 두 축 신설 + 반복 병목 제거

### DIFF
--- a/.github/workflows/agent-tooling-scout.yml
+++ b/.github/workflows/agent-tooling-scout.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: "60"
   schedule:
-    - cron: "0 0 * * *" # 09:00 KST
+    - cron: "0 0 * * 1" # 매주 월 09:00 KST (주간 카테고리 로테이션)
 
 permissions:
   contents: read
@@ -94,7 +94,7 @@ jobs:
               return `${values.year}-${values.month}-${values.day}`;
             };
             const date = summary.generatedDateKst || kstDate();
-            const title = `오늘의 에이전트 툴링 후보 - ${date}`;
+            const title = `이번 주 에이전트·생태계 툴링 후보 - ${date}`;
             const marker = "<!-- agent-tooling-scout -->";
             const issueBody = `${marker}\n\n${body}`;
             const { data: openIssues } = await github.rest.issues.listForRepo({

--- a/.github/workflows/hardening-scout.yml
+++ b/.github/workflows/hardening-scout.yml
@@ -1,0 +1,78 @@
+name: Hardening Scout
+
+# 백엔드·인프라·보안·API·DB·성능 강화 이슈 생성기(결정론, LLM 불필요).
+# ISO 주차로 영역 로테이션 → 매주 다른 축. 자동 구현 없이 검토 이슈까지만.
+
+on:
+  workflow_dispatch:
+    inputs:
+      area:
+        description: "강제 영역(security|infra|api|db|perf). 비우면 주차 로테이션"
+        required: false
+        default: ""
+  schedule:
+    - cron: "0 0 * * 2" # 매주 화 09:00 KST
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hardening-scout
+  cancel-in-progress: false
+
+jobs:
+  scout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run hardening scout
+        env:
+          HARDENING_AREA: ${{ github.event.inputs.area }}
+        run: npm run hardening:scout
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: hardening-scout
+          path: hardening-reports/*
+      - name: Create or update review issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const summary = JSON.parse(fs.readFileSync("hardening-reports/latest.json", "utf8"));
+            if (!summary.findingCount) {
+              core.info(`이번 영역(${summary.area}) 강화 후보 없음 — 이슈 생략`);
+              return;
+            }
+            const body = fs.readFileSync("hardening-reports/latest.md", "utf8");
+            const labels = [
+              { name: "agent-ops", color: "1d76db", description: "Agent operations and tooling" },
+              { name: "hardening-scout", color: "0e8a16", description: "백엔드/인프라/보안/API 강화 스카우트" },
+              { name: "needs-ceo-review", color: "d93f0b", description: "Requires Gwanghyuk review/approval" }
+            ];
+            const { owner, repo } = context.repo;
+            for (const label of labels) {
+              try { await github.rest.issues.createLabel({ owner, repo, ...label }); }
+              catch (error) { if (error.status !== 422) throw error; }
+            }
+            const marker = "<!-- hardening-scout -->";
+            const title = `🛠 강화 스카우트 [${summary.area}] ${summary.generatedDateKst}`;
+            const issueBody = `${marker}\n\n${body}`;
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner, repo, state: "open", labels: "hardening-scout", per_page: 30
+            });
+            const existing = openIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body: issueBody, labels: labels.map((l) => l.name) });
+              core.info(`Updated issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({ owner, repo, title, body: issueBody, labels: labels.map((l) => l.name) });
+              core.info(`Created issue #${created.data.number}`);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ playwright-report/
 playwright/.cache/
 fomo-index-health.json
 agent-tooling-reports/
+hardening-reports/
 .codebase-memory/

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "research:issues": "tsx scripts/research-agent-issues.ts",
     "research:newsletter": "tsx scripts/research-newsletter.ts",
     "agent:tooling-scout": "tsx scripts/agent-tooling-scout.ts",
+    "hardening:scout": "tsx scripts/hardening-scout.ts",
     "fomo:index": "tsx scripts/fomo-index-pipeline.ts",
     "keywords:generate": "tsx scripts/keywords-generate.ts",
     "warm:insights": "tsx scripts/warm-insights.ts",

--- a/scripts/__tests__/scout-rotation.test.ts
+++ b/scripts/__tests__/scout-rotation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, beforeAll } from "vitest";
+
+// import 시 main() 자동실행 방지(네트워크/파일 쓰기).
+beforeAll(() => {
+  process.env["TOOLING_SCOUT_TEST"] = "1";
+  process.env["HARDENING_SCOUT_TEST"] = "1";
+});
+
+describe("반복 방지 — 카테고리·영역 로테이션 + dedup", async () => {
+  const { pickCategory, proposedReposFromIssues, isoWeek } = await import("../agent-tooling-scout");
+  const hardening = await import("../hardening-scout");
+
+  it("Ecosystem: 주차가 다르면 카테고리도 순환한다(매주 같은 후보 방지)", () => {
+    const keys = new Set<string>();
+    for (let w = 0; w < 5; w++) {
+      const date = new Date(Date.UTC(2026, 0, 5 + w * 7)); // 5주 연속(월요일)
+      keys.add(pickCategory(date).key);
+    }
+    expect(keys.size).toBeGreaterThanOrEqual(4); // 5주에 4개 이상 서로 다른 카테고리
+  });
+
+  it("Ecosystem: override 키가 오면 해당 카테고리를 고정 선택", () => {
+    expect(pickCategory(new Date(), "mcp-tooling").key).toBe("mcp-tooling");
+  });
+
+  it("Ecosystem: dedup — 과거 이슈 본문의 제안 repo 를 추출한다", () => {
+    const bodies = [
+      "- 레포: [getzep/graphiti](https://github.com/getzep/graphiti)\n점수 80",
+      "다른 후보 https://github.com/comet-ml/opik 참고.",
+    ];
+    const set = proposedReposFromIssues(bodies);
+    expect(set.has("getzep/graphiti")).toBe(true);
+    expect(set.has("comet-ml/opik")).toBe(true);
+    expect(set.has("never/proposed")).toBe(false);
+  });
+
+  it("Hardening: 주차가 다르면 강화 영역이 순환한다(제품 데이터 아닌 축 커버)", () => {
+    const areas = new Set<string>();
+    for (let w = 0; w < 5; w++) {
+      areas.add(hardening.pickArea(new Date(Date.UTC(2026, 0, 5 + w * 7))));
+    }
+    expect(areas.size).toBe(5); // 5주 = 보안/인프라/API/DB/성능 전부
+  });
+
+  it("Hardening: override 영역 강제 선택", () => {
+    expect(hardening.pickArea(new Date(), "security")).toBe("security");
+    expect(hardening.pickArea(new Date(), "bogus")).not.toBe("bogus");
+  });
+
+  it("isoWeek 는 연속 주에 증가한다", () => {
+    const a = isoWeek(new Date(Date.UTC(2026, 0, 5)));
+    const b = isoWeek(new Date(Date.UTC(2026, 0, 12)));
+    expect(b).toBe(a + 1);
+  });
+});

--- a/scripts/agent-tooling-scout.ts
+++ b/scripts/agent-tooling-scout.ts
@@ -77,6 +77,59 @@ const STRONG_SEED_MIN_SCORE = 65;
 const RUNNER_UP_MAX_SCORE_GAP = 8;
 const REPORT_DIR = "agent-tooling-reports";
 
+/**
+ * 카테고리 풀 — ISO 주차로 로테이션해 매주 다른 축을 탐색한다(반복 후보 방지).
+ * env(TOOLING_SCOUT_SEED_REPOS/SEARCH_QUERIES) 가 오면 그게 우선(수동 dispatch).
+ */
+const CATEGORY_POOL: Array<{ key: string; label: string; seeds: string[]; queries: string[] }> = [
+  { key: "agent-skills", label: "에이전트·스킬", seeds: ["anthropics/claude-code", "openai/codex", "github/github-mcp-server"], queries: ["claude code skills", "codex agent tooling", "ai coding agent skills"] },
+  { key: "mcp-tooling", label: "MCP·워크플로우", seeds: ["modelcontextprotocol/servers", "microsoft/playwright-mcp"], queries: ["mcp server tooling", "model context protocol", "mcp agent workflow"] },
+  { key: "spec-driven", label: "스펙주도·평가", seeds: ["github/spec-kit"], queries: ["spec driven development ai", "llm eval framework", "ai coding spec workflow"] },
+  { key: "tech-debt-scalability", label: "기술부채·확장성", seeds: [], queries: ["typescript monorepo tooling", "codebase refactor automation", "dependency upgrade bot", "code migration tool"] },
+  { key: "testing-observability", label: "테스트·관측", seeds: [], queries: ["llm observability tracing", "ai evaluation framework", "prompt regression testing", "playwright ai testing"] },
+];
+
+/** ISO 주차(월요일 시작). */
+export function isoWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const firstDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNum + 3);
+  return 1 + Math.round((d.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000));
+}
+
+export function pickCategory(date: Date, override?: string): (typeof CATEGORY_POOL)[number] {
+  const found = override ? CATEGORY_POOL.find((c) => c.key === override) : undefined;
+  return found ?? CATEGORY_POOL[isoWeek(date) % CATEGORY_POOL.length]!;
+}
+
+/** dedup 메모리 — 과거 스카우트 이슈(open+closed) 본문에서 제안된 repo 를 뽑아 재제안 제외. */
+export function proposedReposFromIssues(bodies: Array<string | undefined | null>): Set<string> {
+  const out = new Set<string>();
+  for (const body of bodies) {
+    for (const m of (body ?? "").matchAll(/github\.com\/([\w.-]+\/[\w.-]+)/gi)) {
+      out.add(m[1]!.toLowerCase().replace(/[).,]+$/, ""));
+    }
+  }
+  return out;
+}
+
+async function fetchProposedRepos(errors: string[]): Promise<Set<string>> {
+  const repo = env("GITHUB_REPOSITORY");
+  if (!repo) return new Set(); // 로컬/토큰 없음 → dedup 생략
+  try {
+    const issues = await githubRequest<Array<{ body?: string }>>(
+      `/repos/${repo}/issues?labels=tooling-scout&state=all&per_page=100`
+    );
+    return proposedReposFromIssues(issues.map((i) => i.body));
+  } catch (error) {
+    errors.push(`dedup skip: ${(error as Error).message}`);
+    return new Set();
+  }
+}
+
 const FIT_SIGNALS: Array<{ pattern: RegExp; points: number; label: string }> = [
   { pattern: /\bagents?\b/i, points: 18, label: "agent" },
   { pattern: /\bskills?\b/i, points: 18, label: "skill" },
@@ -319,6 +372,7 @@ function collectSelectedCandidates(candidates: ToolingCandidate[]): ToolingCandi
 }
 
 function renderReport(params: {
+  category: string;
   seedRepos: string[];
   searchQueries: string[];
   updatedDays: number;
@@ -331,10 +385,11 @@ function renderReport(params: {
   const [primary, runnerUp] = params.selectedCandidates;
 
   return [
-    "# 오늘의 에이전트 툴링 후보",
+    "# 이번 주 에이전트·생태계 툴링 후보",
     "",
     `- 생성일(KST): ${generatedDateKst}`,
-    `- 기준: stars ${params.minStars.toLocaleString("en-US")}개 이상, 최근 ${params.updatedDays}일 내 업데이트, archived 제외`,
+    `- 이번 주 카테고리(로테이션): ${params.category}`,
+    `- 기준: stars ${params.minStars.toLocaleString("en-US")}개 이상, 최근 ${params.updatedDays}일 내 업데이트, archived 제외, 과거 제안 repo 제외(dedup)`,
     `- 로컬 기준: ${git(["branch", "--show-current"])}@${git(["rev-parse", "--short", "HEAD"])}`,
     "",
     "## 오늘의 1순위",
@@ -393,8 +448,9 @@ function pickSummary(candidate: ToolingCandidate): Pick<ToolingCandidate, "fullN
 }
 
 async function main(): Promise<void> {
-  const seedRepos = parseList(env("TOOLING_SCOUT_SEED_REPOS") ?? env("TOOLING_SCOUT_REPOS"), DEFAULT_SEED_REPOS);
-  const searchQueries = parseList(env("TOOLING_SCOUT_SEARCH_QUERIES"), DEFAULT_SEARCH_QUERIES);
+  const category = pickCategory(new Date(), env("TOOLING_SCOUT_CATEGORY"));
+  const seedRepos = parseList(env("TOOLING_SCOUT_SEED_REPOS") ?? env("TOOLING_SCOUT_REPOS"), category.seeds.length ? category.seeds : DEFAULT_SEED_REPOS);
+  const searchQueries = parseList(env("TOOLING_SCOUT_SEARCH_QUERIES"), category.queries.length ? category.queries : DEFAULT_SEARCH_QUERIES);
   const updatedDays = parsePositiveInt(env("TOOLING_SCOUT_UPDATED_DAYS") ?? env("TOOLING_SCOUT_DAYS"), DEFAULT_UPDATED_DAYS, 120);
   const minStars = parsePositiveInt(env("TOOLING_SCOUT_MIN_STARS"), DEFAULT_MIN_STARS, 1_000_000);
   const generatedAt = new Date().toISOString();
@@ -423,8 +479,10 @@ async function main(): Promise<void> {
     .map(({ repo, source, sourceLabel }) => scoreRepo(repo, source, sourceLabel))
     .filter((candidate): candidate is ToolingCandidate => Boolean(candidate));
 
-  const selectedCandidates = collectSelectedCandidates(candidates);
-  const report = renderReport({ seedRepos, searchQueries, updatedDays, minStars, selectedCandidates, errors, generatedAt });
+  const proposed = await fetchProposedRepos(errors);
+  const freshCandidates = candidates.filter((candidate) => !proposed.has(candidate.fullName.toLowerCase()));
+  const selectedCandidates = collectSelectedCandidates(freshCandidates);
+  const report = renderReport({ category: category.label, seedRepos, searchQueries, updatedDays, minStars, selectedCandidates, errors, generatedAt });
   const summary = buildSummary(generatedAt, selectedCandidates, errors);
   const date = kstDate(new Date(generatedAt));
   const outputDir = path.resolve(process.cwd(), REPORT_DIR);
@@ -443,7 +501,9 @@ async function main(): Promise<void> {
   console.log(path.join(REPORT_DIR, "latest.md"));
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+if (process.env["TOOLING_SCOUT_TEST"] !== "1") {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/hardening-scout.ts
+++ b/scripts/hardening-scout.ts
@@ -1,0 +1,244 @@
+/**
+ * Hardening Scout — 백엔드·인프라·보안·API 강화 이슈 생성기 (결정론, LLM 불필요).
+ *
+ * 왜: daily-product-monitor 는 "제품 데이터"만 본다. 1인 개발자가 약한
+ *     백엔드/인프라/보안/API/DB/성능 축을 매주 다른 영역으로 스캔해 *구체적* 강화 태스크를 이슈화한다.
+ * 반복 방지: ISO 주차로 영역 로테이션(보안→인프라→API→DB→성능) → 매주 다른 축.
+ * 출력: hardening-reports/latest.md + latest.json (findingCount>0 일 때만 워크플로우가 이슈 생성).
+ * 실행: npm run hardening:scout   (HARDENING_AREA=security 로 영역 강제 가능)
+ */
+import { execFileSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const REPORT_DIR = "hardening-reports";
+const AREAS = ["security", "infra", "api", "db", "perf"] as const;
+type Area = (typeof AREAS)[number];
+
+interface Finding {
+  title: string;
+  detail: string;
+}
+interface AreaReport {
+  area: Area;
+  label: string;
+  whyForNonExpert: string;
+  findings: Finding[];
+}
+
+function kstDate(now = new Date()): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  return parts;
+}
+
+/** ISO 주차(월요일 시작) — 영역 로테이션 인덱스. */
+export function isoWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const firstDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNum + 3);
+  return 1 + Math.round((d.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000));
+}
+
+export function pickArea(date: Date, override?: string): Area {
+  if (override && (AREAS as readonly string[]).includes(override)) return override as Area;
+  return AREAS[isoWeek(date) % AREAS.length]!;
+}
+
+function gitGrep(args: string[]): string[] {
+  try {
+    return execFileSync("git", ["grep", "-I", ...args], { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 })
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return []; // git grep exits 1 when 0 matches
+  }
+}
+
+async function readIfExists(rel: string): Promise<string> {
+  try {
+    return await fs.readFile(path.resolve(process.cwd(), rel), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// ── 영역별 결정론 체크 ──────────────────────────────────────────────
+
+async function scanSecurity(): Promise<AreaReport> {
+  const findings: Finding[] = [];
+
+  // 1) 코드가 참조하지만 .env.example 에 없는 env (설정 누락/문서화 공백).
+  const codeEnv = new Set(
+    gitGrep(["-hoE", "process\\.env\\[[\"'][A-Z0-9_]+[\"']\\]", "--", "apps", "packages", "scripts"])
+      .map((line) => line.match(/[A-Z0-9_]+/g)?.slice(-1)[0] ?? "")
+      .filter(Boolean)
+  );
+  const exampleText = await readIfExists(".env.example");
+  const exampleEnv = new Set([...exampleText.matchAll(/^([A-Z0-9_]+)=/gm)].map((m) => m[1]!));
+  const runtimeIgnore = new Set(["NODE_ENV", "CI", "PATH", "VERCEL", "VERCEL_ENV", "npm_lifecycle_event"]);
+  const missing = [...codeEnv].filter((k) => !exampleEnv.has(k) && !runtimeIgnore.has(k)).sort();
+  if (missing.length > 0) {
+    findings.push({
+      title: `.env.example 에 없는 코드 참조 env ${missing.length}개`,
+      detail: `${missing.join(", ")} — 누락 시 배포에서 조용히 오작동. .env.example 에 플레이스홀더 추가하거나 fail-closed 확인.`,
+    });
+  }
+
+  // 2) npm audit 취약점 요약(직접적 공급망 리스크).
+  try {
+    const audit = JSON.parse(execFileSync("npm", ["audit", "--json"], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 }));
+    const v = audit?.metadata?.vulnerabilities ?? {};
+    const high = (v.critical ?? 0) + (v.high ?? 0);
+    if (high > 0) findings.push({ title: `npm audit high/critical ${high}건`, detail: `critical ${v.critical ?? 0}, high ${v.high ?? 0}. \`npm audit\` 로 상세 확인 후 상향/교체.` });
+  } catch {
+    // audit 는 취약점 있으면 exit!=0 → stdout 에 JSON. 파싱 실패 시 무시.
+  }
+
+  // 3) 빈 catch(에러 삼킴 — 관측 공백). CLAUDE.md 코드원칙 6 위반 후보.
+  const emptyCatch = gitGrep(["-lE", "catch\\s*\\([^)]*\\)\\s*\\{\\s*\\}", "--", "apps", "packages"]);
+  if (emptyCatch.length > 0) {
+    findings.push({ title: `빈 catch 블록 파일 ${emptyCatch.length}개`, detail: `${emptyCatch.slice(0, 8).join(", ")}${emptyCatch.length > 8 ? " 외" : ""} — 최소 console.warn/에러상태. 조용한 실패는 디버깅 불가.` });
+  }
+
+  return {
+    area: "security",
+    label: "보안·시크릿·에러가시성",
+    whyForNonExpert: "털리거나 조용히 깨지는 걸 막는 축. env 누락·취약 의존성·삼켜진 에러가 가장 흔한 구멍.",
+    findings,
+  };
+}
+
+async function scanInfra(): Promise<AreaReport> {
+  const findings: Finding[] = [];
+  let wf: string[] = [];
+  try {
+    wf = (await fs.readdir(path.resolve(process.cwd(), ".github/workflows"))).filter((f) => /\.ya?ml$/.test(f));
+  } catch {
+    wf = [];
+  }
+  const noConcurrency: string[] = [];
+  for (const f of wf) {
+    const text = await readIfExists(`.github/workflows/${f}`);
+    if (/^on:\s*[\s\S]*schedule|cron/m.test(text) && !/concurrency:/.test(text)) noConcurrency.push(f);
+  }
+  if (noConcurrency.length > 0) {
+    findings.push({ title: `cron 워크플로우 중 concurrency 없음 ${noConcurrency.length}개`, detail: `${noConcurrency.join(", ")} — 겹쳐 돌면 중복 이슈/레이스. concurrency group 추가 권장.` });
+  }
+  return {
+    area: "infra",
+    label: "CI/CD·워크플로우 안정성",
+    whyForNonExpert: "자동화가 겹치거나 캐시 없이 느리게 도는 걸 잡는 축. 배포 파이프라인 신뢰성.",
+    findings,
+  };
+}
+
+async function scanApi(): Promise<AreaReport> {
+  const findings: Finding[] = [];
+  const routes = gitGrep(["-lE", "export async function (GET|POST|PUT|PATCH|DELETE)", "--", "apps/web/app/api", "apps/fomo-web/app/api"]);
+  const noValidation = routes.filter((f) => {
+    const text = execFileSync("git", ["show", `HEAD:${f}`], { encoding: "utf8" }).slice(0, 20000);
+    return !/zod|\.parse\(|safeParse|validate|schema|z\./i.test(text);
+  });
+  findings.push({ title: `API 라우트 ${routes.length}개 중 명시적 입력검증 흔적 없는 라우트 ${noValidation.length}개`, detail: `${noValidation.slice(0, 10).join(", ")}${noValidation.length > 10 ? " 외" : ""} — 경계 입력검증(allowlist/zod) 점검. docs/SECURITY_CHECKLIST.md '입력 검증' 참조.` });
+  return {
+    area: "api",
+    label: "API 경계·입력검증",
+    whyForNonExpert: "외부 입력이 들어오는 문. 검증 없으면 SSRF·주입·오작동. 라우트별 입력검증 존재 여부.",
+    findings: findings.filter((f) => !f.title.includes("0개")),
+  };
+}
+
+async function scanDb(): Promise<AreaReport> {
+  const findings: Finding[] = [];
+  const schema = await readIfExists("prisma/schema.prisma");
+  if (schema) {
+    const models = [...schema.matchAll(/^model\s+(\w+)/gm)].map((m) => m[1]!);
+    const indexCount = (schema.match(/@@index/g) ?? []).length;
+    const relationNoIndex = models.filter((m) => {
+      const block = schema.slice(schema.indexOf(`model ${m}`), schema.indexOf("}", schema.indexOf(`model ${m}`)));
+      return /@relation/.test(block) && !/@@index/.test(block);
+    });
+    if (relationNoIndex.length > 0) {
+      findings.push({ title: `@relation 있으나 @@index 없는 모델 ${relationNoIndex.length}개`, detail: `${relationNoIndex.join(", ")} — FK 조회 느려질 수 있음(인덱스 검토). 모델 ${models.length}개, 인덱스 ${indexCount}개.` });
+    }
+  }
+  return {
+    area: "db",
+    label: "DB 스키마·인덱스",
+    whyForNonExpert: "데이터 늘면 느려지는 지점. 관계 컬럼 인덱스 누락이 대표적 확장성 병목.",
+    findings,
+  };
+}
+
+async function scanPerf(): Promise<AreaReport> {
+  const findings: Finding[] = [];
+  const clientComps = gitGrep(["-l", "use client", "--", "apps/fomo-web/components", "apps/fomo-web/app"]);
+  const heavyClient = clientComps.filter((f) => {
+    const text = execFileSync("git", ["show", `HEAD:${f}`], { encoding: "utf8" }).slice(0, 20000);
+    return /recharts|framer-motion|three|chart\.js|@react-pdf|xlsx/i.test(text);
+  });
+  if (heavyClient.length > 0) {
+    findings.push({ title: `무거운 라이브러리를 정적 import 하는 client 컴포넌트 ${heavyClient.length}개`, detail: `${heavyClient.slice(0, 8).join(", ")} — next/dynamic 지연로딩 검토(초기 번들↓).` });
+  }
+  findings.push({ title: `client 컴포넌트 ${clientComps.length}개`, detail: `"use client" 컴포넌트 수. 서버 컴포넌트로 내릴 수 있는 건 내리면 번들·TTI 개선.` });
+  return {
+    area: "perf",
+    label: "번들·렌더 성능",
+    whyForNonExpert: "첫 화면이 빨리 뜨게 하는 축. 무거운 라이브러리·과도한 client 컴포넌트가 느림의 주범.",
+    findings,
+  };
+}
+
+const SCANNERS: Record<Area, () => Promise<AreaReport>> = {
+  security: scanSecurity,
+  infra: scanInfra,
+  api: scanApi,
+  db: scanDb,
+  perf: scanPerf,
+};
+
+function renderReport(report: AreaReport, dateKst: string): string {
+  return [
+    `# 강화 스카우트 — ${report.label} (${dateKst})`,
+    "",
+    `> 축: **${report.area}** · 왜 중요한가(비전문가용): ${report.whyForNonExpert}`,
+    `> 결정론 스캔(레포 스냅샷 기준). 매주 다른 축을 돈다. 아래는 *검토 태스크*지 자동수정 아님.`,
+    "",
+    ...(report.findings.length === 0
+      ? ["## 결과", "- 이번 스냅샷에선 이 축에서 걸린 항목 없음. (좋은 신호이거나 체크 확장 필요)"]
+      : ["## 강화 후보", ...report.findings.flatMap((f) => [`### ${f.title}`, f.detail, ""])]),
+    "## 다음 액션",
+    "- 채택: 개별 강화 PR/이슈로 분해.",
+    "- 보류: 우선순위 낮으면 다음 로테이션까지.",
+    "",
+    "## 가드레일",
+    "- 자동 구현 없음(검토 이슈까지만). 제품 카피·투자판단 무관.",
+  ].join("\n");
+}
+
+async function main(): Promise<void> {
+  const now = new Date();
+  const area = pickArea(now, process.env["HARDENING_AREA"]?.trim());
+  const report = await SCANNERS[area]();
+  const dateKst = kstDate(now);
+  const md = renderReport(report, dateKst);
+  const summary = { area, label: report.label, generatedDateKst: dateKst, findingCount: report.findings.length };
+
+  const outDir = path.resolve(process.cwd(), REPORT_DIR);
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(path.join(outDir, "latest.md"), md);
+  await fs.writeFile(path.join(outDir, "latest.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(`[hardening-scout] area=${area} findings=${report.findings.length}`);
+}
+
+if (process.env["HARDENING_SCOUT_TEST"] !== "1") {
+  void main();
+}


### PR DESCRIPTION
## 진단 (BCG)
자동 이슈가 **한 사분면(정적·제품데이터)에만** 몰려 반복:
| 유형 | 원인 |
|---|---|
| `툴링 후보`(tooling-scout) | 고정 seed 6 + 고정 쿼리 5(star순) + **dedup 0** → 매번 같은 후보 |
| `daily-product-monitor` | **제품 데이터만** 감시 — 백엔드/인프라/보안/API 축 부재 |

## 개선 (동적·기억 사분면으로 이동)
- **Ecosystem Scout** (tooling-scout 업그레이드): 카테고리 5종(에이전트·MCP·스펙주도·기술부채/확장성·테스트/관측) **ISO 주차 로테이션** + **과거 이슈 dedup**(제안 repo 재추천 금지) → 매주 다른 후보. cron 주간(월).
- **Hardening Scout** (신규): 보안→인프라→API→DB→성능 **주차 로테이션 결정론 스캔**(env 누락·npm audit·빈 catch·concurrency 없는 cron·입력검증 없는 라우트·인덱스 없는 관계·무거운 client 번들) → 1인 개발자가 약한 축의 구체 강화 이슈. cron 주간(화).
- `daily-product-monitor` 유지.

## 설계
- **결정론 우선(LLM 불필요)** — 런웨이 0 비용. 자동 구현 없이 검토 이슈까지만.
- 반복 방지 핵심(로테이션+dedup) 유닛테스트 6종.

## 검증
- typecheck 통과 · rotation/dedup 테스트 **6/6** · 두 스카우트 로컬 dry-run 정상
- Ecosystem dry-run이 기존 반복 후보 대신 **새 후보 발굴** 확인
- 리포트 산출물은 gitignore(워크플로우 아티팩트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)