### PR TITLE
Add unified daily 30 discovery feed

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -38,6 +38,7 @@ describe("FOMO Web browser auth security", () => {
   it("only proxies explicitly allowed authenticated routes and methods", () => {
     expect(isAllowedProxyRequest("auth/login", "POST")).toBe(true);
     expect(isAllowedProxyRequest("index", "GET")).toBe(true);
+    expect(isAllowedProxyRequest("daily-30", "GET")).toBe(true);
     expect(isAllowedProxyRequest("discovery", "GET")).toBe(true);
     expect(isAllowedProxyRequest("feed", "GET")).toBe(true);
     expect(isAllowedProxyRequest("performance-prices", "POST")).toBe(true);

--- a/apps/fomo-web/__tests__/discovery-country-scope.test.ts
+++ b/apps/fomo-web/__tests__/discovery-country-scope.test.ts
@@ -65,4 +65,30 @@ describe("discovery country scope", () => {
 
     expect(discoveryMatchesCountry(polluted, "US")).toBe(false);
   });
+
+  it("accepts scoped content cards in the matching discovery deck", async () => {
+    expect(
+      discoveryMatchesCountry(
+        {
+          ...baseDiscovery,
+          cards: [
+            ...(baseDiscovery.cards ?? []),
+            { kind: "content", scope: "world" },
+            { kind: "content", scope: "global" },
+          ],
+        },
+        "US"
+      )
+    ).toBe(true);
+
+    expect(
+      discoveryMatchesCountry(
+        {
+          ...baseDiscovery,
+          cards: [...(baseDiscovery.cards ?? []), { kind: "content", scope: "domestic" }],
+        },
+        "US"
+      )
+    ).toBe(false);
+  });
 });

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { CaretUpIcon, CaretDownIcon, XMarkIcon } from "@/components/icons";
 import { KeywordHistory } from "@/components/KeywordHistory";
-import { LoginPage } from "@/components/LoginPage";
 import type {
   FomoIndexResponse,
   TallyResponse,
@@ -23,13 +22,10 @@ import type {
  * (감정 게이트/캘린더/한마디 props는 보존 차원에서 시그니처에 남기되 미사용 — flag로 숨김 유지.)
  */
 type Tab = "card" | "history";
-const FIRST_VISIT_NOTICE_KEY = "fomo_first_visit_notice_v1";
 const NEON = "#D8FF3A";
 
 export function HomeView({
   index,
-  loggedIn,
-  onLoggedIn,
 }: {
   index: FomoIndexResponse | null;
   tally: TallyResponse | null;
@@ -45,20 +41,8 @@ export function HomeView({
   onLoggedIn: () => void;
 }) {
   const [tab, setTab] = useState<Tab>("card");
-  const [authOpen, setAuthOpen] = useState(false);
-  const [noticeOpen, setNoticeOpen] = useState(false);
-  const [noticeChecked, setNoticeChecked] = useState(true);
   const [indexHelpOpen, setIndexHelpOpen] = useState(false);
   const color = index ? scoreToColor(index.score) : undefined;
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      setNoticeOpen(window.localStorage.getItem(FIRST_VISIT_NOTICE_KEY) !== "accepted");
-    } catch {
-      setNoticeOpen(true);
-    }
-  }, []);
 
   /**
    * 전체 폴백 판정: 기본 온도만 있는 상태다.
@@ -76,15 +60,9 @@ export function HomeView({
   return (
     <>
       <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-20 pt-4">
-        {/* 상단 얇은 띠: 로고 + 로그인(취향 기억) */}
+        {/* 상단 얇은 띠: 로고 */}
         <div className="flex items-center justify-between">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-          <button
-            onClick={() => setAuthOpen(true)}
-            className="text-xs text-muted transition-colors hover:text-whiteout"
-          >
-            {loggedIn ? "내 계정" : "로그인"}
-          </button>
         </div>
 
         {/* 시장 온도(FOMO Index) */}
@@ -124,7 +102,7 @@ export function HomeView({
 
         <div className={`mt-3 flex flex-1 flex-col ${tab === "card" ? "justify-center" : ""}`}>
           {tab === "card" ? (
-            <KeywordCardFeed loggedIn={loggedIn} onRequireLogin={() => setAuthOpen(true)} />
+            <KeywordCardFeed loggedIn={true} />
           ) : (
             <KeywordHistory />
           )}
@@ -139,27 +117,7 @@ export function HomeView({
         </div>
       </nav>
 
-      {authOpen && (
-        <LoginPage loggedIn={loggedIn} onClose={() => setAuthOpen(false)} onAuthed={onLoggedIn} />
-      )}
-
       {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
-
-      {noticeOpen && (
-        <FirstVisitNoticeSheet
-          checked={noticeChecked}
-          onCheckedChange={setNoticeChecked}
-          onAccept={() => {
-            if (!noticeChecked) return;
-            try {
-              window.localStorage.setItem(FIRST_VISIT_NOTICE_KEY, "accepted");
-            } catch {
-              /* localStorage 실패 시에도 이번 세션 흐름은 막지 않는다. */
-            }
-            setNoticeOpen(false);
-          }}
-        />
-      )}
     </>
   );
 }

--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -8,7 +8,7 @@ import {
   type SurpriseStock,
 } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
-import { TodayDiscoveryDeck } from "@/components/TodayDiscoveryDeck";
+import { UnifiedDailyDeck } from "@/components/UnifiedDailyDeck";
 import { KEYWORDS_UPDATED_EVENT, fetchKeywords, fetchThemeInsight, recordTaste, type KeywordsResponse } from "@/lib/fomoApi";
 import { keywordInterestScore, recordInterest } from "@/lib/keywordInterest";
 import { recordViewed, getHistory } from "@/lib/keywordHistory";
@@ -146,7 +146,7 @@ interface FeedGate {
 }
 
 export function KeywordCardFeed({ loggedIn, onRequireLogin }: FeedGate = {}) {
-  return <TodayDiscoveryDeck loggedIn={loggedIn} onRequireLogin={onRequireLogin} />;
+  return <UnifiedDailyDeck loggedIn={loggedIn} onRequireLogin={onRequireLogin} />;
 }
 
 /** "오늘" 탭 — 기존 쏠림(키워드) 피드(무변경). */

--- a/apps/fomo-web/components/UnifiedDailyDeck.tsx
+++ b/apps/fomo-web/components/UnifiedDailyDeck.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { StockSwipeDeck } from "@/components/StockSwipeDeck";
+import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
+import { fetchDaily30, type Daily30Response } from "@/lib/fomoApi";
+import { stockDeckCards, type DeckCard, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
+import type { FrontEntry } from "@/components/StockSwipeDeck";
+
+interface UnifiedDailyDeckProps {
+  loggedIn?: boolean | undefined;
+  onRequireLogin?: (() => void) | undefined;
+}
+
+const RETRY_DELAYS_MS = [1_200, 2_400] as const;
+
+const wait = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
+function Daily30Empty({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout" role="status">
+      <p>
+        오늘의 30장을 불러오지 못했어요.
+        <br />
+        다시 불러오는 중이에요.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-5 rounded-full border border-hairline bg-surface px-5 py-2 text-xs font-semibold text-whiteout transition-colors hover:border-whiteout/30"
+      >
+        지금 다시 불러오기
+      </button>
+    </div>
+  );
+}
+
+function cardsFromDaily30(discovery: Daily30Response): { cards: DeckCard[]; fronts: Record<string, FrontEntry> } {
+  const rawCards = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
+  const fronts = discovery.fronts as Record<string, FrontEntry>;
+  return { cards: stockDeckCards(rawCards).slice(0, 30), fronts };
+}
+
+export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDailyDeckProps) {
+  const [retryKey, setRetryKey] = useState(0);
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "error" }
+    | { kind: "ready"; cards: DeckCard[]; fronts: Record<string, FrontEntry> }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    setState({ kind: "loading" });
+    (async () => {
+      let lastError: unknown = null;
+      for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+        try {
+          const discovery = await fetchDaily30();
+          if (!alive) return;
+          const next = cardsFromDaily30(discovery);
+          if (next.cards.length === 0) {
+            setState({ kind: "error" });
+            return;
+          }
+          setState({ kind: "ready", ...next });
+          return;
+        } catch (err) {
+          lastError = err;
+          if (attempt < RETRY_DELAYS_MS.length) {
+            await wait(RETRY_DELAYS_MS[attempt] ?? 0);
+            if (!alive) return;
+          }
+        }
+      }
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[UnifiedDailyDeck] fetch failed", lastError);
+      }
+      if (alive) setState({ kind: "error" });
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [retryKey]);
+
+  useEffect(() => {
+    if (state.kind !== "error") return;
+    const retry = window.setTimeout(() => setRetryKey((value) => value + 1), 3_500);
+    return () => window.clearTimeout(retry);
+  }, [state.kind]);
+
+  if (state.kind === "loading") {
+    return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
+  }
+  if (state.kind === "error") {
+    return <Daily30Empty onRetry={() => setRetryKey((value) => value + 1)} />;
+  }
+
+  return (
+    <StockSwipeDeck
+      cards={state.cards}
+      initialFronts={state.fronts}
+      contextLabel="오늘의 30장"
+      loggedIn={loggedIn}
+      onRequireLogin={onRequireLogin}
+    />
+  );
+}

--- a/apps/fomo-web/lib/auth-proxy.ts
+++ b/apps/fomo-web/lib/auth-proxy.ts
@@ -7,6 +7,7 @@ const ALLOWED_PROXY_REQUESTS = new Map<string, ReadonlySet<string>>([
   ["auth/logout", new Set(["POST"])],
   ["auth/session", new Set(["GET"])],
   ["index", new Set(["GET"])],
+  ["daily-30", new Set(["GET"])],
   ["discovery", new Set(["GET"])],
   ["feed", new Set(["GET"])],
   ["performance-prices", new Set(["POST"])],

--- a/apps/fomo-web/lib/discoveryCountryScope.ts
+++ b/apps/fomo-web/lib/discoveryCountryScope.ts
@@ -24,11 +24,16 @@ export interface DiscoveryScopeNarrative {
   stocks: DiscoveryScopeStock[];
 }
 
+export interface DiscoveryScopeContent {
+  kind: "content";
+  scope?: "domestic" | "world" | "global";
+}
+
 export interface DiscoveryScopeResponse {
   asOf?: string;
   country?: DiscoveryCountryScope;
   stocks: DiscoveryScopeStock[];
-  cards?: Array<DiscoveryScopeStock | DiscoveryScopeThemeBundle | DiscoveryScopeNarrative>;
+  cards?: Array<DiscoveryScopeStock | DiscoveryScopeThemeBundle | DiscoveryScopeNarrative | DiscoveryScopeContent>;
   fronts: Record<string, unknown>;
   confidence?: "L" | "M" | "H";
   source?: string;
@@ -40,10 +45,17 @@ function stockMatchesCountry(stock: DiscoveryScopeStock, country: DiscoveryCount
   return stock.country === "US" && (stock.market === "NASDAQ" || stock.market === "NYSE") && !!stock.symbol && !stock.naverCode;
 }
 
-function cardMatchesCountry(card: DiscoveryScopeStock | DiscoveryScopeThemeBundle | DiscoveryScopeNarrative, country: DiscoveryCountryScope): boolean {
+function cardMatchesCountry(
+  card: DiscoveryScopeStock | DiscoveryScopeThemeBundle | DiscoveryScopeNarrative | DiscoveryScopeContent,
+  country: DiscoveryCountryScope
+): boolean {
   if (country === "all") return true;
   if (card.kind === "theme_bundle") return card.items.length > 0 && card.items.every((item) => stockMatchesCountry(item, country));
   if (card.kind === "narrative") return card.stocks.length > 0 && card.stocks.every((item) => stockMatchesCountry(item, country));
+  if (card.kind === "content") {
+    if (card.scope === "global") return true;
+    return country === "KR" ? card.scope === "domestic" : card.scope === "world";
+  }
   return stockMatchesCountry(card, country);
 }
 

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -31,6 +31,7 @@ const CACHE_TTL = {
   themeInsight: 6 * HOUR,
   stockInsight: 6 * HOUR,
   performancePrices: 10 * MINUTE,
+  daily30: HOUR,
 } as const;
 export const KEYWORDS_UPDATED_EVENT = "fomo:keywords-updated";
 export const DISCOVERY_UPDATED_EVENT = "fomo:discovery-updated";
@@ -46,6 +47,10 @@ export type { DiscoveryCountryScope } from "./discoveryCountryScope";
 
 function discoveryFastPath(country: DiscoveryCountryScope = "KR"): string {
   return `/api/fomo/discovery?fast=1&country=${encodeURIComponent(country)}`;
+}
+
+function daily30Path(): string {
+  return "/api/fomo/daily-30";
 }
 
 function kstDateKey(now = new Date()): string {
@@ -549,7 +554,13 @@ export interface DiscoveryNarrativeResponse {
   asOf: string;
 }
 
-export type DiscoveryCardResponse = DiscoveryStockResponse | DiscoveryThemeBundleResponse | DiscoveryNarrativeResponse;
+export type DiscoveryContentResponse = DeckContent;
+
+export type DiscoveryCardResponse =
+  | DiscoveryStockResponse
+  | DiscoveryThemeBundleResponse
+  | DiscoveryNarrativeResponse
+  | DiscoveryContentResponse;
 
 export interface DiscoveryResponse {
   asOf: string;
@@ -559,6 +570,23 @@ export interface DiscoveryResponse {
   fronts: Record<string, StockFrontResponse>;
   confidence: "L" | "M" | "H";
   source: string;
+}
+
+export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
+
+export interface Daily30Response extends DiscoveryResponse {
+  country: "all";
+  meta?: {
+    targetCount: number;
+    cards: Array<{
+      id: string;
+      assetClass: Daily30AssetClass;
+      quietScore: number;
+      signalScore: number;
+      hypePenalty: number;
+    }>;
+    assetCounts: Record<Daily30AssetClass, number>;
+  };
 }
 
 export interface DiscoveryUpdatedDetail {
@@ -602,6 +630,11 @@ function cardCopyFields(card: DiscoveryCardResponse): string[] {
       card.trigger.headline,
       ...card.stocks.map((stock) => stock.relationReason),
     ].filter((text): text is string => typeof text === "string" && text.trim().length > 0);
+  }
+  if (card.kind === "content") {
+    return [card.headline, ...card.facts.map((fact) => `${fact.label} ${fact.value}`)].filter(
+      (text): text is string => typeof text === "string" && text.trim().length > 0
+    );
   }
   return stockCopyFields(card);
 }
@@ -733,6 +766,52 @@ export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Pro
 }
 
 export const warmDiscovery = (country: DiscoveryCountryScope = "KR") => fetchDiscovery(country);
+
+function hasDaily30Cards(value: Daily30Response | null | undefined): value is Daily30Response {
+  return hasDiscoveryCards(value, "all") && value.country === "all" && (value.cards?.length ?? 0) > 0;
+}
+
+async function fetchDaily30Network(): Promise<Daily30Response> {
+  const path = daily30Path();
+  try {
+    return await fetchJsonWithTimeout<Daily30Response>(
+      path,
+      { cache: "no-store", credentials: "same-origin" },
+      DISCOVERY_SAME_ORIGIN_TIMEOUT_MS,
+      `GET ${path}`
+    );
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[fomoApi] same-origin daily-30 failed; retrying backend", err);
+    }
+  }
+
+  let lastError: unknown = null;
+  for (const origin of backendOrigins()) {
+    try {
+      return await fetchJsonWithTimeout<Daily30Response>(
+        `${origin}${path}`,
+        { cache: "no-store" },
+        DISCOVERY_BACKEND_TIMEOUT_MS,
+        `GET ${origin}${path}`
+      );
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("GET /api/fomo/daily-30 failed");
+}
+
+export async function fetchDaily30(): Promise<Daily30Response> {
+  const key = `daily-30:${DISCOVERY_CACHE_VERSION}:${kstDateKey()}`;
+  const cached = readCached<Daily30Response>(key);
+  if (hasDaily30Cards(cached)) return cached;
+  const fresh = await cachedGet(key, fetchDaily30Network, CACHE_TTL.daily30);
+  if (!hasDaily30Cards(fresh)) throw new Error("GET /api/fomo/daily-30 returned invalid deck");
+  return fresh;
+}
+
+export const warmDaily30 = () => fetchDaily30();
 
 export interface AxisSnapshotEntry {
   axisSignals: import("@fomo/core").AxisSignal[];

--- a/apps/web/app/api/fomo/cron/daily-30/route.ts
+++ b/apps/web/app/api/fomo/cron/daily-30/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { withCors, kstDate } from "../../../../../lib/fomo";
+import type { Daily30Response } from "../../../../../lib/daily-30";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(request: Request) {
+  const startedAt = Date.now();
+  try {
+    const warmUrl = new URL("/api/fomo/daily-30", request.url);
+    const upstream = await fetch(warmUrl, { cache: "no-store" });
+    if (!upstream.ok) throw new Error(`daily-30 warmup ${upstream.status}`);
+    const response = (await upstream.json()) as Daily30Response;
+    return withCors(
+      NextResponse.json(
+        {
+          ok: true,
+          asOf: response.asOf,
+          date: kstDate(),
+          cards: response.cards?.length ?? 0,
+          stocks: response.stocks.length,
+          assetCounts: response.meta.assetCounts,
+          elapsedMs: Date.now() - startedAt,
+        },
+        { headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  } catch (err) {
+    console.warn("[fomo/cron/daily-30] failed", (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        { ok: false, date: kstDate(), error: (err as Error)?.message ?? "daily-30 failed" },
+        { status: 500, headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/app/api/fomo/daily-30/route.ts
+++ b/apps/web/app/api/fomo/daily-30/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { buildDaily30Response, type Daily30Response } from "../../../../lib/daily-30";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const REVALIDATE_S = 60 * 60 * 12;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function GET() {
+  try {
+    const load = unstable_cache(
+      () => buildDaily30Response(),
+      ["fomo-daily-30", cacheVersion(), kstDate()],
+      { revalidate: REVALIDATE_S }
+    );
+    return withCors(
+      NextResponse.json(await load(), {
+        headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+      })
+    );
+  } catch (err) {
+    console.warn("[fomo/daily-30] failed", (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        {
+          asOf: kstDate(),
+          country: "all",
+          stocks: [],
+          cards: [],
+          fronts: {},
+          confidence: "L",
+          source: "데이터 없음",
+          meta: {
+            targetCount: 30,
+            cards: [],
+            assetCounts: { "kr-stock": 0, "us-stock": 0, coin: 0, macro: 0 },
+          },
+        } satisfies Daily30Response,
+        { headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -1,0 +1,336 @@
+import type { CardFrontSignals, StockCountry } from "@fomo/core";
+import {
+  buildDiscoveryResponse,
+  type DiscoveryDeckCardPayload,
+  type DiscoveryFrontSeed,
+  type DiscoveryResponse,
+  type DiscoveryStockPayload,
+} from "./discovery-supply";
+import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContentCard } from "./deck-content";
+
+export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
+
+export interface Daily30MetaCard {
+  id: string;
+  assetClass: Daily30AssetClass;
+  quietScore: number;
+  signalScore: number;
+  hypePenalty: number;
+}
+
+export interface Daily30Response extends DiscoveryResponse {
+  country: "all";
+  meta: {
+    targetCount: number;
+    cards: Daily30MetaCard[];
+    assetCounts: Record<Daily30AssetClass, number>;
+  };
+}
+
+type CandidateKind = "stock" | "content" | "narrative";
+
+interface Daily30Candidate {
+  kind: CandidateKind;
+  id: string;
+  card: DiscoveryDeckCardPayload;
+  stock?: DiscoveryStockPayload;
+  front?: DiscoveryFrontSeed;
+  assetClass: Daily30AssetClass;
+  sector?: string;
+  signalScore: number;
+  hypePenalty: number;
+  quietScore: number;
+}
+
+const DAILY_CARD_TARGET = 30;
+const FAMOUS_STOCKS = new Set([
+  "삼성전자",
+  "SK하이닉스",
+  "현대차",
+  "기아",
+  "NAVER",
+  "카카오",
+  "LG에너지솔루션",
+  "엔비디아",
+  "애플",
+  "마이크로소프트",
+  "알파벳",
+  "아마존",
+  "메타",
+  "테슬라",
+  "브로드컴",
+  "TSMC",
+  "월마트",
+  "버크셔해서웨이",
+]);
+
+const ASSET_CAPS: Record<Daily30AssetClass, number> = {
+  "kr-stock": 12,
+  "us-stock": 12,
+  coin: 3,
+  macro: 6,
+};
+
+function isStockCard(card: DiscoveryDeckCardPayload): card is { kind: "stock" } & DiscoveryStockPayload {
+  return !("kind" in card) || card.kind === "stock";
+}
+
+function isContentCard(card: DiscoveryDeckCardPayload): card is DeckContentCard {
+  return "kind" in card && card.kind === "content";
+}
+
+function isNarrativeCard(card: DiscoveryDeckCardPayload): boolean {
+  return "kind" in card && card.kind === "narrative";
+}
+
+function stockId(stock: Pick<DiscoveryStockPayload, "country" | "canonical" | "symbol" | "naverCode">): string {
+  return `stock:${stock.country}:${stock.symbol ?? stock.naverCode ?? stock.canonical}:${stock.canonical}`;
+}
+
+function stockAssetClass(stock: Pick<DiscoveryStockPayload, "country" | "market">): Daily30AssetClass {
+  return stock.market === "COIN" ? "coin" : stock.country === "US" ? "us-stock" : "kr-stock";
+}
+
+function contentAssetClass(card: DeckContentCard): Daily30AssetClass {
+  return card.contentType === "whale" || card.scope === "global" ? "coin" : "macro";
+}
+
+function frontSignals(front: DiscoveryFrontSeed | undefined): Partial<CardFrontSignals> {
+  return front?.signals ?? {};
+}
+
+function absoluteChange(front: DiscoveryFrontSeed | undefined): number {
+  const value = frontSignals(front).changePct;
+  return typeof value === "number" && Number.isFinite(value) ? Math.abs(value) : 0;
+}
+
+function hasPricedFront(front: DiscoveryFrontSeed | undefined): boolean {
+  return Boolean(front?.priceText) && (front?.sparkline?.length ?? 0) >= 2;
+}
+
+function signalText(stock: DiscoveryStockPayload): string {
+  return [stock.headline, stock.whyShown, stock.reason, stock.insightTag, stock.sourceLabel]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ");
+}
+
+function strongQuietSignal(stock: DiscoveryStockPayload): boolean {
+  return /내부자|자사주|임원|대주주|순매수|기관|외국인|거래량|공시|계약|수주|DART|SEC|Form\s?4|insider|purchase|disclosure/i.test(
+    signalText(stock)
+  );
+}
+
+function computeStockSignal(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): number {
+  const signals = frontSignals(front);
+  const change = absoluteChange(front);
+  const volumeRatio = typeof signals.volumeRatio === "number" && Number.isFinite(signals.volumeRatio) ? signals.volumeRatio : 0;
+  const axisCount = front?.axisSignals?.length ?? 0;
+  let score = 18;
+  if (stock.headline || stock.whyShown || stock.reason) score += 22;
+  score += Math.min(24, change * 2.4);
+  score += Math.min(18, Math.max(0, volumeRatio - 1) * 8);
+  score += Math.min(16, axisCount * 4);
+  if (strongQuietSignal(stock)) score += 18;
+  if (hasPricedFront(front)) score += 10;
+  return score;
+}
+
+function computeHypePenalty(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): number {
+  const signals = frontSignals(front);
+  const mentionScore = typeof signals.mentionScore === "number" && Number.isFinite(signals.mentionScore) ? signals.mentionScore : 0;
+  const marketCapRank =
+    signals.marketCapRank && typeof signals.marketCapRank === "object" && typeof signals.marketCapRank.rank === "number"
+      ? signals.marketCapRank.rank
+      : undefined;
+  let penalty = 0;
+  penalty += Math.min(25, mentionScore * 0.35);
+  if (stock.marquee) penalty += 28;
+  if (FAMOUS_STOCKS.has(stock.canonical)) penalty += 42;
+  if (typeof marketCapRank === "number") {
+    if (marketCapRank <= 30) penalty += 28;
+    else if (marketCapRank <= 100) penalty += 18;
+    else if (marketCapRank <= 250) penalty += 8;
+  }
+  if (absoluteChange(front) >= 15) penalty += 8;
+  return penalty;
+}
+
+function stockCandidate(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): Daily30Candidate | null {
+  if (FAMOUS_STOCKS.has(stock.canonical) && !strongQuietSignal(stock)) return null;
+  const signalScore = computeStockSignal(stock, front);
+  const hypePenalty = computeHypePenalty(stock, front);
+  const quietScore = signalScore - hypePenalty;
+  if (quietScore < 6 && !hasPricedFront(front)) return null;
+  return {
+    kind: "stock",
+    id: stockId(stock),
+    card: { kind: "stock", ...stock },
+    stock,
+    ...(front ? { front } : {}),
+    assetClass: stockAssetClass(stock),
+    sector: stock.sector,
+    signalScore,
+    hypePenalty,
+    quietScore,
+  };
+}
+
+function contentCandidate(card: DeckContentCard): Daily30Candidate | null {
+  if (!card.headline.trim() || card.facts.length === 0) return null;
+  const signalScore = card.contentType === "index" ? 42 : card.contentType === "macro" ? 38 : 34;
+  const hypePenalty = card.contentType === "whale" ? 6 : 2;
+  return {
+    kind: "content",
+    id: card.id,
+    card,
+    assetClass: contentAssetClass(card),
+    signalScore,
+    hypePenalty,
+    quietScore: signalScore - hypePenalty,
+  };
+}
+
+function narrativeCandidate(card: DiscoveryDeckCardPayload): Daily30Candidate | null {
+  if (!isNarrativeCard(card)) return null;
+  const record = card as Extract<DiscoveryDeckCardPayload, { kind: "narrative" }>;
+  if (!record.headline.trim() || record.stocks.length < 2) return null;
+  const signalScore = 46 + Math.min(16, record.stocks.length * 3);
+  const famousPenalty = record.stocks.some((stock) => FAMOUS_STOCKS.has(stock.name)) ? 20 : 0;
+  return {
+    kind: "narrative",
+    id: record.id,
+    card,
+    assetClass: record.scope === "US" ? "us-stock" : "kr-stock",
+    signalScore,
+    hypePenalty: famousPenalty,
+    quietScore: signalScore - famousPenalty,
+  };
+}
+
+function addStockCandidates(
+  out: Daily30Candidate[],
+  discovery: DiscoveryResponse,
+  seen: Set<string>
+): void {
+  const cards = discovery.cards?.length ? discovery.cards : discovery.stocks.map((stock) => ({ kind: "stock", ...stock }) satisfies DiscoveryDeckCardPayload);
+  for (const card of cards) {
+    if (isStockCard(card)) {
+      const stock = card;
+      const id = stockId(stock);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const candidate = stockCandidate(stock, discovery.fronts[stock.canonical]);
+      if (candidate) out.push(candidate);
+      continue;
+    }
+    const narrative = narrativeCandidate(card);
+    if (narrative && !seen.has(narrative.id)) {
+      seen.add(narrative.id);
+      out.push(narrative);
+    }
+  }
+  for (const stock of discovery.stocks) {
+    const id = stockId(stock);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const candidate = stockCandidate(stock, discovery.fronts[stock.canonical]);
+    if (candidate) out.push(candidate);
+  }
+}
+
+function addContentCandidates(out: Daily30Candidate[], content: readonly DeckContentCard[], seen: Set<string>): void {
+  for (const card of content) {
+    const candidate = contentCandidate(card);
+    if (!candidate || seen.has(candidate.id)) continue;
+    seen.add(candidate.id);
+    out.push(candidate);
+  }
+}
+
+export function selectDaily30Candidates(candidates: readonly Daily30Candidate[], targetCount = DAILY_CARD_TARGET): Daily30Candidate[] {
+  const ranked = [...candidates].sort((a, b) => b.quietScore - a.quietScore || a.id.localeCompare(b.id));
+  const selected: Daily30Candidate[] = [];
+  const seen = new Set<string>();
+  const assetCounts: Record<Daily30AssetClass, number> = { "kr-stock": 0, "us-stock": 0, coin: 0, macro: 0 };
+  const sectorCounts = new Map<string, number>();
+
+  const tryTake = (candidate: Daily30Candidate, enforceCaps: boolean): boolean => {
+    if (seen.has(candidate.id)) return false;
+    if (enforceCaps && assetCounts[candidate.assetClass] >= ASSET_CAPS[candidate.assetClass]) return false;
+    if (enforceCaps && candidate.sector && (sectorCounts.get(candidate.sector) ?? 0) >= 5) return false;
+    selected.push(candidate);
+    seen.add(candidate.id);
+    assetCounts[candidate.assetClass] += 1;
+    if (candidate.sector) sectorCounts.set(candidate.sector, (sectorCounts.get(candidate.sector) ?? 0) + 1);
+    return selected.length >= targetCount;
+  };
+
+  for (const candidate of ranked) {
+    if (tryTake(candidate, true)) return selected;
+  }
+  for (const candidate of ranked) {
+    if (tryTake(candidate, false)) return selected;
+  }
+  return selected;
+}
+
+function responseFromSelected(
+  selected: readonly Daily30Candidate[],
+  discoveries: readonly DiscoveryResponse[],
+  asOf: string
+): Daily30Response {
+  const fronts: Record<string, DiscoveryFrontSeed> = {};
+  const stocks: DiscoveryStockPayload[] = [];
+  const stockById = new Map<string, DiscoveryStockPayload>();
+  for (const discovery of discoveries) {
+    for (const [ticker, front] of Object.entries(discovery.fronts)) fronts[ticker] = front;
+  }
+  for (const candidate of selected) {
+    if (!candidate.stock) continue;
+    if (stockById.has(candidate.id)) continue;
+    stockById.set(candidate.id, candidate.stock);
+    stocks.push(candidate.stock);
+  }
+  const assetCounts: Record<Daily30AssetClass, number> = { "kr-stock": 0, "us-stock": 0, coin: 0, macro: 0 };
+  for (const candidate of selected) assetCounts[candidate.assetClass] += 1;
+  return {
+    asOf,
+    country: "all",
+    stocks,
+    cards: selected.map((candidate) => candidate.card),
+    fronts,
+    confidence: selected.length >= DAILY_CARD_TARGET ? "H" : selected.length >= 20 ? "M" : "L",
+    source: "KR/US discovery·수급·내부자·거래량·고래·매크로 통합 quietScore",
+    meta: {
+      targetCount: DAILY_CARD_TARGET,
+      cards: selected.map((candidate) => ({
+        id: candidate.id,
+        assetClass: candidate.assetClass,
+        quietScore: Number(candidate.quietScore.toFixed(2)),
+        signalScore: Number(candidate.signalScore.toFixed(2)),
+        hypePenalty: Number(candidate.hypePenalty.toFixed(2)),
+      })),
+      assetCounts,
+    },
+  };
+}
+
+export async function buildDaily30Response(): Promise<Daily30Response> {
+  const [kr, us, rawContent] = await Promise.all([
+    buildDiscoveryResponse({ country: "KR", targetedMaterial: true, targetedMaterialLimit: 36 }),
+    buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 12 }),
+    fetchDeckContentCards().catch(() => [] as DeckContentCard[]),
+  ]);
+  const content = [
+    ...expandDeckContentCardsForScope(rawContent, "domestic", 3),
+    ...expandDeckContentCardsForScope(rawContent, "world", 3),
+    ...expandDeckContentCardsForScope(rawContent, "global", 2),
+  ];
+  const candidates: Daily30Candidate[] = [];
+  const seen = new Set<string>();
+  addStockCandidates(candidates, kr, seen);
+  addStockCandidates(candidates, us, seen);
+  addContentCandidates(candidates, content, seen);
+  const selected = selectDaily30Candidates(candidates, DAILY_CARD_TARGET);
+  return responseFromSelected(selected, [kr, us], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,5 +2,11 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && npm ci",
   "buildCommand": "cd ../.. && npx prisma generate && npm run build:web",
-  "outputDirectory": ".next-build"
+  "outputDirectory": ".next-build",
+  "crons": [
+    {
+      "path": "/api/fomo/cron/daily-30",
+      "schedule": "0 21 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add cached /api/fomo/daily-30 and cron prewarm for a unified 30-card feed
- rank KR/US stock, narrative, macro, and whale candidates with quietScore = signal strength - hype penalty
- switch the web home card tab to a single unified deck and remove login/onboarding gates from first load
- allow the web BFF to proxy daily-30 and accept scoped content cards in discovery validation

## Validation
- npm run typecheck
- npm run test -- daily-30 discovery-country-scope browser-auth-security
- npm run build:web
- npm run build:fomo-web
- local buildDaily30Response smoke: cards=30, stocks=24, confidence=H, assetCounts={kr-stock:15, us-stock:9, coin:2, macro:4}
