### PR TITLE
Raise US material cap after quote prewarm

### DIFF
--- a/.github/workflows/us-market-prewarm.yml
+++ b/.github/workflows/us-market-prewarm.yml
@@ -60,3 +60,17 @@ jobs:
           else
             curl -fsS "$URL"
           fi
+
+      - name: Warm US discovery after both slots
+        if: steps.slot.outputs.slot == '1'
+        run: |
+          set -euo pipefail
+          curl -fsS "https://fomo-club-backend.vercel.app/api/fomo/discovery?country=US" > /tmp/us-discovery.json
+          node -e '
+            const fs = require("fs");
+            const json = JSON.parse(fs.readFileSync("/tmp/us-discovery.json", "utf8"));
+            const fronts = Object.values(json.fronts || {});
+            const priced = fronts.filter((front) => front && front.priceText && front.priceText !== "$0.00").length;
+            const spark = fronts.filter((front) => Array.isArray(front && front.sparkline) && front.sparkline.length >= 2).length;
+            console.log(JSON.stringify({ stocks: json.stocks?.length || 0, cards: json.cards?.length || 0, fronts: fronts.length, priced, spark }));
+          '

--- a/apps/web/__tests__/api/fomo/discovery-route.test.ts
+++ b/apps/web/__tests__/api/fomo/discovery-route.test.ts
@@ -15,8 +15,8 @@ describe("discovery route loading policy", () => {
 
   it("caps targeted material work on fast routes instead of disabling hooks", () => {
     expect(targetedMaterialLimitFor("KR", true)).toBe(36);
-    expect(targetedMaterialLimitFor("US", true)).toBe(8);
+    expect(targetedMaterialLimitFor("US", true)).toBe(12);
     expect(targetedMaterialLimitFor("KR", false)).toBe(120);
-    expect(targetedMaterialLimitFor("US", false)).toBe(24);
+    expect(targetedMaterialLimitFor("US", false)).toBe(64);
   });
 });

--- a/apps/web/lib/discovery-route-policy.ts
+++ b/apps/web/lib/discovery-route-policy.ts
@@ -6,6 +6,6 @@ export function shouldUseTargetedMaterial(country: DiscoveryCountryScope, fast: 
 }
 
 export function targetedMaterialLimitFor(country: DiscoveryCountryScope, fast: boolean): number | undefined {
-  if (fast) return country === "US" ? 8 : 36;
-  return country === "US" ? 24 : 120;
+  if (fast) return country === "US" ? 12 : 36;
+  return country === "US" ? 64 : 120;
 }


### PR DESCRIPTION
## Summary
- raise only the US discovery material cap now that request-time quote fetching is removed
- keep KR caps unchanged
- warm US discovery after slot 1 quote prewarm so the route cache is built from the fully prewarmed quote cache

## Verification
- npm run typecheck
- npm run test -- discovery-route discovery-supply us-market-source
- npm run build:web