### PR TITLE
Add narrative cards to discovery deck

### DIFF
--- a/apps/fomo-web/__tests__/discoveryDeck.test.ts
+++ b/apps/fomo-web/__tests__/discoveryDeck.test.ts
@@ -4,6 +4,7 @@ import {
   applyAxisSnapshotToStocks,
   buildDiscoveryDeckCards,
   buildContentDeckCards,
+  buildNarrativeDeckCards,
   buildSectorDeckCards,
   buildTodayDiscoveryStocks,
   interleaveSupplementalCards,
@@ -12,6 +13,7 @@ import {
   normalizeDiscoveryDeckCards,
   type DeckCard,
   type DeckContent,
+  type DeckNarrative,
   type DeckStock,
 } from "../lib/discoveryDeck";
 
@@ -97,6 +99,44 @@ function contentCard(id: string, scope: DeckContent["scope"], contentType: DeckC
     headline: id,
     facts: [{ label: "테스트", value: "+1.20%" }],
     source: "테스트",
+    asOf: "2026-07-01",
+  };
+}
+
+function narrativeCard(id: string, scope: "KR" | "US" = "KR"): DeckNarrative {
+  const market = scope === "KR" ? "KOSPI" : "NASDAQ";
+  return {
+    kind: "narrative",
+    id,
+    scope,
+    trigger: {
+      headline: "반도체 공급망 사건",
+      source: "테스트뉴스",
+      asOf: "2026-07-01",
+      anchorTicker: scope === "KR" ? "삼성전자" : "엔비디아",
+    },
+    headline: "반도체 공급망 사건에 연결 종목 동반 강세",
+    stocks: [
+      {
+        ticker: scope === "KR" ? "삼성전자" : "엔비디아",
+        name: scope === "KR" ? "삼성전자" : "엔비디아",
+        market,
+        country: scope,
+        relation: "trigger",
+        relationReason: "이 뉴스에서 직접 언급된 종목입니다.",
+        changePct: 2.4,
+      },
+      {
+        ticker: scope === "KR" ? "SK하이닉스" : "VRT",
+        name: scope === "KR" ? "SK하이닉스" : "VRT",
+        market,
+        country: scope,
+        relation: "beneficiary",
+        relationReason: "관계맵에서 확인된 연결 종목입니다.",
+        changePct: 3.1,
+      },
+    ],
+    source: "테스트뉴스",
     asOf: "2026-07-01",
   };
 }
@@ -333,18 +373,25 @@ describe("buildTodayDiscoveryStocks", () => {
     ]);
   });
 
