### PR TITLE
fix(deck): 금칙 카피 정규식 오탐으로 홈 카드 전체 멈춤 수정

### DIFF
--- a/apps/fomo-web/__tests__/discoveryCopySafe.test.ts
+++ b/apps/fomo-web/__tests__/discoveryCopySafe.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isDiscoveryCopySafe } from "../lib/discoveryCopySafe";
+
+describe("isDiscoveryCopySafe — 금칙 카피 오탐 방지", () => {
+  it("영문 접두 한국 종목명은 안전(조사 뒤 한글이 이어지면 조사가 아님)", () => {
+    // 프로덕션 카드 로딩 멈춤의 실제 원인: SK+이터닉스 의 'SK이'가 '영문+조사(이)'로 오탐됐었다.
+    expect(isDiscoveryCopySafe("기관 6일 연속 순매수 3만주 — SK이터닉스")).toBe(true);
+    expect(isDiscoveryCopySafe("SK이노베이션")).toBe(true);
+    expect(isDiscoveryCopySafe("외국인 5일 연속 순매수 — LG이노텍")).toBe(true);
+  });
+
+  it("실제 미번역 영문+조사 잔여물은 오염으로 판정", () => {
+    expect(isDiscoveryCopySafe("AAPL의 실적이 좋았다")).toBe(false);
+    expect(isDiscoveryCopySafe("Nvidia와 경쟁하는 중")).toBe(false);
+    expect(isDiscoveryCopySafe("the company reported")).toBe(false);
+    expect(isDiscoveryCopySafe("SHPH , ILLR")).toBe(false);
+  });
+
+  it("정상 한국어 카피는 안전", () => {
+    expect(isDiscoveryCopySafe("기관이 6일째 사는 중이에요.")).toBe(true);
+    expect(isDiscoveryCopySafe("52주 저점권에 가까운 상태예요.")).toBe(true);
+  });
+});

--- a/apps/fomo-web/lib/discoveryCopySafe.ts
+++ b/apps/fomo-web/lib/discoveryCopySafe.ts
@@ -1,0 +1,14 @@
+/**
+ * 발견 카드 카피 안전성 — 미번역 영문+한글조사 잔여물 등 오염 카피를 걸러내는 클라 2차 필터.
+ *
+ * 주의: 조사 뒤에 한글이 이어지면 그건 조사가 아니라 고유명사 음절이다
+ * (예: "SK이터닉스"의 SK+이터닉스, "SK이노베이션", "LG이노텍") — 부정 후방탐색으로 오탐을 막는다.
+ * 이 오탐이 정상 30장 덱을 통째로 무효 처리해 홈 카드 로딩이 멈춘 적이 있다(회귀 테스트로 고정).
+ */
+export const UNSAFE_DISCOVERY_COPY_PATTERN =
+  /\b(?:its|the|with|and)\b\s+[A-Za-z]|[A-Za-z]{2,}\s*(?:와|과|의|가|이|은|는|을|를|에|에서|로|으로)(?![가-힣])|SHPH\s*,\s*ILLR|설명하긴\s*이른데|아직\s*공개된\s*계기/i;
+
+/** 카드 카피 안전성 — 오염 카피면 false. 정상 종목명(SK이터닉스 등)은 통과. */
+export function isDiscoveryCopySafe(text: string): boolean {
+  return !UNSAFE_DISCOVERY_COPY_PATTERN.test(text);
+}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -10,6 +10,7 @@ import type {
   ScoredArticle,
 } from "@fomo/core";
 import type { DeckContent } from "./discoveryDeck";
+import { isDiscoveryCopySafe } from "./discoveryCopySafe";
 import { getSessionId } from "@/lib/session";
 import { cachedGet, readCached, refreshCached, setCached } from "./apiCache";
 import { discoveryMatchesCountry, type DiscoveryCountryScope } from "./discoveryCountryScope";
