### PR TITLE
Add discovery performance proof history

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -40,11 +40,13 @@ describe("FOMO Web browser auth security", () => {
     expect(isAllowedProxyRequest("index", "GET")).toBe(true);
     expect(isAllowedProxyRequest("discovery", "GET")).toBe(true);
     expect(isAllowedProxyRequest("feed", "GET")).toBe(true);
+    expect(isAllowedProxyRequest("performance-prices", "POST")).toBe(true);
     expect(isAllowedProxyRequest("stock-front", "GET")).toBe(true);
     expect(isAllowedProxyRequest("emotions/calendar", "GET")).toBe(true);
     expect(isAllowedProxyRequest("account", "DELETE")).toBe(true);
     expect(isAllowedProxyRequest("auth/login", "GET")).toBe(false);
     expect(isAllowedProxyRequest("discovery", "POST")).toBe(false);
+    expect(isAllowedProxyRequest("performance-prices", "GET")).toBe(false);
     expect(isAllowedProxyRequest("../runtime/state", "GET")).toBe(false);
     expect(isAllowedProxyRequest("feed", "POST")).toBe(false);
   });

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { MOCK_KEYWORD_CARDS, scoreToColor, type KeywordCard } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { MyDiscoveryPreview } from "@/components/MyDiscoveryPreview";
+import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
 import { getHistory } from "@/lib/keywordHistory";
