### PR TITLE
feat(discovery): 내부자 카드에 취득가 노출

### DIFF
--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -760,8 +760,11 @@ function insiderClusterLabel(candidate: InsiderClusterCandidate): string {
     typeof delta === "number" && delta >= 1
       ? `내부자 ${candidate.insiderCount}명 클러스터 · 지분 ${Math.round(delta)}% 확대 · ${valueText}`
       : `내부자 ${candidate.insiderCount}명 클러스터 매집 · ${valueText}`;
+  // 현재가 소스 부재(Yahoo egress 차단·TwelveData 쿼터) → 공시된 내부자 취득가를 진입 기준선으로 노출(현재가 아님).
+  const priceText = insiderMoney(candidate.buyPrice);
+  const withPrice = priceText ? `${base} · 취득가 ${priceText}` : base;
   const quiet = typeof candidate.quote?.changePct === "number" && Math.abs(candidate.quote.changePct) < 2;
-  return quiet ? `${base} · 아직 조용한 구간` : base;
+  return quiet ? `${withPrice} · 아직 조용한 구간` : withPrice;
 }
 
 function insiderClusterEvent(candidate: InsiderClusterCandidate, asOf: string): DiscoveryEvent {


### PR DESCRIPTION
## 왜
#793로 내부자 클러스터 발굴 카드는 라이브지만, US 현재가 소스가 전부 막혀(**Yahoo egress 429 차단 + TwelveData 쿼터 소진**) 카드에 시세가 안 뜬다.

## 무엇을
공시된 **내부자 취득가**(openinsider Price 컬럼, 이미 파싱 중)를 진입 기준선으로 카피에 노출. "현재가"가 아니라 "취득가"로 명시 → 정직. 새 데이터 의존성 0.

예: `내부자 5명 클러스터 · 지분 78% 확대 · $140M · 취득가 $8.90`

## 검증
- 격리 테스트: rank 생존 + `provenance=synthesis`, 헤드라인 게이트 통과.
- 카피 가드: lifted/strict **둘 다 통과**("취득가"는 중립어 — 런칭 제약 ON에서도 안전), isFrontHookSafe ✅.
- guard:discovery ✅(KR 불변), spec:analyze error 0, typecheck ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)