@@ -603,8 +604,6 @@ const discoveryStorageKey = (country: DiscoveryCountryScope = "KR") =>
   `fomo:discovery:${DISCOVERY_CACHE_VERSION}:${country}:${kstDateKey()}`;
 const LAST_DISCOVERY_STORAGE_KEY = `fomo:discovery:last-good:${DISCOVERY_CACHE_VERSION}`;
 const lastDiscoveryStorageKey = (country: DiscoveryCountryScope = "KR") => `${LAST_DISCOVERY_STORAGE_KEY}:${country}`;
-const UNSAFE_DISCOVERY_COPY_PATTERN =
-  /\b(?:its|the|with|and)\b\s+[A-Za-z]|[A-Za-z]{2,}\s*(?:와|과|의|가|이|은|는|을|를|에|에서|로|으로)|SHPH\s*,\s*ILLR|설명하긴\s*이른데|아직\s*공개된\s*계기/i;
 
 function isDiscoveryResponse(value: unknown): value is DiscoveryResponse {
   const candidate = value as Partial<DiscoveryResponse> | null;
@@ -644,7 +643,7 @@ function cardCopyFields(card: DiscoveryCardResponse): string[] {
 function hasUnsafeDiscoveryCopy(value: DiscoveryResponse | null | undefined): boolean {
   if (!value) return false;
   const fields = [...value.stocks.flatMap(stockCopyFields), ...(value.cards ?? []).flatMap(cardCopyFields)];
-  return fields.some((text) => UNSAFE_DISCOVERY_COPY_PATTERN.test(text));
+  return fields.some((text) => !isDiscoveryCopySafe(text));
 }
 
 function hasDiscoveryCards(value: DiscoveryResponse | null | undefined, country: DiscoveryCountryScope = "all"): value is DiscoveryResponse {


### PR DESCRIPTION
## 증상
홈이 **"오늘의 30장을 불러오지 못했어요"**에서 계속 멈춤. `/api/fomo/daily-30` 는 **30장을 정상 반환**하는데도 화면은 에러.

## 진짜 근본 원인 (프로덕션 브라우저 디버깅)
클라이언트 `hasDaily30Cards` → `hasUnsafeDiscoveryCopy` 의 금칙 카피 정규식:
```
[A-Za-z]{2,}\s*(?:와|과|의|가|이|은|는|…)
```
이 절이 정상 한국 종목명 **"SK이터닉스"**(SK + 이터닉스)의 `SK이` 를 "영문+조사(이)"로 **오탐**. 오늘 덱에 포함된 카드 카피 `"기관 6일 연속 순매수 3만주 — SK이터닉스"` 한 줄 때문에 **30장 덱 전체가 무효 판정** → `fetchDaily30` throw → 에러 상태. `SK이노베이션`·`LG이노텍` 등 영문 접두 종목명이 들어오면 동일 재발.

## 수정
- 조사 뒤에 한글이 이어지면 그건 조사가 아니라 고유명사 음절 → 부정 후방탐색 **`(?![가-힣])`** 추가. `"AAPL의 실적"`(조사 뒤 공백/끝) 같은 실제 미번역 잔여물은 계속 탐지.
- 정규식과 `isDiscoveryCopySafe` 를 `lib/discoveryCopySafe.ts` 로 분리(테스트 seam, `@/` alias 의존 제거), `fomoApi` 가 재사용.
- 회귀 테스트: SK이터닉스/SK이노베이션/LG이노텍 통과 + 미번역 영문+조사 탐지 유지.

> 참고: 이 PR은 #800(빈 덱 캐시 오염 + 실패 200→503)에 이은 **실제 트리거** 수정입니다. #800 은 "덱이 진짜 비었을 때" 재시도가 멈추지 않게 하고, 이 PR 은 "정상 덱을 오탐으로 버리는" 원인을 제거합니다.

## 검증
- [x] typecheck (fomo-web)
- [x] `@fomo/web build`
- [x] `test` — 109 files / 1057 통과 (신규 회귀 테스트 포함)
- [ ] 배포 후 홈 30장 로딩 확인 (머지 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)