+import { DISCOVERY_PERFORMANCE_UPDATED_EVENT, getDiscoverySeen } from "@/lib/discoveryPerformance";
 import { getWatchlist, type WatchItem } from "@/lib/watchlist";
 
 /**
@@ -23,10 +25,21 @@ function relativeTime(ts: number): string {
 export function KeywordHistory() {
   const [history] = useState(() => getHistory());
   const [watchlist] = useState(() => getWatchlist());
+  const [seenItems, setSeenItems] = useState(() => getDiscoverySeen());
   const [selected, setSelected] = useState<KeywordCard | null>(null);
   const [stockSel, setStockSel] = useState<WatchItem | null>(null);
 
-  if (history.length === 0 && watchlist.length === 0) {
+  useEffect(() => {
+    const refresh = () => setSeenItems(getDiscoverySeen());
+    window.addEventListener(DISCOVERY_PERFORMANCE_UPDATED_EVENT, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(DISCOVERY_PERFORMANCE_UPDATED_EVENT, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+
+  if (history.length === 0 && watchlist.length === 0 && seenItems.length === 0) {
     return (
       <p className="mt-16 text-center text-sm leading-6 text-muted">
         아직 관심 둔 게 없어요.
@@ -38,6 +51,7 @@ export function KeywordHistory() {
 
   return (
     <div className="w-full">
+      <PerformanceProofPanel items={seenItems} />
       <MyDiscoveryPreview items={watchlist} onOpen={setStockSel} />
 
       {history.length > 0 && <p className="mb-3 px-1 text-xs text-muted">내가 본 키워드</p>}

--- a/apps/fomo-web/components/PerformanceProofPanel.tsx
+++ b/apps/fomo-web/components/PerformanceProofPanel.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { fetchDiscoveryPerformancePrices, type DiscoveryPerformancePrice } from "@/lib/fomoApi";
+import {
+  daysSince,
+  formatReturnPct,
+  type DiscoverySeenItem,
+} from "@/lib/discoveryPerformance";
+
+const NEON = "#D8FF3A";
+
+interface PerformanceRow {
+  item: DiscoverySeenItem;
+  current?: DiscoveryPerformancePrice;
+  returnPct?: number;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid] ?? null;
+  const left = sorted[mid - 1];
+  const right = sorted[mid];
+  return typeof left === "number" && typeof right === "number" ? (left + right) / 2 : null;
+}
+
+function asPrice(value: number, country?: string): string {
+  if (country === "KR") return `${Math.round(value).toLocaleString("ko-KR")}원`;
+  return `$${value.toLocaleString("en-US", { maximumFractionDigits: value >= 100 ? 2 : 3 })}`;
+}
+
+function shareText(row: PerformanceRow): string {
+  const days = daysSince(row.item.firstSeenAt);
+  const performance = typeof row.returnPct === "number" ? ` · ${formatReturnPct(row.returnPct)}` : "";
+  return `포모클럽이 ${row.item.stock}을 ${days}일 전 먼저 짚었어요${performance}`;
+}
+
+async function shareRow(row: PerformanceRow): Promise<void> {
+  const text = shareText(row);
+  const shareData = {
+    title: "포모클럽 먼저 짚었어요",
+    text,
+    ...(typeof window !== "undefined" ? { url: window.location.href } : {}),
+  };
+  if (typeof navigator !== "undefined" && "share" in navigator) {
+    try {
+      await navigator.share(shareData);
+      return;
+    } catch {
+      // Fall through to clipboard when the share sheet is cancelled or unavailable.
+    }
+  }
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    await navigator.clipboard.writeText(`${text}\n${"url" in shareData ? shareData.url : ""}`.trim());
+  }
+}
+
+export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeenItem[] }) {
+  const [prices, setPrices] = useState<Record<string, DiscoveryPerformancePrice>>({});
+  const [loading, setLoading] = useState(false);
+  const pricedItems = useMemo(
+    () => items.filter((item) => typeof item.firstSeenPrice === "number").slice(0, 40),
+    [items]
+  );
+
+  useEffect(() => {
+    if (pricedItems.length === 0) return;
+    let cancelled = false;
+    setLoading(true);
+    fetchDiscoveryPerformancePrices(pricedItems)
+      .then((res) => {
+        if (!cancelled) setPrices(res.prices);
+      })
+      .catch((err) => {
+        if (process.env.NODE_ENV !== "production") console.warn("[PerformanceProofPanel] price fetch failed", err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pricedItems]);
+
+  const rows: PerformanceRow[] = useMemo(
+    () =>
+      items.slice(0, 40).map((item) => {
+        const current = prices[item.stock];
+        const start = item.firstSeenPrice;
+        const returnPct =
+          typeof start === "number" && start > 0 && typeof current?.currentPrice === "number"
+            ? ((current.currentPrice - start) / start) * 100
+            : undefined;
+        return {
+          item,
+          ...(current ? { current } : {}),
+          ...(typeof returnPct === "number" ? { returnPct } : {}),
+        };
+      }),
+    [items, prices]
+  );
+  const returns = rows
+    .map((row) => row.returnPct)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  const winRate = returns.length > 0 ? Math.round((returns.filter((value) => value > 0).length / returns.length) * 100) : null;
+  const medianReturn = median(returns);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-center justify-between px-1">
+        <p className="text-xs text-muted">먼저 짚은 성과</p>
+        <span className="text-[10px] font-medium text-muted">{returns.length}/{items.length}</span>
+      </div>
+
+      <div className="rounded-2xl border border-hairline bg-surface-raised px-4 py-4">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <span className="text-[10px] text-muted">상승 비율</span>
+            <p className="mt-1 text-2xl font-bold text-whiteout">{winRate === null ? "확인 중" : `${winRate}%`}</p>
+          </div>
+          <div>
+            <span className="text-[10px] text-muted">중앙값 수익</span>
+            <p className="mt-1 text-2xl font-bold text-whiteout">
+              {medianReturn === null ? "확인 중" : formatReturnPct(medianReturn)}
+            </p>
+          </div>
+        </div>
+        <p className="mt-3 text-xs leading-5 text-muted">
+          처음 본 시점 가격과 현재가가 모두 있는 종목 전체 기준입니다.
+        </p>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-2.5">
+        {rows.slice(0, 10).map((row) => {
+          const up = typeof row.returnPct === "number" && row.returnPct > 0;
+          const days = daysSince(row.item.firstSeenAt);
+          return (
+            <article
+              key={`${row.item.stock}-${row.item.firstSeenAt}`}
+              className="rounded-xl border border-hairline bg-surface px-4 py-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="min-w-0 truncate text-base font-semibold text-whiteout">{row.item.stock}</span>
+                    {row.item.sector && <span className="shrink-0 text-[11px] text-muted"># {row.item.sector}</span>}
+                  </div>
+                  <p className="mt-1 text-xs text-muted">
+                    {days}일 전 발견
+                    {typeof row.item.firstSeenPrice === "number" && (
+                      <span> · 발견가 {row.item.firstSeenPriceText ?? asPrice(row.item.firstSeenPrice, row.item.country)}</span>
+                    )}
+                  </p>
+                </div>
+                <span
+                  className="shrink-0 rounded-full border border-hairline-soft px-2.5 py-1 text-sm font-bold tabular-nums"
+                  style={{ color: up ? NEON : "#A3A3A0" }}
+                >
+                  {typeof row.returnPct === "number" ? formatReturnPct(row.returnPct) : loading ? "확인 중" : "현재가 없음"}
+                </span>
+              </div>
+              {row.item.reason && <p className="mt-2 line-clamp-2 text-xs leading-5 text-muted">{row.item.reason}</p>}
+              {row.current && (
+                <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted">
+                  <span>현재 {asPrice(row.current.currentPrice, row.item.country)}</span>
+                  <button
+                    type="button"
+                    onClick={() => void shareRow(row)}
+                    className="rounded-full border border-hairline-soft px-3 py-1 text-whiteout transition-colors hover:border-muted"
+                  >
+                    공유
+                  </button>
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -16,6 +16,7 @@ import { NarrativeCard } from "@/components/NarrativeCard";
 import { SectorCard } from "@/components/SectorCard";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import type { FeedSignalPoint, StockFrontResponse } from "@/lib/fomoApi";
+import { recordDiscoverySeen } from "@/lib/discoveryPerformance";
 import { recordStockInterest } from "@/lib/stockInterest";
 import { upsertWatch } from "@/lib/watchlist";
 import type { DeckStock } from "@/lib/discoveryDeck";
@@ -847,8 +848,14 @@ export function StockSwipeDeck({
     }
     if (lastSeenStock.current === stock) return;
     lastSeenStock.current = stock;
-    if (isStockCard(card)) recordStockInterest(card.data.canonical, "seen", Date.now());
-  }, [idx, deckCards]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (isStockCard(card)) {
+      const now = Date.now();
+      recordStockInterest(card.data.canonical, "seen", now);
+      recordDiscoverySeen(card.data, now, {
+        ...(front[card.data.canonical] ? { front: front[card.data.canonical] } : {}),
+      });
+    }
+  }, [idx, deckCards, front]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const card = at(idx);
@@ -856,6 +863,7 @@ export function StockSwipeDeck({
     const stock = card.data.canonical;
     if (!front[stock] || hydratedRecorded.current.has(stock)) return;
     hydratedRecorded.current.add(stock);
+    recordDiscoverySeen(card.data, Date.now(), { front: front[stock], reason: whyFor(card.data) });
     recordDiscoveryEvent("card_hydrate");
   }, [idx, front, deckCards]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/fomo-web/lib/auth-proxy.ts
+++ b/apps/fomo-web/lib/auth-proxy.ts
@@ -9,6 +9,7 @@ const ALLOWED_PROXY_REQUESTS = new Map<string, ReadonlySet<string>>([
   ["index", new Set(["GET"])],
   ["discovery", new Set(["GET"])],
   ["feed", new Set(["GET"])],
+  ["performance-prices", new Set(["POST"])],
   ["stock-front", new Set(["GET"])],
   ["emotions/calendar", new Set(["GET"])],
   ["emotions/link", new Set(["POST"])],

--- a/apps/fomo-web/lib/discoveryPerformance.ts
+++ b/apps/fomo-web/lib/discoveryPerformance.ts
@@ -1,0 +1,153 @@
+"use client";
+
+import type { StockCountry, StockMarket } from "@fomo/core";
+import type { DeckStock } from "@/lib/discoveryDeck";
+
+const KEY = "fomo_discovery_seen";
+const CAP = 240;
+const PRICE_CAPTURE_GRACE_MS = 10 * 60_000;
+
+export const DISCOVERY_PERFORMANCE_UPDATED_EVENT = "fomo:discovery-performance-updated";
+
+export interface DiscoverySeenItem {
+  stock: string;
+  firstSeenAt: number;
+  firstSeenPrice?: number;
+  firstSeenPriceText?: string;
+  firstSeenPriceCapturedAt?: number;
+  symbol?: string;
+  naverCode?: string;
+  market?: StockMarket;
+  country?: StockCountry;
+  sector?: string;
+  reason?: string;
+}
+
+export interface DiscoverySeenInput {
+  stock: string;
+  symbol?: string;
+  naverCode?: string;
+  market?: StockMarket;
+  country?: StockCountry;
+  sector?: string;
+  reason?: string;
+}
+
+interface PriceFront {
+  priceText?: string;
+}
+
+function parsePriceText(text: string | undefined): number | undefined {
+  if (!text) return undefined;
+  const normalized = text.replace(/,/g, "").match(/-?\d+(?:\.\d+)?/u)?.[0];
+  if (!normalized) return undefined;
+  const price = Number(normalized);
+  return Number.isFinite(price) && price > 0 ? price : undefined;
+}
+
+function read(): DiscoverySeenItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((row): DiscoverySeenItem | null => {
+        if (!row || typeof row !== "object") return null;
+        const candidate = row as Partial<DiscoverySeenItem>;
+        if (typeof candidate.stock !== "string" || typeof candidate.firstSeenAt !== "number") return null;
+        return {
+          stock: candidate.stock,
+          firstSeenAt: candidate.firstSeenAt,
+          ...(typeof candidate.firstSeenPrice === "number" ? { firstSeenPrice: candidate.firstSeenPrice } : {}),
+          ...(typeof candidate.firstSeenPriceText === "string" ? { firstSeenPriceText: candidate.firstSeenPriceText } : {}),
+          ...(typeof candidate.firstSeenPriceCapturedAt === "number"
+            ? { firstSeenPriceCapturedAt: candidate.firstSeenPriceCapturedAt }
+            : {}),
+          ...(typeof candidate.symbol === "string" ? { symbol: candidate.symbol } : {}),
+          ...(typeof candidate.naverCode === "string" ? { naverCode: candidate.naverCode } : {}),
+          ...(typeof candidate.market === "string" ? { market: candidate.market as StockMarket } : {}),
+          ...(typeof candidate.country === "string" ? { country: candidate.country as StockCountry } : {}),
+          ...(typeof candidate.sector === "string" ? { sector: candidate.sector } : {}),
+          ...(typeof candidate.reason === "string" ? { reason: candidate.reason } : {}),
+        };
+      })
+      .filter((row): row is DiscoverySeenItem => row !== null);
+  } catch {
+    return [];
+  }
+}
+
+function write(items: DiscoverySeenItem[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(items.slice(0, CAP)));
+    window.dispatchEvent(new CustomEvent(DISCOVERY_PERFORMANCE_UPDATED_EVENT));
+  } catch {
+    /* localStorage failure should not block the deck */
+  }
+}
+
+export function getDiscoverySeen(): DiscoverySeenItem[] {
+  return read().sort((a, b) => b.firstSeenAt - a.firstSeenAt);
+}
+
+export function recordDiscoverySeen(
+  stock: DeckStock | DiscoverySeenInput,
+  nowMs: number,
+  opts: { front?: PriceFront; reason?: string } = {}
+): void {
+  if (typeof window === "undefined") return;
+  const stockName = "canonical" in stock ? stock.canonical : stock.stock;
+  if (!stockName) return;
+
+  const price = parsePriceText(opts.front?.priceText);
+  const items = read();
+  const index = items.findIndex((item) => item.stock === stockName);
+  const existing = index >= 0 ? items[index] : undefined;
+  const base: DiscoverySeenItem =
+    existing ??
+    ({
+      stock: stockName,
+      firstSeenAt: nowMs,
+    } satisfies DiscoverySeenItem);
+  const canCapturePrice =
+    typeof price === "number" &&
+    typeof base.firstSeenPrice !== "number" &&
+    nowMs - base.firstSeenAt <= PRICE_CAPTURE_GRACE_MS;
+
+  const next: DiscoverySeenItem = {
+    ...base,
+    ...(("symbol" in stock && stock.symbol) ? { symbol: stock.symbol } : {}),
+    ...(("naverCode" in stock && stock.naverCode) ? { naverCode: stock.naverCode } : {}),
+    ...(("market" in stock && stock.market) ? { market: stock.market } : {}),
+    ...(("country" in stock && stock.country) ? { country: stock.country } : {}),
+    ...(("sector" in stock && stock.sector) ? { sector: stock.sector } : {}),
+    ...(opts.reason ? { reason: opts.reason } : base.reason ? { reason: base.reason } : {}),
+    ...(canCapturePrice
+      ? {
+          firstSeenPrice: price,
+          firstSeenPriceCapturedAt: nowMs,
+          ...(opts.front?.priceText ? { firstSeenPriceText: opts.front.priceText } : {}),
+        }
+      : {}),
+  };
+
+  if (index >= 0) {
+    items[index] = next;
+    write(items.sort((a, b) => b.firstSeenAt - a.firstSeenAt));
+    return;
+  }
+  write([next, ...items]);
+}
+
+export function daysSince(ts: number, nowMs = Date.now()): number {
+  if (!Number.isFinite(ts) || ts <= 0) return 0;
+  return Math.max(0, Math.floor((nowMs - ts) / 86_400_000));
+}
+
+export function formatReturnPct(value: number): string {
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(1)}%`;
+}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -30,6 +30,7 @@ const CACHE_TTL = {
   stockBasics: 6 * HOUR,
   themeInsight: 6 * HOUR,
   stockInsight: 6 * HOUR,
+  performancePrices: 10 * MINUTE,
 } as const;
 export const KEYWORDS_UPDATED_EVENT = "fomo:keywords-updated";
 export const DISCOVERY_UPDATED_EVENT = "fomo:discovery-updated";
@@ -412,6 +413,56 @@ export const fetchStockFront = (stock: string, opts: { lite?: boolean; naverCode
       ),
     CACHE_TTL.stockFront
   );
+
+export interface DiscoveryPerformancePriceRequestItem {
+  stock: string;
+  symbol?: string;
+  naverCode?: string;
+  market?: import("@fomo/core").StockMarket;
+  country?: import("@fomo/core").StockCountry;
+}
+
+export interface DiscoveryPerformancePrice {
+  yahooSymbol: string;
+  currentPrice: number;
+  asOf: string;
+}
+
+export interface DiscoveryPerformancePricesResponse {
+  prices: Record<string, DiscoveryPerformancePrice>;
+}
+
+export async function fetchDiscoveryPerformancePrices(
+  items: readonly DiscoveryPerformancePriceRequestItem[]
+): Promise<DiscoveryPerformancePricesResponse> {
+  const clean = items
+    .filter((item) => item.stock)
+    .slice(0, 40)
+    .map((item) => ({
+      stock: item.stock,
+      ...(item.symbol ? { symbol: item.symbol } : {}),
+      ...(item.naverCode ? { naverCode: item.naverCode } : {}),
+      ...(item.market ? { market: item.market } : {}),
+      ...(item.country ? { country: item.country } : {}),
+    }));
+  const key = `performance-prices:${clean
+    .map((item) => `${item.stock}:${item.symbol ?? ""}:${item.naverCode ?? ""}:${item.market ?? ""}:${item.country ?? ""}`)
+    .join("|")}`;
+  return cachedGet(
+    key,
+    async () => {
+      const res = await fetch(`${API_BASE}/api/fomo/performance-prices`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ items: clean }),
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`POST /api/fomo/performance-prices ${res.status}`);
+      return res.json() as Promise<DiscoveryPerformancePricesResponse>;
+    },
+    CACHE_TTL.performancePrices
+  );
+}
 
 export interface DiscoveryStockResponse {
   kind?: "stock";

--- a/apps/web/app/api/fomo/performance-prices/route.ts
+++ b/apps/web/app/api/fomo/performance-prices/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../lib/fomo";
+import type { StockCountry, StockMarket } from "@fomo/core";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 20;
+
+const YAHOO_HOSTS = ["https://query1.finance.yahoo.com", "https://query2.finance.yahoo.com"];
+const YAHOO_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const MAX_ITEMS = 40;
+
+interface PriceRequestItem {
+  stock: string;
+  symbol?: string;
+  naverCode?: string;
+  market?: StockMarket;
+  country?: StockCountry;
+}
+
+interface PriceResponseItem {
+  stock: string;
+  yahooSymbol: string;
+  currentPrice: number;
+  asOf: string;
+}
+
+function yahooSymbolFor(item: PriceRequestItem): string | null {
+  const rawSymbol = item.symbol?.trim().toUpperCase();
+  if (item.country === "US" || item.market === "NASDAQ" || item.market === "NYSE") {
+    return rawSymbol || item.stock.trim().toUpperCase().replace(/[^A-Z0-9.-]/g, "");
+  }
+  const code = item.naverCode?.trim() || (/^\d{6}$/.test(rawSymbol ?? "") ? rawSymbol : "");
+  if (code && item.market === "KOSDAQ") return `${code}.KQ`;
+  if (code && item.market === "KOSPI") return `${code}.KS`;
+  return null;
+}
+
+async function fetchYahooPrice(yahooSymbol: string): Promise<{ currentPrice: number; asOf: string } | null> {
+  for (const host of YAHOO_HOSTS) {
+    try {
+      const url = `${host}/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?range=3mo&interval=1d`;
+      const res = await fetch(url, {
+        headers: { accept: "application/json", "user-agent": YAHOO_UA },
+        signal: AbortSignal.timeout(7_000),
+        next: { revalidate: 600 },
+      });
+      if (!res.ok) continue;
+      const payload = (await res.json()) as {
+        chart?: {
+          result?: {
+            meta?: { regularMarketPrice?: number };
+            timestamp?: number[];
+            indicators?: { quote?: { close?: (number | null)[] }[] };
+          }[];
+        };
+      };
+      const result = payload.chart?.result?.[0];
+      const closes = result?.indicators?.quote?.[0]?.close?.filter(
+        (value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0
+      );
+      const currentPrice =
+        typeof result?.meta?.regularMarketPrice === "number" && result.meta.regularMarketPrice > 0
+          ? result.meta.regularMarketPrice
+          : closes?.at(-1);
+      if (typeof currentPrice !== "number" || !Number.isFinite(currentPrice) || currentPrice <= 0) continue;
+      const lastTs = result?.timestamp?.at(-1);
+      return {
+        currentPrice,
+        asOf: lastTs ? new Date(lastTs * 1000).toISOString() : new Date().toISOString(),
+      };
+    } catch {
+      // Try the next Yahoo host.
+    }
+  }
+  return null;
+}
+
+async function mapLimit<T, R>(items: T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const chunk = items.slice(i, i + limit);
+    out.push(...(await Promise.all(chunk.map(worker))));
+  }
+  return out;
+}
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as { items?: PriceRequestItem[] };
+    const items = Array.isArray(body.items) ? body.items.slice(0, MAX_ITEMS) : [];
+    const jobs = items
+      .map((item) => ({ item, yahooSymbol: yahooSymbolFor(item) }))
+      .filter((job): job is { item: PriceRequestItem; yahooSymbol: string } => !!job.yahooSymbol && !!job.item.stock);
+
+    const rows = await mapLimit(jobs, 5, async ({ item, yahooSymbol }): Promise<PriceResponseItem | null> => {
+      const price = await fetchYahooPrice(yahooSymbol);
+      if (!price) return null;
+      return { stock: item.stock, yahooSymbol, ...price };
+    });
+
+    const prices = Object.fromEntries(
+      rows
+        .filter((row): row is PriceResponseItem => row !== null)
+        .map((row) => [
+          row.stock,
+          {
+            yahooSymbol: row.yahooSymbol,
+            currentPrice: row.currentPrice,
+            asOf: row.asOf,
+          },
+        ])
+    );
+
+    return withCors(
+      NextResponse.json(
+        { prices },
+        {
+          headers: { "Cache-Control": "public, s-maxage=600, stale-while-revalidate=3600" },
+        }
+      )
+    );
+  } catch {
+    return withCors(NextResponse.json({ prices: {} }, { status: 200 }));
+  }
+}


### PR DESCRIPTION
Implements the history performance proof feature: first-seen discovery stamps, cached Yahoo current-price lookup, honest win-rate/median-return history summary, and shareable per-stock proof rows.\n\nValidation:\n- npm run typecheck\n- npm run test -- browser-auth-security discoveryDeck stock-front-lite\n- npm run build:web\n- npm run build:fomo-web