### PR TITLE
Surface insider purchase filings in discovery

### DIFF
--- a/apps/web/__tests__/lib/sec-edgar.test.ts
+++ b/apps/web/__tests__/lib/sec-edgar.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("SEC EDGAR Form 4 insider purchases", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces only significant Form 4 open-market purchases", async () => {
+    vi.stubEnv("SEC_EDGAR_USER_AGENT", "fomo-test contact@example.com");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("data.sec.gov/submissions")) {
+        return Response.json({
+          filings: {
+            recent: {
+              form: ["4", "8-K"],
+              filingDate: ["2026-06-16", "2026-06-15"],
+              primaryDocument: ["ownership.xml", "form8k.htm"],
+              accessionNumber: ["0001045810-26-000123", "0001045810-26-000122"],
+            },
+          },
+        });
+      }
+      if (url.includes("ownership.xml")) {
+        return new Response(
+          `<?xml version="1.0"?>
+          <ownershipDocument>
+            <reportingOwner>
+              <reportingOwnerId><rptOwnerName>Jane Huang</rptOwnerName></reportingOwnerId>
+              <reportingOwnerRelationship>
+                <isDirector>1</isDirector>
+                <isOfficer>1</isOfficer>
+                <officerTitle>CEO</officerTitle>
+              </reportingOwnerRelationship>
+            </reportingOwner>
+            <nonDerivativeTable>
+              <nonDerivativeTransaction>
+                <transactionDate><value>2026-06-15</value></transactionDate>
+                <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                <transactionAmounts>
+                  <transactionShares><value>210000</value></transactionShares>
+                  <transactionPricePerShare><value>33.50</value></transactionPricePerShare>
+                </transactionAmounts>
+              </nonDerivativeTransaction>
+            </nonDerivativeTable>
+          </ownershipDocument>`,
+          { headers: { "content-type": "application/xml" } },
+        );
+      }
+      return Response.json({});
+    });
+
+    const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
+    const hits = await fetchRecentSecFilings("NVDA", 2);
+
+    expect(hits[0]?.source).toBe("SEC Form 4");
+    expect(hits[0]?.label).toBe("CEO Jane Huang이 $7.0M 규모 자사주 매수 · 6/15");
+    expect(hits[0]?.insiderPurchase).toMatchObject({
+      ownerName: "Jane Huang",
+      ownerRole: "CEO",
+      shares: 210000,
+      price: 33.5,
+      transactionDate: "2026-06-15",
+    });
+  });
+});

