### PR TITLE
Fill US discovery deck with content cards

### DIFF
--- a/apps/web/__tests__/lib/deck-content.test.ts
+++ b/apps/web/__tests__/lib/deck-content.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDeckContentCardsFromSources, expandDeckContentCardsForScope } from "../../lib/deck-content";
+
+describe("deck content cards", () => {
+  it("builds factual world index and whale cards without domestic leakage", () => {
+    const cards = buildDeckContentCardsFromSources({
+      macroQuotes: [
+        { key: "kospi", label: "코스피", change: 0.4, close: 2900 },
+        { key: "spx", label: "S&P500", change: 0.8, close: 6400 },
+        { key: "ndq", label: "나스닥", change: 1.2, close: 22000 },
+        { key: "sox", label: "필라델피아 반도체", change: 2.1, close: 5800 },
+      ],
+      whaleInput: {
+        marketCapChange24h: -1.5,
+        coins: [
+          { name: "Bitcoin", symbol: "btc", change24h: -2.4, athChange: -8 },
+          { name: "Ethereum", symbol: "eth", change24h: 1.1, athChange: -12 },
+        ],
+      },
+    });
+
+    const expanded = expandDeckContentCardsForScope(cards, "world", 8);
+
+    expect(expanded.some((card) => card.id === "content:index:world")).toBe(true);
+    expect(expanded.some((card) => card.id === "content:whale:global")).toBe(true);
+    expect(expanded.some((card) => card.headline.includes("나스닥 +1.20%"))).toBe(true);
+    expect(expanded.some((card) => card.headline.includes("S&P500 +0.80%"))).toBe(true);
+    expect(expanded.some((card) => card.headline.includes("코스피"))).toBe(false);
+    expect(expanded.every((card) => card.kind === "content" && card.facts.length > 0)).toBe(true);
+  });
+});

