### PR TITLE
Use fallback quote fields for US prewarm cache

### DIFF
--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -629,10 +629,16 @@ function strongMomentumRows(rows: readonly DiscoveryMarketRow[]): number {
 }
 
 function mergeSparkline(row: DiscoveryMarketRow, fallback: DiscoveryMarketRow | undefined): DiscoveryMarketRow {
-  if (!fallback?.sparkline || (row.sparkline?.length ?? 0) >= 2) return row;
+  if (!fallback) return row;
+  const needsQuoteFallback = !row.priceText || row.priceText === "$0.00";
   return {
     ...row,
-    sparkline: fallback.sparkline,
+    ...(needsQuoteFallback && fallback.priceText ? { priceText: fallback.priceText } : {}),
+    ...(needsQuoteFallback && typeof fallback.changePct === "number" ? { changePct: fallback.changePct } : {}),
+    ...(needsQuoteFallback && fallback.changeText ? { changeText: fallback.changeText } : {}),
+    ...(needsQuoteFallback && fallback.changeDir ? { changeDir: fallback.changeDir } : {}),
+    ...(needsQuoteFallback && typeof fallback.tradingValue === "number" ? { tradingValue: fallback.tradingValue } : {}),
+    ...(fallback.sparkline && (row.sparkline?.length ?? 0) < 2 ? { sparkline: fallback.sparkline } : {}),
     ...(fallback.sessionLabel ? { sessionLabel: fallback.sessionLabel } : {}),
   };
 }


### PR DESCRIPTION
## Summary
- when cron prewarm hydrates US rows from Nasdaq fallback, also copy fallback price/change fields if the primary quote lacks a real price
- keep discovery request path cache-only

## Verification
- npm run typecheck
- npm run test -- us-market-source discovery-route discovery-supply
- npm run build:web