--- a/apps/web/lib/dart-disclosures.ts
+++ b/apps/web/lib/dart-disclosures.ts
@@ -6,6 +6,13 @@ export interface DartDisclosureHit {
   source: string;
   asOf: string;
   url?: string;
+  insiderPurchase?: {
+    ownerRole: string;
+    shares?: number;
+    price?: number;
+    value?: number;
+    transactionDate: string;
+  };
 }
 
 interface DartListItem {
@@ -31,6 +38,8 @@ const DART_MATERIAL_REPORT =
   /단일판매|공급계약|수주|주요사항보고|유상증자|무상증자|자기주식|타법인|합병|분할|영업양수|영업양도|소송|조회공시|투자판단|시설투자|신규시설|특허권|임상|기술이전|라이선스/i;
 const DART_ROUTINE_REPORT =
   /사업보고서|반기보고서|분기보고서|증권발행실적|투자설명서|첨부정정|정정신고|임원ㆍ주요주주|임원·주요주주|주식등의대량보유|최대주주등소유주식변동/i;
+const DART_INSIDER_OWNERSHIP_REPORT = /임원[ㆍ·]?\s*주요주주.*특정증권.*소유상황보고서/i;
+const DART_INSIDER_PURCHASE_TEXT = /장내매수|매수|취득/i;
 
 function dartKey(): string | undefined {
   if (process.env.DISCOVERY_DART_LIVE === "0") return undefined;
@@ -58,6 +67,84 @@ function cleanReportName(name: string | undefined): string | undefined {
     .trim();
   if (!cleaned || DART_ROUTINE_REPORT.test(cleaned) || !DART_MATERIAL_REPORT.test(cleaned)) return undefined;
   return cleaned.length > 44 ? `${cleaned.slice(0, 42).trim()}…` : cleaned;
+}
+
+function cleanInsiderReportName(name: string | undefined): string | undefined {
+  const cleaned = decodeHtmlEntities(name ?? "")
+    .replace(/^\s*(?:\[[^\]]+\]|\([^)]*\))\s*/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return DART_INSIDER_OWNERSHIP_REPORT.test(cleaned) ? cleaned : undefined;
+}
+
+function numberFromKoreanText(text: string | undefined): number | undefined {
+  if (!text) return undefined;
+  const n = Number(text.replace(/,/g, ""));
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function stripHtml(html: string): string {
+  return decodeHtmlEntities(html)
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function compactWon(value: number): string {
+  if (value >= 100_000_000) return `${Math.round(value / 100_000_000).toLocaleString("ko-KR")}억`;
+  if (value >= 10_000) return `${Math.round(value / 10_000).toLocaleString("ko-KR")}만`;
+  return value.toLocaleString("ko-KR");
+}
+
+function compactShares(value: number): string {
+  if (value >= 10_000) return `${Math.round(value / 10_000).toLocaleString("ko-KR")}만주`;
+  return `${value.toLocaleString("ko-KR")}주`;
+}
+
+async function fetchDartReportText(rceptNo: string | undefined): Promise<string | undefined> {
+  const url = dartReportUrl(rceptNo);
+  if (!url) return undefined;
+  const res = await fetch(url, {
+    headers: { accept: "text/html,application/xhtml+xml" },
+    signal: AbortSignal.timeout(6_000),
+    next: { revalidate: 3_600 },
+  });
+  if (!res.ok) return undefined;
+  return stripHtml(await res.text());
+}
+
+async function insiderPurchaseFromDartItem(
+  ticker: string,
+  item: DartListItem,
+  asOf: string,
+): Promise<DartDisclosureHit | null> {
+  if (!cleanInsiderReportName(item.report_nm)) return null;
+  const text = await fetchDartReportText(item.rcept_no).catch(() => undefined);
+  if (!text || !DART_INSIDER_PURCHASE_TEXT.test(text)) return null;
+  const shares = numberFromKoreanText(text.match(/(?:매수|취득|장내매수)[^\d]{0,24}(\d[\d,]*)\s*주/)?.[1])
+    ?? numberFromKoreanText(text.match(/(\d[\d,]*)\s*주[^\n]{0,40}(?:매수|취득|장내매수)/)?.[1]);
+  const price = numberFromKoreanText(text.match(/(?:단가|취득가액|가격)[^\d]{0,16}(\d[\d,]*)\s*원/)?.[1]);
+  const value = shares && price ? shares * price : undefined;
+  const reportedAt = isoFromDartDate(item.rcept_dt, asOf);
+  const amountText = value ? `${compactWon(value)}원 규모` : shares ? `${compactShares(shares)}` : "특정증권";
+  const hit: DartDisclosureHit = {
+    ticker,
+    label: `임원·주요주주가 ${amountText} 취득 신고 · ${Number(reportedAt.slice(5, 7))}/${Number(reportedAt.slice(8, 10))}`,
+    source: "DART 내부자 공시",
+    asOf: reportedAt,
+    insiderPurchase: {
+      ownerRole: "임원·주요주주",
+      ...(shares ? { shares } : {}),
+      ...(price ? { price } : {}),
+      ...(value ? { value } : {}),
+      transactionDate: reportedAt,
+    },
+  };
+  const url = dartReportUrl(item.rcept_no);
+  if (url) hit.url = url;
+  return hit;
 }
 
 async function fetchDartPage(key: string, date: string, page: number): Promise<DartListResponse | null> {
@@ -110,6 +197,29 @@ export async function fetchDartDisclosuresByStock(asOf: string): Promise<Record<
   return out;
 }
 
+export async function fetchDartInsiderPurchasesByStock(asOf: string): Promise<Record<string, DartDisclosureHit>> {
+  const key = dartKey();
+  if (!key) return {};
+
+  const byCode = new Map(STOCK_VOCAB.filter((stock) => stock.naverCode).map((stock) => [stock.naverCode!, stock.canonical]));
+  const out: Record<string, DartDisclosureHit> = {};
+
+  for (let page = 1; page <= DART_MAX_PAGES; page += 1) {
+    const data = await fetchDartPage(key, asOf, page).catch(() => null);
+    if (!data?.list?.length || (data.status && data.status !== "000")) break;
+    for (const item of data.list) {
+      const code = item.stock_code?.trim();
+      const ticker = code ? byCode.get(code) : undefined;
+      if (!ticker || out[ticker] || !cleanInsiderReportName(item.report_nm)) continue;
+      const hit = await insiderPurchaseFromDartItem(ticker, item, asOf);
+      if (hit) out[ticker] = hit;
+    }
+    if (typeof data.total_page === "number" && page >= data.total_page) break;
+  }
+
+  return out;
+}
+
 export async function fetchDartDisclosuresForCode(
   code: string,
   stock: string,
@@ -136,6 +246,29 @@ export async function fetchDartDisclosuresForCode(
       };
       if (url) hit.url = url;
       out.push(hit);
+    }
+    if (typeof data.total_page === "number" && page >= data.total_page) break;
+  }
+  return out;
+}
+
+export async function fetchDartInsiderPurchasesForCode(
+  code: string,
+  stock: string,
+  asOf: string
+): Promise<DartDisclosureHit[]> {
+  const key = dartKey();
+  const normalized = code.trim();
+  if (!key || !/^\d{6}$/.test(normalized)) return [];
+
+  const out: DartDisclosureHit[] = [];
+  for (let page = 1; page <= DART_MAX_PAGES; page += 1) {
+    const data = await fetchDartPage(key, asOf, page).catch(() => null);
+    if (!data?.list?.length || (data.status && data.status !== "000")) break;
+    for (const item of data.list) {
+      if (item.stock_code?.trim() !== normalized || !cleanInsiderReportName(item.report_nm)) continue;
+      const hit = await insiderPurchaseFromDartItem(stock, item, asOf);
+      if (hit) out.push(hit);
     }
     if (typeof data.total_page === "number" && page >= data.total_page) break;
   }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -31,7 +31,13 @@ import {
   type StockCountry,
   type RawArticle,
 } from "@fomo/core";
-import { fetchDartDisclosuresByStock, fetchDartDisclosuresForCode, type DartDisclosureHit } from "./dart-disclosures";
+import {
+  fetchDartDisclosuresByStock,
+  fetchDartDisclosuresForCode,
+  fetchDartInsiderPurchasesByStock,
+  fetchDartInsiderPurchasesForCode,
+  type DartDisclosureHit,
+} from "./dart-disclosures";
 import { fetchNaverCompanyResearch, fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
 import type { DiscoveryCountryScope, DiscoveryMarketRow } from "./market-source-types";
 import { relatedTo, type RelatedNode } from "./relation-graph";
@@ -564,10 +570,11 @@ function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallb
 }
 
 function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEvent {
+  const insiderPurchase = Boolean(disclosure.insiderPurchase);
   return {
     kind: "disclosure",
     firstSeen: true,
-    strength: 0.96,
+    strength: insiderPurchase ? 0.99 : 0.96,
     source: disclosure.source,
     asOf: disclosure.asOf,
     confidence: "H",
@@ -575,6 +582,7 @@ function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEv
     sourceTitle: disclosure.label,
     summary: disclosure.label,
     sourceName: disclosure.source,
+    ...(insiderPurchase ? { headlineHook: disclosure.label, insiderPurchase: true } : {}),
     ...(disclosure.url ? { sourceUrl: disclosure.url } : {}),
   };
 }
@@ -657,15 +665,16 @@ function withRuleHeadlineHook(
 async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string): Promise<DiscoveryEvent | null> {
   if (row.country !== "KR") {
     const [filingResult, newsResult] = await Promise.allSettled([
-      fetchRecentSecFilings(row.symbol, 2),
+      fetchRecentSecFilings(row.symbol, 6),
       fetchYahooStockNews(row.symbol, 10),
     ]);
-    const filing = filingResult.status === "fulfilled" ? filingResult.value[0] : undefined;
+    const filings = filingResult.status === "fulfilled" ? filingResult.value : [];
+    const filing = filings.find((item) => item.insiderPurchase) ?? filings[0];
     if (filing) {
       return {
         kind: "disclosure",
         firstSeen: true,
-        strength: 0.92,
+        strength: filing.insiderPurchase ? 0.99 : 0.92,
         source: filing.source,
         asOf: filing.asOf,
         confidence: "H",
@@ -673,6 +682,7 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
         sourceTitle: filing.label,
         summary: filing.label,
         sourceName: filing.source,
+        ...(filing.insiderPurchase ? { headlineHook: filing.label, insiderPurchase: true } : {}),
         ...(filing.url ? { sourceUrl: filing.url } : {}),
       };
     }
@@ -680,6 +690,11 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
     return stockNews ? materialEventFromUsArticle(stockNews, asOf, "Yahoo Finance") : null;
   }
   if (!row.naverCode || !/^\d{6}$/.test(row.naverCode)) return null;
+  const insider = (await fetchDartInsiderPurchasesForCode(row.naverCode, row.canonical, asOf).catch(
+    (): DartDisclosureHit[] => []
+  ))[0];
+  if (insider) return materialEventFromDisclosure(insider);
+
   const disclosure = (await fetchDartDisclosuresForCode(row.naverCode, row.canonical, asOf).catch(
     (): DartDisclosureHit[] => []
   ))[0];
@@ -1063,7 +1078,7 @@ function eventAxisSignal(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
     event.kind !== "news_mention"
   ) return null;
   const axis =
-    event.kind === "theme_link" ? "herd" : event.kind === "flow_entry" ? "flow" : "time";
+    event.kind === "theme_link" ? "herd" : event.kind === "flow_entry" || event.insiderPurchase ? "flow" : "time";
   const sourceKind =
     event.kind === "theme_link"
       ? "market"
@@ -1078,7 +1093,9 @@ function eventAxisSignal(event: DiscoveryEvent, candidate: DiscoveryCandidate): 
     strength:
       event.kind === "theme_link"
           ? Math.max(0.91, event.strength)
-          : event.kind === "news_mention"
+          : event.insiderPurchase
+            ? Math.max(0.98, event.strength)
+            : event.kind === "news_mention"
             ? Math.max(0.94, event.strength)
             : Math.max(0.93, event.strength),
     rarity: 0,
@@ -1816,10 +1833,9 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     if (events.length > 0) byTicker.set(ticker, { row: { ...row, canonical: ticker }, events });
   }
 
-  const disclosureMap = await fetchDartDisclosuresByStock(asOf).catch((): Record<string, DartDisclosureHit> => ({}));
-  for (const [ticker, disclosure] of Object.entries(disclosureMap)) {
+  const addDartDisclosure = (ticker: string, disclosure: DartDisclosureHit) => {
     const def = resolveStock(ticker);
-    if (!def?.naverCode || !eligibleTickers.has(def.canonical)) continue;
+    if (!def?.naverCode || !eligibleTickers.has(def.canonical)) return;
     const row =
       normalizedRows.find((r) => r.naverCode === def.naverCode) ??
       ({
@@ -1833,6 +1849,17 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     const current = byTicker.get(def.canonical);
     const event = materialEventFromDisclosure(disclosure);
     byTicker.set(def.canonical, { row: { ...row, canonical: def.canonical }, events: [...(current?.events ?? []), event] });
+  };
+
+  const insiderDisclosureMap = await fetchDartInsiderPurchasesByStock(asOf).catch((): Record<string, DartDisclosureHit> => ({}));
+  for (const [ticker, disclosure] of Object.entries(insiderDisclosureMap)) {
+    addDartDisclosure(ticker, disclosure);
+  }
+
+  const disclosureMap = await fetchDartDisclosuresByStock(asOf).catch((): Record<string, DartDisclosureHit> => ({}));
+  for (const [ticker, disclosure] of Object.entries(disclosureMap)) {
+    if (insiderDisclosureMap[ticker]) continue;
+    addDartDisclosure(ticker, disclosure);
   }
 
   const targetedRows = [...byTicker.entries()]

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -6,10 +6,19 @@ export interface SecFilingHit {
   source: string;
   asOf: string;
   url?: string;
+  insiderPurchase?: {
+    ownerName: string;
+    ownerRole: string;
+    shares: number;
+    price: number;
+    value: number;
+    transactionDate: string;
+  };
 }
 
 const SEC_ARCHIVES = "https://www.sec.gov/Archives/edgar/data";
 const SEC_SUBMISSIONS = "https://data.sec.gov/submissions";
+const SEC_INSIDER_PURCHASE_MIN_VALUE = 100_000;
 
 function secUserAgent(): string | undefined {
   return process.env.SEC_EDGAR_USER_AGENT?.trim();
@@ -17,6 +26,130 @@ function secUserAgent(): string | undefined {
 
 function accessionPath(cik: string, accession: string): string {
   return `${SEC_ARCHIVES}/${String(Number(cik))}/${accession.replace(/-/g, "")}/${accession}-index.html`;
+}
+
+function documentPath(cik: string, accession: string, document: string | undefined): string | undefined {
+  const doc = document?.trim();
+  if (!doc) return undefined;
+  return `${SEC_ARCHIVES}/${String(Number(cik))}/${accession.replace(/-/g, "")}/${encodeURIComponent(doc)}`;
+}
+
+function xmlText(value: string): string {
+  return value
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tagValue(xml: string, tag: string): string | undefined {
+  const match = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "i"));
+  return match ? xmlText(match[1] ?? "") : undefined;
+}
+
+function tagBlocks(xml: string, tag: string): string[] {
+  return [...xml.matchAll(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "gi"))].map((match) => match[1] ?? "");
+}
+
+function numberTag(xml: string, tag: string): number | undefined {
+  const raw = tagValue(xml, tag);
+  if (!raw) return undefined;
+  const n = Number(raw.replace(/,/g, ""));
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function ownerRoleFromRelationship(xml: string): string {
+  const officerTitle = tagValue(xml, "officerTitle");
+  if (officerTitle) return officerTitle;
+  if (tagValue(xml, "isOfficer") === "1") return "임원";
+  if (tagValue(xml, "isDirector") === "1") return "이사";
+  if (tagValue(xml, "isTenPercentOwner") === "1") return "10% 대주주";
+  return "내부자";
+}
+
+function formatUsd(value: number): string {
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}K`;
+  return `$${Math.round(value).toLocaleString("en-US")}`;
+}
+
+function formatCompactShares(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M주`;
+  if (value >= 1_000) return `${Math.round(value / 1_000)}K주`;
+  return `${Math.round(value).toLocaleString("en-US")}주`;
+}
+
+function mmdd(date: string): string {
+  const match = date.match(/^\d{4}-(\d{2})-(\d{2})$/);
+  return match ? `${Number(match[1])}/${Number(match[2])}` : date;
+}
+
+function parseForm4InsiderPurchase(symbol: string, xml: string): SecFilingHit["insiderPurchase"] | undefined {
+  const ownerBlock = tagBlocks(xml, "reportingOwner")[0] ?? "";
+  const ownerName = tagValue(ownerBlock, "rptOwnerName") ?? tagValue(xml, "rptOwnerName");
+  if (!ownerName) return undefined;
+  const ownerRole = ownerRoleFromRelationship(ownerBlock || xml);
+  const purchases = tagBlocks(xml, "nonDerivativeTransaction")
+    .filter((block) => tagValue(block, "transactionCode") === "P")
+    .map((block) => {
+      const shares = numberTag(tagBlocks(block, "transactionShares")[0] ?? block, "value");
+      const price = numberTag(tagBlocks(block, "transactionPricePerShare")[0] ?? block, "value");
+      const transactionDate = tagValue(tagBlocks(block, "transactionDate")[0] ?? block, "value");
+      if (typeof shares !== "number" || typeof price !== "number" || !transactionDate) return null;
+      return { shares, price, value: shares * price, transactionDate };
+    })
+    .filter((purchase): purchase is { shares: number; price: number; value: number; transactionDate: string } => purchase !== null);
+  if (purchases.length === 0) return undefined;
+  const total = purchases.reduce(
+    (acc, purchase) => ({
+      shares: acc.shares + purchase.shares,
+      value: acc.value + purchase.value,
+      transactionDate: acc.transactionDate > purchase.transactionDate ? acc.transactionDate : purchase.transactionDate,
+    }),
+    { shares: 0, value: 0, transactionDate: purchases[0]?.transactionDate ?? "" },
+  );
+  if (total.value < SEC_INSIDER_PURCHASE_MIN_VALUE) return undefined;
+  return {
+    ownerName: xmlText(ownerName),
+    ownerRole,
+    shares: total.shares,
+    price: total.value / total.shares,
+    value: total.value,
+    transactionDate: total.transactionDate,
+  };
+}
+
+async function fetchForm4InsiderPurchase(
+  symbol: string,
+  cik: string,
+  accession: string,
+  primaryDocument: string | undefined,
+  userAgent: string,
+): Promise<SecFilingHit | null> {
+  const url = documentPath(cik, accession, primaryDocument);
+  if (!url) return null;
+  const res = await fetch(url, {
+    headers: { accept: "application/xml,text/xml,text/plain", "user-agent": userAgent },
+    signal: AbortSignal.timeout(4_500),
+    next: { revalidate: 3_600 },
+  });
+  if (!res.ok) return null;
+  const purchase = parseForm4InsiderPurchase(symbol, await res.text());
+  if (!purchase) return null;
+  const label = `${purchase.ownerRole} ${purchase.ownerName}이 ${formatUsd(purchase.value)} 규모 자사주 매수 · ${mmdd(purchase.transactionDate)}`;
+  return {
+    symbol: symbol.toUpperCase(),
+    label,
+    source: "SEC Form 4",
+    asOf: purchase.transactionDate,
+    url: accessionPath(cik, accession),
+    insiderPurchase: purchase,
+  };
 }
 
 export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<SecFilingHit[]> {
@@ -38,10 +171,15 @@ export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<
     const out: SecFilingHit[] = [];
     for (let i = 0; i < recent.form.length && out.length < limit; i += 1) {
       const form = recent.form[i];
-      if (form !== "8-K" && form !== "10-Q" && form !== "10-K") continue;
+      if (form !== "8-K" && form !== "10-Q" && form !== "10-K" && form !== "4") continue;
       const asOf = recent.filingDate?.[i];
       const accession = recent.accessionNumber?.[i];
       if (!asOf || !accession) continue;
+      if (form === "4") {
+        const hit = await fetchForm4InsiderPurchase(symbol, cik, accession, recent.primaryDocument?.[i], userAgent).catch(() => null);
+        if (hit) out.push(hit);
+        continue;
+      }
       out.push({
         symbol: symbol.toUpperCase(),
         label: `${form} 공시가 확인됐어요.`,

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -39,6 +39,8 @@ export interface DiscoveryEvent {
   flowDays?: number;
   /** Human-scale net amount, e.g. 12만주. */
   flowAmountText?: string;
+  /** Confirmed insider open-market purchase from SEC Form 4 or DART ownership report. */
+  insiderPurchase?: boolean;
   themeRank?: number;
   themePeerCount?: number;
   themeAverageChangePct?: number;
@@ -340,6 +342,7 @@ function eventKindTone(event: DiscoveryEvent | undefined): DiscoverySynthesisTon
 
 function displayTag(event: DiscoveryEvent | undefined): string {
   if (!event) return "미노출";
+  if (event.insiderPurchase) return "내부자 매수";
   if (event.kind === "disclosure") return "공시 재료";
   if (event.kind === "news_mention") return "뉴스 재료";
   if (event.kind === "flow_entry") return "💎 수급 선행";
@@ -351,6 +354,7 @@ function displayTag(event: DiscoveryEvent | undefined): string {
 }
 
 function eventGroup(event: DiscoveryEvent): "material" | "flow" | "volume" | "context" | "price" {
+  if (event.insiderPurchase) return "flow";
   if (event.kind === "disclosure" || event.kind === "news_mention") return "material";
   if (event.kind === "flow_entry") return "flow";
   if (event.kind === "volume_spike") return "volume";


### PR DESCRIPTION
## Summary
- parse SEC Form 4 XML and surface only significant open-market purchase (P) transactions
- extend DART disclosure connector to look for insider ownership reports and only mark them when purchase/acquisition text is present
- route insider purchase disclosures through existing swipe-card material pipeline with a flow-axis hook

## Verification
- npm run typecheck
- npm run test -- sec-edgar discovery-supply us-market-source discovery-route theme-understanding-naver-code
- npm run build:web