--- a/apps/web/lib/deck-content.ts
+++ b/apps/web/lib/deck-content.ts
@@ -1,0 +1,337 @@
+import { buildFeedCards, pct, type RawSignal } from "@fomo/core";
+import { fetchMacro, fetchWhale } from "./fomo-market-sources";
+import { fetchFredDocsForSeries } from "./fred";
+
+const DEEP_UNDERWATER = -30;
+const FRED_DOMESTIC_SERIES = ["DEXKOUS", "DGS10"] as const;
+const FRED_WORLD_SERIES = ["DGS10", "VIXCLS"] as const;
+const FRED_CONTENT_TIMEOUT_MS = 4_500;
+
+export type DeckContentScope = "domestic" | "world" | "global";
+export type DeckContentType = "macro" | "index" | "whale";
+
+export interface DeckContentFact {
+  label: string;
+  value: string;
+}
+
+export interface DeckContentCard {
+  kind: "content";
+  id: string;
+  contentType: DeckContentType;
+  scope: DeckContentScope;
+  headline: string;
+  facts: DeckContentFact[];
+  source: string;
+  asOf: string;
+}
+
+const INDEX_SCOPE: Record<string, DeckContentScope> = {
+  kospi: "domestic",
+  kosdaq: "domestic",
+  spx: "world",
+  ndq: "world",
+  sox: "world",
+};
+
+function kstDate(): string {
+  return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function signedPct(value: number): string {
+  return `${value > 0 ? "+" : ""}${value.toFixed(2)}%`;
+}
+
+function compactNumber(value: number | null | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return value >= 1000
+    ? value.toLocaleString("en-US", { maximumFractionDigits: 2 })
+    : value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
+function contentScoreFromFeed(cards: ReturnType<typeof buildFeedCards>): Map<string, number> {
+  const scores = new Map<string, number>();
+  for (const group of Object.values(cards)) {
+    for (const card of group) {
+      if (card.id.startsWith("mock-")) continue;
+      scores.set(card.id.replace(/^feed-/, ""), card.confidence);
+    }
+  }
+  return scores;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise.finally(() => {
+      if (timeout) clearTimeout(timeout);
+    }),
+    new Promise<T>((resolve) => {
+      timeout = setTimeout(() => resolve(fallback), timeoutMs);
+    }),
+  ]);
+}
+
+export function rawSignalsFromMacroQuotes(macroQuotes: Awaited<ReturnType<typeof fetchMacro>>): RawSignal[] {
+  return macroQuotes.flatMap((quote) => {
+    if (typeof quote.change !== "number") return [];
+    return [{
+      id: `macro-${quote.key}`,
+      source: "macro",
+      label: quote.label,
+      changePct: quote.change,
+      value: pct(quote.change),
+    }];
+  });
+}
+
+export function rawSignalsFromWhale(whaleInput: Awaited<ReturnType<typeof fetchWhale>>): RawSignal[] {
+  const raws: RawSignal[] = [];
+  const { marketCapChange24h, coins } = whaleInput;
+  if (typeof marketCapChange24h === "number") {
+    raws.push({
+      id: "whale-marketcap",
+      source: "whale",
+      label: "암호화폐 시장",
+      changePct: marketCapChange24h,
+      value: pct(marketCapChange24h),
+    });
+  }
+  for (const coin of coins ?? []) {
+    if (typeof coin.change24h === "number") {
+      raws.push({
+        id: `whale-${coin.symbol}`,
+        source: "whale",
+        label: coin.name,
+        changePct: coin.change24h,
+        value: pct(coin.change24h),
+      });
+    }
+    if (typeof coin.athChange === "number" && coin.athChange <= DEEP_UNDERWATER) {
+      raws.push({
+        id: `whale-${coin.symbol}-ath`,
+        source: "whale",
+        label: coin.name,
+        athChangePct: coin.athChange,
+        value: pct(coin.athChange),
+      });
+    }
+  }
+  return raws;
+}
+
+export function buildIndexContent(
+  macroQuotes: Awaited<ReturnType<typeof fetchMacro>>,
+  feedScores: ReadonlyMap<string, number>
+): DeckContentCard[] {
+  const byScope = new Map<DeckContentScope, Array<{ label: string; change: number; close?: number | null; score: number }>>();
+  for (const quote of macroQuotes) {
+    if (typeof quote.change !== "number") continue;
+    const scope = INDEX_SCOPE[quote.key];
+    if (!scope) continue;
+    const arr = byScope.get(scope) ?? [];
+    arr.push({
+      label: quote.label,
+      change: quote.change,
+      ...(typeof quote.close === "number" ? { close: quote.close } : {}),
+      score: feedScores.get(`macro-${quote.key}`) ?? Math.min(0.59, Math.abs(quote.change) / 5),
+    });
+    byScope.set(scope, arr);
+  }
+
+  const cards: DeckContentCard[] = [];
+  for (const scope of ["domestic", "world"] as const) {
+    const rows = (byScope.get(scope) ?? [])
+      .sort((a, b) => b.score - a.score || Math.abs(b.change) - Math.abs(a.change))
+      .slice(0, scope === "world" ? 3 : 2);
+    if (rows.length === 0) continue;
+    const facts = rows.map((row) => ({
+      label: row.label,
+      value: compactNumber(row.close) ? `${signedPct(row.change)} · ${compactNumber(row.close)}` : signedPct(row.change),
+    }));
+    cards.push({
+      kind: "content",
+      id: `content:index:${scope}`,
+      contentType: "index",
+      scope,
+      headline: facts.map((fact) => `${fact.label} ${fact.value.split(" · ")[0]}`).join(", "),
+      facts,
+      source: "시장 지수",
+      asOf: kstDate(),
+    });
+  }
+  return cards;
+}
+
+function fredFactFromTitle(title: string): DeckContentFact | null {
+  const clean = title.replace(/\s+/g, " ").trim();
+  const match = clean.match(/^(.+?)\s+(-?\d+(?:\.\d+)?(?:%|원|달러)?)$/);
+  if (!match) return null;
+  return { label: match[1]!.trim(), value: match[2]!.trim() };
+}
+
+export async function buildMacroContent(): Promise<DeckContentCard[]> {
+  const [domestic, world] = await Promise.allSettled([
+    withTimeout(
+      fetchFredDocsForSeries(
+        FRED_DOMESTIC_SERIES,
+        (() => {
+          let i = 0;
+          return () => `fred-domestic-${++i}`;
+        })()
+      ),
+      FRED_CONTENT_TIMEOUT_MS,
+      []
+    ),
+    withTimeout(
+      fetchFredDocsForSeries(
+        FRED_WORLD_SERIES,
+        (() => {
+          let i = 0;
+          return () => `fred-world-${++i}`;
+        })()
+      ),
+      FRED_CONTENT_TIMEOUT_MS,
+      []
+    ),
+  ]);
+  const rows: Array<{ scope: Exclude<DeckContentScope, "global">; docs: Awaited<ReturnType<typeof fetchFredDocsForSeries>> }> = [
+    { scope: "domestic", docs: domestic.status === "fulfilled" ? domestic.value : [] },
+    { scope: "world", docs: world.status === "fulfilled" ? world.value : [] },
+  ];
+  const cards: DeckContentCard[] = [];
+  for (const row of rows) {
+    const facts = row.docs.map((doc) => fredFactFromTitle(doc.title)).filter((fact): fact is DeckContentFact => fact !== null).slice(0, 3);
+    if (facts.length === 0) continue;
+    cards.push({
+      kind: "content",
+      id: `content:macro:${row.scope}`,
+      contentType: "macro",
+      scope: row.scope,
+      headline: facts.map((fact) => `${fact.label} ${fact.value}`).join(", "),
+      facts,
+      source: "FRED(미 연준)",
+      asOf: row.docs[0]?.publishedAt?.slice(0, 10) ?? kstDate(),
+    });
+  }
+  return cards;
+}
+
+export function buildWhaleContent(
+  whaleInput: Awaited<ReturnType<typeof fetchWhale>>,
+  feedScores: ReadonlyMap<string, number>
+): DeckContentCard[] {
+  const facts: DeckContentFact[] = [];
+  const { marketCapChange24h, coins } = whaleInput;
+  if (typeof marketCapChange24h === "number") facts.push({ label: "암호화폐 시총 24h", value: signedPct(marketCapChange24h) });
+  const leadingCoins = (coins ?? [])
+    .filter((coin) => typeof coin.change24h === "number")
+    .map((coin) => ({
+      label: coin.name,
+      value: signedPct(coin.change24h as number),
+      score: feedScores.get(`whale-${coin.symbol}`) ?? Math.min(0.59, Math.abs(coin.change24h as number) / 8),
+    }))
+    .sort((a, b) => b.score - a.score || Math.abs(Number.parseFloat(b.value)) - Math.abs(Number.parseFloat(a.value)))
+    .slice(0, 2);
+  facts.push(...leadingCoins.map(({ label, value }) => ({ label, value })));
+  if (facts.length === 0) return [];
+  return [
+    {
+      kind: "content",
+      id: "content:whale:global",
+      contentType: "whale",
+      scope: "global",
+      headline: facts.map((fact) => `${fact.label} ${fact.value}`).join(", "),
+      facts,
+      source: "CoinGecko",
+      asOf: kstDate(),
+    },
+  ];
+}
+
+export function buildDeckContentCardsFromSources({
+  macroQuotes,
+  whaleInput,
+}: {
+  macroQuotes?: Awaited<ReturnType<typeof fetchMacro>>;
+  whaleInput?: Awaited<ReturnType<typeof fetchWhale>>;
+}): DeckContentCard[] {
+  const raws = [
+    ...(macroQuotes ? rawSignalsFromMacroQuotes(macroQuotes) : []),
+    ...(whaleInput ? rawSignalsFromWhale(whaleInput) : []),
+  ];
+  const feedScores = contentScoreFromFeed(buildFeedCards(raws));
+  return [
+    ...(macroQuotes ? buildIndexContent(macroQuotes, feedScores) : []),
+    ...(whaleInput ? buildWhaleContent(whaleInput, feedScores) : []),
+  ];
+}
+
+export async function fetchDeckContentCards(): Promise<DeckContentCard[]> {
+  const [macroQuotes, whaleInput] = await Promise.allSettled([fetchMacro(), fetchWhale()]);
+  const sourceContent = buildDeckContentCardsFromSources({
+    ...(macroQuotes.status === "fulfilled" ? { macroQuotes: macroQuotes.value } : {}),
+    ...(whaleInput.status === "fulfilled" ? { whaleInput: whaleInput.value } : {}),
+  });
+  const macroContent = await buildMacroContent().catch((err) => {
+    console.warn("[deck-content] fred content error", err);
+    return [] as DeckContentCard[];
+  });
+  return [...sourceContent, ...macroContent].filter((card) => card.headline.trim().length > 0 && card.facts.length > 0);
+}
+
+function contentScopeMatches(scope: DeckContentScope, target: DeckContentScope): boolean {
+  if (scope === target) return true;
+  return scope === "global" && (target === "domestic" || target === "world");
+}
+
+function contentTypePriority(type: DeckContentType): number {
+  switch (type) {
+    case "index":
+      return 0;
+    case "macro":
+      return 1;
+    case "whale":
+      return 2;
+  }
+}
+
+function factCardId(baseId: string, fact: DeckContentFact, index: number): string {
+  return `${baseId}:fact:${index}:${fact.label
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32)}`;
+}
+
+function splitFactCards(card: DeckContentCard): DeckContentCard[] {
+  if (card.facts.length <= 1) return [];
+  return card.facts.map((fact, index) => ({
+    ...card,
+    id: factCardId(card.id, fact, index),
+    headline: `${fact.label} ${fact.value}`,
+    facts: [fact],
+  }));
+}
+
+export function expandDeckContentCardsForScope(
+  cards: readonly DeckContentCard[],
+  scope: DeckContentScope,
+  limit: number
+): DeckContentCard[] {
+  if (limit <= 0) return [];
+  const scoped = cards
+    .filter((card) => card.kind === "content" && contentScopeMatches(card.scope, scope))
+    .filter((card) => card.headline.trim().length > 0 && card.facts.length > 0)
+    .sort((a, b) => contentTypePriority(a.contentType) - contentTypePriority(b.contentType) || a.id.localeCompare(b.id));
+  const expanded = [...scoped, ...scoped.flatMap(splitFactCards)];
+  const seen = new Set<string>();
+  const out: DeckContentCard[] = [];
+  for (const card of expanded) {
+    if (seen.has(card.id)) continue;
+    seen.add(card.id);
+    out.push(card);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -53,6 +53,7 @@ import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
 import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
 import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
 import { isAbstractTemplate } from "./copy-guards";
+import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContentCard } from "./deck-content";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -76,6 +77,8 @@ const THEME_BUNDLE_MAX_ITEMS = 4;
 const NARRATIVE_MAX_CARDS = 1;
 const NARRATIVE_MIN_STOCKS = 2;
 const NARRATIVE_MAX_STOCKS = 4;
+const US_DISCOVERY_MIN_RESPONSE_CARDS = 10;
+const US_DISCOVERY_CONTENT_CARD_LIMIT = 12;
 const TARGETED_MATERIAL_CANDIDATE_LIMIT = TARGETED_MATERIAL_DEFAULT_ENABLED
   ? Math.max(0, Math.min(720, Number(process.env.DISCOVERY_TARGETED_MATERIAL_LIMIT ?? 720) || 720))
   : 0;
@@ -144,7 +147,8 @@ export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
 export type DiscoveryDeckCardPayload =
   | ({ kind: "stock" } & DiscoveryStockPayload)
   | DiscoveryThemeBundleCard
-  | DiscoveryNarrativeCardPayload;
+  | DiscoveryNarrativeCardPayload
+  | DeckContentCard;
 
 export interface DiscoveryNarrativeStockPayload {
   ticker: string;
@@ -1800,9 +1804,25 @@ function interleaveThemeBundles(
   stocks: readonly DiscoveryStockPayload[],
   bundles: readonly DiscoveryThemeBundleCard[],
   narratives: readonly DiscoveryNarrativeCardPayload[] = [],
+  contents: readonly DeckContentCard[] = [],
 ): DiscoveryDeckCardPayload[] {
   const cards: DiscoveryDeckCardPayload[] = stocks.map((stock) => ({ kind: "stock", ...stock }));
-  if ((bundles.length === 0 && narratives.length === 0) || cards.length < 8) return cards;
+  if (bundles.length === 0 && narratives.length === 0 && contents.length === 0) return cards;
+  if (cards.length < 8) {
+    const supplemental: DiscoveryDeckCardPayload[] = [...bundles, ...narratives, ...contents];
+    if (cards.length === 0) return supplemental;
+    const out: DiscoveryDeckCardPayload[] = [];
+    let supplementalIndex = 0;
+    cards.forEach((card, index) => {
+      out.push(card);
+      if ((index + 1) % 2 === 0 && supplementalIndex < supplemental.length) {
+        out.push(supplemental[supplementalIndex]!);
+        supplementalIndex += 1;
+      }
+    });
+    out.push(...supplemental.slice(supplementalIndex));
+    return out;
+  }
   const out = [...cards];
   bundles.forEach((bundle, index) => {
     const insertAt = Math.min(out.length, 6 + index * 10);
@@ -1811,6 +1831,10 @@ function interleaveThemeBundles(
   narratives.forEach((narrative, index) => {
     const insertAt = Math.min(out.length, 8 + index * 12);
     out.splice(insertAt, 0, narrative);
+  });
+  contents.forEach((content, index) => {
+    const insertAt = Math.min(out.length, 5 + index * 7);
+    out.splice(insertAt, 0, content);
   });
   return out;
 }
@@ -1823,6 +1847,13 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     ? targetedMaterialCandidateLimit(scope, options.targetedMaterialLimit)
     : 0;
   const asOf = discoveryAsOf(scope);
+  const discoveryContentPromise =
+    scope === "US"
+      ? fetchDeckContentCards().catch((err) => {
+        console.warn("[discovery-supply] US content cards failed", err);
+        return [] as DeckContentCard[];
+      })
+      : Promise.resolve([] as DeckContentCard[]);
   const [rows, attentionMap] = await Promise.all([
     fetchMarketRows(scope),
     scope === "US"
@@ -2069,12 +2100,21 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   });
   const bundleCards = buildThemeBundleCards(ranked, rowsByTicker);
   const narrativeCards = buildNarrativeCards(ranked, rowsByTicker);
+  const rawContentCards = await discoveryContentPromise;
+  const usContentLimit =
+    scope === "US"
+      ? Math.min(
+        US_DISCOVERY_CONTENT_CARD_LIMIT,
+        Math.max(3, US_DISCOVERY_MIN_RESPONSE_CARDS - stocks.length - bundleCards.length - narrativeCards.length)
+      )
+      : 0;
+  const contentCards = scope === "US" ? expandDeckContentCardsForScope(rawContentCards, "world", usContentLimit) : [];
 
   return {
     asOf,
     country: scope,
     stocks,
-    cards: interleaveThemeBundles(stocks, bundleCards, narrativeCards),
+    cards: interleaveThemeBundles(stocks, bundleCards, narrativeCards, contentCards),
     fronts,
     confidence: stocks.length >= deckCardCount ? "H" : stocks.length >= Math.min(30, Math.ceil(deckCardCount * 0.75)) ? "M" : "L",
     source: targetedMaterialEnabled ? DISCOVERY_SOURCE_LABEL : "시장 시세·공시·수급 캐시",


### PR DESCRIPTION
## Summary
- add backend DeckContent builders for factual index, macro, and whale cards
- append US-only content cards into discovery responses when stock material cards are sparse
- expand real content facts into separate cards so US discovery can reach 10+ cards without lowering stock material quality

## Verification
- npm run test -- deck-content discoveryDeck discovery-supply feed
- npm run typecheck
- npm run diag:collection -- --country=US
- npm run diag:headline -- --country=US
- npm run build:web
- npm run build:fomo-web
- direct buildDiscoveryResponse({ country: 'US' }) check: stocks=5 cards=10 content=5