### PR TITLE
Block Gemini AI costs by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,12 @@ WEEKLY_REPORT_DAY="SUN"
 REPORT_PROVIDER="rule-based"
 MARKET_DATA_PROVIDER="binance"
 RESEARCH_PIPELINE_PROVIDER="auto"
-AI_API_URL="https://models.github.ai/inference/chat/completions"
-AI_API_KEY="USE_GITHUB_TOKEN"
-AI_MODEL="openai/gpt-4.1"
+AI_API_URL="https://api.groq.com/openai/v1/chat/completions"
+AI_API_KEY=""                              # 권장: 비워두고 GROQ_API_KEY 사용
+AI_MODEL="llama-3.3-70b-versatile"
+GROQ_API_KEY=""                            # Groq OpenAI-compatible 무료/저비용 키
+GROQ_MODEL="llama-3.3-70b-versatile"
+ALLOW_GEMINI_API="0"                       # 1로 명시하지 않으면 gemini-* 모델/Google endpoint 호출 차단
 AI_TEMPERATURE="0.2"
 # opik — LLM 호출 관측·평가(comet-ml/opik). 모든 callAI(@fomo/shared)가 자동 추적.
 # 미설정 시 추적만 생략(fail-open, 제품 정상). self-host(docker) 또는 클라우드(comet.com) 둘 다 가능.
@@ -96,9 +99,8 @@ GITHUB_REPO="mlender-ai/fomo-club"   # GitHub 레포 (owner/repo)
 TWELVE_DATA_API_KEY=""
 
 # ─── AI Agent Chat (Phase 3) ─────────────────────────────────────────────────
-AI_API_URL=""                             # AI API 엔드포인트 (예: https://models.github.ai/inference/chat/completions)
-AI_API_KEY=""                             # AI API 키
-AI_MODEL="openai/gpt-4o"                 # AI 모델 (provider/model 형식)
+# 제품 LLM은 packages/shared/src/ai-client.ts 단일 경로 사용.
+# Gemini 비용 방지: gemini-* 모델/Google endpoint는 ALLOW_GEMINI_API=1 없이는 차단되고, GROQ_API_KEY가 있으면 Groq로 대체.
 
 # ─── FOMO 방향 전환 Feature Flags (docs/PIVOT_FEED_FIRST.md) ─────────────────
 # 기본값은 packages/fomo-core/src/features.ts 코드 상수. 환경변수는 덮어쓰기용.

--- a/packages/shared/__tests__/ai-client.test.ts
+++ b/packages/shared/__tests__/ai-client.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { callAI, isAiConfigured } from "../src/ai-client";
+
+const ENV_KEYS = ["AI_API_URL", "AI_API_KEY", "AI_MODEL", "GROQ_API_KEY", "GROQ_MODEL", "ALLOW_GEMINI_API"] as const;
+const oldEnv = new Map<string, string | undefined>();
+
+function snapshotEnv() {
+  oldEnv.clear();
+  for (const key of ENV_KEYS) oldEnv.set(key, process.env[key]);
+}
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    const value = oldEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+describe("ai-client provider routing", () => {
+  afterEach(() => {
+    restoreEnv();
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks Gemini model calls by default when no Groq fallback exists", async () => {
+    snapshotEnv();
+    process.env.AI_API_URL = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+    process.env.AI_API_KEY = "gemini-key";
+    process.env.AI_MODEL = "gemini-2.5-flash";
+    delete process.env.GROQ_API_KEY;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(isAiConfigured()).toBe(false);
+    const res = await callAI({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(res.ok).toBe(false);
+    expect(res.model).toBe("gemini-2.5-flash");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reroutes Gemini model config to Groq when GROQ_API_KEY is available", async () => {
+    snapshotEnv();
+    process.env.AI_API_URL = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+    process.env.AI_API_KEY = "gemini-key";
+    process.env.AI_MODEL = "gemini-2.5-flash";
+    process.env.GROQ_API_KEY = "groq-key";
+    process.env.GROQ_MODEL = "llama-3.3-70b-versatile";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(isAiConfigured()).toBe(true);
+    const res = await callAI({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(res.ok).toBe(true);
+    expect(res.content).toBe("ok");
+    expect(res.model).toBe("llama-3.3-70b-versatile");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.groq.com/openai/v1/chat/completions",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer groq-key" }),
+      })
+    );
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string) as { model: string };
+    expect(body.model).toBe("llama-3.3-70b-versatile");
+  });
+
+  it("uses Groq by default when only GROQ_API_KEY is configured", async () => {
+    snapshotEnv();
+    delete process.env.AI_API_URL;
+    delete process.env.AI_API_KEY;
+    delete process.env.AI_MODEL;
+    process.env.GROQ_API_KEY = "groq-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(isAiConfigured()).toBe(true);
+    const res = await callAI({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(res.ok).toBe(true);
+    expect(res.model).toBe("llama-3.3-70b-versatile");
+    expect(fetchMock).toHaveBeenCalledWith("https://api.groq.com/openai/v1/chat/completions", expect.any(Object));
+  });
+});

