### PR TITLE
Require priced fronts in daily 30 feed

### DIFF
--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -156,11 +156,12 @@ function computeHypePenalty(stock: DiscoveryStockPayload, front: DiscoveryFrontS
 }
 
 function stockCandidate(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): Daily30Candidate | null {
+  if (!hasPricedFront(front)) return null;
   if (FAMOUS_STOCKS.has(stock.canonical) && !strongQuietSignal(stock)) return null;
   const signalScore = computeStockSignal(stock, front);
   const hypePenalty = computeHypePenalty(stock, front);
   const quietScore = signalScore - hypePenalty;
-  if (quietScore < 6 && !hasPricedFront(front)) return null;
+  if (quietScore < 6) return null;
   return {
     kind: "stock",
     id: stockId(stock),


### PR DESCRIPTION
## Summary
- only allow stock cards into /api/fomo/daily-30 when a cached front has priceText and sparkline data
- keeps content cards as fallback, but prevents stock cards from rendering as chart/price placeholders

## Validation
- npm run typecheck
- npm run test -- daily-30 discovery-country-scope browser-auth-security
- local buildDaily30Response smoke: cards=30, stockCards=23, priced=23, spark=23
