### PR TITLE
feat(pc): WO-PC-VERSION — lg(1024px) 3컬럼 대시보드

### DIFF
--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { CardVerdict } from "@fomo/core";
+import { StockInsightView } from "@/components/KeywordDepthPage";
+import { ContentCard } from "@/components/ContentCard";
+import { NarrativeCard } from "@/components/NarrativeCard";
+import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
+import { FlickerSpinner } from "@/components/FlickerSpinner";
+import { fetchDaily30, type Daily30Response } from "@/lib/fomoApi";
+import { stockDeckCards, type DeckCard, type DeckStock, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
+import { getDiscoverySeen } from "@/lib/discoveryPerformance";
+import type { FrontEntry } from "@/components/StockSwipeDeck";
+
+/**
+ * PC(≥1024px) 3컬럼 대시보드 — WO-PC-VERSION.
+ * 좌=오늘의 30장 리스트(태그 필터), 중앙=선택 종목 뎁스(StockInsightView inline), 우=콘텐츠·시장·성과.
+ * 새 API 없음 — daily-30·기존 컴포넌트 재배치만. 모바일 UI(틴더 덱)는 HomeView 분기에서 불변.
+ */
+
+const NEON = "#D8FF3A";
+
+/** CSS 브레이크포인트(lg=1024px) 감지 — UA 스니핑 아님, Tailwind lg 와 동일 기준. */
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const update = () => setIsDesktop(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  return isDesktop;
+}
+
+type FilterTag = "all" | "kr" | "us" | "coin" | "macro";
+
+const FILTER_TABS: Array<{ key: FilterTag; label: string }> = [
+  { key: "all", label: "전체" },
+  { key: "kr", label: "국장" },
+  { key: "us", label: "미장" },
+  { key: "coin", label: "코인" },
+  { key: "macro", label: "매크로" },
+];
+
+/** 카드 → 필터 태그 분류(daily-30 assetClass 규칙과 동일 기준, 클라 재계산). */
+function cardTag(card: DeckCard): FilterTag {
+  if (card.type === "content") {
+    return card.data.contentType === "whale" || card.data.scope === "global" ? "coin" : "macro";
+  }
+  if (card.type === "narrative") return card.data.scope === "US" ? "us" : "kr";
+  if (card.type === "sector") return "kr";
+  const stock = card.data;
+  if (stock.market === "COIN") return "coin";
+  return stock.country === "US" ? "us" : "kr";
+}
+
+const STANCE_BADGE: Record<CardVerdict["stance"], { label: string; color: string }> = {
+  enter: { label: "진입 검토", color: NEON },
+  watch: { label: "관망", color: "#C9C9C4" },
+  avoid: { label: "회피", color: "#8A8A86" },
+};
+
+function cardId(card: DeckCard): string {
+  if (card.type === "stock") return `stock:${card.data.canonical}`;
+  return `${card.type}:${card.data.id}`;
+}
+
+/** 좌측 리스트 한 줄 — 모바일 카드의 축약형(종목·훅·판단 뱃지). */
+function CardListRow({
+  card,
+  front,
+  active,
+  onSelect,
+}: {
+  card: DeckCard;
+  front: FrontEntry | undefined;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const verdict = front?.verdict;
+  const badge = verdict ? STANCE_BADGE[verdict.stance] : undefined;
+  const title =
+    card.type === "stock" ? card.data.canonical : card.type === "sector" ? `${card.data.sector} 섹터` : card.data.headline;
+  const hook = card.type === "stock" ? card.data.headline ?? card.data.reason : card.type === "content" ? card.data.facts[0]?.label : undefined;
+  const kicker =
+    card.type === "stock"
+      ? [card.data.market, front?.priceText].filter(Boolean).join(" · ")
+      : card.type === "content"
+        ? "MARKET NOTE"
+        : card.type === "narrative"
+          ? "STORY"
+          : "SECTOR";
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={active}
+      className="w-full rounded-xl border px-3.5 py-3 text-left transition-colors"
+      style={{
+        borderColor: active ? NEON : "var(--hairline, #2a2a2a)",
+        backgroundColor: active ? "rgba(216,255,58,0.06)" : "rgba(255,255,255,0.03)",
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="min-w-0 truncate text-sm font-bold text-whiteout">{title}</span>
+        {badge && (
+          <span
+            className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-bold"
+            style={{ borderColor: badge.color, color: badge.color }}
+          >
+            {badge.label}
+          </span>
+        )}
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted">{kicker}</div>
+      {hook && (
+        <p className="mt-1 truncate text-xs leading-5 text-muted">{hook}</p>
+      )}
+    </button>
+  );
+}
+
+export function DesktopDashboard() {
+  const [daily, setDaily] = useState<Daily30Response | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [filter, setFilter] = useState<FilterTag>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [seenItems] = useState(() => getDiscoverySeen());
+
+  useEffect(() => {
+    let alive = true;
+    fetchDaily30()
+      .then((d) => alive && setDaily(d))
+      .catch(() => alive && setFailed(true));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const cards = useMemo<DeckCard[]>(() => {
+    if (!daily) return [];
+    const raw = ((daily.cards?.length ? daily.cards : daily.stocks) ?? []) as DiscoveryDeckCard[];
+    return stockDeckCards(raw).slice(0, 30);
+  }, [daily]);
+
+  const fronts = (daily?.fronts ?? {}) as Record<string, FrontEntry>;
+  const filtered = useMemo(
+    () => (filter === "all" ? cards : cards.filter((card) => cardTag(card) === filter)),
+    [cards, filter]
+  );
+
+  // 첫 진입 — 1번 카드 뎁스 자동 표시(빈 화면 금지). 필터로 목록이 바뀌어 선택이 사라지면 첫 항목로.
+  useEffect(() => {
+    if (filtered.length === 0) return;
+    if (selectedId && filtered.some((card) => cardId(card) === selectedId)) return;
+    setSelectedId(cardId(filtered[0]!));
+  }, [filtered, selectedId]);
+
+  const selected = filtered.find((card) => cardId(card) === selectedId) ?? filtered[0];
+  const contentCards = cards.filter((card): card is Extract<DeckCard, { type: "content" }> => card.type === "content");
+  const narrativeCards = cards.filter((card): card is Extract<DeckCard, { type: "narrative" }> => card.type === "narrative");
+
+  const depthContext = (stock: DeckStock) => ({
+    fromTheme: stock.sector,
+    ...(stock.reason ?? stock.whyShown ? { reason: stock.reason ?? stock.whyShown } : {}),
+    ...(stock.sourceLabel ? { sourceLabel: stock.sourceLabel } : {}),
+    ...(stock.sourceUrl ? { sourceUrl: stock.sourceUrl } : {}),
+    ...(stock.naverCode ? { naverCode: stock.naverCode } : {}),
+    ...(stock.symbol ? { symbol: stock.symbol } : {}),
+    market: stock.market,
+    country: stock.country,
+    ...(fronts[stock.canonical] ? { frontSeed: fronts[stock.canonical] } : {}),
+  });
+
+  if (failed) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted">
+        오늘의 30장을 불러오지 못했어요. 새로고침해 주세요.
+      </div>
+    );
+  }
+  if (!daily) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <FlickerSpinner size={36} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-[300px_minmax(0,1fr)_340px] gap-4">
+      {/* ① 좌 — 오늘의 30장 리스트 + 태그 필터 */}
+      <section className="flex min-h-0 flex-col rounded-2xl border border-hairline bg-surface">
+        <div className="border-b border-hairline px-4 py-3">
+          <p className="font-pixel text-sm text-whiteout">오늘의 30장</p>
+          <div className="mt-2.5 flex flex-wrap gap-1.5" role="tablist" aria-label="시장 필터">
+            {FILTER_TABS.map((tab) => {
+              const active = filter === tab.key;
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setFilter(tab.key)}
+                  className="rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors"
+                  style={{
+                    borderColor: active ? NEON : "var(--hairline, #2a2a2a)",
+                    color: active ? "#0a0a0a" : "#8a8a8a",
+                    backgroundColor: active ? NEON : "transparent",
+                  }}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="scrollbar-none min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-3">
+          {filtered.map((card) => (
+            <CardListRow
+              key={cardId(card)}
+              card={card}
+              front={card.type === "stock" ? fronts[card.data.canonical] : undefined}
+              active={cardId(card) === selectedId}
+              onSelect={() => setSelectedId(cardId(card))}
+            />
+          ))}
+          {filtered.length === 0 && (
+            <p className="px-1 py-6 text-center text-xs text-muted">이 필터에 해당하는 카드가 오늘은 없어요.</p>
+          )}
+        </div>
+      </section>
+
+      {/* ② 중앙 — 선택 카드 뎁스(병렬 보기 = PC 핵심 가치) */}
+      <section className="min-h-0 overflow-hidden rounded-2xl border border-hairline bg-surface">
+        {selected?.type === "stock" ? (
+          <StockInsightView
+            key={selected.data.canonical}
+            stock={selected.data.canonical}
+            context={depthContext(selected.data)}
+            onClose={() => undefined}
+            inline
+          />
+        ) : selected?.type === "content" ? (
+          <div className="mx-auto h-full max-w-lg px-8 py-8">
+            <ContentCard card={selected.data} />
+          </div>
+        ) : selected?.type === "narrative" ? (
+          <div className="mx-auto h-full max-w-lg px-8 py-8">
+            <NarrativeCard card={selected.data} />
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted">카드를 선택해 주세요.</div>
+        )}
+      </section>
+
+      {/* ③ 우 — 콘텐츠·시장 + 성과 되짚기 */}
+      <section className="scrollbar-none min-h-0 space-y-3 overflow-y-auto">
+        {contentCards.slice(0, 4).map((card) => (
+          <div key={card.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">
+            <ContentCard card={card.data} />
+          </div>
+        ))}
+        {narrativeCards.slice(0, 2).map((card) => (
+          <div key={card.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">
+            <NarrativeCard card={card.data} />
+          </div>
+        ))}
+        <div className="rounded-2xl border border-hairline bg-surface px-4 py-4">
+          <PerformanceProofPanel items={seenItems} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -5,6 +5,7 @@ import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { CaretUpIcon, CaretDownIcon, XMarkIcon } from "@/components/icons";
 import { KeywordHistory } from "@/components/KeywordHistory";
+import { DesktopDashboard, useIsDesktop } from "@/components/DesktopDashboard";
 import type {
   FomoIndexResponse,
   TallyResponse,
@@ -42,6 +43,7 @@ export function HomeView({
 }) {
   const [tab, setTab] = useState<Tab>("card");
   const [indexHelpOpen, setIndexHelpOpen] = useState(false);
+  const isDesktop = useIsDesktop();
   const color = index ? scoreToColor(index.score) : undefined;
 
   /**
@@ -56,6 +58,36 @@ export function HomeView({
       index.components.whale === 0 &&
       !index.aiSummary
     : false;
+
+  // PC(≥1024px) — WO-PC-VERSION 3컬럼 대시보드. lg 미만 모바일 트리는 아래 그대로(틴더 덱 불가침).
+  if (isDesktop) {
+    return (
+      <>
+        <main className="fomo-phase-in mx-auto flex h-screen max-w-[1400px] flex-col gap-4 px-6 py-5">
+          <div className="flex shrink-0 items-center justify-between">
+            <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
+            <button
+              type="button"
+              onClick={() => setIndexHelpOpen(true)}
+              className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
+              aria-label="오늘의 시장 온도 계산 방식 보기"
+            >
+              <span>온도</span>
+              {index ? (
+                <span className="font-number text-sm font-bold leading-none" style={{ color }}>
+                  {index.score}
+                </span>
+              ) : (
+                <span>—</span>
+              )}
+            </button>
+          </div>
+          <DesktopDashboard />
+        </main>
+        {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1286,10 +1286,13 @@ export function StockInsightView({
   stock,
   context,
   onClose,
+  inline = false,
 }: {
   stock: string;
   context?: StockContext;
   onClose: () => void;
+  /** PC 대시보드 중앙 컬럼용(WO-PC-VERSION) — 풀스크린 오버레이 대신 부모 컨테이너 안에 렌더. 모바일 기본 불변. */
+  inline?: boolean;
 }) {
   const [insight, setInsight] = useState<CondensedInsight | null>(null);
   const [loading, setLoading] = useState(true);
@@ -1373,13 +1376,15 @@ export function StockInsightView({
     !hasInsight && !insight?.officialFacts?.length && auditWordings(insight).length === 0;
 
   return (
-    <div className="fixed inset-0 z-[70] bg-black">
-      <div className="mx-auto flex h-full max-w-md flex-col">
+    <div className={inline ? "flex h-full min-h-0 flex-col" : "fixed inset-0 z-[70] bg-black"}>
+      <div className={inline ? "flex h-full min-h-0 flex-col" : "mx-auto flex h-full max-w-md flex-col"}>
         <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
           <div className="flex items-center gap-2.5">
-            <button onClick={onClose} className="font-pixel text-sm text-muted hover:text-whiteout" aria-label="뒤로">
-              ← 뒤로
-            </button>
+            {!inline && (
+              <button onClick={onClose} className="font-pixel text-sm text-muted hover:text-whiteout" aria-label="뒤로">
+                ← 뒤로
+              </button>
+            )}
             <span className="text-lg font-bold text-whiteout">{cleanText(stock)}</span>
           </div>
           <button


### PR DESCRIPTION
## Spec
WO-PC-VERSION — 모바일=틴더 덱 그대로, PC=멀티컬럼 대시보드(있는 컴포넌트 재배치만).

## Summary
- **분기**: `matchMedia(min-width:1024px)` — Tailwind `lg` 와 동일 기준(CSS 브레이크포인트, UA 스니핑 아님). 단일 트리 렌더로 모바일 덱의 지표 사이드이펙트(seen 기록 등) 이중 발화 방지. **lg 미만 모바일 코드 무변경**.
- **① 좌**: 오늘의 30장 세로 리스트 — 종목·훅·stance 뱃지 축약 카드 + 태그 필터(전체/국장/미장/코인/매크로, daily-30 assetClass 와 동일 분류 규칙).
- **② 중앙**: 카드 클릭 → 뎁스 즉시 렌더(`StockInsightView` `inline` prop 신규 — 오버레이 대신 컬럼 안). 첫 진입 시 1번 카드 자동 표시(빈 화면 금지). 콘텐츠/내러티브 카드는 해당 카드 확대 렌더.
- **③ 우**: `ContentCard`(매크로·지수·고래) + `NarrativeCard` + `PerformanceProofPanel`(성과 되짚기) 스택.
- 새 API·새 데이터 0(daily-30 재사용), 다크 디자인 시스템(라임 포인트) 유지.

## 검증
- [x] typecheck / test 1057 / guard:discovery ✅ (49장) / build
- [ ] 배포 후 실제 PC 폭(≥1024px)에서 3컬럼 + 카드 클릭→뎁스 갱신 확인
- [ ] 모바일 폭(<1024px) 기존 UI 회귀 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)