### PR TITLE
feat(verdict): Conviction Card Phase 1 — 카드 판단 층 장착

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1092,6 +1092,113 @@ function ChartAnalysisTab({ ta, basisDays }: { ta?: StockFrontResponse["ta"]; ba
   );
 }
 
+// 판단 층(WO Phase 1) — 와이코프 국면 표기(뎁스 문단용).
+const DEPTH_PHASE_TEXT: Record<string, string> = {
+  accumulation: "저점권 횡보에 거래가 수축된 축적형 구조",
+  markup: "이동평균 정배열에 거래량이 붙은 상승 국면",
+  distribution: "고점권에서 거래는 늘고 가격은 정체된 분산형 구조",
+  markdown: "이동평균 역배열에 저점을 갱신 중인 하락 국면",
+};
+
+const DEPTH_CONFIDENCE_TEXT: Record<string, string> = {
+  high: "여러 신호가 같은 방향을 가리키고 있어요.",
+  medium: "근거가 일부 신호에 몰려 있어 무게는 중간이에요.",
+  low: "신뢰도는 낮은 편이라 가볍게 봐야 해요.",
+};
+
+/** 뎁스 3문단(왜 사나/뭘 보고 있나/언제 틀리나) — verdict+관찰 신호에서 결정론 조립. 30초 독해. */
+function buildConvictionParagraphs(
+  front: StockFrontResponse | null,
+  insight: CondensedInsight | null
+): { why: string; watching: string; wrong: string } {
+  const verdict = front?.verdict;
+  const points = buildReadPoints(front, insight);
+
+  const why: string[] = [];
+  if (verdict) {
+    why.push(verdict.stanceText);
+    if (verdict.evidence.length > 0) why.push(`확인된 근거는 ${verdict.evidence.join(" / ")}.`);
+    else why.push("확인된 근거는 아직 얇아요.");
+    why.push(DEPTH_CONFIDENCE_TEXT[verdict.confidence] ?? "");
+  } else {
+    why.push("아직 판단을 세울 만큼 가격 데이터가 쌓이지 않았어요.");
+    why.push("카드에 보인 재료와 아래 신호만 확인하고, 판단은 보류하는 게 맞아요.");
+  }
+
+  const watching: string[] = [];
+  if (verdict?.phase && DEPTH_PHASE_TEXT[verdict.phase]) {
+    watching.push(`차트 구조는 ${DEPTH_PHASE_TEXT[verdict.phase]}로 읽혀요.`);
+  } else {
+    watching.push("국면을 확정할 만큼 차트 구조가 뚜렷하진 않아요.");
+  }
+  const foreignStreak = front?.signals.foreignNetStreak;
+  const instStreak = front?.signals.institutionNetStreak;
+  if (typeof foreignStreak === "number" && foreignStreak !== 0) {
+    watching.push(`수급은 외국인이 ${Math.abs(foreignStreak)}일 연속 ${foreignStreak > 0 ? "순매수" : "순매도"} 중이에요.`);
+  } else if (typeof instStreak === "number" && instStreak !== 0) {
+    watching.push(`수급은 기관이 ${Math.abs(instStreak)}일 연속 ${instStreak > 0 ? "순매수" : "순매도"} 중이에요.`);
+  }
+  const taText = front?.taFact ? translateTaFact(front.taFact) : undefined;
+  if (taText) watching.push(taText);
+  const material = insight && insight.confidence !== "insufficient" ? cleanText(insight.whyHot).split(/(?<=요\.|다\.)/)[0]?.trim() : undefined;
+  if (material && watching.length < 4) watching.push(material);
+
+  const wrong: string[] = [];
+  wrong.push(verdict?.invalidation ?? "무효화 레벨을 계산할 가격 데이터가 아직 부족해요.");
+  const counter = points.bear[0]?.text;
+  if (counter && !wrong[0]!.includes(counter)) wrong.push(`반대쪽 신호로는 ${counter.replace(/\.$/, "")}는 점도 있어요.`);
+  wrong.push("이 조건을 벗어나면 관점을 버리고 다시 관찰로 돌아가는 게 규칙이에요.");
+
+  return {
+    why: why.filter(Boolean).join(" "),
+    watching: watching.filter(Boolean).slice(0, 4).join(" "),
+    wrong: wrong.filter(Boolean).slice(0, 4).join(" "),
+  };
+}
+
+/** 뎁스 본문 — 딱 3문단. 섹션 나열식 폐기(WO Phase 1). 원문 근거 링크는 하단 OfficialFactsBlock 유지. */
+function ConvictionParagraphs({
+  front,
+  insight,
+}: {
+  front: StockFrontResponse | null;
+  insight: CondensedInsight | null;
+}) {
+  const p = buildConvictionParagraphs(front, insight);
+  const stance = front?.verdict?.stance;
+  const stanceMeta =
+    stance === "enter"
+      ? { label: "진입 검토", color: "#D8FF3A" }
+      : stance === "avoid"
+        ? { label: "회피", color: "#8A8A86" }
+        : stance === "watch"
+          ? { label: "관망", color: "#C9C9C4" }
+          : undefined;
+  const blocks: Array<{ title: string; body: string }> = [
+    { title: "왜 사나", body: p.why },
+    { title: "뭘 보고 있나", body: p.watching },
+    { title: "언제 틀리나", body: p.wrong },
+  ];
+  return (
+    <section className="mt-6 space-y-4">
+      {stanceMeta && (
+        <span
+          className="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-bold"
+          style={{ borderColor: stanceMeta.color, color: stanceMeta.color }}
+        >
+          {stanceMeta.label}
+        </span>
+      )}
+      {blocks.map((block) => (
+        <div key={block.title} className="rounded-2xl border border-hairline bg-surface px-4 py-4">
+          <p className="font-pixel text-sm text-whiteout">{block.title}</p>
+          <p className="mt-2 text-sm leading-6 text-whiteout">{block.body}</p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
 export function StockInsightView({
   stock,
   context,
@@ -1234,52 +1341,11 @@ export function StockInsightView({
           {/* 차트 — 가격 다음으로 현재 흐름을 확인. */}
           <DetailChart front={front} />
 
-          <StockSynthesisBlock
-            front={front}
-            insight={insight}
-            contextReason={contextReason}
-            contextSourceLabel={context?.sourceLabel}
-          />
+          {/* 뎁스 본문 — 딱 3문단(왜 사나/뭘 보고 있나/언제 틀리나). 30초 독해(WO Phase 1). */}
+          <ConvictionParagraphs front={front} insight={insight} />
 
-          {/* 핵심 해석 — 강세/약세 원문이 부족해도 가격·차트·수급으로 읽을 재료를 먼저 보여준다. */}
-          <StockReadGuide front={front} insight={insight} loading={false} context={context} />
-
-          {/* 포모 상태 — 카드와 같은 단일 출처지만, 상세의 첫 주인공은 가격/차트가 담당. */}
-          <div className="mt-6">
-            <FomoHero
-              front={front}
-              {...(context?.axisHeadline ? { headlineOverride: context.axisHeadline } : {})}
-              {...(front?.signals.marketCapRank ? { rankLabel: `시총 ${front.signals.marketCapRank.rank}위` } : {})}
-            />
-          </div>
-
-          {/* 원문/공식 데이터 — 있으면 보여주고, 없으면 위 '오늘 읽는 법'에서 부족 상태를 이미 설명한다. */}
-          {hasInsight && (
-            <section className="mt-6">
-              <p className="font-pixel text-sm text-whiteout">원문 요약</p>
-              <p className="mt-2 text-sm leading-6 text-muted">{cleanText(insight!.whyHot)}</p>
-              {insight!.lean.bullCount + insight!.lean.bearCount > 0 && (
-                <p className="mt-2 text-[11px] leading-5 text-muted">
-                  원문 쏠림 · <span style={{ color: "var(--up, #ff5a5f)" }}>강세 {insight!.lean.bullCount}</span>
-                  {" : "}
-                  <span style={{ color: "var(--down, #4f8cff)" }}>약세 {insight!.lean.bearCount}</span>
-                  {insight!.lean.oneSided ? " · 반대 관점 안 보임" : ""}
-                </p>
-              )}
-              {insight!.singleOutlet && insight!.outlets.length > 0 && (
-                <p className="mt-2 rounded-lg border border-hairline bg-surface px-3 py-2 text-[11px] leading-5 text-muted">
-                  오늘은 <span className="text-whiteout">{insight!.outlets[0]}</span> 한 곳 기준이에요.
-                </p>
-              )}
-            </section>
-          )}
-
+          {/* 원문 근거 링크 — 하단 유지. */}
           <OfficialFactsBlock facts={insight?.officialFacts} />
-          <CommunityWordingBlock insight={insight} />
-
-          <div className="mt-7">
-            <StockFundamentalsBlock basics={basics} front={front} />
-          </div>
 
           {showThinSourceFootnote && (
             <p className="mt-5 text-[12px] leading-5 text-muted">

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -5,6 +5,7 @@ import { fomoCardView, computeFomoScore, selectFomoHook, sparklinePath } from "@
 import type {
   AxisSignal,
   CardFrontSignals,
+  CardVerdict,
   FomoScoreResult,
   FomoCardView,
   MultiAxisHookSelection,
@@ -55,6 +56,7 @@ export type FrontEntry = {
   feedBear?: FeedSignalPoint;
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;
+  verdict?: CardVerdict;
 };
 
 type UndoEntry = {
@@ -293,9 +295,44 @@ function BundleCardFace({ bundle, progress }: { bundle: DeckThemeBundle; progres
   );
 }
 
+// 판단 층(WO Phase 1) stance 표기 — enter=라임(발견 액센트), watch=중립, avoid=회색. 공포색 금지.
+const STANCE_META: Record<CardVerdict["stance"], { label: string; color: string }> = {
+  enter: { label: "진입 검토", color: NEON },
+  watch: { label: "관망", color: "#C9C9C4" },
+  avoid: { label: "회피", color: "#8A8A86" },
+};
+
+/** 카드 판단 층 — 판단 1줄 + 근거 최대 3 + 무효화 1줄. 스와이프 UX 불변, 카드 안에서 스크롤 없음. */
+function VerdictBlock({ verdict }: { verdict: CardVerdict }) {
+  const meta = STANCE_META[verdict.stance];
+  return (
+    <div className="mt-2.5 shrink-0 rounded-lg border border-hairline bg-white/[0.035] px-3 py-2">
+      <p className="text-sm leading-5 text-whiteout" style={clampStyle(2)}>
+        <span className="font-bold" style={{ color: meta.color }}>
+          {meta.label}
+        </span>
+        <span className="mx-1.5 text-muted/60">·</span>
+        {verdict.stanceText}
+      </p>
+      {verdict.evidence.length > 0 && (
+        <ul className="mt-1.5 space-y-0.5">
+          {verdict.evidence.slice(0, 3).map((line, i) => (
+            <li key={`ev-${i}`} className="text-xs leading-4 text-muted" style={clampStyle(1)}>
+              · {line}
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="mt-1.5 text-[10px] leading-4 text-muted/80" style={clampStyle(1)}>
+        {verdict.invalidation}
+      </p>
+    </div>
+  );
+}
+
 /**
  * 종목 카드 앞면 — 포모 점수(척추 ②, 단일 출처)로 점수·라벨·헤드라인·톤. 휴리스틱 대체.
- * 정체성 / 현재가 / 포모점수+라벨 / 테마태그 / 헤드라인 / 스파크라인 / 재료. 점수=주목도(품질 아님), 예측 0.
+ * 정체성 / 현재가 / 포모점수+라벨 / 테마태그 / 헤드라인 / 판단 층 / 스파크라인. 점수=주목도(품질 아님).
  */
 function StockCardFace({
   stock,
@@ -311,6 +348,7 @@ function StockCardFace({
   feedBull,
   feedBear,
   why,
+  verdict,
   progress,
 }: {
   stock: DeckStock;
@@ -326,6 +364,7 @@ function StockCardFace({
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
   why?: string | undefined;
+  verdict?: CardVerdict | undefined;
   progress?: string | undefined;
 }) {
   const displayChangeText = normalizeChangeText(changeText);
@@ -391,23 +430,30 @@ function StockCardFace({
         {view.headline}
       </p>
 
-      {why && (
-        <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
-          <span className="shrink-0 text-[10px] leading-5 text-muted">이유</span>
-          <span className="min-w-0 flex-1 text-sm leading-5 text-whiteout" style={clampStyle(1)}>
-            {why}
-          </span>
-        </div>
-      )}
+      {/* 판단 층(WO Phase 1) — 있으면 이유/신호 스트립을 대체(카드 밀도 유지, 스크롤 금지). */}
+      {verdict ? (
+        <VerdictBlock verdict={verdict} />
+      ) : (
+        <>
+          {why && (
+            <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
+              <span className="shrink-0 text-[10px] leading-5 text-muted">이유</span>
+              <span className="min-w-0 flex-1 text-sm leading-5 text-whiteout" style={clampStyle(1)}>
+                {why}
+              </span>
+            </div>
+          )}
 
-      <FeedSignalStrip bull={feedBull} bear={feedBear} />
+          <FeedSignalStrip bull={feedBull} bear={feedBear} />
 
-      {subLine && !why && !feedBull && !feedBear && (
-        <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
-          <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
-            {subLine}
-          </span>
-        </div>
+          {subLine && !why && !feedBull && !feedBear && (
+            <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
+              <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
+                {subLine}
+              </span>
+            </div>
+          )}
+        </>
       )}
 
       {/* 미니 스파크라인(최근 흐름) — lite 응답도 짧은 라인차트를 싣는다. */}
@@ -554,6 +600,7 @@ export function StockSwipeDeck({
               ...(d.feedBear ? { feedBear: d.feedBear } : {}),
               ...(d.axisSignals ? { axisSignals: d.axisSignals } : {}),
               ...(d.axisHook ? { axisHook: d.axisHook } : {}),
+              ...(d.verdict ? { verdict: d.verdict } : {}),
             },
           }))
         )
@@ -654,6 +701,7 @@ export function StockSwipeDeck({
         feedBull={deduped.feedBull}
         feedBear={deduped.feedBear}
         why={deduped.why}
+        verdict={e?.verdict}
         progress={progress}
       />
     );

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -399,6 +399,8 @@ export interface StockFrontResponse {
   feedBear?: FeedSignalPoint;
   axisSignals?: import("@fomo/core").AxisSignal[];
   axisHook?: import("@fomo/core").MultiAxisHookSelection;
+  /** 판단 층(WO Phase 1) — stance/근거/무효화. 캔들 부족 종목은 없음. */
+  verdict?: import("@fomo/core").CardVerdict;
 }
 
 export interface FeedSignalPoint {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -17,6 +17,9 @@ import {
   selectMultiAxisHook,
   stockMentionRole,
   synthesizeDiscoveryInsight,
+  computeCardVerdict,
+  type CardVerdict,
+  type DailyOhlcv,
   type AxisSignal,
   type CardFrontSignals,
   type DiscoveryCandidate,
@@ -131,6 +134,8 @@ export interface DiscoveryFrontSeed {
   changeDir?: "up" | "down" | "flat";
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;
+  /** 판단 층(WO Phase 1) — 캔들이 있는 종목만(가짜 판단 금지). */
+  verdict?: CardVerdict;
 }
 
 export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {
@@ -1671,6 +1676,41 @@ function frontSeed(
   };
 }
 
+/**
+ * 덱 카드 판단 층 — 실제 캔들 + 확인된 이벤트(수급 streak·내부자·재료·거래량)만 입력.
+ * 캔들이 없으면(주로 US 덱 경로) 판단을 만들지 않는다 — 가짜 판단 금지.
+ */
+function verdictForCandidate(candidate: DiscoveryCandidate, candles: readonly DailyOhlcv[]): CardVerdict | undefined {
+  if (candles.length === 0) return undefined;
+  let foreignNetStreak: number | undefined;
+  let institutionNetStreak: number | undefined;
+  let insiderConfirmed = false;
+  let materialStrength: number | undefined;
+  let volumeRatio: number | undefined;
+  for (const event of candidate.events) {
+    if (event.kind === "flow_entry" && typeof event.flowDays === "number") {
+      if (event.flowActor === "foreign") foreignNetStreak = event.flowDays;
+      if (event.flowActor === "institution") institutionNetStreak = event.flowDays;
+    }
+    if (event.insiderPurchase === true) insiderConfirmed = true;
+    if ((event.kind === "news_mention" || event.kind === "disclosure") && Number.isFinite(event.strength)) {
+      materialStrength = Math.max(materialStrength ?? 0, Math.max(0, Math.min(1, event.strength)));
+    }
+    if (event.kind === "volume_spike" && typeof event.volumeRatio === "number") {
+      volumeRatio = event.volumeRatio;
+    }
+  }
+  return computeCardVerdict({
+    candles,
+    ...(typeof foreignNetStreak === "number" ? { foreignNetStreak } : {}),
+    ...(typeof institutionNetStreak === "number" ? { institutionNetStreak } : {}),
+    ...(insiderConfirmed ? { insider: { confirmed: true } } : {}),
+    ...(typeof materialStrength === "number" ? { materialStrength } : {}),
+    ...(typeof volumeRatio === "number" ? { volumeRatio } : {}),
+    currency: candidate.country === "US" ? "USD" : "KRW",
+  });
+}
+
 function relationCopy(relation: RelatedNode["relation"]): string {
   switch (relation) {
     case "customer":
@@ -2152,6 +2192,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     if (!row) continue;
     const attention = attentionMap[candidate.ticker];
     const front = frontSeed(row, candidate, attention, themeSignals.get(candidate.ticker), sparklineByTicker.get(candidate.ticker) ?? []);
+    const verdict = verdictForCandidate(candidate, dailyByTicker.get(candidate.ticker)?.candles ?? []);
+    if (verdict) front.verdict = verdict;
     const stock = await stockPayload(row, candidate, front);
     const headline = stock.headline?.trim();
     if (stock.headlineProvenance?.provenance === "suppressed" || !headline) {

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -10,6 +10,8 @@ import {
   selectMultiAxisHook,
   computeTechnicalAnalysis,
   selectTaFact,
+  computeCardVerdict,
+  type CardVerdict,
   type CardFrontSignals,
   type FomoScoreResult,
   type DailyOhlcv,
@@ -163,6 +165,8 @@ export interface StockFrontData {
   axisSignals?: AxisSignal[];
   /** 다축 후킹 대표 문장. 카드/상세 헤드라인의 우선 출처. */
   axisHook?: MultiAxisHookSelection;
+  /** 판단 층(WO Phase 1) — 결정론 verdict 엔진. 캔들 부족 시 생략(가짜 판단 금지). */
+  verdict?: CardVerdict;
 }
 
 export interface StockFrontOptions {
@@ -362,11 +366,20 @@ export async function assembleStockFront(
     const feedPoints = buildFeedPoints(signals, cachedFront?.changeDir, cachedFront?.changeText);
     const axisSignals = buildAxisSignals({ signals });
     const axisHook = selectMultiAxisHook(axisSignals);
+    const verdict = computeCardVerdict({
+      candles: daily.candles,
+      ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
+      ...(signals.newsEventLabel && typeof signals.mentionScore === "number"
+        ? { materialStrength: signals.mentionScore / 100 }
+        : {}),
+      currency: "USD",
+    });
     return {
       signals,
       fomo,
       ...(taFact ? { taFact } : {}),
       ta,
+      ...(verdict ? { verdict } : {}),
       sparkline,
       ...(cachedFront?.priceText ? { priceText: cachedFront.priceText } : {}),
       ...(cachedFront?.changeText ? { changeText: cachedFront.changeText } : {}),
@@ -416,12 +429,23 @@ export async function assembleStockFront(
   const feedPoints = buildFeedPoints(signals, basics?.changeDir, basics?.changeText);
   const axisSignals = buildAxisSignals({ signals });
   const axisHook = selectMultiAxisHook(axisSignals);
+  const verdict = computeCardVerdict({
+    candles: daily.candles,
+    ...(typeof signals.foreignNetStreak === "number" ? { foreignNetStreak: signals.foreignNetStreak } : {}),
+    ...(typeof signals.institutionNetStreak === "number" ? { institutionNetStreak: signals.institutionNetStreak } : {}),
+    ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
+    ...(signals.newsEventLabel && typeof signals.mentionScore === "number"
+      ? { materialStrength: signals.mentionScore / 100 }
+      : {}),
+    currency: "KRW",
+  });
 
   return {
     signals,
     fomo,
     ...(taFact ? { taFact } : {}),
     ...(ta ? { ta } : {}),
+    ...(verdict ? { verdict } : {}),
     sparkline: daily.closes.slice(lite ? -42 : -66),
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),

--- a/packages/fomo-core/__tests__/verdict.test.ts
+++ b/packages/fomo-core/__tests__/verdict.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCardVerdict,
+  formatVerdictLevel,
+  type DailyOhlcv,
+  type VerdictInput,
+} from "../src";
+
+/** 구간별 선형 보간 캔들 생성 — 결정론(난수 없음). */
+function mkCandles(segments: Array<{ days: number; from: number; to: number; vol: number }>): DailyOhlcv[] {
+  const out: DailyOhlcv[] = [];
+  let prevClose: number | undefined;
+  for (const seg of segments) {
+    for (let i = 0; i < seg.days; i += 1) {
+      const t = seg.days === 1 ? 1 : i / (seg.days - 1);
+      const close = seg.from + (seg.to - seg.from) * t;
+      out.push({
+        open: prevClose ?? close,
+        high: close * 1.01,
+        low: close * 0.99,
+        close,
+        volume: seg.vol,
+      });
+      prevClose = close;
+    }
+  }
+  return out;
+}
+
+/** 축적형: 하락 → 저점권 횡보 + 거래 수축(최근 20일 거래량 < 직전 20일). */
+function accumulationCandles(): DailyOhlcv[] {
+  return [
+    ...mkCandles([{ days: 80, from: 20000, to: 10000, vol: 1_000_000 }]),
+    ...mkCandles([{ days: 40, from: 10200, to: 10250, vol: 800_000 }]),
+    ...mkCandles([{ days: 20, from: 10250, to: 10200, vol: 480_000 }]),
+  ];
+}
+
+/** 상승형: 지그재그 상승(RSI 과열 방지) + 최근 거래 확대. */
+function markupCandles(): DailyOhlcv[] {
+  const out: DailyOhlcv[] = [];
+  let close = 10000;
+  for (let i = 0; i < 140; i += 1) {
+    close *= i % 2 === 0 ? 1.015 : 0.991;
+    const vol = i >= 120 ? 1_400_000 : 1_000_000;
+    out.push({ open: close / 1.01, high: close * 1.01, low: close * 0.99, close, volume: vol });
+  }
+  return out;
+}
+
+/** 분산형: 급등 후 고점권 정체 + 거래 확대. */
+function distributionCandles(): DailyOhlcv[] {
+  return [
+    ...mkCandles([{ days: 100, from: 10000, to: 20000, vol: 900_000 }]),
+    ...mkCandles([{ days: 20, from: 19900, to: 19800, vol: 1_000_000 }]),
+    ...mkCandles([{ days: 20, from: 19850, to: 19900, vol: 1_600_000 }]),
+  ];
+}
+
+/** 하락형: 역배열 + 저점 갱신 지속. */
+function markdownCandles(): DailyOhlcv[] {
+  return mkCandles([{ days: 140, from: 20000, to: 10000, vol: 1_000_000 }]);
+}
+
+describe("computeCardVerdict — 결정론 판단 엔진", () => {
+  it("같은 입력 → 같은 출력(결정론)", () => {
+    const input: VerdictInput = { candles: accumulationCandles(), foreignNetStreak: 5, currency: "KRW" };
+    const a = computeCardVerdict(input);
+    const b = computeCardVerdict(input);
+    expect(a).toBeDefined();
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("캔들 30거래일 미만 → 판단 보류(undefined)", () => {
+    const few = mkCandles([{ days: 20, from: 10000, to: 10100, vol: 500_000 }]);
+    expect(computeCardVerdict({ candles: few })).toBeUndefined();
+  });
+
+  it("60거래일 미만 → 국면(phase) 억지 판정 없음, 판단은 가능", () => {
+    const short = mkCandles([{ days: 45, from: 10000, to: 10200, vol: 500_000 }]);
+    const v = computeCardVerdict({ candles: short });
+    expect(v).toBeDefined();
+    expect(v!.phase).toBeUndefined();
+  });
+
+  it("축적 + 수급 유입 → enter, 무효화는 실제 창 저점 레벨", () => {
+    const candles = accumulationCandles();
+    const v = computeCardVerdict({ candles, foreignNetStreak: 5, currency: "KRW" });
+    expect(v).toBeDefined();
+    expect(v!.phase).toBe("accumulation");
+    expect(v!.stance).toBe("enter");
+    const windowLow = Math.min(...candles.map((c) => c.low));
+    expect(v!.invalidation).toContain(formatVerdictLevel(windowLow, "KRW"));
+    expect(v!.evidence.length).toBeGreaterThan(0);
+    expect(v!.evidence.length).toBeLessThanOrEqual(3);
+  });
+
+  it("축적 + 내부자 vs 축적 + 수급 — 같은 stance라도 문구가 다르다", () => {
+    const candles = accumulationCandles();
+    const byInsider = computeCardVerdict({ candles, insider: { insiderCount: 3, valueUsd: 1_200_000 } });
+    const byFlow = computeCardVerdict({ candles, foreignNetStreak: 5 });
+    expect(byInsider!.stance).toBe("enter");
+    expect(byFlow!.stance).toBe("enter");
+    expect(byInsider!.stanceText).not.toBe(byFlow!.stanceText);
+  });
+
+  it("상승 국면 + 거래량 확인 → enter(markup)", () => {
+    const v = computeCardVerdict({ candles: markupCandles(), volumeRatio: 1.6 });
+    expect(v).toBeDefined();
+    expect(v!.phase).toBe("markup");
+    expect(v!.stance).toBe("enter");
+    expect(v!.invalidation).toMatch(/20일선/);
+  });
+
+  it("분산 + 수급 이탈 → avoid", () => {
+    const v = computeCardVerdict({ candles: distributionCandles(), foreignNetStreak: -4 });
+    expect(v).toBeDefined();
+    expect(v!.phase).toBe("distribution");
+    expect(v!.stance).toBe("avoid");
+  });
+
+  it("하락 국면 → avoid, 회복 레벨 무효화", () => {
+    const v = computeCardVerdict({ candles: markdownCandles() });
+    expect(v).toBeDefined();
+    expect(v!.phase).toBe("markdown");
+    expect(v!.stance).toBe("avoid");
+    expect(v!.invalidation).toMatch(/위 마감 시|회복 시/);
+  });
+
+  it("신호 없는 횡보 → watch(판별력 — 모든 카드가 enter가 아니다)", () => {
+    const flat = mkCandles([{ days: 100, from: 10000, to: 10050, vol: 500_000 }]);
+    const v = computeCardVerdict({ candles: flat });
+    expect(v).toBeDefined();
+    expect(v!.stance).toBe("watch");
+  });
+
+  it("4개 시나리오가 서로 다른 stance 분포를 낸다(enter 단일화 금지)", () => {
+    const stances = [
+      computeCardVerdict({ candles: accumulationCandles(), foreignNetStreak: 5 })!.stance,
+      computeCardVerdict({ candles: markupCandles(), volumeRatio: 1.6 })!.stance,
+      computeCardVerdict({ candles: distributionCandles(), foreignNetStreak: -4 })!.stance,
+      computeCardVerdict({ candles: markdownCandles() })!.stance,
+    ];
+    expect(new Set(stances).size).toBeGreaterThanOrEqual(2);
+    expect(stances.filter((s) => s === "enter").length).toBeLessThan(stances.length);
+  });
+
+  it("USD 통화 레벨 표기", () => {
+    const candles = accumulationCandles().map((c) => ({
+      ...c,
+      open: c.open / 100,
+      high: c.high / 100,
+      low: c.low / 100,
+      close: c.close / 100,
+    }));
+    const v = computeCardVerdict({ candles, foreignNetStreak: 5, currency: "USD" });
+    expect(v).toBeDefined();
+    expect(v!.invalidation).toContain("$");
+  });
+
+  it("무효화 문구에 가짜 수치 없음 — 캔들에서 계산 가능한 레벨만", () => {
+    const candles = accumulationCandles();
+    const v = computeCardVerdict({ candles, foreignNetStreak: 5, currency: "KRW" });
+    const windowLow = Math.min(...candles.map((c) => c.low));
+    const closes = candles.map((c) => c.close);
+    const ma20 = closes.slice(-20).reduce((a, b) => a + b, 0) / 20;
+    const allowed = [formatVerdictLevel(windowLow, "KRW"), formatVerdictLevel(ma20, "KRW")];
+    expect(allowed.some((level) => v!.invalidation.includes(level))).toBe(true);
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -11,3 +11,4 @@ export * from "./multi-axis-hook";
 export * from "./discovery-supply";
 export * from "./fomo-score";
 export * from "./technical-analysis";
+export * from "./verdict";

--- a/packages/fomo-core/src/keyword-cards/verdict.ts
+++ b/packages/fomo-core/src/keyword-cards/verdict.ts
@@ -1,0 +1,346 @@
+import { computeTechnicalAnalysis, type DailyOhlcv } from "./technical-analysis";
+
+/**
+ * 판단 엔진(verdict) — 카드의 "그래서 살 만한가" 층. WO-PHASE1-CONVICTION-CARD.
+ *
+ * 결정론 규칙만 사용한다(같은 입력 → 같은 출력, LLM 없음).
+ * 와이코프 국면(축적/상승/분산/하락)을 실제 캔들로 판정하고, 수급 streak·내부자·재료·거래량을
+ * 조합해 stance(enter/watch/avoid)를 낸다. 무효화 레벨은 반드시 실제 캔들 계산값 — 없는 수치 금지.
+ * 데이터가 부족하면 국면을 억지 판정하지 않고 생략하며, 캔들 자체가 부족하면 판단 전체를 보류한다.
+ */
+
+export type VerdictStance = "enter" | "watch" | "avoid";
+export type WyckoffPhase = "accumulation" | "markup" | "distribution" | "markdown";
+
+export interface VerdictInput {
+  /** 실제 일봉(오래된→최신). 레벨(저점·이동평균) 계산의 유일한 출처. */
+  candles: readonly DailyOhlcv[];
+  /** 외국인 연속 순매수(+N)/순매도(-N) 일수. */
+  foreignNetStreak?: number;
+  /** 기관 연속 순매수(+N)/순매도(-N) 일수. */
+  institutionNetStreak?: number;
+  /** 내부자 매수(공시 확인분만). count 미상이어도 공시 확인이면 confirmed=true. */
+  insider?: { confirmed?: boolean; insiderCount?: number; valueUsd?: number };
+  /** 종목 직접 언급 재료(뉴스·공시) 강도 0~1. */
+  materialStrength?: number;
+  /** 최신일 거래량 / 최근 20일 평균. */
+  volumeRatio?: number;
+  currency?: "KRW" | "USD";
+}
+
+export interface CardVerdict {
+  stance: VerdictStance;
+  /** 판단 1줄 — 근거 조합(driver)에 따라 문구가 달라진다. */
+  stanceText: string;
+  phase?: WyckoffPhase;
+  /** 근거 최대 3개 — 전부 실데이터 문장. */
+  evidence: string[];
+  /** 무효화 조건 1개 — 실제 캔들에서 계산한 레벨 기반. */
+  invalidation: string;
+  confidence: "high" | "medium" | "low";
+}
+
+const MIN_CANDLES_FOR_VERDICT = 30;
+const MIN_CANDLES_FOR_PHASE = 60;
+
+const num = (x: number | undefined): x is number => typeof x === "number" && Number.isFinite(x);
+
+function sma(values: readonly number[], n: number): number | undefined {
+  if (values.length < n) return undefined;
+  const slice = values.slice(-n);
+  return slice.reduce((a, b) => a + b, 0) / n;
+}
+
+function avg(values: readonly number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** 레벨 표기 — 실계산값을 통화별로 사람이 읽는 형태로. */
+export function formatVerdictLevel(value: number, currency: "KRW" | "USD"): string {
+  if (currency === "USD") {
+    return `$${value.toLocaleString("en-US", { minimumFractionDigits: value < 100 ? 2 : 0, maximumFractionDigits: 2 })}`;
+  }
+  return `${Math.round(value).toLocaleString("ko-KR")}원`;
+}
+
+/** 가용 캔들 창 라벨 — 240거래일(≈52주) 이상이면 52주, 아니면 개월 수로 정직하게. */
+function windowLabel(tradingDays: number): string {
+  if (tradingDays >= 240) return "52주";
+  const months = Math.max(1, Math.round(tradingDays / 21));
+  return `최근 ${months}개월`;
+}
+
+interface PriceStructure {
+  close: number;
+  ma20?: number;
+  ma60?: number;
+  ma120?: number;
+  windowLow: number;
+  windowHigh: number;
+  windowText: string;
+  /** 최근 20일 평균 거래량 / 직전 20일 평균 거래량. */
+  volumeTrend?: number;
+  /** 최근 10일 내 창 저점 갱신 여부. */
+  recentNewLow: boolean;
+  /** 최근 10일 종가 순변화율. */
+  stall10: number;
+  /** MA20의 10일 기울기(비율) — 상승 지속(양수 큼) vs 고점 정체(≈0) 판별자. */
+  ma20Slope10?: number;
+  days: number;
+}
+
+function priceStructure(candles: readonly DailyOhlcv[]): PriceStructure | undefined {
+  const clean = candles.filter(
+    (c) => num(c.open) && num(c.high) && num(c.low) && num(c.close) && num(c.volume) && c.high >= c.low && c.close > 0
+  );
+  if (clean.length < MIN_CANDLES_FOR_VERDICT) return undefined;
+  const closes = clean.map((c) => c.close);
+  const volumes = clean.map((c) => c.volume);
+  const close = closes[closes.length - 1]!;
+  const windowLow = Math.min(...clean.map((c) => c.low));
+  const windowHigh = Math.max(...clean.map((c) => c.high));
+  const recent20Vol = avg(volumes.slice(-20).filter((v) => v > 0));
+  const prior20Vol = clean.length >= 40 ? avg(volumes.slice(-40, -20).filter((v) => v > 0)) : undefined;
+  const last10 = clean.slice(-10);
+  const first10Close = last10[0]?.close;
+  const min10Low = Math.min(...last10.map((c) => c.low));
+  const ma20 = sma(closes, 20);
+  const ma60 = sma(closes, 60);
+  const ma120 = sma(closes, 120);
+  const ma20Prev10 = closes.length >= 30 ? sma(closes.slice(0, -10), 20) : undefined;
+  const ma20Slope10 = num(ma20) && num(ma20Prev10) && ma20Prev10 > 0 ? ma20 / ma20Prev10 - 1 : undefined;
+  return {
+    close,
+    ...(num(ma20) ? { ma20 } : {}),
+    ...(num(ma60) ? { ma60 } : {}),
+    ...(num(ma120) ? { ma120 } : {}),
+    windowLow,
+    windowHigh,
+    windowText: windowLabel(clean.length),
+    ...(num(recent20Vol) && num(prior20Vol) && prior20Vol > 0 ? { volumeTrend: recent20Vol / prior20Vol } : {}),
+    recentNewLow: min10Low <= windowLow * 1.005,
+    stall10: num(first10Close) && first10Close > 0 ? close / first10Close - 1 : 0,
+    ...(num(ma20Slope10) ? { ma20Slope10 } : {}),
+    days: clean.length,
+  };
+}
+
+/**
+ * 와이코프 국면 판정 — 데이터 60거래일 미만이면 판정하지 않는다(억지 금지).
+ * 판정 순서: 하락(저점 갱신) → 축적(하락 멈춤+저점권+거래 수축) → 분산(고점권+정체+거래 확대) → 상승(정배열+거래 확인).
+ */
+function wyckoffPhase(s: PriceStructure, squeeze: boolean, volumeRatio: number | undefined): WyckoffPhase | undefined {
+  if (s.days < MIN_CANDLES_FOR_PHASE || !num(s.ma20) || !num(s.ma60)) return undefined;
+  const bearAligned = s.ma20 < s.ma60 && (!num(s.ma120) || s.ma60 < s.ma120);
+  const bullAligned = s.ma20 > s.ma60 && (!num(s.ma120) || s.ma60 > s.ma120);
+  const nearLow = s.close <= s.windowLow * 1.12;
+  const nearHigh = s.close >= s.windowHigh * 0.95;
+  const volumeContracting = squeeze || (num(s.volumeTrend) && s.volumeTrend <= 0.9);
+  const volumeExpanding = (num(s.volumeTrend) && s.volumeTrend >= 1.15) || (num(volumeRatio) && volumeRatio >= 1.5);
+  const flat = Math.abs(s.close / s.ma20 - 1) <= 0.05;
+
+  // 분산 vs 상승 판별자: 분산은 MA20이 평탄해진 고점 정체, 상승은 MA20이 계속 오른다.
+  const ma20Flat = !num(s.ma20Slope10) || s.ma20Slope10 <= 0.015;
+
+  if (bearAligned && s.recentNewLow) return "markdown";
+  if (nearLow && volumeContracting && flat && !s.recentNewLow) return "accumulation";
+  if (nearHigh && volumeExpanding && s.stall10 <= 0.02 && ma20Flat) return "distribution";
+  if (bullAligned && s.close > s.ma20 && volumeExpanding) return "markup";
+  return undefined;
+}
+
+const PHASE_TEXT: Record<WyckoffPhase, string> = {
+  accumulation: "저점권 횡보에 거래가 수축된 축적형 구조",
+  markup: "이동평균 정배열에 거래량이 붙은 상승 국면",
+  distribution: "고점권에서 거래는 늘고 가격은 정체된 분산형 구조",
+  markdown: "이동평균 역배열에 저점을 갱신 중인 하락 국면",
+};
+
+type Driver =
+  | "accumulation_inflow"
+  | "markup_confirmed"
+  | "signal_stack"
+  | "mixed"
+  | "quiet"
+  | "overheat"
+  | "phase_exit"
+  | "markdown"
+  | "signal_drain";
+
+function stanceText(stance: VerdictStance, driver: Driver, primaryEvidenceKind: string | undefined): string {
+  if (stance === "enter") {
+    if (driver === "accumulation_inflow") {
+      return primaryEvidenceKind === "insider"
+        ? "저점 다지기 구간에 내부자 매수가 겹쳐, 분할 진입을 검토할 만한 자리로 보여요."
+        : "저점 다지기 구간에 기관·외국인 유입이 붙어, 분할 진입을 검토할 만한 자리로 보여요.";
+    }
+    if (driver === "markup_confirmed") {
+      return "추세 초입에 거래량 확인이 붙어, 흐름을 따라가 볼 만한 자리로 보여요.";
+    }
+    return "가격 구조보다 신호 조합이 먼저 좋아진 상태 — 가볍게 진입을 검토할 만해요.";
+  }
+  if (stance === "avoid") {
+    if (driver === "phase_exit") return "고점권 분산에 수급 이탈이 겹쳐, 지금 들어갈 자리는 아니에요.";
+    if (driver === "markdown") return "하락 추세가 진행 중이라, 바닥 확인 전엔 피하는 게 맞아요.";
+    return "확인되는 신호가 약세 쪽에 몰려 있어, 지금은 피할 구간이에요.";
+  }
+  if (driver === "overheat") return "추세는 살아 있지만 단기 과열 상태 — 눌림을 기다려 볼 구간이에요.";
+  if (driver === "mixed") return "강세·약세 신호가 상충해, 지금은 지켜볼 구간이에요.";
+  return "판단을 기울일 확인 신호가 아직 부족해요. 관찰 목록에 두는 정도가 맞아요.";
+}
+
+interface Factor {
+  kind: string;
+  text: string;
+}
+
+function bullFactors(input: VerdictInput, s: PriceStructure): Factor[] {
+  const out: Factor[] = [];
+  const insiderCount = input.insider?.insiderCount;
+  if (num(insiderCount) && insiderCount >= 2) {
+    const valueUsd = input.insider?.valueUsd;
+    const valueText = num(valueUsd) && valueUsd > 0 ? ` 총 $${Math.round(valueUsd / 1000).toLocaleString("en-US")}k` : "";
+    out.push({ kind: "insider", text: `내부자 ${insiderCount}인이${valueText} 동반 매수(공시 확인)` });
+  } else if (input.insider?.confirmed === true) {
+    out.push({ kind: "insider", text: "내부자 공개시장 매수 공시 확인" });
+  }
+  if (num(input.foreignNetStreak) && input.foreignNetStreak >= 3) {
+    out.push({ kind: "flow", text: `외국인 ${input.foreignNetStreak}일 연속 순매수` });
+  }
+  if (num(input.institutionNetStreak) && input.institutionNetStreak >= 3) {
+    out.push({ kind: "flow", text: `기관 ${input.institutionNetStreak}일 연속 순매수` });
+  }
+  if (num(input.materialStrength) && input.materialStrength >= 0.6) {
+    out.push({ kind: "material", text: "이 종목을 직접 언급한 재료(뉴스·공시)가 확인됨" });
+  }
+  if (num(input.volumeRatio) && input.volumeRatio >= 1.5) {
+    out.push({ kind: "volume", text: `거래량이 20일 평균의 ${input.volumeRatio.toFixed(1)}배` });
+  }
+  if (num(s.ma20) && num(s.ma60) && s.ma20 > s.ma60 && s.close > s.ma20) {
+    out.push({ kind: "trend", text: "20·60일선 정배열 위에서 가격 유지 중" });
+  }
+  return out;
+}
+
+function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undefined): Factor[] {
+  const out: Factor[] = [];
+  if (num(input.foreignNetStreak) && input.foreignNetStreak <= -3) {
+    out.push({ kind: "flow", text: `외국인 ${Math.abs(input.foreignNetStreak)}일 연속 순매도` });
+  }
+  if (num(input.institutionNetStreak) && input.institutionNetStreak <= -3) {
+    out.push({ kind: "flow", text: `기관 ${Math.abs(input.institutionNetStreak)}일 연속 순매도` });
+  }
+  if (num(rsi) && rsi >= 70) {
+    out.push({ kind: "overheat", text: `RSI ${Math.round(rsi)} — 단기 과열 영역` });
+  }
+  if (num(s.ma20) && num(s.ma60) && s.ma20 < s.ma60 && s.close < s.ma20) {
+    out.push({ kind: "trend", text: "20·60일선 역배열 아래에서 가격 하락 중" });
+  }
+  if (s.recentNewLow) {
+    out.push({ kind: "newlow", text: `${s.windowText} 저점을 최근 갱신` });
+  }
+  return out;
+}
+
+function phaseEvidence(phase: WyckoffPhase, s: PriceStructure, currency: "KRW" | "USD"): Factor {
+  if (phase === "accumulation") {
+    const pct = ((s.close / s.windowLow - 1) * 100).toFixed(1);
+    return { kind: "phase", text: `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 대비 +${pct}% — ${PHASE_TEXT[phase]}` };
+  }
+  if (phase === "distribution") {
+    const pct = ((1 - s.close / s.windowHigh) * 100).toFixed(1);
+    return { kind: "phase", text: `${s.windowText} 고점 ${formatVerdictLevel(s.windowHigh, currency)} 대비 -${pct}% — ${PHASE_TEXT[phase]}` };
+  }
+  return { kind: "phase", text: PHASE_TEXT[phase] };
+}
+
+function invalidationText(
+  stance: VerdictStance,
+  driver: Driver,
+  s: PriceStructure,
+  currency: "KRW" | "USD"
+): string {
+  if (stance === "enter") {
+    if (driver === "accumulation_inflow") {
+      return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 시 이 관점은 무효예요.`;
+    }
+    if (num(s.ma20)) {
+      return `20일선 ${formatVerdictLevel(s.ma20, currency)} 아래 마감 시 이 관점은 무효예요.`;
+    }
+    return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 시 이 관점은 무효예요.`;
+  }
+  if (stance === "avoid") {
+    if (num(s.ma20)) {
+      return `20일선 ${formatVerdictLevel(s.ma20, currency)} 위 마감 시 약세 관점은 무효예요.`;
+    }
+    return `${s.windowText} 고점 ${formatVerdictLevel(s.windowHigh, currency)} 회복 시 약세 관점은 무효예요.`;
+  }
+  return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 여부가 다음 판단 기준이에요.`;
+}
+
+/**
+ * 카드 판단 계산 — 결정론(같은 입력 → 같은 출력).
+ * 캔들 30거래일 미만이면 undefined(판단 보류 — 가짜 판단 금지).
+ */
+export function computeCardVerdict(input: VerdictInput): CardVerdict | undefined {
+  const s = priceStructure(input.candles);
+  if (!s) return undefined;
+  const currency = input.currency ?? "KRW";
+  const ta = computeTechnicalAnalysis(input.candles);
+  const rsi = ta.latest?.rsi14;
+  const squeeze = ta.inputs.bollingerSqueeze === true;
+  const phase = wyckoffPhase(s, squeeze, input.volumeRatio);
+
+  const bulls = bullFactors(input, s);
+  const bears = bearFactors(input, s, rsi);
+  const hasInflow = bulls.some((f) => f.kind === "insider" || f.kind === "flow");
+  const hasOutflow = bears.some((f) => f.kind === "flow");
+  const overheated = num(rsi) && rsi >= 70;
+
+  let stance: VerdictStance;
+  let driver: Driver;
+  if (phase === "accumulation" && hasInflow) {
+    stance = "enter";
+    driver = "accumulation_inflow";
+  } else if (phase === "markup" && !overheated && (hasInflow || bulls.some((f) => f.kind === "volume"))) {
+    stance = "enter";
+    driver = "markup_confirmed";
+  } else if ((phase === "distribution" || phase === "markdown") && (hasOutflow || bears.length >= 2)) {
+    stance = "avoid";
+    driver = phase === "distribution" ? "phase_exit" : "markdown";
+  } else if (phase === "markdown") {
+    stance = "avoid";
+    driver = "markdown";
+  } else if (bulls.length >= 2 && bears.length === 0) {
+    stance = "enter";
+    driver = "signal_stack";
+  } else if (bears.length >= 2 && bulls.length === 0) {
+    stance = "avoid";
+    driver = "signal_drain";
+  } else {
+    stance = "watch";
+    driver = overheated && phase === "markup" ? "overheat" : bulls.length > 0 && bears.length > 0 ? "mixed" : "quiet";
+  }
+
+  const sided = stance === "enter" ? bulls : stance === "avoid" ? bears : [...bulls, ...bears];
+  const evidence: string[] = [];
+  if (phase) evidence.push(phaseEvidence(phase, s, currency).text);
+  for (const f of sided) {
+    if (evidence.length >= 3) break;
+    if (!evidence.includes(f.text)) evidence.push(f.text);
+  }
+
+  const sidedCount = stance === "enter" ? bulls.length : stance === "avoid" ? bears.length : Math.max(bulls.length, bears.length);
+  const confidence: CardVerdict["confidence"] =
+    phase && sidedCount >= 2 ? "high" : phase || sidedCount >= 2 ? "medium" : "low";
+
+  return {
+    stance,
+    stanceText: stanceText(stance, driver, sided[0]?.kind),
+    ...(phase ? { phase } : {}),
+    evidence,
+    invalidation: invalidationText(stance, driver, s, currency),
+    confidence,
+  };
+}


### PR DESCRIPTION
## Spec
WO-PHASE1-CONVICTION-CARD (광혁 직접 지시). 카드 = 발굴 훅 + **판단 1줄 + 근거 최대 3 + 무효화 1줄**, 뎁스 = 3문단.

## Summary
- **`packages/fomo-core/src/keyword-cards/verdict.ts` 신규** — 결정론 판단 엔진(LLM 0)
  - 와이코프 국면 판정: 축적/상승/분산/하락 — 실제 캔들 기반, 60거래일 미만이면 생략(억지 판정 금지)
  - stance: 축적+수급/내부자 유입→enter, 상승+거래량 확인(RSI<70)→enter, 분산·하락+이탈→avoid, 상충→watch
  - 무효화 레벨 전부 실계산(창 저점·MA20). 캔들 30거래일 미만 → 판단 자체 보류(가짜 판단 금지)
  - 같은 stance라도 근거 조합(driver)별 문구 분기 — 템플릿 단일화 방지
- **파이프라인**: `assembleStockFront`(KR lite/full·US full) + 발견 덱 `buildDiscoveryResponse`(KR, 110일 캔들) → `DiscoveryFrontSeed.verdict`. US 덱 카드는 캔들이 없어 verdict 생략(정직) — 뎁스 진입 시 US도 verdict 표시
- **카드 UI**(`StockSwipeDeck`): 판단 1줄(enter=라임 #D8FF3A / watch=중립 / avoid=회색 — 공포색 금지) + 근거 3 + 무효화. 틴더 스와이프 UX 불변, 카드 내 스크롤 없음
- **뎁스 3문단**(`KeywordDepthPage` StockInsightView): 섹션 나열 폐기 → "왜 사나 / 뭘 보고 있나 / 언제 틀리나" 각 3~4문장. 원문 근거 링크(OfficialFactsBlock) 하단 유지

## 검증 커버리지
- [x] `npm run typecheck` — 전체 통과
- [x] `npm run test` — 108 files / 1054 tests 통과 (verdict 결정론 테스트 12개 포함)
- [x] `npm run guard:discovery` — ✅ passed (cards 48, front band 16)
- [x] `npm run spec:analyze` — guard 실행 완료, 스펙 커버리지는 본 PR 본문에 기재
- [x] `npm run build:web` + `@fomo/web build` — 통과

## 수용 기준 체크
- 판단·근거·무효화가 카드에 노출 (KR 덱 카드 + 전 종목 뎁스)
- 무효화 레벨 = 실제 캔들 계산값 (테스트로 검증: 창 저점/MA20 외 수치 불가)
- 같은 stance 문구 다양성 (테스트: 내부자 조합 vs 수급 조합 문구 상이)
- 결정론 (테스트: 같은 입력 → 같은 출력)
- 모든 카드 enter 방지 (테스트: 4개 시나리오 stance 분포 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)