### PR TITLE
fix(deck): 홈 카드 로딩 멈춤 — 빈 덱 캐시 오염 + 실패 200 응답 수정

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -808,9 +808,17 @@ export async function fetchDaily30(): Promise<Daily30Response> {
   const key = `daily-30:${DISCOVERY_CACHE_VERSION}:${kstDateKey()}`;
   const cached = readCached<Daily30Response>(key);
   if (hasDaily30Cards(cached)) return cached;
-  const fresh = await cachedGet(key, fetchDaily30Network, CACHE_TTL.daily30);
-  if (!hasDaily30Cards(fresh)) throw new Error("GET /api/fomo/daily-30 returned invalid deck");
-  return fresh;
+  // 유효성 검사를 fetcher 안에서 던진다 — 빈/무효 덱이 cachedGet 에 저장돼 재시도가 캐시된 빈 덱으로
+  // 단락되는 오염을 막는다(서버 콜드빌드 폴백 200-빈덱 대응). 검사 통과분만 캐시된다.
+  return cachedGet(
+    key,
+    async () => {
+      const fresh = await fetchDaily30Network();
+      if (!hasDaily30Cards(fresh)) throw new Error("GET /api/fomo/daily-30 returned invalid deck");
+      return fresh;
+    },
+    CACHE_TTL.daily30
+  );
 }
 
 export const warmDaily30 = () => fetchDaily30();

--- a/apps/web/app/api/fomo/daily-30/route.ts
+++ b/apps/web/app/api/fomo/daily-30/route.ts
@@ -26,6 +26,7 @@ export async function GET() {
     );
   } catch (err) {
     console.warn("[fomo/daily-30] failed", (err as Error)?.message);
+    // 실패는 반드시 비200으로 — 200-빈덱을 성공으로 캐시/렌더하면 클라 재시도가 멈춘다(빈 덱 stuck).
     return withCors(
       NextResponse.json(
         {
@@ -42,7 +43,7 @@ export async function GET() {
             assetCounts: { "kr-stock": 0, "us-stock": 0, coin: 0, macro: 0 },
           },
         } satisfies Daily30Response,
-        { headers: { "Cache-Control": "no-store" } }
+        { status: 503, headers: { "Cache-Control": "no-store" } }
       )
     );
   }

--- a/apps/web/app/api/fomo/discovery/route.ts
+++ b/apps/web/app/api/fomo/discovery/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: Request) {
     );
   } catch (err) {
     console.warn("[fomo/discovery] failed", (err as Error)?.message);
+    // 실패는 비200으로 — 200-빈덱을 성공으로 취급하면 재시도/폴백 경로가 빈 덱에서 멈춘다.
     return withCors(
       NextResponse.json(
         {
@@ -52,7 +53,7 @@ export async function GET(request: Request) {
           confidence: "L",
           source: "데이터 없음",
         } satisfies DiscoveryResponse,
-        { headers: { "Cache-Control": "no-store" } }
+        { status: 503, headers: { "Cache-Control": "no-store" } }
       )
     );
   }


### PR DESCRIPTION
## 증상
배포 직후 홈이 **"오늘의 30장을 불러오지 못했어요"**에서 영구히 멈춤. 재시도 버튼을 눌러도 회복 안 됨.

## 원인 규명 (프로덕션 브라우저 디버깅)
- `/api/fomo/daily-30` 는 **HTTP 200 + 30장**을 정상 반환하는데도 화면은 에러 상태.
- 재시도 클릭 시 **daily-30 네트워크 요청이 새로 발생하지 않음**(`newRequestFired: false`) → 클라 캐시 단락 확인.

### 근본 원인 2가지
1. **서버**: `daily-30`·`discovery` 라우트가 콜드빌드 실패/타임아웃 시 `catch` 에서 **HTTP 200 + 빈 카드**를 반환 → 클라가 성공으로 오인.
2. **클라**: `fetchDaily30` 이 `cachedGet` 으로 응답을 **먼저 캐시한 뒤** 유효성 검사 → 빈 덱이 메모리 캐시에 저장되고, 이후 모든 재시도가 `cachedGet` 의 캐시된 빈 덱으로 단락되어 **재요청 없이 영구 에러**(TTL 만료 전까지).

## 수정
- **`fetchDaily30`**: 유효성 검사를 `cachedGet` fetcher **내부로 이동** → 검사 통과분만 캐시. 무효 덱은 throw → 재시도가 실제 네트워크 재요청. (`fetchDiscovery` 의 안전 패턴과 일치)
- **`daily-30`·`discovery` 라우트**: 실패 폴백 `200 → 503`. CDN 미캐시 + 클라가 실패로 인식해 재시도. 서버 워밍되면 **자동 회복**.

## 검증
- [x] typecheck (fomo-web, web)
- [x] `build:web` + `@fomo/web build`
- [x] `guard:discovery` ✅ passed (cards 44, front band 16)
- [x] `test` — 108 files / 1054 통과
- [ ] 배포 후 홈 30장 로딩 확인 (머지 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)