### PR TITLE
Raise discovery function timeout

### DIFF
--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -6,7 +6,7 @@ import type { DiscoveryCountryScope } from "../../../../lib/market-source-types"
 import { shouldUseTargetedMaterial, targetedMaterialLimitFor } from "../../../../lib/discovery-route-policy";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 const REVALIDATE_S = 600;
 


### PR DESCRIPTION
## Summary
- raise discovery route maxDuration from 30s to 60s to stop Vercel function timeout on US discovery
- keeps earlier US request-path reductions in place

## Validation
- npm run typecheck
- npm run test -- discovery-route