### PR TITLE
fix(depth): 차트분석 빈 데이터 해결(동적 종목) + 뎁스 여백·위계

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1011,7 +1011,7 @@ function DepthTabBar({ tab, onChange }: { tab: "why" | "ta"; onChange: (t: "why"
     { key: "ta", label: "차트분석" },
   ];
   return (
-    <div className="mb-4 flex gap-1 rounded-full border border-hairline bg-surface p-1" role="tablist">
+    <div className="mt-6 mb-5 flex gap-1 rounded-full border border-hairline bg-surface p-1" role="tablist">
       {tabs.map((t) => {
         const active = tab === t.key;
         return (
@@ -1138,7 +1138,7 @@ export function StockInsightView({
     setBasicsLoaded(false);
     setFrontLoaded(!!seed);
     // 가격 헤더만 먼저 허용하고, 아래 가변 섹션은 세 요청이 모두 끝난 뒤 한 번에 연다.
-    fetchStockFront(stock)
+    fetchStockFront(stock, context?.naverCode ? { naverCode: context.naverCode } : {})
       .then((r) => alive && setFront(mergeFrontSeed(seed, r)))
       .catch(() => alive && setFront(seed))
       .finally(() => alive && setFrontLoaded(true));

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -395,12 +395,14 @@ export interface FeedSignalPoint {
   text: string;
   source: "뉴스" | "수급" | "테마" | "가격" | "주목" | "위치" | "거래";
 }
-export const fetchStockFront = (stock: string, opts: { lite?: boolean } = {}) =>
+export const fetchStockFront = (stock: string, opts: { lite?: boolean; naverCode?: string } = {}) =>
   cachedGet(
-    `stock-front:${opts.lite ? "lite" : "full"}:${stock}`,
+    `stock-front:${opts.lite ? "lite" : "full"}:${stock}:${opts.naverCode ?? ""}`,
     () =>
       get<StockFrontResponse>(
-        `/api/fomo/stock-front?stock=${encodeURIComponent(stock)}${opts.lite ? "&lite=1" : ""}`
+        `/api/fomo/stock-front?stock=${encodeURIComponent(stock)}${opts.lite ? "&lite=1" : ""}${
+          opts.naverCode ? `&naverCode=${encodeURIComponent(opts.naverCode)}` : ""
+        }`
       ),
     CACHE_TTL.stockFront
   );

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -50,7 +50,7 @@ async function getThemeRelativeMap(sector: StockSector): Promise<Record<string, 
   return load();
 }
 
-async function getFront(stock: string, lite = false): Promise<StockFrontData> {
+async function getFront(stock: string, lite = false, naverCode?: string): Promise<StockFrontData> {
   const today = kstDate();
   const load = unstable_cache(
     async () => {
@@ -67,9 +67,9 @@ async function getFront(stock: string, lite = false): Promise<StockFrontData> {
       return assembleStockFront(stock, rankMap, {
         ...(attentionMap[canonical] ? { attention: attentionMap[canonical] } : {}),
         ...(themeRelativeMap[canonical] ? { themeRelative: themeRelativeMap[canonical] } : {}),
-      }, { lite });
+      }, { lite, ...(naverCode ? { naverCode } : {}) });
     },
-    ["fomo-stock-front", lite ? "lite" : "full", cacheVersion(), today, stock],
+    ["fomo-stock-front", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? ""],
     { revalidate: REVALIDATE_S }
   );
   return load();
@@ -79,11 +79,12 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const stock = url.searchParams.get("stock")?.trim();
   const lite = url.searchParams.get("lite") === "1";
+  const naverCode = url.searchParams.get("naverCode")?.trim() || undefined;
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
   try {
-    const data = await getFront(stock, lite);
+    const data = await getFront(stock, lite, naverCode);
     return withCors(
       NextResponse.json(data, {
         headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400" },

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -164,6 +164,8 @@ export interface StockFrontData {
 export interface StockFrontOptions {
   /** 카드 앞면용 경량 경로. 시총순위·TA·상세 지표를 빼고 가격/수급/언급/짧은 차트만 쓴다. */
   lite?: boolean;
+  /** 동적 발견 종목(STOCK_VOCAB 미등재)용 네이버 코드. 있으면 vocab 없이도 캔들·TA 조회. */
+  naverCode?: string;
 }
 
 export interface FeedSignalPoint {
@@ -256,7 +258,7 @@ export async function assembleStockFront(
   options: StockFrontOptions = {}
 ): Promise<StockFrontData> {
   const def = resolveStock(stock);
-  const code = def?.naverCode;
+  const code = options.naverCode ?? def?.naverCode;
   if (!code) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
   const lite = options.lite === true;
 


### PR DESCRIPTION
## 문제 1 — 차트분석 탭이 항상 비어 있음
동신건설(+30% 상한가)에서도 "차트에서 두드러진 신호는 아직 없어요"만 떴음.

**근본 원인**: `assembleStockFront` 가 종목 코드를 **STOCK_VOCAB 의 naverCode 로만** 해소 → 동신건설 같은 **동적 발견 종목(vocab 미등재)** 은 코드가 없어 **즉시 빈값 반환**(캔들 0 → TA 0). front API·`fetchStockFront` 도 naverCode 를 안 넘겨서 뎁스가 코드를 전달할 방법이 없었음. (가격/스파크라인은 discovery seed 라 떠서 TA 만 빈 것처럼 보임.)

**수정**: `StockFrontOptions.naverCode` 추가 → 넘겨받은 코드로 캔들 조회. front 라우트 `naverCode` 파라미터(+캐시키), `fetchStockFront` 전달, 뎁스가 `context.naverCode` 전달.

**검증(프로브)**: 동신건설(025950) non-lite → **ta facts 3개**(20·60·120일선 정렬 / MACD / ATR 확장). 코드 없이는 0(기존 버그 재현).

## 문제 2 — 위계·여백
가격 ↔ 토글 ↔ 콘텐츠 마진이 0이라 답답. `DepthTabBar` 에 `mt-6 mb-5` 로 간격·위계 복원(가격=히어로 → 탭 → 콘텐츠).

## 검증
- typecheck(web+fomo-web) · test **1020/1020** · build:web · **guard:discovery 통과(47카드)**
- 브라우저 캡처로 여백 + TA 3건 렌더 확인

## 비고
US 종목 TA(naver 아닌 심볼 캔들 경로)는 별도 — 이번은 국장 동적 종목 수정. 후보로 둠.

🤖 Generated with [Claude Code](https://claude.com/claude-code)