### PR TITLE
feat(depth): 미장 TA 활성 — US 일봉 캔들 파이프라인(260일) [PR1/2]

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1138,7 +1138,10 @@ export function StockInsightView({
     setBasicsLoaded(false);
     setFrontLoaded(!!seed);
     // 가격 헤더만 먼저 허용하고, 아래 가변 섹션은 세 요청이 모두 끝난 뒤 한 번에 연다.
-    fetchStockFront(stock, context?.naverCode ? { naverCode: context.naverCode } : {})
+    fetchStockFront(stock, {
+      ...(context?.naverCode ? { naverCode: context.naverCode } : {}),
+      ...(context?.symbol ? { symbol: context.symbol } : {}),
+    })
       .then((r) => alive && setFront(mergeFrontSeed(seed, r)))
       .catch(() => alive && setFront(seed))
       .finally(() => alive && setFrontLoaded(true));

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -397,14 +397,14 @@ export interface FeedSignalPoint {
   text: string;
   source: "뉴스" | "수급" | "테마" | "가격" | "주목" | "위치" | "거래";
 }
-export const fetchStockFront = (stock: string, opts: { lite?: boolean; naverCode?: string } = {}) =>
+export const fetchStockFront = (stock: string, opts: { lite?: boolean; naverCode?: string; symbol?: string } = {}) =>
   cachedGet(
-    `stock-front:${opts.lite ? "lite" : "full"}:${stock}:${opts.naverCode ?? ""}`,
+    `stock-front:${opts.lite ? "lite" : "full"}:${stock}:${opts.naverCode ?? ""}:${opts.symbol ?? ""}`,
     () =>
       get<StockFrontResponse>(
         `/api/fomo/stock-front?stock=${encodeURIComponent(stock)}${opts.lite ? "&lite=1" : ""}${
           opts.naverCode ? `&naverCode=${encodeURIComponent(opts.naverCode)}` : ""
-        }`
+        }${opts.symbol ? `&symbol=${encodeURIComponent(opts.symbol)}` : ""}`
       ),
     CACHE_TTL.stockFront
   );

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -50,7 +50,7 @@ async function getThemeRelativeMap(sector: StockSector): Promise<Record<string, 
   return load();
 }
 
-async function getFront(stock: string, lite = false, naverCode?: string): Promise<StockFrontData> {
+async function getFront(stock: string, lite = false, naverCode?: string, symbol?: string): Promise<StockFrontData> {
   const today = kstDate();
   const load = unstable_cache(
     async () => {
@@ -67,9 +67,9 @@ async function getFront(stock: string, lite = false, naverCode?: string): Promis
       return assembleStockFront(stock, rankMap, {
         ...(attentionMap[canonical] ? { attention: attentionMap[canonical] } : {}),
         ...(themeRelativeMap[canonical] ? { themeRelative: themeRelativeMap[canonical] } : {}),
-      }, { lite, ...(naverCode ? { naverCode } : {}) });
+      }, { lite, ...(naverCode ? { naverCode } : {}), ...(symbol ? { symbol } : {}) });
     },
-    ["fomo-stock-front", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? ""],
+    ["fomo-stock-front", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? "", symbol ?? ""],
     { revalidate: REVALIDATE_S }
   );
   return load();
@@ -80,11 +80,12 @@ export async function GET(req: Request) {
   const stock = url.searchParams.get("stock")?.trim();
   const lite = url.searchParams.get("lite") === "1";
   const naverCode = url.searchParams.get("naverCode")?.trim() || undefined;
+  const symbol = url.searchParams.get("symbol")?.trim() || undefined;
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
   try {
-    const data = await getFront(stock, lite, naverCode);
+    const data = await getFront(stock, lite, naverCode, symbol);
     return withCors(
       NextResponse.json(data, {
         headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400" },

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -19,6 +19,7 @@ import {
   type MultiAxisHookSelection,
 } from "@fomo/core";
 import { fetchStockBasics, fetchStockBasicsLite } from "./stock-basics";
+import { fetchUsDailyCandles } from "./us-market-source";
 import { readSupplyDemandHistory } from "./supply-demand-store";
 import type { StockAttentionSignal, ThemeRelativeSignal } from "./stock-signal-coverage";
 
@@ -166,6 +167,8 @@ export interface StockFrontOptions {
   lite?: boolean;
   /** 동적 발견 종목(STOCK_VOCAB 미등재)용 네이버 코드. 있으면 vocab 없이도 캔들·TA 조회. */
   naverCode?: string;
+  /** 미장 심볼(예: NVDA). 네이버 코드가 없을 때 US 일봉(TwelveData)으로 TA 계산. depth(non-lite)만. */
+  symbol?: string;
 }
 
 export interface FeedSignalPoint {
@@ -259,13 +262,19 @@ export async function assembleStockFront(
 ): Promise<StockFrontData> {
   const def = resolveStock(stock);
   const code = options.naverCode ?? def?.naverCode;
-  if (!code) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
+  // 미장: 네이버 코드가 없고 심볼이 있으면 US 일봉(TwelveData)로 캔들·TA. 카드(lite)는 비용 회피로 스킵.
+  const usSymbol = !code && options.symbol ? options.symbol.trim() : undefined;
+  if (!code && !usSymbol) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
   const lite = options.lite === true;
 
   const [basics, history, daily] = await Promise.all([
-    (lite ? fetchStockBasicsLite(stock) : fetchStockBasics(stock)).catch(() => null),
-    readSupplyDemandHistory(code).catch(() => []),
-    fetchStockDaily(code, lite ? 110 : 420),
+    code ? (lite ? fetchStockBasicsLite(stock) : fetchStockBasics(stock)).catch(() => null) : Promise.resolve(null),
+    code ? readSupplyDemandHistory(code).catch(() => []) : Promise.resolve([] as Awaited<ReturnType<typeof readSupplyDemandHistory>>),
+    usSymbol
+      ? lite
+        ? Promise.resolve({ candles: [], closes: [], volumes: [] })
+        : fetchUsDailyCandles(usSymbol, 260)
+      : fetchStockDaily(code!, lite ? 110 : 420),
   ]);
 
   const signals: CardFrontSignals = basics ? signalsFromBasics(basics) : {};
@@ -289,7 +298,7 @@ export async function assembleStockFront(
     if (streak.institution !== 0) signals.institutionNetStreak = streak.institution;
   }
 
-  const rank = lite ? undefined : rankMap?.[code];
+  const rank = lite || !code ? undefined : rankMap?.[code];
   if (rank) signals.marketCapRank = { scope: "market", market: rank.market, rank: rank.rank };
 
   // ── 포모 점수(척추) — 거래량 회전·가격(등락·추세)·수급. 언급량·prevScore 는 후속(없으면 제외). ──

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -1,4 +1,4 @@
-import type { DiscoveryMarket } from "@fomo/core";
+import type { DiscoveryMarket, DailyOhlcv } from "@fomo/core";
 import type { DiscoveryMarketRow } from "./market-source-types";
 import { readUsMarketQuoteRows } from "./us-market-cache";
 import { usDiscoverySeedForSymbol, usDiscoveryUniverse, type UsDiscoverySymbol } from "./us-symbols";
@@ -572,6 +572,61 @@ async function fetchQuoteBatches(symbols: readonly string[], key: string): Promi
     if (index < batches.length - 1) await sleep(TWELVE_BATCH_PAUSE_MS);
   }
   return out;
+}
+
+function parseUsOhlcv(data: unknown): { candles: DailyOhlcv[]; closes: number[]; volumes: number[] } {
+  const empty = { candles: [] as DailyOhlcv[], closes: [] as number[], volumes: [] as number[] };
+  if (!data || typeof data !== "object") return empty;
+  const values = (data as { values?: Array<Record<string, string>> }).values;
+  if (!Array.isArray(values)) return empty;
+  const candles: DailyOhlcv[] = [];
+  for (const v of [...values].reverse()) {
+    // TwelveData 는 최신순 → reverse 해 오름차순(TA 는 오래된→최신 기대).
+    const open = num(v.open);
+    const high = num(v.high);
+    const low = num(v.low);
+    const close = num(v.close);
+    const volume = num(v.volume);
+    if (open === undefined || high === undefined || low === undefined || close === undefined) continue;
+    candles.push({ ...(v.datetime ? { date: v.datetime } : {}), open, high, low, close, volume: volume ?? 0 });
+  }
+  return { candles, closes: candles.map((c) => c.close), volumes: candles.map((c) => c.volume) };
+}
+
+/**
+ * US 일봉 OHLCV(TwelveData time_series) — TA용 풀 히스토리(기본 260 거래일, MA120·52주 활성화).
+ * 종목 1개 단위(depth lazy) 호출 — 상위(front 라우트 unstable_cache)에서 캐시되므로 자체 캐시 불필요.
+ * 유니버스 일괄 조회가 아니라 단일 심볼이라 discovery 504 경로와 무관.
+ */
+export async function fetchUsDailyCandles(
+  symbol: string,
+  outputsize = 260
+): Promise<{ candles: DailyOhlcv[]; closes: number[]; volumes: number[] }> {
+  const empty = { candles: [] as DailyOhlcv[], closes: [] as number[], volumes: [] as number[] };
+  const key = tdKey();
+  const clean = symbol.trim().toUpperCase();
+  if (!key || !clean) return empty;
+  const url = new URL(TWELVE_TIME_SERIES_URL);
+  url.searchParams.set("symbol", clean);
+  url.searchParams.set("interval", "1day");
+  url.searchParams.set("outputsize", String(Math.max(20, Math.min(5000, outputsize))));
+  url.searchParams.set("apikey", key);
+  for (let attempt = 0; attempt < TWELVE_RETRY_DELAYS_MS.length; attempt += 1) {
+    const delay = TWELVE_RETRY_DELAYS_MS[attempt] ?? 0;
+    if (delay > 0) await sleep(delay);
+    try {
+      const res = await fetch(url.toString(), {
+        headers: { accept: "application/json", "user-agent": UA },
+        signal: AbortSignal.timeout(6_000),
+        next: { revalidate: 21_600 },
+      });
+      if (res.ok) return parseUsOhlcv(await res.json());
+      if (!shouldRetryTwelveStatus(res.status)) return empty;
+    } catch {
+      // 소규모 재시도 예산 내 일시 오류는 무시.
+    }
+  }
+  return empty;
 }
 
 async function fetchSparklines(symbols: readonly string[], key: string): Promise<Record<string, number[]>> {


### PR DESCRIPTION
## 발견 (WO 전제 보정)
`computeTechnicalAnalysis` 는 `stock-front.ts` 한 곳에서만 호출되고 캔들 소스가 **네이버(국장 전용)**. → **US 종목은 TA 캔들 경로 자체가 없었음**(naverCode 없어 즉시 빈값). WO 전제("데이터 길이만 병목")는 국장엔 맞지만 미장엔 누락 — outputsize 확대가 아니라 **US 캔들 파이프라인 신설**이 필요.

## PR1 (이 PR) — 미장 TA 활성
- `us-market-source.fetchUsDailyCandles(symbol, 260)`: TwelveData `time_series` **OHLCV 풀 히스토리** → MA120·52주 고저·정배열 활성. **단일 심볼(depth lazy)** 이라 discovery 유니버스(504) 경로와 무관.
- `assembleStockFront` US 분기: 네이버 코드 없고 `symbol` 있으면 US 캔들→TA. **카드(lite)는 비용 회피로 스킵, depth(non-lite)만 260일.**
- `symbol` 관통: front 라우트 param(+캐시키) → `fetchStockFront` → depth(`context.symbol`).
- **국장 경로 무변경**(code 있으면 기존 그대로), `code` undefined 가드.

## 검증
- typecheck(web+fomo-web) · test **1030/1030** · build:web · guard:discovery(47카드) 통과
- 로컬 TwelveData 키 없음 → **US 값 검증은 prod 배포 후** `discovery?country=US` + 미장 종목 depth 차트분석 탭에서(머지 후 확인 보고 예정)

## PR2 (다음)
거래량 진공 발굴 카드(최근 거래량 말라붙음 + 52주 저점 부근, 사실 수치 근거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)