### PR TITLE
Shorten US discovery material fetch

### DIFF
--- a/apps/web/__tests__/api/fomo/discovery-route.test.ts
+++ b/apps/web/__tests__/api/fomo/discovery-route.test.ts
@@ -15,8 +15,8 @@ describe("discovery route loading policy", () => {
 
   it("caps targeted material work on fast routes instead of disabling hooks", () => {
     expect(targetedMaterialLimitFor("KR", true)).toBe(36);
-    expect(targetedMaterialLimitFor("US", true)).toBe(14);
+    expect(targetedMaterialLimitFor("US", true)).toBe(6);
     expect(targetedMaterialLimitFor("KR", false)).toBe(120);
-    expect(targetedMaterialLimitFor("US", false)).toBe(32);
+    expect(targetedMaterialLimitFor("US", false)).toBe(8);
   });
 });

--- a/apps/web/lib/discovery-route-policy.ts
+++ b/apps/web/lib/discovery-route-policy.ts
@@ -6,6 +6,6 @@ export function shouldUseTargetedMaterial(country: DiscoveryCountryScope, fast: 
 }
 
 export function targetedMaterialLimitFor(country: DiscoveryCountryScope, fast: boolean): number | undefined {
-  if (fast) return country === "US" ? 14 : 36;
-  return country === "US" ? 32 : 120;
+  if (fast) return country === "US" ? 6 : 36;
+  return country === "US" ? 8 : 120;
 }

--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -44,7 +44,7 @@ async function fetchYahooSymbol(symbol: string, nowIso: string): Promise<RawArti
     url.searchParams.set("lang", "en-US");
     const res = await fetch(url.toString(), {
       headers: { "user-agent": UA, accept: "application/rss+xml, application/xml" },
-      signal: AbortSignal.timeout(8_000),
+      signal: AbortSignal.timeout(3_500),
       // 10분 데이터 캐시 — Yahoo 레이트리밋 보호.
       next: { revalidate: 600 },
     });

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -26,7 +26,7 @@ export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<
   try {
     const res = await fetch(`${SEC_SUBMISSIONS}/CIK${cik}.json`, {
       headers: { accept: "application/json", "user-agent": userAgent },
-      signal: AbortSignal.timeout(8_000),
+      signal: AbortSignal.timeout(3_500),
       next: { revalidate: 3_600 },
     });
     if (!res.ok) return [];


### PR DESCRIPTION
## Summary
- reduce request-time US material hydration from 32 to 8 candidates
- shorten Yahoo Finance and SEC EDGAR per-request timeouts to prevent discovery function timeouts
- keeps Phase 3 narrative card work intact while restoring US 200 responses

## Validation
- npm run typecheck
- npm run test -- us-market-source discovery-supply narrative
- local US buildDiscoveryResponse targetedMaterialLimit=8: ~3.0s