### PR TITLE
Skip KR attention on US discovery

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -1785,7 +1785,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   const asOf = discoveryAsOf(scope);
   const [rows, attentionMap] = await Promise.all([
     fetchMarketRows(scope),
-    computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
+    scope === "US"
+      ? Promise.resolve({} as Record<string, StockAttentionSignal>)
+      : computeStockAttentionSignals().catch((): Record<string, StockAttentionSignal> => ({})),
   ]);
   const vocabByCode = new Map(STOCK_VOCAB.filter((s) => s.naverCode).map((s) => [s.naverCode!, s]));
   const scopedRows = rows.filter((row) => isDiscoveryRowAllowedForScope(row, scope));


### PR DESCRIPTION
## Summary
- skip KR stock attention collection when building US discovery
- avoids the shared ~28s request-time bottleneck that pushed US over Vercel's 30s timeout
- keeps KR discovery behavior unchanged

## Validation
- npm run typecheck
- npm run test -- discovery-supply narrative discovery-route us-market-source