### PR TITLE
feat(discovery): 내부자 클러스터 매수 발굴 피드 (US)

### DIFF
--- a/apps/web/__tests__/lib/insider-source.test.ts
+++ b/apps/web/__tests__/lib/insider-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseOpenInsiderClusterBuys } from "../../lib/insider-source";
+
+function row(cells: string[], tickerHref: string): string {
+  const tds = cells.map((c) => `<td>${c}</td>`).join("");
+  // 티커 셀은 openinsider 처럼 툴팁 잔여물 + href 형태로 구성.
+  const withTicker = tds.replace(
+    "<td>__TICKER__</td>",
+    `<td><a href="/${tickerHref}" onmouseover="Tip('...', DELAY, 1)" onmouseout="UnTip()">${tickerHref}</a></td>`
+  );
+  return `<tr>${withTicker}</tr>`;
+}
+
+// 열: X, Filing, Trade, Ticker, Company, Industry, Ins, TradeType, Price, Qty, Owned, ΔOwn, Value, 1d, 1w, 1m, 6m
+function clusterRow(o: {
+  ticker: string; company: string; ins: string; type: string; price: string; delta: string; value: string; filing?: string; trade?: string;
+}): string {
+  return row(
+    ["M", o.filing ?? "2026-06-30 17:06:54", o.trade ?? "2026-06-26", "__TICKER__", o.company, "Industry X", o.ins, o.type, o.price, "+1,000", "10,000", o.delta, o.value, "", "", "", ""],
+    o.ticker
+  );
+}
+
+function table(rows: string[]): string {
+  const header =
+    "<tr><th>X</th><th>Filing</th><th>Trade</th><th>Ticker</th><th>Company</th><th>Industry</th><th>Ins</th><th>Trade Type</th><th>Price</th><th>Qty</th><th>Owned</th><th>ΔOwn</th><th>Value</th><th>1d</th><th>1w</th><th>1m</th><th>6m</th></tr>";
+  return `<html><body><table class="tinytable">${header}${rows.join("")}</table></body></html>`;
+}
+
+describe("parseOpenInsiderClusterBuys", () => {
+  it("parses cluster purchase rows with ticker, insider count, ownership delta, value", () => {
+    const html = table([
+      clusterRow({ ticker: "LILA", company: "Liberty Latin America", ins: "5", type: "P - Purchase", price: "$8.90", delta: "+78%", value: "+$140,345,259" }),
+    ]);
+    const rows = parseOpenInsiderClusterBuys(html);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      symbol: "LILA",
+      companyName: "Liberty Latin America",
+      insiderCount: 5,
+      buyPrice: 8.9,
+      ownershipDeltaPct: 78,
+      valueUsd: 140345259,
+      filingDate: "2026-06-30",
+      tradeDate: "2026-06-26",
+    });
+  });
+
+  it("drops non-purchases, single-insider rows, and sub-$100k noise", () => {
+    const html = table([
+      clusterRow({ ticker: "SELL", company: "Sale Co", ins: "3", type: "S - Sale", price: "$5.00", delta: "-10%", value: "-$5,000,000" }),
+      clusterRow({ ticker: "SOLO", company: "Solo Co", ins: "1", type: "P - Purchase", price: "$5.00", delta: "+2%", value: "+$1,000,000" }),
+      clusterRow({ ticker: "TINY", company: "Tiny Co", ins: "3", type: "P - Purchase", price: "$5.00", delta: "+2%", value: "+$50,000" }),
+      clusterRow({ ticker: "GOOD", company: "Good Co", ins: "4", type: "P - Purchase", price: "$5.00", delta: "+9%", value: "+$500,000" }),
+    ]);
+    const rows = parseOpenInsiderClusterBuys(html);
+    expect(rows.map((r) => r.symbol)).toEqual(["GOOD"]);
+  });
+
+  it("returns empty when no tinytable present", () => {
+    expect(parseOpenInsiderClusterBuys("<html><body>no table</body></html>")).toEqual([]);
+  });
+});

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -49,6 +49,7 @@ import { selectDominantAxis } from "./card-axis";
 import { fetchSupplyDemand } from "./supply-demand";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
 import { fetchCachedUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
+import { fetchInsiderClusterCandidates, type InsiderClusterCandidate } from "./insider-source";
 import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
 import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
 import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
@@ -737,6 +738,109 @@ async function hydrateUsMarketWideMaterial(
     const event = materialEventFromUsArticle(article, asOf, article.source || "시장 뉴스");
     if (!event) continue;
     byTicker.set(ticker, { ...current, events: [...current.events, event] });
+  }
+}
+
+function insiderValueText(usd: number): string {
+  if (usd >= 1_000_000) return `$${(usd / 1_000_000).toFixed(usd >= 10_000_000 ? 0 : 1)}M`;
+  if (usd >= 1_000) return `$${Math.round(usd / 1_000)}K`;
+  return `$${Math.round(usd)}`;
+}
+
+function insiderMoney(price: number | undefined): string | undefined {
+  if (typeof price !== "number" || !Number.isFinite(price)) return undefined;
+  return `$${price >= 100 ? price.toLocaleString("en-US", { maximumFractionDigits: 2 }) : price.toFixed(2)}`;
+}
+
+/** 내부자 클러스터 매수 → 관측 서술 카피(사실만·판단/예측 없음). "클러스터" 키워드로 재료성 확보. */
+function insiderClusterLabel(candidate: InsiderClusterCandidate): string {
+  const valueText = insiderValueText(candidate.valueUsd);
+  const delta = candidate.ownershipDeltaPct;
+  const base =
+    typeof delta === "number" && delta >= 1
+      ? `내부자 ${candidate.insiderCount}명 클러스터 · 지분 ${Math.round(delta)}% 확대 · ${valueText}`
+      : `내부자 ${candidate.insiderCount}명 클러스터 매집 · ${valueText}`;
+  const quiet = typeof candidate.quote?.changePct === "number" && Math.abs(candidate.quote.changePct) < 2;
+  return quiet ? `${base} · 아직 조용한 구간` : base;
+}
+
+function insiderClusterEvent(candidate: InsiderClusterCandidate, asOf: string): DiscoveryEvent {
+  const label = insiderClusterLabel(candidate);
+  // 발굴(오늘 노출) 시점 기준 — addStaticRecoveryRows 와 동일 패턴. 실제 공시일은 summary 로 명시(정직).
+  const filingText = /^\d{4}-\d{2}-\d{2}$/.test(candidate.filingDate)
+    ? `${candidate.filingDate} 공시`
+    : "최근 공시";
+  return {
+    kind: "disclosure",
+    firstSeen: true,
+    strength: 0.99,
+    source: "SEC Form 4 · openinsider",
+    asOf,
+    confidence: "H",
+    direction: "flat",
+    label,
+    sourceTitle: `${filingText} · 내부자 ${candidate.insiderCount}명 공개시장 매수 (SEC Form 4)`,
+    summary: `${filingText} · 내부자 ${candidate.insiderCount}명 공개시장 매수`,
+    sourceName: "SEC Form 4",
+    headlineHook: label,
+    insiderPurchase: true,
+    sourceUrl: `http://openinsider.com/${candidate.symbol}`,
+  };
+}
+
+/** openinsider 영문 업종 → 한글 섹터(INDUSTRY_HINTS 매칭). 못 맞추면 undefined(다운스트림 폴백). */
+function insiderSectorHint(symbol: string, industry: string | undefined): string | undefined {
+  if (!industry) return undefined;
+  const label = inferDiscoverySectorLabel(symbol, [
+    { kind: "market_context", firstSeen: false, strength: 0, source: "", asOf: "", confidence: "L", label: industry },
+  ]);
+  return label === "기타 업종" ? undefined : label;
+}
+
+function insiderClusterRow(candidate: InsiderClusterCandidate): DiscoveryMarketRow {
+  const quote = candidate.quote;
+  const changePct = quote?.changePct;
+  const changeDir: "up" | "down" | "flat" =
+    typeof changePct !== "number" ? "flat" : changePct > 0 ? "up" : changePct < 0 ? "down" : "flat";
+  const priceText = insiderMoney(quote?.price);
+  return {
+    canonical: candidate.symbol,
+    symbol: candidate.symbol,
+    market: "NASDAQ",
+    country: "US",
+    currency: "USD",
+    marketCapRank: 900,
+    ...(priceText ? { priceText } : {}),
+    ...(typeof changePct === "number" ? { changePct, changeDir } : {}),
+    ...(quote?.sparkline && quote.sparkline.length >= 2 ? { sparkline: quote.sparkline } : {}),
+    ...(insiderSectorHint(candidate.symbol, candidate.industry) ? { sectorHint: insiderSectorHint(candidate.symbol, candidate.industry)! } : {}),
+    sessionLabel: latestUsSessionAsOf().label,
+  };
+}
+
+/**
+ * US 내부자 클러스터 매수 발굴 — 조용한 종목까지 덱에 주입한다.
+ * 이미 유니버스에 있으면 내부자 이벤트만 보강, 없으면 합성 row+event를 직접 주입(eligible 게이트 우회).
+ * openinsider 실패 시 조용히 no-op(fail-open).
+ */
+async function hydrateUsInsiderClusterRows(
+  byTicker: Map<string, { row: DiscoveryMarketRow; events: DiscoveryEvent[] }>,
+  asOf: string
+): Promise<void> {
+  const candidates = await fetchInsiderClusterCandidates().catch((): InsiderClusterCandidate[] => []);
+  if (candidates.length === 0) return;
+  for (const candidate of candidates) {
+    const event = insiderClusterEvent(candidate, asOf);
+    const existing = [...byTicker.entries()].find(
+      ([, value]) => value.row.country === "US" && value.row.symbol?.toUpperCase() === candidate.symbol
+    );
+    if (existing) {
+      const [ticker, current] = existing;
+      if (current.events.some((e) => e.insiderPurchase)) continue;
+      byTicker.set(ticker, { ...current, events: [...current.events, event] });
+      continue;
+    }
+    byTicker.set(candidate.symbol, { row: insiderClusterRow(candidate), events: [event] });
   }
 }
 
