### PR TITLE
Prewarm US market quotes via cron

### DIFF
--- a/.github/workflows/us-market-prewarm.yml
+++ b/.github/workflows/us-market-prewarm.yml
@@ -1,0 +1,62 @@
+name: US Market Prewarm
+
+# Twelve Data free tier is tight, so split the US quote/sparkline prewarm into two
+# alternating slots. Vercel native cron is not available on the current backend
+# project plan; this workflow calls the production prewarm endpoint instead.
+
+on:
+  schedule:
+    - cron: "0,10,20,30,40,50 * * * *"
+    - cron: "5,15,25,35,45,55 * * * *"
+  workflow_dispatch:
+    inputs:
+      slot:
+        description: "Prewarm slot to run (0 or 1). Defaults to current schedule slot."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: us-market-prewarm
+  cancel-in-progress: false
+
+jobs:
+  prewarm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve slot
+        id: slot
+        env:
+          INPUT_SLOT: ${{ github.event.inputs.slot }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_SLOT:-}" ]; then
+            SLOT="$INPUT_SLOT"
+          else
+            MINUTE="$(date -u +%M)"
+            if [ $((10#$MINUTE % 10)) -eq 0 ]; then
+              SLOT="0"
+            else
+              SLOT="1"
+            fi
+          fi
+          if [ "$SLOT" != "0" ] && [ "$SLOT" != "1" ]; then
+            echo "invalid slot: $SLOT" >&2
+            exit 1
+          fi
+          echo "slot=$SLOT" >> "$GITHUB_OUTPUT"
+
+      - name: Call production prewarm endpoint
+        env:
+          SLOT: ${{ steps.slot.outputs.slot }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          URL="https://fomo-club-backend.vercel.app/api/fomo/cron/us-market-prewarm/${SLOT}"
+          if [ -n "${CRON_SECRET:-}" ]; then
+            curl -fsS "$URL" -H "Authorization: Bearer ${CRON_SECRET}"
+          else
+            curl -fsS "$URL"
+          fi

--- a/apps/web/__tests__/api/fomo/discovery-route.test.ts
+++ b/apps/web/__tests__/api/fomo/discovery-route.test.ts
@@ -15,8 +15,8 @@ describe("discovery route loading policy", () => {
 
   it("caps targeted material work on fast routes instead of disabling hooks", () => {
     expect(targetedMaterialLimitFor("KR", true)).toBe(36);
-    expect(targetedMaterialLimitFor("US", true)).toBe(4);
+    expect(targetedMaterialLimitFor("US", true)).toBe(8);
     expect(targetedMaterialLimitFor("KR", false)).toBe(120);
-    expect(targetedMaterialLimitFor("US", false)).toBe(6);
+    expect(targetedMaterialLimitFor("US", false)).toBe(24);
   });
 });

--- a/apps/web/app/api/fomo/cron/us-market-prewarm/[slot]/route.ts
+++ b/apps/web/app/api/fomo/cron/us-market-prewarm/[slot]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { writeUsMarketQuoteRows } from "@/lib/us-market-cache";
+import { fetchUsMarketRowsFromSource, latestUsSessionAsOf } from "@/lib/us-market-source";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const SLOT_COUNT = 2;
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return true;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+function parseSlot(value: string | undefined): number | null {
+  const slot = Number(value);
+  if (!Number.isInteger(slot) || slot < 0 || slot >= SLOT_COUNT) return null;
+  return slot;
+}
+
+export async function GET(request: Request, context: { params: Promise<{ slot?: string }> }) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const params = await context.params;
+  const slot = parseSlot(params.slot);
+  if (slot === null) {
+    return NextResponse.json({ ok: false, error: "invalid_slot", slot: params.slot, slotCount: SLOT_COUNT }, { status: 400 });
+  }
+
+  const rows = await fetchUsMarketRowsFromSource({ slot, slotCount: SLOT_COUNT });
+  const written = await writeUsMarketQuoteRows(rows, {
+    slot,
+    sessionDate: latestUsSessionAsOf().date,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    slot,
+    slotCount: SLOT_COUNT,
+    fetched: rows.length,
+    written: written.rows,
+    rowsWithPrice: written.rowsWithPrice,
+    rowsWithSparkline: written.rowsWithSparkline,
+  });
+}

--- a/apps/web/lib/discovery-route-policy.ts
+++ b/apps/web/lib/discovery-route-policy.ts
@@ -6,6 +6,6 @@ export function shouldUseTargetedMaterial(country: DiscoveryCountryScope, fast: 
 }
 
 export function targetedMaterialLimitFor(country: DiscoveryCountryScope, fast: boolean): number | undefined {
-  if (fast) return country === "US" ? 4 : 36;
-  return country === "US" ? 6 : 120;
+  if (fast) return country === "US" ? 8 : 36;
+  return country === "US" ? 24 : 120;
 }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -42,7 +42,7 @@ import { resolveCardHeadline, type CardHeadline } from "./card-headline";
 import { selectDominantAxis } from "./card-axis";
 import { fetchSupplyDemand } from "./supply-demand";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
-import { fetchUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
+import { fetchCachedUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
 import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
 import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
 import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
@@ -295,7 +295,7 @@ async function fetchKrMarketRows(): Promise<DiscoveryMarketRow[]> {
 
 async function fetchMarketRows(scope: DiscoveryCountryScope): Promise<DiscoveryMarketRow[]> {
   const sources: Array<Promise<DiscoveryMarketRow[]>> =
-    scope === "US" ? [fetchUsMarketRows()] : scope === "all" ? [fetchKrMarketRows(), fetchUsMarketRows()] : [fetchKrMarketRows()];
+    scope === "US" ? [fetchCachedUsMarketRows()] : scope === "all" ? [fetchKrMarketRows(), fetchCachedUsMarketRows()] : [fetchKrMarketRows()];
   const settled = await Promise.allSettled(sources);
   return settled.flatMap((result) => (result.status === "fulfilled" ? result.value : []));
 }

--- a/apps/web/lib/us-market-cache.ts
+++ b/apps/web/lib/us-market-cache.ts
@@ -1,0 +1,100 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "./prisma";
+import type { DiscoveryMarketRow } from "./market-source-types";
+
+const US_MARKET_QUOTE_CACHE_MAX_AGE_HOURS = 18;
+
+export interface UsMarketQuoteCacheWriteOptions {
+  sessionDate: string;
+  slot: number;
+}
+
+export interface UsMarketQuoteCacheReadOptions {
+  maxAgeHours?: number;
+}
+
+export interface UsMarketQuoteCacheStats {
+  rows: number;
+  rowsWithPrice: number;
+  rowsWithSparkline: number;
+}
+
+interface CachedUsMarketQuoteRow {
+  symbol: string;
+  row: unknown;
+  updatedAt: Date;
+}
+
+let ensured = false;
+
+async function ensureUsMarketQuoteCacheTable(): Promise<void> {
+  if (ensured) return;
+  await prisma.$executeRaw`
+    CREATE TABLE IF NOT EXISTS "UsMarketQuoteCache" (
+      "symbol" TEXT PRIMARY KEY,
+      "row" JSONB NOT NULL,
+      "sessionDate" TEXT NOT NULL,
+      "slot" INTEGER NOT NULL,
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+  await prisma.$executeRaw`
+    CREATE INDEX IF NOT EXISTS "UsMarketQuoteCache_updatedAt_idx"
+    ON "UsMarketQuoteCache" ("updatedAt" DESC)
+  `;
+  ensured = true;
+}
+
+function isUsMarketRow(value: unknown): value is DiscoveryMarketRow {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<DiscoveryMarketRow>;
+  return row.country === "US" && typeof row.symbol === "string" && row.symbol.length > 0 && typeof row.canonical === "string";
+}
+
+function hasUsQuote(row: DiscoveryMarketRow): boolean {
+  return typeof row.changePct === "number" || typeof row.priceText === "string" || (row.sparkline?.length ?? 0) >= 2;
+}
+
+export async function writeUsMarketQuoteRows(
+  rows: readonly DiscoveryMarketRow[],
+  options: UsMarketQuoteCacheWriteOptions,
+): Promise<UsMarketQuoteCacheStats> {
+  await ensureUsMarketQuoteCacheTable();
+  const quoteRows = rows.filter((row) => row.country === "US" && hasUsQuote(row));
+  for (const row of quoteRows) {
+    await prisma.$executeRaw`
+      INSERT INTO "UsMarketQuoteCache" ("symbol", "row", "sessionDate", "slot", "updatedAt")
+      VALUES (${row.symbol.toUpperCase()}, ${JSON.stringify(row)}::jsonb, ${options.sessionDate}, ${options.slot}, NOW())
+      ON CONFLICT ("symbol") DO UPDATE
+      SET "row" = EXCLUDED."row",
+          "sessionDate" = EXCLUDED."sessionDate",
+          "slot" = EXCLUDED."slot",
+          "updatedAt" = NOW()
+    `;
+  }
+  return {
+    rows: quoteRows.length,
+    rowsWithPrice: quoteRows.filter((row) => typeof row.changePct === "number" || row.priceText).length,
+    rowsWithSparkline: quoteRows.filter((row) => (row.sparkline?.length ?? 0) >= 2).length,
+  };
+}
+
+export async function readUsMarketQuoteRows(options: UsMarketQuoteCacheReadOptions = {}): Promise<DiscoveryMarketRow[]> {
+  const maxAgeHours = Math.max(1, Math.min(72, options.maxAgeHours ?? US_MARKET_QUOTE_CACHE_MAX_AGE_HOURS));
+  const since = new Date(Date.now() - maxAgeHours * 60 * 60 * 1000);
+  try {
+    const records = await prisma.$queryRaw<CachedUsMarketQuoteRow[]>`
+      SELECT "symbol", "row", "updatedAt"
+      FROM "UsMarketQuoteCache"
+      WHERE "updatedAt" >= ${since}
+      ORDER BY COALESCE(("row"->>'marketCapRank')::int, 9999), "symbol" ASC
+    `;
+    return records
+      .map((record) => record.row)
+      .filter(isUsMarketRow)
+      .filter(hasUsQuote);
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2010") return [];
+    return [];
+  }
+}

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -1,5 +1,6 @@
 import type { DiscoveryMarket } from "@fomo/core";
 import type { DiscoveryMarketRow } from "./market-source-types";
+import { readUsMarketQuoteRows } from "./us-market-cache";
 import { usDiscoverySeedForSymbol, usDiscoveryUniverse, type UsDiscoverySymbol } from "./us-symbols";
 
 const TWELVE_DATA_URL = "https://api.twelvedata.com/quote";
@@ -12,7 +13,8 @@ const NASDAQ_UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
 const US_DYNAMIC_UNIVERSE_LIMIT = 60;
 const US_QUOTE_BATCH_SIZE = 60;
-const US_SPARKLINE_LIMIT = 20;
+const US_SPARKLINE_LIMIT = 30;
+const US_PREWARM_CACHE_MAX_AGE_HOURS = 18;
 const US_NASDAQ_SCREENER_LIMIT = 7000;
 const US_NASDAQ_FALLBACK_LIMIT = 120;
 const US_NASDAQ_FALLBACK_CONCURRENCY = 3;
@@ -71,6 +73,11 @@ interface NasdaqScreenerRow {
   country?: string;
   sector?: string;
   industry?: string;
+}
+
+export interface UsMarketRowsSourceOptions {
+  slot?: number;
+  slotCount?: number;
 }
 
 function tdKey(): string | undefined {
@@ -446,6 +453,14 @@ function seedRows(): DiscoveryMarketRow[] {
   }));
 }
 
+function selectPrewarmSeeds(seeds: readonly UsDiscoverySymbol[], options: UsMarketRowsSourceOptions): UsDiscoverySymbol[] {
+  if (typeof options.slot !== "number" || typeof options.slotCount !== "number" || options.slotCount <= 1) return [...seeds];
+  const slot = Math.trunc(options.slot);
+  const slotCount = Math.trunc(options.slotCount);
+  if (slot < 0 || slot >= slotCount) return [];
+  return seeds.filter((_, index) => index % slotCount === slot);
+}
+
 function normalizeQuoteResponse(data: unknown): Record<string, TwelveQuote> {
   if (!data || typeof data !== "object") return {};
   const root = data as Record<string, unknown>;
@@ -644,9 +659,9 @@ function mergePreferredRows(primary: readonly DiscoveryMarketRow[], fallback: re
   });
 }
 
-async function fetchUsMarketRowsInternal(): Promise<{ rows: DiscoveryMarketRow[]; diagnostics: UsMarketDiagnostics }> {
+async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}): Promise<{ rows: DiscoveryMarketRow[]; diagnostics: UsMarketDiagnostics }> {
   const key = tdKey();
-  const seeds = usDiscoveryUniverse();
+  const seeds = selectPrewarmSeeds(usDiscoveryUniverse(), options);
   const seedSymbols = new Set(seeds.map((seed) => seed.symbol.toUpperCase()));
   const fallbackDiagnostics = (rows: DiscoveryMarketRow[], source: UsMarketDiagnostics["source"]): UsMarketDiagnostics => ({
     seedCount: seeds.length,
@@ -748,8 +763,17 @@ async function fetchUsMarketRowsInternal(): Promise<{ rows: DiscoveryMarketRow[]
  * If the key is absent or the upstream fails, return a verified seed universe without price data.
  * We never synthesize quotes: price/change fields are present only when a live source returns them.
  */
+export async function fetchUsMarketRowsFromSource(options: UsMarketRowsSourceOptions = {}): Promise<DiscoveryMarketRow[]> {
+  return (await fetchUsMarketRowsInternal(options)).rows;
+}
+
 export async function fetchUsMarketRows(): Promise<DiscoveryMarketRow[]> {
-  return (await fetchUsMarketRowsInternal()).rows;
+  return fetchUsMarketRowsFromSource();
+}
+
+export async function fetchCachedUsMarketRows(): Promise<DiscoveryMarketRow[]> {
+  const rows = await readUsMarketQuoteRows({ maxAgeHours: US_PREWARM_CACHE_MAX_AGE_HOURS });
+  return rows.length > 0 ? rows : seedRows();
 }
 
 export async function fetchUsMarketDiagnostics(): Promise<UsMarketDiagnostics> {


### PR DESCRIPTION
## Summary
- add a US-only quote/sparkline prewarm cron split across six slots
- store prewarmed US rows in a DB-backed cache and make discovery read that cache instead of fetching quotes on request
- raise only the US targeted material cap now that request-time quote fetching is removed

## Verification
- npm run typecheck
- npm run test -- us-market-source discovery-route
- npm run test -- discovery-supply discoveryDeck
- npm run build:web