### PR TITLE
Fix public index API 404 fallback

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -173,19 +173,6 @@ async function fetchIndexNetwork({
   sameOriginTimeoutMs?: number;
   backendTimeoutMs?: number;
 } = {}): Promise<FomoIndexResponse> {
-  try {
-    return await fetchJsonWithTimeout<FomoIndexResponse>(
-      "/api/fomo/index",
-      { cache: "no-store", credentials: "same-origin" },
-      sameOriginTimeoutMs,
-      "GET /api/fomo/index"
-    );
-  } catch (sameOriginErr) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[fetchIndex] same-origin failed; retrying backend", sameOriginErr);
-    }
-  }
-
   let lastError: unknown = null;
   for (const origin of backendOrigins()) {
     try {
@@ -199,6 +186,21 @@ async function fetchIndexNetwork({
       lastError = err;
     }
   }
+
+  if (process.env.NODE_ENV !== "production") {
+    try {
+      return await fetchJsonWithTimeout<FomoIndexResponse>(
+        "/api/fomo/index",
+        { cache: "no-store", credentials: "same-origin" },
+        sameOriginTimeoutMs,
+        "GET /api/fomo/index"
+      );
+    } catch (sameOriginErr) {
+      lastError = sameOriginErr;
+      console.warn("[fetchIndex] backend failed; retrying same-origin fallback failed", sameOriginErr);
+    }
+  }
+
   throw lastError instanceof Error ? lastError : new Error("GET /api/fomo/index failed");
 }
 


### PR DESCRIPTION
## Summary
- call the backend index endpoint before same-origin proxy for public index reads
- keep same-origin index proxy only as a non-production fallback
- avoids production console 404 when the fomo-web proxy route is stale or unavailable

## Verification
- npm run typecheck
- npm run test -- browser-auth-security
- npm run build:fomo-web