@@ -1940,6 +2044,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   }
 
   if (scope === "US") {
+    await hydrateUsInsiderClusterRows(byTicker, asOf);
     await hydrateUsMarketWideMaterial(byTicker, asOf);
   }
 

--- a/apps/web/lib/insider-source.ts
+++ b/apps/web/lib/insider-source.ts
@@ -1,0 +1,222 @@
+/**
+ * 내부자 클러스터 매수 발굴 소스 (US, DATA_ENGINE_STRATEGY 선행/수급 축).
+ *
+ * openinsider "latest cluster buys"(여러 내부자가 동반 매수한 공개시장 매수, SEC Form 4 집계)를
+ * 매일 수집해 조용한 종목까지 발굴 카드로 띄운다. 현재가/스파크라인은 Yahoo chart(무료·무차단)로 보강한다.
+ *
+ * 순수 데이터(LLM 0). 관측 서술만 — 매수·매도 판단/예측 없음.
+ * openinsider가 막히거나 비면 조용히 빈 배열(fail-open) — 제품은 기존 US 유니버스로 정상 동작.
+ */
+
+const OPENINSIDER_CLUSTER_URL = "http://openinsider.com/latest-cluster-buys";
+/** Yahoo chart 호스트 폴백(둘 다 429 나면 시세는 best-effort 생략, 카드는 openinsider 근거로 정상). */
+const YAHOO_CHART_HOSTS = [
+  "https://query1.finance.yahoo.com/v8/finance/chart",
+  "https://query2.finance.yahoo.com/v8/finance/chart",
+] as const;
+const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
+const YAHOO_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+/** 노이즈 컷 — 소액·단독 매수 제외. 클러스터(내부자 2인+) & 총액 $100k+ 만 발굴. */
+const MIN_INSIDER_COUNT = 2;
+const MIN_TOTAL_VALUE_USD = 100_000;
+/** 상위 N개만(비용·집중). 총액 큰 순. */
+const MAX_CLUSTER_ROWS = 20;
+/** 접수(공개) 후 N일 이내 공시만 — 오래된 매집은 발굴 대상에서 제외(최근 누적만). */
+const MAX_FILING_AGE_DAYS = 21;
+const YAHOO_CONCURRENCY = 4;
+const FETCH_TIMEOUT_MS = 12_000;
+
+export interface InsiderClusterBuy {
+  symbol: string;
+  companyName: string;
+  industry?: string;
+  /** 동반 매수한 내부자 수(openinsider "Ins"). */
+  insiderCount: number;
+  /** 최근 거래일(YYYY-MM-DD). */
+  tradeDate: string;
+  /** 공시 접수일(YYYY-MM-DD). */
+  filingDate: string;
+  /** 매수 단가($). */
+  buyPrice?: number;
+  /** 지분 변동률(%) — openinsider "ΔOwn". */
+  ownershipDeltaPct?: number;
+  /** 총 매수 금액($). */
+  valueUsd: number;
+}
+
+export interface InsiderClusterQuote {
+  /** Yahoo 현재가($). */
+  price?: number;
+  currency?: string;
+  changePct?: number;
+  sparkline?: number[];
+}
+
+export type InsiderClusterCandidate = InsiderClusterBuy & { quote?: InsiderClusterQuote };
+
+async function fetchText(url: string, ua: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": ua, Accept: "text/html,application/json" }, signal: controller.signal });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stripTags(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function numFrom(text: string | undefined): number | undefined {
+  if (!text) return undefined;
+  const n = Number(text.replace(/[$,%+\s]/g, ""));
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function isoDate(text: string | undefined): string {
+  const m = (text ?? "").match(/\d{4}-\d{2}-\d{2}/);
+  return m ? m[0] : "";
+}
+
+/**
+ * openinsider "latest cluster buys" 테이블 파싱.
+ * 열: [0]X [1]Filing [2]Trade [3]Ticker [4]Company [5]Industry [6]Ins [7]TradeType [8]Price [9]Qty [10]Owned [11]ΔOwn [12]Value ...
+ */
+export function parseOpenInsiderClusterBuys(html: string): InsiderClusterBuy[] {
+  const tableMatch = html.match(/<table[^>]*class="tinytable"[^>]*>([\s\S]*?)<\/table>/i);
+  if (!tableMatch) return [];
+  const rows = (tableMatch[1] ?? "").match(/<tr[^>]*>[\s\S]*?<\/tr>/gi) ?? [];
+  const out: InsiderClusterBuy[] = [];
+  for (const rowHtml of rows) {
+    const cellMatches = rowHtml.match(/<td[^>]*>[\s\S]*?<\/td>/gi);
+    if (!cellHasEnough(cellMatches)) continue;
+    const cells = cellMatches.map((c) => stripTags(c));
+    const tradeType = cells[7] ?? "";
+    if (!/purchase/i.test(tradeType)) continue;
+    // 티커: 셀[3]에 툴팁 잔여물이 붙으므로 href="/TICKER"에서 추출.
+    const tickerMatch = rowHtml.match(/href="\/([A-Z][A-Z.]{0,5})"/);
+    const symbol = tickerMatch?.[1]?.toUpperCase();
+    if (!symbol) continue;
+    const insiderCount = numFrom(cells[6]) ?? 0;
+    const valueUsd = numFrom(cells[12]) ?? 0;
+    if (insiderCount < MIN_INSIDER_COUNT) continue;
+    if (valueUsd < MIN_TOTAL_VALUE_USD) continue;
+    const buyPrice = numFrom(cells[8]);
+    const ownershipDeltaPct = numFrom(cells[11]);
+    out.push({
+      symbol,
+      companyName: cells[4] ?? symbol,
+      ...(cells[5] ? { industry: cells[5] } : {}),
+      insiderCount,
+      tradeDate: isoDate(cells[2]),
+      filingDate: isoDate(cells[1]),
+      ...(buyPrice !== undefined ? { buyPrice } : {}),
+      ...(ownershipDeltaPct !== undefined ? { ownershipDeltaPct } : {}),
+      valueUsd,
+    });
+  }
+  return out;
+}
+
+function cellHasEnough(cells: RegExpMatchArray | null): cells is RegExpMatchArray {
+  return Boolean(cells && cells.length >= 13);
+}
+
+function filingAgeDays(filingDate: string): number | undefined {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(filingDate)) return undefined;
+  const filed = Date.parse(`${filingDate}T00:00:00Z`);
+  if (!Number.isFinite(filed)) return undefined;
+  return Math.floor((Date.now() - filed) / 86_400_000);
+}
+
+/** 최근 접수(공개)분만 유지 → 심볼 중복 제거(총액 큰 것) → 총액 내림차순 상위 N. */
+function dedupeAndRank(rows: InsiderClusterBuy[]): InsiderClusterBuy[] {
+  const best = new Map<string, InsiderClusterBuy>();
+  for (const row of rows) {
+    const age = filingAgeDays(row.filingDate);
+    if (age === undefined || age < 0 || age > MAX_FILING_AGE_DAYS) continue;
+    const prev = best.get(row.symbol);
+    if (!prev || row.valueUsd > prev.valueUsd) best.set(row.symbol, row);
+  }
+  return [...best.values()].sort((a, b) => b.valueUsd - a.valueUsd).slice(0, MAX_CLUSTER_ROWS);
+}
+
+async function fetchYahooQuote(symbol: string): Promise<InsiderClusterQuote | undefined> {
+  let text: string | null = null;
+  for (const host of YAHOO_CHART_HOSTS) {
+    text = await fetchText(`${host}/${encodeURIComponent(symbol)}?interval=1d&range=1mo`, YAHOO_UA);
+    if (text && text.trimStart().startsWith("{")) break; // 429/HTML 응답이면 다음 호스트
+    text = null;
+  }
+  if (!text) return undefined;
+  try {
+    const json = JSON.parse(text);
+    const result = json?.chart?.result?.[0];
+    if (!result) return undefined;
+    const meta = result.meta ?? {};
+    const closesRaw: Array<number | null> = result.indicators?.quote?.[0]?.close ?? [];
+    const closes = closesRaw.filter((c): c is number => typeof c === "number" && Number.isFinite(c));
+    const price: number | undefined = typeof meta.regularMarketPrice === "number" ? meta.regularMarketPrice : closes.at(-1);
+    const prevClose =
+      typeof meta.chartPreviousClose === "number"
+        ? meta.chartPreviousClose
+        : closes.length >= 2
+          ? closes[closes.length - 2]
+          : undefined;
+    const changePct =
+      typeof price === "number" && typeof prevClose === "number" && prevClose !== 0
+        ? ((price - prevClose) / prevClose) * 100
+        : undefined;
+    return {
+      ...(typeof price === "number" ? { price } : {}),
+      ...(typeof meta.currency === "string" ? { currency: meta.currency } : {}),
+      ...(typeof changePct === "number" ? { changePct } : {}),
+      ...(closes.length >= 2 ? { sparkline: closes.slice(-30) } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  async function worker() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      out[index] = await fn(items[index] as T);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return out;
+}
+
+/**
+ * 오늘자 내부자 클러스터 매수 후보(현재가 보강 포함).
+ * 실데이터만 — 소스 실패 시 빈 배열(fail-open).
+ */
+export async function fetchInsiderClusterCandidates(): Promise<InsiderClusterCandidate[]> {
+  const html = await fetchText(OPENINSIDER_CLUSTER_URL, UA);
+  if (!html) return [];
+  const ranked = dedupeAndRank(parseOpenInsiderClusterBuys(html));
+  if (ranked.length === 0) return [];
+  const quotes = await mapLimit(ranked, YAHOO_CONCURRENCY, (row) => fetchYahooQuote(row.symbol).catch(() => undefined));
+  return ranked.map((row, i) => ({ ...row, ...(quotes[i] ? { quote: quotes[i] } : {}) }));
+}


### PR DESCRIPTION
## 무엇을 / 왜
여러 내부자가 **동반 매수(클러스터)** 한 미국 종목을 매일 수집해 발굴 카드로 US 덱에 띄운다. 아직 가격이 반응 안 한 **조용한 종목**도 유니버스 게이트를 우회해 노출 → "선행/수급" 발견 축 강화. 관측 서술만, 매수/매도 판단·예측 없음.

## 변경
- **`apps/web/lib/insider-source.ts`** (신설): openinsider `latest-cluster-buys` 파싱 — `P - Purchase` + 내부자 2인+ + 총액 $100k+ + 접수 21일 이내만. 심볼 dedup·총액 상위 20. 현재가/스파크라인은 Yahoo chart로 **best-effort** 보강.
- **`apps/web/lib/discovery-supply.ts`**: `hydrateUsInsiderClusterRows` — 기존 `disclosure`+`insiderPurchase` 이벤트 재사용(태그 "내부자 매수", 수급 축). 이미 유니버스에 있으면 이벤트 보강, 없으면 합성 row 직접 주입. 헤드라인 게이트 통과를 위해 "클러스터" 키워드 사용.
- 파서 유닛테스트 추가.

## 데이터 소스 정책
- 근거(grounding)는 **openinsider 이벤트**(sourceUrl + "SEC Form 4"). 시세는 부가 정보라 **Yahoo egress 차단(429) 시에도 카드 정상 노출**(graceful degrade).
- TwelveData 쿼터와 무관 — US 발굴을 독립적으로 되살림.
- 국장(KR)은 **기존 DART 내부자 경로 유지 · 불변**.

## 검증
- 실데이터 파싱: openinsider 20건 → 카피 가드 12/12 통과(런칭 제약 ON 포함).
- E2E `buildDiscoveryResponse({country:"US"})`: **내부자 카드 20개** 응답 확인(before/after-rank disclosure:20, 헤드라인·소스URL 정상).
- 헤드라인 게이트 격리 테스트: rank 생존 + `provenance=synthesis`(비-suppressed).
- `npm run guard:discovery` ✅ (KR 덱 46카드·불변), `spec:analyze` ✅(error 0), typecheck ✅, 파서 유닛테스트 3/3 ✅.

## 관측 서술 예
`내부자 5명 클러스터 · 지분 78% 확대 · $140M` / `내부자 7명 클러스터 매집 · $71M · 아직 조용한 구간`

🤖 Generated with [Claude Code](https://claude.com/claude-code)