+  it("filters narrative cards by country scope and requires real linked stocks", () => {
+    const thin = { ...narrativeCard("thin", "KR"), stocks: [narrativeCard("thin", "KR").stocks[0]!] };
+    expect(buildNarrativeDeckCards([narrativeCard("kr-story", "KR"), narrativeCard("us-story", "US"), thin], "KR").map((card) => card.type === "narrative" ? card.data.id : "")).toEqual(["kr-story"]);
+    expect(buildNarrativeDeckCards([narrativeCard("kr-story", "KR"), narrativeCard("us-story", "US")], "US").map((card) => card.type === "narrative" ? card.data.id : "")).toEqual(["us-story"]);
+  });
+
   it("interleaves sector and content cards after stock intervals", () => {
     const stocks: DeckCard[] = Array.from({ length: 11 }, (_, i) => ({ type: "stock", data: deckStock(`종목${i}`, "AI") }));
     const sector: DeckCard = {
       type: "sector",
       data: { id: "sector:KR:AI", sector: "AI", country: "KR", stance: "bull-dominant", stanceNote: "테스트", stocks: [] },
     };
+    const narrative: DeckCard = { type: "narrative", data: narrativeCard("kr-story", "KR") };
     const content: DeckCard = { type: "content", data: contentCard("domestic-index", "domestic") };
 
-    const result = interleaveSupplementalCards(stocks, [sector, content], 5);
+    const result = interleaveSupplementalCards(stocks, [sector, narrative, content], 5);
 
     expect(result[5]?.type).toBe("sector");
-    expect(result[11]?.type).toBe("content");
+    expect(result[11]?.type).toBe("narrative");
   });
 
   it("builds discovery deck cards with stock and sector card types", () => {
@@ -352,10 +399,12 @@ describe("buildTodayDiscoveryStocks", () => {
     const result = buildDiscoveryDeckCards(stocks, {
       country: "KR",
       fronts: frontsFor(stocks),
+      interval: 3,
       contentCards: [contentCard("domestic-index", "domestic"), contentCard("world-index", "world")],
     });
 
     expect(result.some((card) => card.type === "sector")).toBe(true);
+    expect(buildDiscoveryDeckCards([...stocks, narrativeCard("kr-story", "KR")], { country: "KR", fronts: frontsFor(stocks), interval: 3 }).some((card) => card.type === "narrative")).toBe(true);
     expect(result.some((card) => card.type === "content" && card.data.id === "domestic-index")).toBe(true);
     expect(result.some((card) => card.type === "content" && card.data.id === "world-index")).toBe(false);
     expect(result.filter((card) => card.type === "stock")).toHaveLength(11);

--- a/apps/fomo-web/components/NarrativeCard.tsx
+++ b/apps/fomo-web/components/NarrativeCard.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import type { DeckNarrative } from "@/lib/discoveryDeck";
+import { CaretDownIcon, CaretUpIcon } from "@/components/icons";
+
+const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
+
+function clampStyle(lines: number): CSSProperties {
+  return {
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: lines,
+    overflow: "hidden",
+  };
+}
+
+function relationLabel(relation: DeckNarrative["stocks"][number]["relation"]): string {
+  switch (relation) {
+    case "trigger":
+      return "트리거";
+    case "customer":
+      return "수요처";
+    case "supplier":
+      return "공급사";
+    case "material":
+      return "원재료";
+    case "beneficiary":
+      return "확산 수혜";
+    case "peer":
+    default:
+      return "동행주";
+  }
+}
+
+function changeParts(changePct: number): { text: string; dir: "up" | "down" | "flat" } {
+  const dir = changePct > 0 ? "up" : changePct < 0 ? "down" : "flat";
+  return { text: `${changePct > 0 ? "+" : ""}${changePct.toFixed(1)}%`, dir };
+}
+
+export function NarrativeCard({ card, progress }: { card: DeckNarrative; progress?: string | undefined }) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0">
+        <span className="font-pixel text-[10px] uppercase tracking-wide text-muted">STORY</span>
+        <h3 className="mt-3 text-2xl font-bold leading-8 text-whiteout" style={clampStyle(3)}>
+          {card.headline}
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-muted" style={clampStyle(2)}>
+          {card.trigger.headline}
+        </p>
+      </div>
+
+      <div className="mt-5 grid min-h-0 gap-2 overflow-hidden">
+        {card.stocks.slice(0, 4).map((stock) => {
+          const change = changeParts(stock.changePct);
+          return (
+            <div key={`${card.id}:${stock.ticker}`} className="rounded-xl border border-hairline bg-white/[0.035] px-3 py-2.5">
+              <div className="flex min-w-0 items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="min-w-0 truncate text-base font-bold text-whiteout">{stock.name}</span>
+                    <span className="shrink-0 rounded-full border border-hairline-soft px-2 py-0.5 text-[10px] text-muted">
+                      {relationLabel(stock.relation)}
+                    </span>
+                  </div>
+                </div>
+                <span className="inline-flex shrink-0 items-center gap-1 text-sm font-bold tabular-nums" style={{ color: DIR_COLOR[change.dir] }}>
+                  {change.dir === "up" && <CaretUpIcon size={11} />}
+                  {change.dir === "down" && <CaretDownIcon size={11} />}
+                  {change.text}
+                </span>
+              </div>
+              <p className="mt-1 text-xs leading-5 text-muted" style={clampStyle(1)}>
+                {stock.relationReason}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-auto flex shrink-0 items-center justify-between pt-3">
+        <span className="font-pixel text-[11px] text-muted">
+          {card.source} · {card.asOf}
+        </span>
+        {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { ContentCard } from "@/components/ContentCard";
+import { NarrativeCard } from "@/components/NarrativeCard";
 import { SectorCard } from "@/components/SectorCard";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import type { FeedSignalPoint, StockFrontResponse } from "@/lib/fomoApi";
@@ -221,6 +222,7 @@ function cardKey(card: DeckCard): string {
 function cardLabel(card: DeckCard): string {
   if (card.type === "stock") return card.data.canonical;
   if (card.type === "sector") return `${card.data.sector} 섹터`;
+  if (card.type === "narrative") return card.data.headline;
   return card.data.headline;
 }
 
@@ -616,6 +618,7 @@ export function StockSwipeDeck({
   };
   const renderFace = (card: DeckCard, progress?: string) => {
     if (card.type === "sector") return <SectorCard card={card.data} progress={progress} />;
+    if (card.type === "narrative") return <NarrativeCard card={card.data} progress={progress} />;
     if (card.type === "content") return <ContentCard card={card.data} progress={progress} />;
     const stock = card.data;
     const e = front[stock.canonical];
@@ -681,6 +684,7 @@ export function StockSwipeDeck({
       if (!isStockCard(card)) {
         setUndoEntry({ idx, dir, card });
         if (card.type === "sector") recordTaste("theme", card.data.sector, dir === "right" ? "more" : "less");
+        if (card.type === "narrative") recordTaste("stock", card.data.trigger.anchorTicker, dir === "right" ? "more" : "less");
         recordDiscoveryEvent("swipe", { direction: dir, hydrated: true });
         flingNext(dir);
         return;
@@ -726,6 +730,9 @@ export function StockSwipeDeck({
       if (card.type === "sector") {
         recordTaste("theme", card.data.sector, "more");
         fireMatch(`${card.data.sector} 섹터`, kind);
+      } else if (card.type === "narrative") {
+        recordTaste("stock", card.data.trigger.anchorTicker, "more");
+        fireMatch("사건 흐름", kind);
       } else {
         fireMatch(card.data.contentType === "whale" ? "고래 동향" : "시장 메모", kind);
       }

--- a/apps/fomo-web/lib/discoveryCountryScope.ts
+++ b/apps/fomo-web/lib/discoveryCountryScope.ts
@@ -18,11 +18,17 @@ export interface DiscoveryScopeThemeBundle {
   items: DiscoveryScopeStock[];
 }
 
+export interface DiscoveryScopeNarrative {
+  kind: "narrative";
+  scope?: Extract<DiscoveryCountryScope, "KR" | "US">;
+  stocks: DiscoveryScopeStock[];
+}
+
 export interface DiscoveryScopeResponse {
   asOf?: string;
   country?: DiscoveryCountryScope;
   stocks: DiscoveryScopeStock[];
-  cards?: Array<DiscoveryScopeStock | DiscoveryScopeThemeBundle>;
+  cards?: Array<DiscoveryScopeStock | DiscoveryScopeThemeBundle | DiscoveryScopeNarrative>;
   fronts: Record<string, unknown>;
   confidence?: "L" | "M" | "H";
   source?: string;
@@ -34,9 +40,10 @@ function stockMatchesCountry(stock: DiscoveryScopeStock, country: DiscoveryCount
   return stock.country === "US" && (stock.market === "NASDAQ" || stock.market === "NYSE") && !!stock.symbol && !stock.naverCode;
 }
 
-function cardMatchesCountry(card: DiscoveryScopeStock | DiscoveryScopeThemeBundle, country: DiscoveryCountryScope): boolean {
+function cardMatchesCountry(card: DiscoveryScopeStock | DiscoveryScopeThemeBundle | DiscoveryScopeNarrative, country: DiscoveryCountryScope): boolean {
   if (country === "all") return true;
   if (card.kind === "theme_bundle") return card.items.length > 0 && card.items.every((item) => stockMatchesCountry(item, country));
+  if (card.kind === "narrative") return card.stocks.length > 0 && card.stocks.every((item) => stockMatchesCountry(item, country));
   return stockMatchesCountry(card, country);
 }
 

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -101,7 +101,36 @@ export interface DeckContent {
   asOf: string;
 }
 
-export type DiscoveryDeckCard = DeckStock | DeckThemeBundle | DeckContent;
+export interface DeckNarrativeStock {
+  ticker: string;
+  name: string;
+  market: StockMarket;
+  country: StockCountry;
+  relation: "trigger" | DeckRelationKind;
+  relationReason: string;
+  changePct: number;
+  naverCode?: string;
+  symbol?: string;
+}
+
+export interface DeckNarrative {
+  kind: "narrative";
+  id: string;
+  scope: Extract<StockCountry, "KR" | "US">;
+  trigger: {
+    headline: string;
+    source: string;
+    asOf: string;
+    anchorTicker: string;
+    url?: string;
+  };
+  headline: string;
+  stocks: DeckNarrativeStock[];
+  source: string;
+  asOf: string;
+}
+
+export type DiscoveryDeckCard = DeckStock | DeckThemeBundle | DeckContent | DeckNarrative;
 
 export interface DeckSectorStock {
   canonical: string;
@@ -127,7 +156,8 @@ export interface DeckSectorCardData {
 export type DeckCard =
   | { type: "stock"; data: DeckStock }
   | { type: "sector"; data: DeckSectorCardData }
-  | { type: "content"; data: DeckContent };
+  | { type: "content"; data: DeckContent }
+  | { type: "narrative"; data: DeckNarrative };
 
 export const SECTOR_CARD_INTERVAL = 5;
 
@@ -139,9 +169,14 @@ export function isContentCard(card: DiscoveryDeckCard): card is DeckContent {
   return card.kind === "content";
 }
 
+export function isNarrativeCard(card: DiscoveryDeckCard): card is DeckNarrative {
+  return card.kind === "narrative";
+}
+
 export function deckCardFromDiscovery(card: DiscoveryDeckCard): DeckCard | null {
   if (isThemeBundleCard(card)) return null;
   if (isContentCard(card)) return { type: "content", data: card };
+  if (isNarrativeCard(card)) return { type: "narrative", data: card };
   return { type: "stock", data: card };
 }
 
@@ -168,7 +203,7 @@ function normalizeThemeBundleIdentifiers(bundle: DeckThemeBundle): DeckThemeBund
 
 export function normalizeDiscoveryDeckCards(cards: readonly DiscoveryDeckCard[]): DiscoveryDeckCard[] {
   return cards.map((card) =>
-    isThemeBundleCard(card) ? normalizeThemeBundleIdentifiers(card) : isContentCard(card) ? card : normalizeDeckStockIdentifiers(card)
+    isThemeBundleCard(card) ? normalizeThemeBundleIdentifiers(card) : isContentCard(card) || isNarrativeCard(card) ? card : normalizeDeckStockIdentifiers(card)
   );
 }
 
@@ -631,13 +666,32 @@ export function buildContentDeckCards(
     .map((card) => ({ type: "content", data: card }) satisfies DeckCard);
 }
 
-function alternateSupplementalCards(sectorCards: readonly DeckCard[], contentCards: readonly DeckCard[]): DeckCard[] {
+export function buildNarrativeDeckCards(
+  narrativeCards: readonly DeckNarrative[] = [],
+  country: StockCountry,
+  limit = 2
+): DeckCard[] {
+  return narrativeCards
+    .filter((card) => card.kind === "narrative" && card.scope === country)
+    .filter((card) => card.headline.trim().length > 0 && card.trigger.headline.trim().length > 0)
+    .filter((card) => card.stocks.length >= 2 && card.stocks.every((stock) => stock.country === country && typeof stock.changePct === "number"))
+    .slice(0, limit)
+    .map((card) => ({ type: "narrative", data: card }) satisfies DeckCard);
+}
+
+function alternateSupplementalCards(
+  sectorCards: readonly DeckCard[],
+  narrativeCards: readonly DeckCard[],
+  contentCards: readonly DeckCard[]
+): DeckCard[] {
   const out: DeckCard[] = [];
-  const max = Math.max(sectorCards.length, contentCards.length);
+  const max = Math.max(sectorCards.length, narrativeCards.length, contentCards.length);
   for (let i = 0; i < max; i += 1) {
     const sector = sectorCards[i];
+    const narrative = narrativeCards[i];
     const content = contentCards[i];
     if (sector) out.push(sector);
+    if (narrative) out.push(narrative);
     if (content) out.push(content);
   }
   return out;
@@ -678,13 +732,14 @@ export function buildDiscoveryDeckCards(
   options: SectorDeckBuildOptions
 ): DeckCard[] {
   const normalized = normalizeDiscoveryDeckCards(discoveryCards);
-  const stocks = normalized.filter((card): card is DeckStock => !isThemeBundleCard(card) && !isContentCard(card));
+  const stocks = normalized.filter((card): card is DeckStock => !isThemeBundleCard(card) && !isContentCard(card) && !isNarrativeCard(card));
   const stockCards = stockDeckCards(stocks);
   const sectorCards = buildSectorDeckCards(stocks, options);
+  const narrativeCards = buildNarrativeDeckCards(normalized.filter(isNarrativeCard), options.country);
   const contentCards = buildContentDeckCards(
     [...normalized.filter(isContentCard), ...(options.contentCards ?? [])],
     options.country
   );
-  const supplementalCards = alternateSupplementalCards(sectorCards, contentCards);
+  const supplementalCards = alternateSupplementalCards(sectorCards, narrativeCards, contentCards);
   return interleaveSupplementalCards(stockCards, supplementalCards, options.interval ?? SECTOR_CARD_INTERVAL);
 }

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -465,7 +465,36 @@ export interface DiscoveryThemeBundleResponse {
   items: DiscoveryThemeBundleItemResponse[];
 }
 
-export type DiscoveryCardResponse = DiscoveryStockResponse | DiscoveryThemeBundleResponse;
+export interface DiscoveryNarrativeStockResponse {
+  ticker: string;
+  name: string;
+  market: import("@fomo/core").StockMarket;
+  country: import("@fomo/core").StockCountry;
+  relation: "trigger" | "customer" | "supplier" | "material" | "peer" | "beneficiary";
+  relationReason: string;
+  changePct: number;
+  naverCode?: string;
+  symbol?: string;
+}
+
+export interface DiscoveryNarrativeResponse {
+  kind: "narrative";
+  id: string;
+  scope: Extract<DiscoveryCountryScope, "KR" | "US">;
+  trigger: {
+    headline: string;
+    source: string;
+    asOf: string;
+    anchorTicker: string;
+    url?: string;
+  };
+  headline: string;
+  stocks: DiscoveryNarrativeStockResponse[];
+  source: string;
+  asOf: string;
+}
+
+export type DiscoveryCardResponse = DiscoveryStockResponse | DiscoveryThemeBundleResponse | DiscoveryNarrativeResponse;
 
 export interface DiscoveryResponse {
   asOf: string;
@@ -511,6 +540,13 @@ function cardCopyFields(card: DiscoveryCardResponse): string[] {
     return [card.title, card.subtitle, ...card.items.map((item) => item.reason)].filter(
       (text): text is string => typeof text === "string" && text.trim().length > 0
     );
+  }
+  if (card.kind === "narrative") {
+    return [
+      card.headline,
+      card.trigger.headline,
+      ...card.stocks.map((stock) => stock.relationReason),
+    ].filter((text): text is string => typeof text === "string" && text.trim().length > 0);
   }
   return stockCopyFields(card);
 }

--- a/apps/web/__tests__/lib/discovery-narrative.test.ts
+++ b/apps/web/__tests__/lib/discovery-narrative.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { DiscoveryCandidate } from "@fomo/core";
+import { buildNarrativeCards } from "../../lib/discovery-supply";
+import type { DiscoveryMarketRow } from "../../lib/market-source-types";
+
+function row(canonical: string, symbol: string, changePct?: number): DiscoveryMarketRow {
+  return {
+    canonical,
+    symbol,
+    market: "NASDAQ",
+    country: "US",
+    currency: "USD",
+    sectorHint: "AI",
+    ...(typeof changePct === "number" ? { changePct } : {}),
+  };
+}
+
+function candidate(ticker: string): DiscoveryCandidate {
+  return {
+    ticker,
+    market: "NASDAQ",
+    country: "US",
+    sector: "AI",
+    asOf: "2026-07-01",
+    events: [
+      {
+        kind: "news_mention",
+        firstSeen: true,
+        strength: 0.9,
+        source: "Yahoo Finance",
+        sourceName: "Yahoo Finance",
+        sourceUrl: "https://finance.yahoo.com/test",
+        asOf: "2026-07-01",
+        confidence: "H",
+        label: "엔비디아 데이터센터 실적 서프라이즈",
+        headlineHook: "엔비디아 데이터센터 실적 서프라이즈",
+        changePct: 3.2,
+      },
+    ],
+  };
+}
+
+describe("discovery narrative cards", () => {
+  it("builds a factual narrative from a material trigger and relation-map stocks with real moves", () => {
+    const rows = new Map<string, DiscoveryMarketRow>([
+      ["엔비디아", row("엔비디아", "NVDA", 3.2)],
+      ["VRT", row("VRT", "VRT", 2.4)],
+    ]);
+
+    const cards = buildNarrativeCards([candidate("엔비디아")], rows);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: "narrative",
+      scope: "US",
+      trigger: { headline: "엔비디아 데이터센터 실적 서프라이즈", anchorTicker: "엔비디아" },
+    });
+    expect(cards[0]!.stocks.map((stock) => [stock.ticker, stock.relation, stock.changePct])).toEqual([
+      ["엔비디아", "trigger", 3.2],
+      ["VRT", "beneficiary", 2.4],
+    ]);
+  });
+
+  it("skips narratives when linked stocks do not have measured changePct", () => {
+    const rows = new Map<string, DiscoveryMarketRow>([
+      ["엔비디아", row("엔비디아", "NVDA", 3.2)],
+      ["VRT", row("VRT", "VRT")],
+    ]);
+
+    expect(buildNarrativeCards([candidate("엔비디아")], rows)).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -67,6 +67,9 @@ const DISCOVERY_LIVE_FLOW_TIMEOUT_MS = Math.max(2_000, Math.min(12_000, Number(p
 const THEME_BUNDLE_MAX_CARDS = 2;
 const THEME_BUNDLE_MIN_ITEMS = 2;
 const THEME_BUNDLE_MAX_ITEMS = 4;
+const NARRATIVE_MAX_CARDS = 1;
+const NARRATIVE_MIN_STOCKS = 2;
+const NARRATIVE_MAX_STOCKS = 4;
 const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_DEFAULT_ENABLED
   ? Math.max(0, Math.min(720, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 720) || 720))
   : 0;
@@ -134,7 +137,37 @@ export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
 
 export type DiscoveryDeckCardPayload =
   | ({ kind: "stock" } & DiscoveryStockPayload)
-  | DiscoveryThemeBundleCard;
+  | DiscoveryThemeBundleCard
+  | DiscoveryNarrativeCardPayload;
+
+export interface DiscoveryNarrativeStockPayload {
+  ticker: string;
+  name: string;
+  market: DiscoveryMarket;
+  country: StockCountry;
+  relation: RelatedNode["relation"] | "trigger";
+  relationReason: string;
+  changePct: number;
+  naverCode?: string;
+  symbol?: string;
+}
+
+export interface DiscoveryNarrativeCardPayload {
+  kind: "narrative";
+  id: string;
+  scope: Extract<DiscoveryCountryScope, "KR" | "US">;
+  trigger: {
+    headline: string;
+    source: string;
+    asOf: string;
+    anchorTicker: string;
+    url?: string;
+  };
+  headline: string;
+  stocks: DiscoveryNarrativeStockPayload[];
+  source: string;
+  asOf: string;
+}
 
 export interface DiscoveryResponse {
   asOf: string;
@@ -1514,6 +1547,25 @@ function bundleAnchorEvent(candidate: DiscoveryCandidate): DiscoveryEvent | unde
     })[0];
 }
 
+function narrativeAnchorEvent(candidate: DiscoveryCandidate): DiscoveryEvent | undefined {
+  return candidate.events
+    .filter((event) => isDeckDisplayEvent(event, candidate))
+    .filter((event) => event.kind === "disclosure" || event.kind === "news_mention")
+    .filter((event) => Boolean(narrativeTriggerHeadline(event)))
+    .sort((a, b) => {
+      const priority = (event: DiscoveryEvent) => (event.kind === "disclosure" ? 0 : 1);
+      return priority(a) - priority(b) || b.strength - a.strength || a.kind.localeCompare(b.kind);
+    })[0];
+}
+
+function narrativeTriggerHeadline(event: DiscoveryEvent): string | undefined {
+  const text = (event.headlineHook ?? event.label ?? "").replace(/\s+/g, " ").trim();
+  if (!text || text.length < 8) return undefined;
+  return text
+    .replace(/\s*에\s*[+-]?\d+(?:\.\d+)?%$/g, "")
+    .replace(/[.!?。]+$/g, "");
+}
+
 function relationItemFromNode(
   node: RelatedNode,
   row: DiscoveryMarketRow,
@@ -1532,6 +1584,127 @@ function relationItemFromNode(
     ...(row.naverCode ?? node.naverCode ? { naverCode: row.naverCode ?? node.naverCode } : {}),
     ...(row.symbol ?? node.symbol ? { symbol: row.symbol ?? node.symbol } : {}),
   };
+}
+
+function narrativeStockFromRow(
+  row: DiscoveryMarketRow,
+  relation: DiscoveryNarrativeStockPayload["relation"],
+  relationReason: string,
+): DiscoveryNarrativeStockPayload | null {
+  if (typeof row.changePct !== "number") return null;
+  return {
+    ticker: row.canonical,
+    name: row.canonical,
+    market: row.market,
+    country: row.country as StockCountry,
+    relation,
+    relationReason,
+    changePct: row.changePct,
+    ...(row.naverCode ? { naverCode: row.naverCode } : {}),
+    ...(row.symbol ? { symbol: row.symbol } : {}),
+  };
+}
+
+function sameThemeNarrativeStocks(
+  anchor: DiscoveryCandidate,
+  ranked: readonly DiscoveryCandidate[],
+  rowsByTicker: ReadonlyMap<string, DiscoveryMarketRow>,
+): DiscoveryNarrativeStockPayload[] {
+  if (!anchor.sector || !anchor.country) return [];
+  return ranked
+    .filter((candidate) => candidate.ticker !== anchor.ticker)
+    .filter((candidate) => candidate.country === anchor.country && candidate.sector === anchor.sector)
+    .map((candidate) => {
+      const row = rowsByTicker.get(candidate.ticker);
+      if (!row) return null;
+      return narrativeStockFromRow(row, "peer", `같은 ${anchor.sector} 테마에서 오늘 등락률이 함께 확인됐어요.`);
+    })
+    .filter((item): item is DiscoveryNarrativeStockPayload => item !== null)
+    .sort((a, b) => Math.abs(b.changePct) - Math.abs(a.changePct) || a.ticker.localeCompare(b.ticker));
+}
+
+function narrativeHeadline(trigger: string, stocks: readonly DiscoveryNarrativeStockPayload[], sector: string | undefined): string {
+  const positive = stocks.filter((stock) => stock.changePct > 0).length;
+  const theme = sector ? `${sector} ` : "";
+  const direction = positive >= Math.ceil(stocks.length / 2) ? "동반 강세" : "동반 움직임";
+  return `${trigger}에 ${theme}연결 종목 ${direction}`;
+}
+
+export function buildNarrativeCards(
+  ranked: readonly DiscoveryCandidate[],
+  rowsByTicker: ReadonlyMap<string, DiscoveryMarketRow>,
+): DiscoveryNarrativeCardPayload[] {
+  const cards: DiscoveryNarrativeCardPayload[] = [];
+  const usedTriggers = new Set<string>();
+  const usedSectorScopes = new Set<string>();
+  for (const candidate of ranked) {
+    if (cards.length >= NARRATIVE_MAX_CARDS) break;
+    if (candidate.country !== "KR" && candidate.country !== "US") continue;
+    const anchorRow = rowsByTicker.get(candidate.ticker);
+    if (!anchorRow || anchorRow.country !== candidate.country) continue;
+    const event = narrativeAnchorEvent(candidate);
+    const triggerHeadline = event ? narrativeTriggerHeadline(event) : undefined;
+    if (!event || !triggerHeadline) continue;
+    const triggerKey = `${candidate.ticker}:${event.kind}:${triggerHeadline}`;
+    if (usedTriggers.has(triggerKey)) continue;
+    const sectorScopeKey = candidate.sector ? `${candidate.country}:${candidate.sector}` : undefined;
+    if (sectorScopeKey && usedSectorScopes.has(sectorScopeKey)) continue;
+
+    const anchorStock = narrativeStockFromRow(
+      anchorRow,
+      "trigger",
+      event.kind === "disclosure" ? "이 공시의 직접 당사자입니다." : "이 뉴스에서 직접 언급된 종목입니다."
+    );
+    if (!anchorStock) continue;
+
+    const relationStocks = relatedTo({
+      kind: "event",
+      ticker: candidate.ticker,
+      ...(candidate.sector ? { theme: candidate.sector } : {}),
+    })
+      .filter((node) => node.ticker !== candidate.ticker)
+      .map((node) => {
+        const row = rowsByTicker.get(node.ticker);
+        if (!row || row.country !== candidate.country) return null;
+        return narrativeStockFromRow(row, node.relation, node.reason);
+      })
+      .filter((item): item is DiscoveryNarrativeStockPayload => item !== null);
+
+    const seen = new Set([anchorStock.ticker]);
+    const related = [...relationStocks, ...sameThemeNarrativeStocks(candidate, ranked, rowsByTicker)]
+      .filter((stock) => {
+        if (seen.has(stock.ticker)) return false;
+        seen.add(stock.ticker);
+        return true;
+      })
+      .sort((a, b) => {
+        const relationRank = (stock: DiscoveryNarrativeStockPayload) => (stock.relation === "peer" ? 1 : 0);
+        return relationRank(a) - relationRank(b) || Math.abs(b.changePct) - Math.abs(a.changePct) || a.ticker.localeCompare(b.ticker);
+      })
+      .slice(0, NARRATIVE_MAX_STOCKS - 1);
+
+    const stocks = [anchorStock, ...related].slice(0, NARRATIVE_MAX_STOCKS);
+    if (stocks.length < NARRATIVE_MIN_STOCKS) continue;
+    cards.push({
+      kind: "narrative",
+      id: `narrative:${candidate.country}:${candidate.ticker}:${event.kind}:${event.asOf.slice(0, 10)}`,
+      scope: candidate.country,
+      trigger: {
+        headline: triggerHeadline,
+        source: event.sourceName ?? event.source,
+        asOf: (event.publishedAt ?? event.asOf).slice(0, 10),
+        anchorTicker: candidate.ticker,
+        ...(event.sourceUrl ? { url: event.sourceUrl } : {}),
+      },
+      headline: narrativeHeadline(triggerHeadline, stocks, candidate.sector),
+      stocks,
+      source: event.sourceName ?? event.source,
+      asOf: (event.publishedAt ?? event.asOf).slice(0, 10),
+    });
+    usedTriggers.add(triggerKey);
+    if (sectorScopeKey) usedSectorScopes.add(sectorScopeKey);
+  }
+  return cards;
 }
 
 export function buildThemeBundleCards(
@@ -1586,13 +1759,18 @@ export function buildThemeBundleCards(
 function interleaveThemeBundles(
   stocks: readonly DiscoveryStockPayload[],
   bundles: readonly DiscoveryThemeBundleCard[],
+  narratives: readonly DiscoveryNarrativeCardPayload[] = [],
 ): DiscoveryDeckCardPayload[] {
   const cards: DiscoveryDeckCardPayload[] = stocks.map((stock) => ({ kind: "stock", ...stock }));
-  if (bundles.length === 0 || cards.length < 8) return cards;
+  if ((bundles.length === 0 && narratives.length === 0) || cards.length < 8) return cards;
   const out = [...cards];
   bundles.forEach((bundle, index) => {
     const insertAt = Math.min(out.length, 6 + index * 10);
     out.splice(insertAt, 0, bundle);
+  });
+  narratives.forEach((narrative, index) => {
+    const insertAt = Math.min(out.length, 8 + index * 12);
+    out.splice(insertAt, 0, narrative);
   });
   return out;
 }
@@ -1830,12 +2008,13 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     };
   });
   const bundleCards = buildThemeBundleCards(ranked, rowsByTicker);
+  const narrativeCards = buildNarrativeCards(ranked, rowsByTicker);
 
   return {
     asOf,
     country: scope,
     stocks,
-    cards: interleaveThemeBundles(stocks, bundleCards),
+    cards: interleaveThemeBundles(stocks, bundleCards, narrativeCards),
     fronts,
     confidence: stocks.length >= deckCardCount ? "H" : stocks.length >= Math.min(30, Math.ceil(deckCardCount * 0.75)) ? "M" : "L",
     source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "시장 시세·공시·수급 캐시",


### PR DESCRIPTION
## Summary
- add factual narrative cards built from discovery material events, relation graph links, and measured same-day moves
- render narrative cards in the multi-type swipe deck without changing stock/sector/content behavior
- validate country scoping and skip thin or unmeasured narratives

## Verification
- npm run typecheck
- npm run test -- discoveryDeck relation-graph narrative
- npm run diag:headline -- --country=KR
- npm --workspace @fomo/web run build