--- a/packages/shared/src/ai-client.ts
+++ b/packages/shared/src/ai-client.ts
@@ -45,6 +45,60 @@ interface LlmResponse {
   choices?: Array<{ message?: { content?: string } }>;
 }
 
+const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_GROQ_MODEL = "llama-3.3-70b-versatile";
+
+function isGeminiEndpoint(url: string): boolean {
+  return /generativelanguage\.googleapis\.com|\/google\/|googleapis\.com\/v1beta\/openai/i.test(url);
+}
+
+function isGeminiModel(model: string): boolean {
+  return /^gemini(?:-|\/)/i.test(model) || /gemini-2\.5-flash/i.test(model);
+}
+
+function geminiApiAllowed(): boolean {
+  return process.env["ALLOW_GEMINI_API"] === "1";
+}
+
+function groqKey(): string {
+  return process.env["GROQ_API_KEY"] ?? "";
+}
+
+function groqModel(): string {
+  return process.env["GROQ_MODEL"] || DEFAULT_GROQ_MODEL;
+}
+
+function resolveRuntimeConfig(opts: Pick<CallAiOptions, "apiUrl" | "apiKey" | "model">): {
+  url: string;
+  key: string;
+  model: string;
+  blockedProvider?: "gemini";
+} {
+  let url = aiApiUrl(opts.apiUrl);
+  let key = resolveAiKey(opts.apiKey);
+  let model = resolveModel(opts.model);
+
+  if (!url && groqKey()) {
+    url = GROQ_API_URL;
+    key = groqKey();
+    model = groqModel();
+  }
+
+  if ((isGeminiEndpoint(url) || isGeminiModel(model)) && !geminiApiAllowed()) {
+    const fallbackKey = groqKey();
+    if (fallbackKey) {
+      return {
+        url: GROQ_API_URL,
+        key: fallbackKey,
+        model: groqModel(),
+      };
+    }
+    return { url: "", key: "", model, blockedProvider: "gemini" };
+  }
+
+  return { url, key, model };
+}
+
 /** AI_API_KEY → (공란/USE_GITHUB_TOKEN) GITHUB_TOKEN 폴백. 7곳 중복이던 키 해소 로직 단일화. */
 export function resolveAiKey(apiKey?: string): string {
   const configured = apiKey ?? process.env["AI_API_KEY"] ?? "";
@@ -64,7 +118,11 @@ export function resolveModel(model?: string): string {
 
 /** 호출 가능 여부(URL+키). 미설정이면 호출 생략하고 정직한 빈 결과. */
 export function isAiConfigured(apiUrl?: string, apiKey?: string): boolean {
-  return Boolean(aiApiUrl(apiUrl)) && Boolean(resolveAiKey(apiKey));
+  const runtime = resolveRuntimeConfig({
+    ...(apiUrl !== undefined ? { apiUrl } : {}),
+    ...(apiKey !== undefined ? { apiKey } : {}),
+  });
+  return Boolean(runtime.url) && Boolean(runtime.key);
 }
 
 /**
@@ -72,10 +130,13 @@ export function isAiConfigured(apiUrl?: string, apiKey?: string): boolean {
  * 예외를 던지지 않는다 — 호출부는 result.ok 로 분기하고 자체 폴백을 유지한다.
  */
 export async function callAI(opts: CallAiOptions): Promise<CallAiResult> {
-  const url = aiApiUrl(opts.apiUrl);
-  const key = resolveAiKey(opts.apiKey);
-  const model = resolveModel(opts.model);
+  const runtime = resolveRuntimeConfig(opts);
+  const { url, key, model } = runtime;
   const result: CallAiResult = { content: "", ok: false, status: 0, model };
+  if (runtime.blockedProvider === "gemini") {
+    console.warn("[ai-client] Gemini API 호출 차단: GROQ_API_KEY가 없어 LLM 호출을 생략합니다.");
+    return result;
+  }
   if (!url || !key) return result;
 
   const finishTrace = beginTrace(opts.trace, {


### PR DESCRIPTION
## Summary
- audited Gemini usage: no direct Gemini SDK/API calls in product code; AI calls route through shared callAI or Slack Groq path
- block Gemini endpoints/models by default in shared callAI unless ALLOW_GEMINI_API=1 is explicitly set
- reroute Gemini configs to Groq when GROQ_API_KEY exists; otherwise skip LLM calls and preserve existing rule fallbacks
- update env example to prefer Groq and add tests for Gemini block/reroute behavior

## Usage found
- apps/web/lib/theme-understanding.ts: theme/stock understanding + wording safety judge via callAI
- apps/web/lib/fomo-translate.ts: English headline translation via callAI
- apps/web/lib/fomo-comment.ts: article one-line comments via callAI
- apps/web/lib/fomo-keyword-comment.ts: keyword comments via callAI
- apps/web/lib/news-reprocess.ts: US news hook compression via callAI
- apps/web/lib/insight-synthesis.ts: discovery why synthesis via callAI
- scripts/eval-understanding*.ts and scripts/council-meeting.ts: script/workflow-only AI calls
- apps/web/app/api/slack/events/route.ts already uses Groq directly

## Verification
- npm run test -- ai-client
- npm run typecheck
- npm run build:shared