### PR TITLE
Skip Nasdaq sparkline fallback for keyed US discovery

### DIFF
--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -706,15 +706,7 @@ async function fetchUsMarketRowsInternal(): Promise<{ rows: DiscoveryMarketRow[]
       const fallbackRows = nasdaqRows.length > 0 ? nasdaqRows : seedRows();
       return { rows: fallbackRows, diagnostics: fallbackDiagnostics(fallbackRows, nasdaqRows.length > 0 ? "nasdaq-fallback" : "seed") };
     }
-    let hydratedRows = rows;
-    if (Object.keys(sparklines).length === 0) {
-      const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
-      const nasdaqBySymbol = new Map(nasdaqRows.map((row) => [row.symbol.toUpperCase(), row]));
-      hydratedRows = rows.map((row) => {
-        const fallback = nasdaqBySymbol.get(row.symbol.toUpperCase());
-        return fallback?.sparkline && (row.sparkline?.length ?? 0) < 2 ? { ...row, sparkline: fallback.sparkline } : row;
-      });
-    }
+    const hydratedRows = rows;
     return {
       rows: hydratedRows,
       diagnostics: {


### PR DESCRIPTION
## Summary
- stop keyed US discovery from falling back to 120 Nasdaq historical calls when Twelve Data sparklines fail
- quote rows now return immediately even if sparkline batch is empty
- this removes the request-time path that exceeded 60s in production

## Validation
- npm run typecheck
- npm run test -- us-market-source discovery-supply
- local US buildDiscoveryResponse targetedMaterialLimit=6: ~15.7s