### PR TITLE
Hydrate US prewarm sparklines from fallback

### DIFF
--- a/apps/web/app/api/fomo/cron/us-market-prewarm/[slot]/route.ts
+++ b/apps/web/app/api/fomo/cron/us-market-prewarm/[slot]/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request, context: { params: Promise<{ slot?: 
     return NextResponse.json({ ok: false, error: "invalid_slot", slot: params.slot, slotCount: SLOT_COUNT }, { status: 400 });
   }
 
-  const rows = await fetchUsMarketRowsFromSource({ slot, slotCount: SLOT_COUNT });
+  const rows = await fetchUsMarketRowsFromSource({ slot, slotCount: SLOT_COUNT, hydrateSparklineFallback: true });
   const written = await writeUsMarketQuoteRows(rows, {
     slot,
     sessionDate: latestUsSessionAsOf().date,

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -78,6 +78,7 @@ interface NasdaqScreenerRow {
 export interface UsMarketRowsSourceOptions {
   slot?: number;
   slotCount?: number;
+  hydrateSparklineFallback?: boolean;
 }
 
 function tdKey(): string | undefined {
@@ -721,7 +722,11 @@ async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}
       const fallbackRows = nasdaqRows.length > 0 ? nasdaqRows : seedRows();
       return { rows: fallbackRows, diagnostics: fallbackDiagnostics(fallbackRows, nasdaqRows.length > 0 ? "nasdaq-fallback" : "seed") };
     }
-    const hydratedRows = rows;
+    const fallbackRows =
+      options.hydrateSparklineFallback && rows.some((row) => (row.sparkline?.length ?? 0) < 2)
+        ? await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => [])
+        : [];
+    const hydratedRows = fallbackRows.length > 0 ? mergePreferredRows(rows, fallbackRows) : rows;
     return {
       rows: hydratedRows,
       diagnostics: {


### PR DESCRIPTION
## Summary
- keep discovery request path cache-only
- let the US prewarm cron route hydrate missing sparklines from Nasdaq historical data
- preserve the existing price cache writes and slot split

## Verification
- npm run typecheck
- npm run test -- us-market-source discovery-route discovery-supply
- npm run build:web