### PR TITLE
feat(depth): WO Phase 1.5 — 뎁스·카드 품질 수정 (User Zero 피드백 6건)

### DIFF
--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -60,47 +60,35 @@ export function HomeView({
   return (
     <>
       <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-20 pt-4">
-        {/* 상단 얇은 띠: 로고 */}
+        {/* 상단 얇은 띠: 로고 + 시장 온도 축약 배지(WO 1.5 E — 큰 바는 몰입 방해라 접었다. 탭하면 설명 시트). */}
         <div className="flex items-center justify-between">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
+          <button
+            type="button"
+            onClick={() => setIndexHelpOpen(true)}
+            className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
+            aria-label="오늘의 시장 온도 계산 방식 보기"
+          >
+            <span>온도</span>
+            {index ? (
+              <>
+                <span className="font-number text-sm font-bold leading-none" style={{ color }}>
+                  {index.score}
+                </span>
+                {!isFullFallback && index.prevDayDelta !== 0 && (
+                  <span className="inline-flex items-center" style={{ color }}>
+                    {index.prevDayDelta > 0 ? <CaretUpIcon size={9} /> : <CaretDownIcon size={9} />}
+                    {Math.abs(index.prevDayDelta)}
+                  </span>
+                )}
+              </>
+            ) : (
+              <span>—</span>
+            )}
+          </button>
         </div>
 
-        {/* 시장 온도(FOMO Index) */}
-        {index ? (
-          <button
-            type="button"
-            onClick={() => setIndexHelpOpen(true)}
-            className="mt-3 flex w-full items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5 text-left transition-colors hover:border-whiteout/20"
-            aria-label="오늘의 시장 온도 계산 방식 보기"
-          >
-            <span className="text-xs text-muted">오늘의 시장 온도</span>
-            <div className="flex items-baseline gap-2">
-              <span className="font-number text-xl font-bold leading-none" style={{ color }}>
-                {index.score}
-              </span>
-              <span className="font-pixel text-[11px] text-muted">{index.state}</span>
-              {!isFullFallback && index.prevDayDelta !== 0 && (
-                <span className="inline-flex items-center gap-0.5 text-[11px] font-medium" style={{ color }}>
-                  · 어제보다
-                  {index.prevDayDelta > 0 ? <CaretUpIcon size={10} /> : <CaretDownIcon size={10} />}
-                  {index.prevDayDelta > 0 ? `+${index.prevDayDelta}` : `${index.prevDayDelta}`}
-                </span>
-              )}
-            </div>
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setIndexHelpOpen(true)}
-            className="mt-3 flex w-full items-center justify-between rounded-xl border border-hairline bg-surface px-4 py-2.5 text-left transition-colors hover:border-whiteout/20"
-            aria-label="오늘의 시장 온도 계산 방식 보기"
-          >
-            <span className="text-xs text-muted">오늘의 시장 온도</span>
-            <span className="font-pixel text-[11px] text-muted">데이터 수집 중…</span>
-          </button>
-        )}
-
-        <div className={`mt-3 flex flex-1 flex-col ${tab === "card" ? "justify-center" : ""}`}>
+        <div className="mt-3 flex min-h-0 flex-1 flex-col">
           {tab === "card" ? (
             <KeywordCardFeed loggedIn={true} />
           ) : (

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -378,6 +378,8 @@ function mergeFrontSeed(
     ...(fresh.feedBear ?? seed.feedBear ? { feedBear: fresh.feedBear ?? seed.feedBear } : {}),
     ...(fresh.axisSignals?.length ? { axisSignals: fresh.axisSignals } : seed.axisSignals?.length ? { axisSignals: seed.axisSignals } : {}),
     ...(fresh.axisHook ?? seed.axisHook ? { axisHook: fresh.axisHook ?? seed.axisHook } : {}),
+    // 판단 층 단일 진실(WO 1.5 A) — 카드(seed)의 verdict 우선. 카드=뎁스 stance 모순 금지.
+    ...(seed.verdict ?? fresh.verdict ? { verdict: seed.verdict ?? fresh.verdict } : {}),
   };
 }
 
@@ -1106,57 +1108,81 @@ const DEPTH_CONFIDENCE_TEXT: Record<string, string> = {
   low: "신뢰도는 낮은 편이라 가볍게 봐야 해요.",
 };
 
-/** 뎁스 3문단(왜 사나/뭘 보고 있나/언제 틀리나) — verdict+관찰 신호에서 결정론 조립. 30초 독해. */
-function buildConvictionParagraphs(
+/** 근거 확장 줄 중복 제거 — 이미 있는 줄과 사실상 같은 내용이면 버린다. */
+function pushEvidence(out: string[], line: string | undefined): void {
+  const clean = (line ?? "").trim();
+  if (!clean) return;
+  if (out.some((existing) => copyRestates(existing, clean))) return;
+  out.push(clean);
+}
+
+/**
+ * 뎁스 판단 섹션(WO 1.5 A+B+C) — 카드와 동일한 verdict 를 렌더(단일 진실, 모순 금지).
+ * 근거는 카드 근거 + TA 실수치·수급·재료로 확장. 데이터 없는 섹션은 생략(보일러플레이트 금지).
+ */
+function buildVerdictSections(
   front: StockFrontResponse | null,
   insight: CondensedInsight | null
-): { why: string; watching: string; wrong: string } {
+): { stanceText?: string; confidenceText?: string; evidence: string[]; invalidation?: string } {
   const verdict = front?.verdict;
-  const points = buildReadPoints(front, insight);
+  const evidence: string[] = [];
 
-  const why: string[] = [];
-  if (verdict) {
-    why.push(verdict.stanceText);
-    if (verdict.evidence.length > 0) why.push(`확인된 근거는 ${verdict.evidence.join(" / ")}.`);
-    else why.push("확인된 근거는 아직 얇아요.");
-    why.push(DEPTH_CONFIDENCE_TEXT[verdict.confidence] ?? "");
-  } else {
-    why.push("아직 판단을 세울 만큼 가격 데이터가 쌓이지 않았어요.");
-    why.push("카드에 보인 재료와 아래 신호만 확인하고, 판단은 보류하는 게 맞아요.");
-  }
+  // 1) 카드와 동일한 근거(단일 진실) 먼저.
+  for (const line of verdict?.evidence ?? []) pushEvidence(evidence, line);
 
-  const watching: string[] = [];
+  // 2) 국면 상세 — 카드 근거에 국면이 없을 때만 추가.
   if (verdict?.phase && DEPTH_PHASE_TEXT[verdict.phase]) {
-    watching.push(`차트 구조는 ${DEPTH_PHASE_TEXT[verdict.phase]}로 읽혀요.`);
-  } else {
-    watching.push("국면을 확정할 만큼 차트 구조가 뚜렷하진 않아요.");
+    pushEvidence(evidence, `차트 구조: ${DEPTH_PHASE_TEXT[verdict.phase]}`);
   }
+
+  // 3) 수급 확장 — 외국인·기관 모두(카드는 1~2줄만 실림).
   const foreignStreak = front?.signals.foreignNetStreak;
   const instStreak = front?.signals.institutionNetStreak;
   if (typeof foreignStreak === "number" && foreignStreak !== 0) {
-    watching.push(`수급은 외국인이 ${Math.abs(foreignStreak)}일 연속 ${foreignStreak > 0 ? "순매수" : "순매도"} 중이에요.`);
-  } else if (typeof instStreak === "number" && instStreak !== 0) {
-    watching.push(`수급은 기관이 ${Math.abs(instStreak)}일 연속 ${instStreak > 0 ? "순매수" : "순매도"} 중이에요.`);
+    pushEvidence(evidence, `외국인 ${Math.abs(foreignStreak)}일 연속 ${foreignStreak > 0 ? "순매수" : "순매도"}`);
+  }
+  if (typeof instStreak === "number" && instStreak !== 0) {
+    pushEvidence(evidence, `기관 ${Math.abs(instStreak)}일 연속 ${instStreak > 0 ? "순매수" : "순매도"}`);
+  }
+
+  // 4) TA 실수치 — 있는 지표만(가짜 금지).
+  const latest = front?.ta?.latest;
+  if (typeof latest?.rsi14 === "number") pushEvidence(evidence, `RSI ${Math.round(latest.rsi14)}`);
+  if (typeof latest?.closeTo52WeekHighPct === "number") {
+    const gap = Math.round((100 - latest.closeTo52WeekHighPct) * 10) / 10;
+    pushEvidence(evidence, gap <= 0.5 ? "52주 고점권" : `52주 고점 대비 -${gap}%`);
+  }
+  if (typeof front?.signals.volumeRatio === "number" && front.signals.volumeRatio >= 1.2) {
+    pushEvidence(evidence, `거래량 20일 평균의 ${front.signals.volumeRatio.toFixed(1)}배`);
   }
   const taText = front?.taFact ? translateTaFact(front.taFact) : undefined;
-  if (taText) watching.push(taText);
-  const material = insight && insight.confidence !== "insufficient" ? cleanText(insight.whyHot).split(/(?<=요\.|다\.)/)[0]?.trim() : undefined;
-  if (material && watching.length < 4) watching.push(material);
+  if (taText) pushEvidence(evidence, taText);
 
-  const wrong: string[] = [];
-  wrong.push(verdict?.invalidation ?? "무효화 레벨을 계산할 가격 데이터가 아직 부족해요.");
-  const counter = points.bear[0]?.text;
-  if (counter && !wrong[0]!.includes(counter)) wrong.push(`반대쪽 신호로는 ${counter.replace(/\.$/, "")}는 점도 있어요.`);
-  wrong.push("이 조건을 벗어나면 관점을 버리고 다시 관찰로 돌아가는 게 규칙이에요.");
+  // 5) 재료 — 원문 grounded 1문장.
+  const material =
+    insight && insight.confidence !== "insufficient"
+      ? cleanText(insight.whyHot).split(/(?<=요\.|다\.)/)[0]?.trim()
+      : undefined;
+  if (material) pushEvidence(evidence, material);
 
   return {
-    why: why.filter(Boolean).join(" "),
-    watching: watching.filter(Boolean).slice(0, 4).join(" "),
-    wrong: wrong.filter(Boolean).slice(0, 4).join(" "),
+    ...(verdict ? { stanceText: verdict.stanceText } : {}),
+    ...(verdict ? { confidenceText: DEPTH_CONFIDENCE_TEXT[verdict.confidence] } : {}),
+    evidence: evidence.slice(0, 6),
+    ...(verdict?.invalidation ? { invalidation: verdict.invalidation } : {}),
   };
 }
 
-/** 뎁스 본문 — 딱 3문단. 섹션 나열식 폐기(WO Phase 1). 원문 근거 링크는 하단 OfficialFactsBlock 유지. */
+const STANCE_BADGE: Record<string, { label: string; color: string }> = {
+  enter: { label: "진입 검토", color: "#D8FF3A" },
+  watch: { label: "관망", color: "#C9C9C4" },
+  avoid: { label: "회피", color: "#8A8A86" },
+};
+
+/**
+ * 뎁스 본문(WO 1.5) — 판단 / 근거 / 무효 조건. 카드 verdict 와 동일 stance(모순 금지).
+ * 데이터 없는 블록은 통째로 생략 — 전 종목 공통 보일러플레이트 금지.
+ */
 function ConvictionParagraphs({
   front,
   insight,
@@ -1164,37 +1190,94 @@ function ConvictionParagraphs({
   front: StockFrontResponse | null;
   insight: CondensedInsight | null;
 }) {
-  const p = buildConvictionParagraphs(front, insight);
+  const s = buildVerdictSections(front, insight);
   const stance = front?.verdict?.stance;
-  const stanceMeta =
-    stance === "enter"
-      ? { label: "진입 검토", color: "#D8FF3A" }
-      : stance === "avoid"
-        ? { label: "회피", color: "#8A8A86" }
-        : stance === "watch"
-          ? { label: "관망", color: "#C9C9C4" }
-          : undefined;
-  const blocks: Array<{ title: string; body: string }> = [
-    { title: "왜 사나", body: p.why },
-    { title: "뭘 보고 있나", body: p.watching },
-    { title: "언제 틀리나", body: p.wrong },
-  ];
+  const badge = stance ? STANCE_BADGE[stance] : undefined;
+  if (!s.stanceText && s.evidence.length === 0 && !s.invalidation) return null;
+
   return (
     <section className="mt-6 space-y-4">
-      {stanceMeta && (
-        <span
-          className="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-bold"
-          style={{ borderColor: stanceMeta.color, color: stanceMeta.color }}
-        >
-          {stanceMeta.label}
-        </span>
-      )}
-      {blocks.map((block) => (
-        <div key={block.title} className="rounded-2xl border border-hairline bg-surface px-4 py-4">
-          <p className="font-pixel text-sm text-whiteout">{block.title}</p>
-          <p className="mt-2 text-sm leading-6 text-whiteout">{block.body}</p>
+      {s.stanceText && (
+        <div className="rounded-2xl border border-hairline bg-surface px-4 py-4">
+          <div className="flex items-center gap-2.5">
+            <p className="font-pixel text-sm text-whiteout">판단</p>
+            {badge && (
+              <span
+                className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-bold"
+                style={{ borderColor: badge.color, color: badge.color }}
+              >
+                {badge.label}
+              </span>
+            )}
+          </div>
+          <p className="mt-2 text-sm leading-6 text-whiteout">{s.stanceText}</p>
+          {s.confidenceText && <p className="mt-1 text-[12px] leading-5 text-muted">{s.confidenceText}</p>}
         </div>
-      ))}
+      )}
+
+      {s.evidence.length > 0 && (
+        <div className="rounded-2xl border border-hairline bg-surface px-4 py-4">
+          <p className="font-pixel text-sm text-whiteout">근거</p>
+          <ul className="mt-2 space-y-1.5">
+            {s.evidence.map((line, i) => (
+              <li key={`vd-ev-${i}`} className="text-sm leading-6 text-whiteout">
+                · {line}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {s.invalidation && (
+        <div className="rounded-2xl border border-hairline bg-surface px-4 py-4">
+          <p className="font-pixel text-sm text-whiteout">무효 조건</p>
+          <p className="mt-2 text-sm leading-6 text-whiteout">{s.invalidation}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * 재무 한눈에(WO 1.5 F) — "이 회사 돈 잘 버나" 최소셋. 시총·PER·실적 추세를 한 줄씩.
+ * KR=네이버 금융, US=Yahoo quoteSummary(이미 연결된 소스). 없는 항목은 생략(가짜 금지).
+ */
+function FinanceGlanceBlock({ basics }: { basics: StockBasics | null }) {
+  if (!basics) return null;
+  const lines: Array<{ label: string; value: string; note?: string }> = [];
+  if (basics.marketCap) lines.push({ label: "시가총액", value: basics.marketCap });
+  for (const m of basics.metrics.slice(0, 4)) {
+    lines.push({ label: m.term ? `${m.label} (${m.term})` : m.label, value: m.value });
+  }
+  const fin = basics.financials;
+  if (fin && fin.periods.length >= 2) {
+    for (const row of fin.rows.slice(0, 2)) {
+      const last = fin.periods.length - 1;
+      const prev = last - 1;
+      const prevVal = row.values[prev];
+      const lastVal = row.values[last];
+      if (prevVal && lastVal && prevVal !== "—" && lastVal !== "—") {
+        lines.push({
+          label: row.label,
+          value: `${fin.periods[prev]!.title} ${prevVal} → ${fin.periods[last]!.title} ${lastVal}${fin.periods[last]!.estimate ? " (추정)" : ""}`,
+        });
+      }
+    }
+  }
+  if (lines.length === 0) return null;
+  const source = fin?.note?.includes("Nasdaq") ? "Nasdaq" : "네이버 금융";
+  return (
+    <section className="mt-4 rounded-2xl border border-hairline bg-surface px-4 py-4">
+      <p className="font-pixel text-sm text-whiteout">재무 한눈에</p>
+      <ul className="mt-2 space-y-1.5">
+        {lines.slice(0, 5).map((line, i) => (
+          <li key={`fin-${i}`} className="flex items-baseline justify-between gap-3 text-sm leading-6">
+            <span className="shrink-0 text-muted">{line.label}</span>
+            <span className="min-w-0 text-right text-whiteout">{line.value}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-2 text-[10px] leading-4 text-muted">출처: {source}</p>
     </section>
   );
 }
@@ -1252,7 +1335,10 @@ export function StockInsightView({
       .then((r) => alive && setFront(mergeFrontSeed(seed, r)))
       .catch(() => alive && setFront(seed))
       .finally(() => alive && setFrontLoaded(true));
-    fetchStockBasics(stock, context?.naverCode ? { naverCode: context.naverCode } : {})
+    fetchStockBasics(stock, {
+      ...(context?.naverCode ? { naverCode: context.naverCode } : {}),
+      ...(context?.symbol ? { symbol: context.symbol } : {}),
+    })
       .then((r) => alive && setBasics(r))
       .catch(() => alive && setBasics(null))
       .finally(() => alive && setBasicsLoaded(true));
@@ -1341,17 +1427,25 @@ export function StockInsightView({
           {/* 차트 — 가격 다음으로 현재 흐름을 확인. */}
           <DetailChart front={front} />
 
-          {/* 뎁스 본문 — 딱 3문단(왜 사나/뭘 보고 있나/언제 틀리나). 30초 독해(WO Phase 1). */}
+          {/* 뎁스 본문 — 판단/근거/무효 조건(WO 1.5). 카드 verdict 와 단일 진실, 부족 블록은 생략. */}
           <ConvictionParagraphs front={front} insight={insight} />
 
-          {/* 원문 근거 링크 — 하단 유지. */}
-          <OfficialFactsBlock facts={insight?.officialFacts} />
+          {/* 재무 한눈에(WO 1.5 F) — 근거 아래. KR=네이버·US=Yahoo, 없으면 생략. */}
+          <FinanceGlanceBlock basics={basics} />
 
           {showThinSourceFootnote && (
             <p className="mt-5 text-[12px] leading-5 text-muted">
               {hasVerifiedFloor
                 ? "원문 기반 요약은 아직 얇아요."
                 : "이 종목으로 모인 원문은 아직 적어요. 확인된 자료가 들어오면 이 화면에 붙어요."}
+            </p>
+          )}
+
+          {/* 포모 점수 — 카드 메인에서 강등된 배지(WO 1.5 E). 주목도 참고용, 판단 아님. */}
+          {typeof front?.fomo?.fomoScore === "number" && (
+            <p className="mt-6 text-center text-[11px] leading-5 text-muted">
+              포모 <span className="font-number font-bold" style={{ color: "#D8FF3A" }}>{front.fomo.fomoScore}</span>
+              {` · ${fomoStateSummary(front.fomo)}`}
             </p>
           )}
 

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -399,23 +399,7 @@ function StockCardFace({
         </div>
       )}
 
-      {/* 포모 점수 + 강도 미터 + 라벨 (척추) — 숫자=픽셀 디스플레이(라틴), 한글 라벨=Pretendard. 주목도(품질 아님). */}
-      {view.scoreText && (
-        <div className="mt-3.5 flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5">
-          <div className="flex items-baseline gap-1.5">
-            <span className="text-[10px] uppercase tracking-wide text-text-secondary">포모</span>
-            <span className="font-number text-3xl font-bold leading-none" style={{ color: NEON }}>
-              {view.scoreText.replace(/[^0-9]/g, "")}
-            </span>
-          </div>
-          <FomoMeter score={Number(view.scoreText.replace(/[^0-9]/g, "")) || 0} color={NEON} />
-          <span className="inline-flex items-center gap-1 text-sm font-bold text-whiteout">
-            {view.emoji === "🔥" && <FlameIcon size={15} />}
-            {view.emoji === "💎" && <GemIcon size={15} />}
-            {view.badge}
-          </span>
-        </div>
-      )}
+      {/* 포모 점수는 카드 메인에서 제거(WO 1.5 E) — 뎁스 하단 배지로 강등. 몰입은 종목·재료·판단이 담당. */}
 
       {/* 테마 태그 */}
       {themeLabel && (
@@ -929,8 +913,9 @@ export function StockSwipeDeck({
   const topReady = isStockCard(top) ? !!front[top.data.canonical] : true;
 
   return (
-    <div className="w-full">
-      <div className="relative mx-auto h-[52svh] min-h-[380px] max-h-[520px] w-full select-none sm:min-h-[420px]">
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col">
+      {/* 풀스크린 틴더 카드(WO 1.5 E) — 부모 flex 안에서 남는 높이를 전부 차지. max-h 캡 제거(잘림 방지). */}
+      <div className="relative mx-auto min-h-[52svh] w-full flex-1 select-none">
         {/* 다음 카드 — 뒤에 살짝 드러나는 스택(틴더식 peek). 위 카드가 불투명이라 body 통과 비침은 없음. */}
         {deckCards.length > 1 && (
           <div
@@ -990,7 +975,7 @@ export function StockSwipeDeck({
         )}
       </div>
 
-      <div className="mt-4 flex items-center justify-center gap-4">
+      <div className="mt-4 flex shrink-0 items-center justify-center gap-4">
         <button
           onClick={undoLast}
           disabled={!!exiting || restoring || !undoEntry}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -372,12 +372,12 @@ export const fetchStockInsight = (stock: string, opts: { naverCode?: string; mar
 
 /** 종목 기본 정보(바닥 — 주가·개요·시총·지표·재무). 항상 깔린다(원문 무관). */
 export type { StockBasics } from "@fomo/core";
-export const fetchStockBasics = (stock: string, opts: { naverCode?: string } = {}) =>
+export const fetchStockBasics = (stock: string, opts: { naverCode?: string; symbol?: string } = {}) =>
   cachedGet(
-    `stock-basics:${opts.naverCode ?? "name"}:${stock}`,
+    `stock-basics:${opts.naverCode ?? opts.symbol ?? "name"}:${stock}`,
     () =>
       get<import("@fomo/core").StockBasics>(
-        `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}${opts.naverCode ? `&code=${encodeURIComponent(opts.naverCode)}` : ""}`
+        `/api/fomo/stock-basics?stock=${encodeURIComponent(stock)}${opts.naverCode ? `&code=${encodeURIComponent(opts.naverCode)}` : ""}${opts.symbol ? `&symbol=${encodeURIComponent(opts.symbol)}` : ""}`
       ),
     CACHE_TTL.stockBasics
   );

--- a/apps/web/app/api/fomo/stock-basics/route.ts
+++ b/apps/web/app/api/fomo/stock-basics/route.ts
@@ -24,15 +24,15 @@ function validNaverCode(code: string | null): string | undefined {
   return c && /^\d{6}$/.test(c) ? c : undefined;
 }
 
-async function getBasics(stock: string, naverCode?: string): Promise<StockBasics> {
+async function getBasics(stock: string, naverCode?: string, symbol?: string): Promise<StockBasics> {
   const today = kstDate();
-  const key = `${today}:${stock}:${naverCode ?? ""}`;
+  const key = `${today}:${stock}:${naverCode ?? ""}:${symbol ?? ""}`;
   const running = inflight.get(key);
   if (running) return running;
 
   const load = unstable_cache(
-    async () => fetchStockBasics(stock, naverCode),
-    ["fomo-stock-basics", cacheVersion(), today, stock, naverCode ?? ""],
+    async () => fetchStockBasics(stock, naverCode, symbol),
+    ["fomo-stock-basics", cacheVersion(), today, stock, naverCode ?? "", symbol ?? ""],
     { revalidate: REVALIDATE_S }
   );
   const p = load().finally(() => inflight.delete(key));
@@ -46,7 +46,8 @@ export async function GET(req: Request) {
   if (!stock) {
     return withCors(NextResponse.json({ error: "stock required" }, { status: 400 }));
   }
-  const payload = await getBasics(stock, validNaverCode(url.searchParams.get("code")));
+  const symbol = url.searchParams.get("symbol")?.trim().toUpperCase() || undefined;
+  const payload = await getBasics(stock, validNaverCode(url.searchParams.get("code")), symbol);
   return withCors(
     NextResponse.json(payload, {
       headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=1800" },

--- a/apps/web/lib/stock-basics.ts
+++ b/apps/web/lib/stock-basics.ts
@@ -55,11 +55,17 @@ export async function fetchStockBasicsLite(stock: string, timeoutMs = 3500, nave
 }
 
 /** 종목명으로 기본 정보. discovery row 의 naverCode 가 있으면 vocab 미등록 종목도 조회한다. */
-export async function fetchStockBasics(stock: string, naverCode?: string): Promise<StockBasics> {
+export async function fetchStockBasics(stock: string, naverCode?: string, symbol?: string): Promise<StockBasics> {
   const def = resolveStock(stock);
   const code = validNaverCode(naverCode) ?? def?.naverCode;
   if (!code) {
-    // 국내 코드 없음 → 네이버 종목 API 경로 없음. 정직하게 이름만(상위에서 수급/해석으로 보완).
+    // 국내 코드 없음 → US 심볼이 있으면 Yahoo quoteSummary(무료·이미 쓰는 소스군)로 재무 바닥을 깐다.
+    const usSymbol = symbol?.trim().toUpperCase();
+    if (usSymbol && /^[A-Z][A-Z.\-]{0,6}$/.test(usSymbol)) {
+      const us = await fetchUsStockBasics(def?.canonical ?? stock, usSymbol);
+      if (us) return us;
+    }
+    // 소스 실패/심볼 없음 → 정직하게 이름만(상위에서 수급/해석으로 보완).
     return { name: def?.canonical ?? stock, metrics: [] };
   }
   const base = `https://m.stock.naver.com/api/stock/${encodeURIComponent(code)}`;
@@ -69,4 +75,106 @@ export async function fetchStockBasics(stock: string, naverCode?: string): Promi
     getJson(`${base}/finance/annual`),
   ]);
   return assembleStockBasics(def?.canonical ?? stock, basic, integration, finance);
+}
+
+// ── US 기본 정보 — api.nasdaq.com (WO Phase 1.5 F). 이미 쓰는 무료 소스(us-market-source 동일 계열).
+//    Yahoo quoteSummary 는 crumb 인증이 걸려 사용 불가(확인됨) — Nasdaq summary+financials 로 대체.
+//    실데이터만, 실패/결측 시 항목 생략 또는 null(fail-open). ──
+
+const NASDAQ_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+async function getNasdaqJson(url: string): Promise<unknown> {
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": NASDAQ_UA, Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.warn("[stock-basics] nasdaq fetch failed", url, (err as Error)?.message);
+    return null;
+  }
+}
+
+/** "$416,161,000"(천 달러) → "$416.2B" 식 축약. 숫자 없으면 null(가짜 금지). */
+function formatUsdThousands(value: string | undefined): string | null {
+  const digits = String(value ?? "").replace(/[^\d.-]/g, "");
+  if (!/\d/.test(digits)) return null;
+  const dollars = Number(digits) * 1000;
+  if (!Number.isFinite(dollars)) return null;
+  return formatUsdCompact(dollars);
+}
+
+function formatUsdCompact(dollars: number): string {
+  const abs = Math.abs(dollars);
+  const sign = dollars < 0 ? "-" : "";
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(1)}M`;
+  return `${sign}$${Math.round(abs).toLocaleString("en-US")}`;
+}
+
+interface NasdaqLabelValue {
+  label?: string;
+  value?: string;
+}
+
+/** Nasdaq summary+financials → StockBasics. 시총·52주·배당 + 연간 매출/영업이익. PER 미제공 시 생략(정직). */
+export async function fetchUsStockBasics(name: string, symbol: string): Promise<StockBasics | null> {
+  const [summaryRaw, financialsRaw] = await Promise.all([
+    getNasdaqJson(`https://api.nasdaq.com/api/quote/${encodeURIComponent(symbol)}/summary?assetclass=stocks`),
+    getNasdaqJson(`https://api.nasdaq.com/api/company/${encodeURIComponent(symbol)}/financials?frequency=1`),
+  ]);
+
+  const summary = (summaryRaw as { data?: { summaryData?: Record<string, NasdaqLabelValue> } } | null)?.data?.summaryData;
+  const metrics: StockBasics["metrics"] = [];
+  let marketCap: string | undefined;
+  let market: string | undefined;
+  let sector: string | undefined;
+  if (summary) {
+    const capDigits = String(summary.MarketCap?.value ?? "").replace(/[^\d]/g, "");
+    if (capDigits) marketCap = formatUsdCompact(Number(capDigits));
+    if (summary.Exchange?.value && summary.Exchange.value !== "N/A") market = summary.Exchange.value;
+    if (summary.Sector?.value && summary.Sector.value !== "N/A") sector = summary.Sector.value;
+    const range52 = summary.FiftTwoWeekHighLow?.value;
+    if (range52 && range52 !== "N/A") metrics.push({ label: "52주 고점/저점", value: range52, term: "52주" });
+    const divYield = summary.Yield?.value;
+    if (divYield && divYield !== "N/A") metrics.push({ label: "배당수익률", value: divYield, term: "배당" });
+  }
+
+  let financials: StockBasics["financials"];
+  const income = (financialsRaw as {
+    data?: { incomeStatementTable?: { headers?: Record<string, string>; rows?: Array<Record<string, string>> } };
+  } | null)?.data?.incomeStatementTable;
+  if (income?.headers && income.rows?.length) {
+    // headers: value2=최신 → value4=과거. 최근 3개 연도를 오래된→최신으로.
+    const keys = (["value4", "value3", "value2"] as const).filter((k) => income.headers?.[k]);
+    const periods = keys.map((k) => ({ title: income.headers![k]!, estimate: false }));
+    const pickRow = (label: RegExp) => income.rows!.find((row) => label.test(row.value1 ?? ""));
+    const buildRow = (label: string, source: Record<string, string> | undefined) => {
+      if (!source) return null;
+      const values = keys.map((k) => formatUsdThousands(source[k]) ?? "—");
+      return values.some((v) => v !== "—") ? { label, values } : null;
+    };
+    const rows = [
+      buildRow("벌어들인 돈(매출)", pickRow(/^Total Revenue$/i)),
+      buildRow("남긴 돈(영업이익)", pickRow(/^Operating Income$/i)),
+      buildRow("최종 이익(순이익)", pickRow(/^Net Income$/i)),
+    ].filter((row): row is NonNullable<typeof row> => row !== null);
+    if (periods.length >= 2 && rows.length > 0) {
+      financials = { periods, rows: rows.slice(0, 2), note: "출처: Nasdaq 연간 실적(단위 축약)" };
+    }
+  }
+
+  if (!marketCap && metrics.length === 0 && !financials) return null;
+  return {
+    name,
+    ...(market ? { market } : {}),
+    ...(marketCap ? { marketCap } : {}),
+    ...(sector ? { sector } : {}),
+    metrics,
+    ...(financials ? { financials } : {}),
+  };
 }


### PR DESCRIPTION
## Spec
WO-PHASE1_5-DEPTH-CARD-FIX (User Zero 피드백 5건 + 모순 1건 — 원인 확정분 수정).

## Summary

| # | 수정 |
|---|---|
| A | **카드=뎁스 verdict 단일 진실** — `mergeFrontSeed` 가 verdict 를 떨어뜨리던 버그가 모순("카드 진입검토 ↔ 뎁스 데이터부족")의 원인. 카드(seed) verdict 우선 병합으로 stance 100% 일치 |
| B | 뎁스 근거 = 카드 근거의 확장 — 수급 양쪽 streak, TA 실수치(RSI·52주 고점 대비 %·거래량비), 재료 1문장. **보일러플레이트 전면 삭제** — 데이터 없는 블록은 통째 생략 → 종목마다 뎁스가 달라짐 |
| C | 라벨 교체: → **판단 / 근거 / 무효 조건**, 판단 헤더에 stance 뱃지 |
| D | 확정데이터(매크로 S&P·VIX·10년물) 종목 뎁스에서 **삭제** |
| E | **풀스크린 틴더 카드** — max-h 캡 제거(잘림 해결)·flex-1, 국/미 동일 레이아웃, 포모점수 메인 제거→뎁스 하단 배지, 시장온도 바→헤더 축약 배지(탭 시 설명 시트) |
| F | 뎁스 **"재무 한눈에"** — KR=네이버(기존 basics 재사용: 시총·PER·실적 추세), US=**api.nasdaq.com** summary+financials 신규 연결(시총·52주·배당·매출/영업이익 3년). Yahoo quoteSummary 는 crumb 인증 확인되어 미사용. 없는 값 생략(가짜 0), 출처 표기 |

## 검증
- [x] typecheck (fomo-web, web) / test 1057 / guard:discovery ✅ (cards 50) / 빌드 2종
- [x] US 재무 실데이터 라이브 확인: AAPL 시총 \$4.53T · 매출 \$383.3B→\$416.2B (Nasdaq)
- [ ] 배포 후: 카드-뎁스 stance 일치 · 종목별 뎁스 상이 · 재무 블록 노출 (머지 후 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)