### PR TITLE
Skip US discovery AI hydration

### DIFF
--- a/apps/web/__tests__/api/fomo/discovery-route.test.ts
+++ b/apps/web/__tests__/api/fomo/discovery-route.test.ts
@@ -15,8 +15,8 @@ describe("discovery route loading policy", () => {
 
   it("caps targeted material work on fast routes instead of disabling hooks", () => {
     expect(targetedMaterialLimitFor("KR", true)).toBe(36);
-    expect(targetedMaterialLimitFor("US", true)).toBe(6);
+    expect(targetedMaterialLimitFor("US", true)).toBe(4);
     expect(targetedMaterialLimitFor("KR", false)).toBe(120);
-    expect(targetedMaterialLimitFor("US", false)).toBe(8);
+    expect(targetedMaterialLimitFor("US", false)).toBe(6);
   });
 });

--- a/apps/web/lib/discovery-route-policy.ts
+++ b/apps/web/lib/discovery-route-policy.ts
@@ -6,6 +6,6 @@ export function shouldUseTargetedMaterial(country: DiscoveryCountryScope, fast: 
 }
 
 export function targetedMaterialLimitFor(country: DiscoveryCountryScope, fast: boolean): number | undefined {
-  if (fast) return country === "US" ? 6 : 36;
-  return country === "US" ? 8 : 120;
+  if (fast) return country === "US" ? 4 : 36;
+  return country === "US" ? 6 : 120;
 }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -1920,7 +1920,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   if (targetedMaterialLimit > 0 && scope !== "US") {
     ranked = await hydrateFrontBandMaterial(ranked, rowsByTicker, asOf);
   }
-  ranked = await hydrateReachedNewsHooks(ranked, rowsByTicker, asOf);
+  if (scope !== "US") {
+    ranked = await hydrateReachedNewsHooks(ranked, rowsByTicker, asOf);
+  }
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];
 
@@ -1942,7 +1944,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     dailyRows.flatMap((row) => (row.status === "fulfilled" ? [[row.value.ticker, row.value.daily] as const] : []))
   );
   ranked = attachReachedVolumeEvents(ranked, rowsByTicker, dailyByTicker, asOf);
-  ranked = await hydrateReachedWhySynthesis(ranked);
+  if (scope !== "US") {
+    ranked = await hydrateReachedWhySynthesis(ranked);
+  }
   logDiscoverySignalCoverage("after-rank", ranked);
   const sparklineByTicker = new Map(
     [...dailyByTicker.entries()].map(([ticker, daily]) => [ticker, daily.closes.slice(-42)] as const)


### PR DESCRIPTION
## Summary
- skip AI news/why hydration on US discovery request path
- keep rule-based material hooks for US cards
- reduce US material route budget to keep full discovery below function timeout

## Validation
- npm run typecheck
- npm run test -- discovery-supply narrative discovery-route us-market-source
- local US buildDiscoveryResponse targetedMaterialLimit=6: ~3.1s