### PR TITLE
feat(discovery): 내부자 카드 현재가·미니차트 복구 (Nasdaq)

### DIFF
--- a/apps/web/lib/insider-source.ts
+++ b/apps/web/lib/insider-source.ts
@@ -2,11 +2,14 @@
  * 내부자 클러스터 매수 발굴 소스 (US, DATA_ENGINE_STRATEGY 선행/수급 축).
  *
  * openinsider "latest cluster buys"(여러 내부자가 동반 매수한 공개시장 매수, SEC Form 4 집계)를
- * 매일 수집해 조용한 종목까지 발굴 카드로 띄운다. 현재가/스파크라인은 Yahoo chart(무료·무차단)로 보강한다.
+ * 매일 수집해 조용한 종목까지 발굴 카드로 띄운다. 현재가/스파크라인은 Nasdaq(Vercel egress 통과)
+ * 우선·Yahoo 폴백으로 보강한다.
  *
  * 순수 데이터(LLM 0). 관측 서술만 — 매수·매도 판단/예측 없음.
  * openinsider가 막히거나 비면 조용히 빈 배열(fail-open) — 제품은 기존 US 유니버스로 정상 동작.
  */
+
+import { fetchNasdaqQuote } from "./us-market-source";
 
 const OPENINSIDER_CLUSTER_URL = "http://openinsider.com/latest-cluster-buys";
 /** Yahoo chart 호스트 폴백(둘 다 429 나면 시세는 best-effort 생략, 카드는 openinsider 근거로 정상). */
@@ -157,6 +160,20 @@ function dedupeAndRank(rows: InsiderClusterBuy[]): InsiderClusterBuy[] {
   return [...best.values()].sort((a, b) => b.valueUsd - a.valueUsd).slice(0, MAX_CLUSTER_ROWS);
 }
 
+/** 시세 보강: Nasdaq(Vercel egress 통과) 우선, 실패 시 Yahoo 폴백. */
+async function fetchSymbolQuote(symbol: string): Promise<InsiderClusterQuote | undefined> {
+  const nasdaq = await fetchNasdaqQuote(symbol).catch(() => null);
+  if (nasdaq) {
+    return {
+      price: nasdaq.price,
+      currency: "USD",
+      ...(typeof nasdaq.changePct === "number" ? { changePct: nasdaq.changePct } : {}),
+      ...(nasdaq.sparkline && nasdaq.sparkline.length >= 2 ? { sparkline: nasdaq.sparkline } : {}),
+    };
+  }
+  return fetchYahooQuote(symbol);
+}
+
 async function fetchYahooQuote(symbol: string): Promise<InsiderClusterQuote | undefined> {
   let text: string | null = null;
   for (const host of YAHOO_CHART_HOSTS) {
@@ -217,6 +234,6 @@ export async function fetchInsiderClusterCandidates(): Promise<InsiderClusterCan
   if (!html) return [];
   const ranked = dedupeAndRank(parseOpenInsiderClusterBuys(html));
   if (ranked.length === 0) return [];
-  const quotes = await mapLimit(ranked, YAHOO_CONCURRENCY, (row) => fetchYahooQuote(row.symbol).catch(() => undefined));
+  const quotes = await mapLimit(ranked, YAHOO_CONCURRENCY, (row) => fetchSymbolQuote(row.symbol).catch(() => undefined));
   return ranked.map((row, i) => ({ ...row, ...(quotes[i] ? { quote: quotes[i] } : {}) }));
 }

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -432,6 +432,52 @@ async function fetchNasdaqDaily(seed: UsDiscoverySymbol): Promise<DiscoveryMarke
   return parseNasdaqRow(seed, parseNasdaqHistorical(await res.json()));
 }
 
+export interface NasdaqSymbolQuote {
+  price: number;
+  changePct?: number;
+  sparkline?: number[];
+  sessionLabel?: string;
+}
+
+/**
+ * 임의 US 심볼의 시세(현재가·등락·스파크라인) — api.nasdaq.com historical 재사용.
+ * Yahoo egress 차단·TwelveData 쿼터와 무관하게 Vercel 에서 동작(스크리너와 동일 경로).
+ * 실패 시 null(fail-open).
+ */
+export async function fetchNasdaqQuote(symbol: string): Promise<NasdaqSymbolQuote | null> {
+  const sym = symbol.trim().toUpperCase();
+  if (!sym) return null;
+  const { from, to } = historyRange();
+  const url = new URL(`${NASDAQ_HISTORICAL_URL}/${encodeURIComponent(sym)}/historical`);
+  url.searchParams.set("assetclass", "stocks");
+  url.searchParams.set("fromdate", from);
+  url.searchParams.set("todate", to);
+  url.searchParams.set("limit", "42");
+  const res = await fetch(url.toString(), {
+    headers: {
+      accept: "application/json, text/plain, */*",
+      "user-agent": NASDAQ_UA,
+      origin: "https://www.nasdaq.com",
+      referer: "https://www.nasdaq.com/",
+    },
+    signal: AbortSignal.timeout(6_000),
+    next: { revalidate: 1_800 },
+  }).catch(() => null);
+  if (!res || !res.ok) return null;
+  const points = parseNasdaqHistorical(await res.json().catch(() => null)).filter((p) => Number.isFinite(p.close));
+  if (points.length < 1) return null;
+  const latest = points.at(-1)!;
+  const previous = points.length >= 2 ? points.at(-2) : undefined;
+  const changePct = previous && previous.close !== 0 ? ((latest.close - previous.close) / previous.close) * 100 : undefined;
+  const sparkline = points.slice(-30).map((p) => p.close);
+  return {
+    price: latest.close,
+    ...(typeof changePct === "number" ? { changePct } : {}),
+    ...(sparkline.length >= 2 ? { sparkline } : {}),
+    sessionLabel: usSessionAsOfLabel(latest.date).label,
+  };
+}
+
 async function fetchNasdaqRows(seeds: readonly UsDiscoverySymbol[]): Promise<DiscoveryMarketRow[]> {
   const settled = await mapLimit(seeds.slice(0, US_NASDAQ_FALLBACK_LIMIT), US_NASDAQ_FALLBACK_CONCURRENCY, fetchNasdaqDaily);
   return settled


### PR DESCRIPTION
## 왜
#793/#794로 내부자 발굴 카드는 라이브지만 US 현재가/미니차트가 비어 있었다 (Yahoo egress 429 + TwelveData 쿼터).

## 무엇을
이 레포가 **이미 프로덕션에서 쓰는 `api.nasdaq.com/historical`** 경로(스크리너 폴백과 동일, Vercel egress 통과)를 임의 심볼용으로 노출: `us-market-source::fetchNasdaqQuote`. 내부자 소스가 **Nasdaq 우선 · Yahoo 폴백**으로 현재가/등락/스파크라인 보강.

## 검증
- 실측 `fetchInsiderClusterCandidates()`: 후보 20개 중 **19개 현재가 + 30봉 스파크라인 확보**(신규 상장만 봉 적음). 예: LILA $7.92(취득가 $8.90), PSUS $38.88(취득가 $49.92).
- 카드 = 현재가(헤더/미니차트) + 취득가(내부자 진입선) 병기.
- typecheck ✅, guard:discovery ✅(KR 불변), spec:analyze error 0.
- 새 외부 의존성 0 — 기존 Nasdaq 경로 재사용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)