### PR TITLE
feat(card): WO 1.6 — 카드 표준화(바이오비쥬 포맷) + 차트분석 탭 개선

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -380,6 +380,8 @@ function mergeFrontSeed(
     ...(fresh.axisHook ?? seed.axisHook ? { axisHook: fresh.axisHook ?? seed.axisHook } : {}),
     // 판단 층 단일 진실(WO 1.5 A) — 카드(seed)의 verdict 우선. 카드=뎁스 stance 모순 금지.
     ...(seed.verdict ?? fresh.verdict ? { verdict: seed.verdict ?? fresh.verdict } : {}),
+    // 차트 시리즈(WO 1.6 D)는 non-lite 응답(fresh)에만 실린다.
+    ...(fresh.chartSeries ?? seed.chartSeries ? { chartSeries: fresh.chartSeries ?? seed.chartSeries } : {}),
   };
 }
 
@@ -1042,54 +1044,203 @@ const TA_ROLE_GROUPS: Array<{ role: "event" | "balance" | "confirmation"; label:
   { role: "confirmation", label: "보조 확인" },
 ];
 
-/**
- * 차트분석(TA) 탭 — 엔진(technical-analysis.ts)이 관측한 사실을 role 별로 그대로 노출.
- * 추천·예측성 문구 추가 금지(관측 서술만 노출). facts 0개면 정직한 빈 상태.
- * 데이터 부족 지표(MA120·52주)는 엔진이 이미 스킵하므로 여기선 자연히 안 뜬다.
- */
-function ChartAnalysisTab({ ta, basisDays }: { ta?: StockFrontResponse["ta"]; basisDays: number }) {
-  const facts = ta?.facts ?? [];
-  if (facts.length === 0) {
-    return (
-      <section className="mt-2">
-        {basisDays > 0 && (
-          <p className="mb-3 text-[11px] text-muted">최근 {basisDays}거래일 종가·거래량 기준</p>
+// 차트 선 색 — 등락색 금지 원칙 유지. 종가=밝음, MA는 회색 계조 + 주목 오렌지, 무효선=라임 점선.
+const CHART_COLOR = {
+  close: "#FAFAFA",
+  ma20: "#FF8A50",
+  ma60: "#9A9A96",
+  ma120: "#5A5A57",
+  invalidation: "#D8FF3A",
+  volume: "rgba(255,255,255,0.18)",
+} as const;
+
+/** 종가+MA20/60/120+거래량+무효화 레벨선(WO 1.6 D-1) — 기존 svg 방식 확장, 라이브러리 없음. */
+function AnalysisChart({
+  series,
+  invalidationLevel,
+}: {
+  series: NonNullable<StockFrontResponse["chartSeries"]>;
+  invalidationLevel?: number | undefined;
+}) {
+  const W = 320;
+  const PRICE_H = 132;
+  const VOL_TOP = 142;
+  const VOL_H = 36;
+  const H = VOL_TOP + VOL_H;
+  const n = series.closes.length;
+  if (n < 2) return null;
+
+  const lineValues = [
+    ...series.closes,
+    ...series.ma20.filter((v): v is number => v !== null),
+    ...series.ma60.filter((v): v is number => v !== null),
+    ...series.ma120.filter((v): v is number => v !== null),
+  ];
+  // 무효 레벨이 가격대 근처(±25%)면 스케일에 포함해 화면 안에 그린다.
+  const includeLevel =
+    typeof invalidationLevel === "number" &&
+    invalidationLevel > Math.min(...series.closes) * 0.75 &&
+    invalidationLevel < Math.max(...series.closes) * 1.25;
+  if (includeLevel) lineValues.push(invalidationLevel!);
+  const min = Math.min(...lineValues);
+  const max = Math.max(...lineValues);
+  const span = max - min || 1;
+  const x = (i: number) => (i / (n - 1)) * W;
+  const y = (v: number) => 4 + (1 - (v - min) / span) * (PRICE_H - 8);
+
+  const linePath = (values: Array<number | null>): string => {
+    let d = "";
+    let pen = false;
+    values.forEach((v, i) => {
+      if (v === null) {
+        pen = false;
+        return;
+      }
+      d += `${pen ? "L" : "M"}${x(i).toFixed(1)},${y(v).toFixed(1)}`;
+      pen = true;
+    });
+    return d;
+  };
+
+  const maxVol = Math.max(...series.volumes, 1);
+  const barW = Math.max(1, W / n - 0.6);
+
+  return (
+    <div>
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label="종가·이동평균·거래량 차트">
+        {series.volumes.map((v, i) => {
+          const h = (v / maxVol) * VOL_H;
+          return <rect key={`v-${i}`} x={x(i) - barW / 2} y={VOL_TOP + (VOL_H - h)} width={barW} height={h} fill={CHART_COLOR.volume} />;
+        })}
+        <path d={linePath(series.ma120)} fill="none" stroke={CHART_COLOR.ma120} strokeWidth="1.1" />
+        <path d={linePath(series.ma60)} fill="none" stroke={CHART_COLOR.ma60} strokeWidth="1.1" />
+        <path d={linePath(series.ma20)} fill="none" stroke={CHART_COLOR.ma20} strokeWidth="1.2" />
+        <path d={linePath(series.closes.map((v) => v))} fill="none" stroke={CHART_COLOR.close} strokeWidth="1.6" />
+        {includeLevel && (
+          <>
+            <line
+              x1="0"
+              x2={W}
+              y1={y(invalidationLevel!)}
+              y2={y(invalidationLevel!)}
+              stroke={CHART_COLOR.invalidation}
+              strokeWidth="1.2"
+              strokeDasharray="5 4"
+            />
+            <text x={W - 4} y={Math.max(10, y(invalidationLevel!) - 4)} textAnchor="end" fontSize="9" fill={CHART_COLOR.invalidation}>
+              무효 레벨
+            </text>
+          </>
         )}
+      </svg>
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted">
+        <span><span style={{ color: CHART_COLOR.close }}>—</span> 종가</span>
+        <span><span style={{ color: CHART_COLOR.ma20 }}>—</span> MA20</span>
+        <span><span style={{ color: CHART_COLOR.ma60 }}>—</span> MA60</span>
+        <span><span style={{ color: CHART_COLOR.ma120 }}>—</span> MA120</span>
+        {includeLevel && <span><span style={{ color: CHART_COLOR.invalidation }}>┄</span> 무효화 레벨</span>}
+      </div>
+    </div>
+  );
+}
+
+/** 관측 문장에 수치(WO 1.6 D-3) — latest 지표값을 fact 종류별로 붙인다. 값 없으면 원문 그대로. */
+function taFactValueSuffix(kind: string, latest: NonNullable<StockFrontResponse["ta"]>["latest"]): string | undefined {
+  if (!latest) return undefined;
+  if ((kind === "rsi_overbought" || kind === "rsi_oversold") && typeof latest.rsi14 === "number") {
+    return `RSI ${Math.round(latest.rsi14)} · 기준 ${kind === "rsi_overbought" ? "70 초과" : "30 미만"}`;
+  }
+  if (kind === "bollinger_squeeze" && typeof latest.bollingerWidthPct === "number") {
+    return `밴드 폭 ${latest.bollingerWidthPct}%`;
+  }
+  if (kind === "atr_expanded" && typeof latest.atrPct === "number") {
+    return `하루 변동폭 ${latest.atrPct}%`;
+  }
+  if (kind === "near_52w_high" && typeof latest.closeTo52WeekHighPct === "number") {
+    return `고점 대비 -${(Math.round((100 - latest.closeTo52WeekHighPct) * 10) / 10).toFixed(1)}%`;
+  }
+  if (kind === "near_52w_low" && typeof latest.closeTo52WeekLowPct === "number") {
+    return `저점 대비 +${(Math.round((latest.closeTo52WeekLowPct - 100) * 10) / 10).toFixed(1)}%`;
+  }
+  return undefined;
+}
+
+/**
+ * 차트분석 탭(WO 1.6 D) — 실제 차트(종가+MA+거래량+무효선) + 와이코프 국면 뱃지 + 수치 붙은 관측.
+ * 이 관측들은 판단(verdict)의 근거다 — 제약 잔재 문구 금지.
+ */
+function ChartAnalysisTab({ front, basisDays }: { front: StockFrontResponse | null; basisDays: number }) {
+  const ta = front?.ta;
+  const facts = ta?.facts ?? [];
+  const verdict = front?.verdict;
+  const phaseText = verdict?.phase ? DEPTH_PHASE_TEXT[verdict.phase] : undefined;
+  const series = front?.chartSeries;
+
+  return (
+    <section className="mt-2">
+      {/* 와이코프 국면 뱃지 — verdict.phase 실계산분만(억지 금지). */}
+      {phaseText && verdict?.phase && (
+        <div className="mb-3 flex items-center gap-2">
+          <span
+            className="inline-flex shrink-0 items-center rounded-full border px-2.5 py-0.5 text-xs font-bold"
+            style={{ borderColor: "#D8FF3A", color: "#D8FF3A" }}
+          >
+            국면: {verdict.phase === "accumulation" ? "축적" : verdict.phase === "markup" ? "상승" : verdict.phase === "distribution" ? "분산" : "하락"}
+          </span>
+          <span className="min-w-0 text-[11px] leading-4 text-muted">{phaseText}</span>
+        </div>
+      )}
+
+      {/* 실제 차트 — 뭘 보고 판단하는지 눈에 보이게. */}
+      {series && series.closes.length >= 2 ? (
+        <div className="rounded-xl border border-hairline bg-surface px-3 pb-2 pt-3">
+          <AnalysisChart series={series} invalidationLevel={verdict?.invalidationLevel} />
+          {verdict?.invalidation && (
+            <p className="mt-1.5 border-t border-hairline pt-2 text-[11px] leading-4" style={{ color: "#D8FF3A" }}>
+              {verdict.invalidation}
+            </p>
+          )}
+        </div>
+      ) : (
+        basisDays > 0 && <p className="mb-3 text-[11px] text-muted">최근 {basisDays}거래일 종가·거래량 기준</p>
+      )}
+
+      {facts.length > 0 && (
+        <div className="mt-4 space-y-4">
+          {TA_ROLE_GROUPS.map(({ role, label }) => {
+            const rows = facts.filter((f) => f.role === role);
+            if (rows.length === 0) return null;
+            return (
+              <div key={role}>
+                <p className="font-pixel text-sm text-whiteout">{label}</p>
+                <ul className="mt-2 space-y-2">
+                  {rows.map((f, i) => {
+                    const valueSuffix = taFactValueSuffix(f.kind, ta?.latest);
+                    return (
+                      <li key={`${role}-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
+                        <span className="block text-sm leading-6 text-whiteout">{f.text}</span>
+                        {valueSuffix && (
+                          <span className="mt-0.5 block font-number text-[11px] leading-4 text-muted">{valueSuffix}</span>
+                        )}
+                        {f.confidence === "low" && (
+                          <span className="mt-1 block text-[11px] leading-4 text-muted">참고 신호(신뢰도 낮음)</span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {facts.length === 0 && !series && (
         <div className="rounded-lg border border-hairline bg-surface px-3 py-5 text-center">
           <p className="text-sm leading-6 text-muted">차트에서 두드러진 신호는 아직 없어요.</p>
           <p className="mt-1 text-[11px] leading-5 text-muted">데이터가 더 쌓이면 지표가 여기에 붙어요.</p>
         </div>
-        <p className="mt-4 text-center text-[11px] leading-5 text-muted">차트에서 관측되는 사실이에요 · 매수·매도 판단은 아니에요.</p>
-      </section>
-    );
-  }
-  return (
-    <section className="mt-2">
-      {basisDays > 0 && (
-        <p className="mb-3 text-[11px] text-muted">최근 {basisDays}거래일 종가·거래량 기준</p>
       )}
-      <div className="space-y-4">
-        {TA_ROLE_GROUPS.map(({ role, label }) => {
-          const rows = facts.filter((f) => f.role === role);
-          if (rows.length === 0) return null;
-          return (
-            <div key={role}>
-              <p className="font-pixel text-sm text-whiteout">{label}</p>
-              <ul className="mt-2 space-y-2">
-                {rows.map((f, i) => (
-                  <li key={`${role}-${i}`} className="rounded-lg border border-hairline bg-surface px-3 py-2">
-                    <span className="block text-sm leading-6 text-whiteout">{f.text}</span>
-                    {f.confidence === "low" && (
-                      <span className="mt-1 block text-[11px] leading-4 text-muted">참고 신호(신뢰도 낮음)</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          );
-        })}
-      </div>
-      <p className="mt-5 text-center text-[11px] leading-5 text-muted">차트에서 관측되는 사실이에요 · 매수·매도 판단은 아니에요.</p>
+      <p className="mt-5 text-center text-[11px] leading-5 text-muted">이 관측들이 위 판단의 근거예요.</p>
     </section>
   );
 }
@@ -1426,7 +1577,7 @@ export function StockInsightView({
           <>
           <DepthTabBar tab={depthTab} onChange={setDepthTab} />
           {depthTab === "ta" ? (
-            <ChartAnalysisTab ta={front?.ta} basisDays={front?.sparkline?.length ?? 0} />
+            <ChartAnalysisTab front={front} basisDays={front?.sparkline?.length ?? 0} />
           ) : (
           <>
           {/* 차트 — 가격 다음으로 현재 흐름을 확인. */}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -323,9 +323,11 @@ function VerdictBlock({ verdict }: { verdict: CardVerdict }) {
           ))}
         </ul>
       )}
-      <p className="mt-1.5 text-[10px] leading-4 text-muted/80" style={clampStyle(1)}>
-        {verdict.invalidation}
-      </p>
+      {verdict.invalidation && (
+        <p className="mt-1.5 text-[10px] leading-4 text-muted/80" style={clampStyle(1)}>
+          {verdict.invalidation}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -400,8 +400,16 @@ export interface StockFrontResponse {
   feedBear?: FeedSignalPoint;
   axisSignals?: import("@fomo/core").AxisSignal[];
   axisHook?: import("@fomo/core").MultiAxisHookSelection;
-  /** 판단 층(WO Phase 1) — stance/근거/무효화. 캔들 부족 종목은 없음. */
+  /** 판단 층(WO Phase 1) — stance/근거/무효화. 캔들 부족 시 최소 verdict(관망). */
   verdict?: import("@fomo/core").CardVerdict;
+  /** 차트분석 탭 시리즈(WO 1.6 D) — 종가+MA20/60/120+거래량. non-lite 응답에만. */
+  chartSeries?: {
+    closes: number[];
+    volumes: number[];
+    ma20: Array<number | null>;
+    ma60: Array<number | null>;
+    ma120: Array<number | null>;
+  };
 }
 
 export interface FeedSignalPoint {

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -155,8 +155,20 @@ function computeHypePenalty(stock: DiscoveryStockPayload, front: DiscoveryFrontS
   return penalty;
 }
 
+/**
+ * 렌더 전 표준 검증 게이트(WO 1.6 C) — 바이오비쥬 포맷 필수 필드.
+ * 가격·등락률·헤드라인·verdict 미달 카드는 30장에서 제외(다음 quietScore 후보가 채움). 에러 카드 노출 0.
+ */
+function meetsCardStandard(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): boolean {
+  if (!hasPricedFront(front)) return false;
+  if (typeof frontSignals(front).changePct !== "number") return false;
+  if (!(stock.headline ?? "").trim()) return false;
+  if (!front?.verdict) return false;
+  return true;
+}
+
 function stockCandidate(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): Daily30Candidate | null {
-  if (!hasPricedFront(front)) return null;
+  if (!meetsCardStandard(stock, front)) return null;
   if (FAMOUS_STOCKS.has(stock.canonical) && !strongQuietSignal(stock)) return null;
   const signalScore = computeStockSignal(stock, front);
   const hypePenalty = computeHypePenalty(stock, front);

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -51,7 +51,7 @@ import { resolveCardHeadline, type CardHeadline } from "./card-headline";
 import { selectDominantAxis } from "./card-axis";
 import { fetchSupplyDemand } from "./supply-demand";
 import { readSupplyDemandHistoryByTickers } from "./supply-demand-store";
-import { fetchCachedUsMarketRows, latestUsSessionAsOf } from "./us-market-source";
+import { fetchCachedUsMarketRows, fetchNasdaqDailyCandles, latestUsSessionAsOf } from "./us-market-source";
 import { fetchInsiderClusterCandidates, type InsiderClusterCandidate } from "./insider-source";
 import { US_DISCOVERY_SYMBOLS } from "./us-symbols";
 import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./news-reprocess";
@@ -1678,10 +1678,9 @@ function frontSeed(
 
 /**
  * 덱 카드 판단 층 — 실제 캔들 + 확인된 이벤트(수급 streak·내부자·재료·거래량)만 입력.
- * 캔들이 없으면(주로 US 덱 경로) 판단을 만들지 않는다 — 가짜 판단 금지.
+ * 캔들이 부족하면 엔진이 최소 verdict(관망·신호 축적)로 강등 — verdict 박스 없는 카드 금지(WO 1.6).
  */
-function verdictForCandidate(candidate: DiscoveryCandidate, candles: readonly DailyOhlcv[]): CardVerdict | undefined {
-  if (candles.length === 0) return undefined;
+function verdictForCandidate(candidate: DiscoveryCandidate, candles: readonly DailyOhlcv[]): CardVerdict {
   let foreignNetStreak: number | undefined;
   let institutionNetStreak: number | undefined;
   let insiderConfirmed = false;
@@ -2164,16 +2163,29 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   const dailyRows = await mapLimit(
     ranked.slice(0, deckCardCount),
     SPARKLINE_CONCURRENCY,
-    async (candidate) => ({
-      ticker: candidate.ticker,
-      daily: candidate.naverCode
-        ? await fetchStockDaily(candidate.naverCode, 110)
-        : {
-          candles: [],
+    async (candidate) => {
+      if (candidate.naverCode) {
+        return { ticker: candidate.ticker, daily: await fetchStockDaily(candidate.naverCode, 110) };
+      }
+      // US(내부자 포함) — Nasdaq OHLCV 로 verdict 엔진까지 캔들 공급(WO 1.6 A/B: 국/미 무차별 표준).
+      const usSymbol = rowsByTicker.get(candidate.ticker)?.symbol;
+      if (candidate.country === "US" && usSymbol) {
+        const daily = await fetchNasdaqDailyCandles(usSymbol, 270).catch(() => ({
+          candles: [] as DailyOhlcv[],
+          closes: [] as number[],
+          volumes: [] as number[],
+        }));
+        if (daily.closes.length >= 2) return { ticker: candidate.ticker, daily };
+      }
+      return {
+        ticker: candidate.ticker,
+        daily: {
+          candles: [] as DailyOhlcv[],
           closes: rowsByTicker.get(candidate.ticker)?.sparkline ?? [],
-          volumes: [],
+          volumes: [] as number[],
         },
-    })
+      };
+    }
   );
   const dailyByTicker = new Map(
     dailyRows.flatMap((row) => (row.status === "fulfilled" ? [[row.value.ticker, row.value.daily] as const] : []))
@@ -2192,8 +2204,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     if (!row) continue;
     const attention = attentionMap[candidate.ticker];
     const front = frontSeed(row, candidate, attention, themeSignals.get(candidate.ticker), sparklineByTicker.get(candidate.ticker) ?? []);
-    const verdict = verdictForCandidate(candidate, dailyByTicker.get(candidate.ticker)?.candles ?? []);
-    if (verdict) front.verdict = verdict;
+    front.verdict = verdictForCandidate(candidate, dailyByTicker.get(candidate.ticker)?.candles ?? []);
     const stock = await stockPayload(row, candidate, front);
     const headline = stock.headline?.trim();
     if (stock.headlineProvenance?.provenance === "suppressed" || !headline) {

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -83,6 +83,33 @@ export async function fetchStockDaily(
   }
 }
 
+/** 차트분석 탭용 시리즈(WO 1.6 D) — 종가·거래량 + MA20/60/120 정렬 배열(창 이전 구간은 null). */
+export interface StockChartSeries {
+  closes: number[];
+  volumes: number[];
+  ma20: Array<number | null>;
+  ma60: Array<number | null>;
+  ma120: Array<number | null>;
+}
+
+function buildChartSeries(candles: readonly DailyOhlcv[], window = 120): StockChartSeries | undefined {
+  const clean = candles.filter((c) => Number.isFinite(c.close) && c.close > 0);
+  if (clean.length < 20) return undefined;
+  const closes = clean.map((c) => c.close);
+  const volumes = clean.map((c) => (Number.isFinite(c.volume) && c.volume > 0 ? c.volume : 0));
+  const maAt = (i: number, n: number): number | null =>
+    i + 1 >= n ? closes.slice(i + 1 - n, i + 1).reduce((a, b) => a + b, 0) / n : null;
+  const start = Math.max(0, closes.length - window);
+  const idx = Array.from({ length: closes.length - start }, (_, k) => start + k);
+  return {
+    closes: idx.map((i) => closes[i]!),
+    volumes: idx.map((i) => volumes[i]!),
+    ma20: idx.map((i) => maAt(i, 20)),
+    ma60: idx.map((i) => maAt(i, 60)),
+    ma120: idx.map((i) => maAt(i, 120)),
+  };
+}
+
 /** 평소 대비 거래량 배수(거래량 회전) — 최신일 / 직전 ~20거래일 평균. 데이터 부족이면 undefined(가짜숫자 금지). */
 function volumeTurnover(volumes: number[]): number | undefined {
   if (volumes.length < 6) return undefined;
@@ -165,8 +192,10 @@ export interface StockFrontData {
   axisSignals?: AxisSignal[];
   /** 다축 후킹 대표 문장. 카드/상세 헤드라인의 우선 출처. */
   axisHook?: MultiAxisHookSelection;
-  /** 판단 층(WO Phase 1) — 결정론 verdict 엔진. 캔들 부족 시 생략(가짜 판단 금지). */
+  /** 판단 층(WO Phase 1) — 결정론 verdict 엔진. 캔들 부족 시 최소 verdict(관망·신호 축적). */
   verdict?: CardVerdict;
+  /** 차트분석 탭 시리즈(WO 1.6 D) — 종가+MA20/60/120+거래량. non-lite 에서만. */
+  chartSeries?: StockChartSeries;
 }
 
 export interface StockFrontOptions {
@@ -374,12 +403,14 @@ export async function assembleStockFront(
         : {}),
       currency: "USD",
     });
+    const chartSeries = buildChartSeries(daily.candles);
     return {
       signals,
       fomo,
       ...(taFact ? { taFact } : {}),
       ta,
-      ...(verdict ? { verdict } : {}),
+      verdict,
+      ...(chartSeries ? { chartSeries } : {}),
       sparkline,
       ...(cachedFront?.priceText ? { priceText: cachedFront.priceText } : {}),
       ...(cachedFront?.changeText ? { changeText: cachedFront.changeText } : {}),
@@ -439,13 +470,15 @@ export async function assembleStockFront(
       : {}),
     currency: "KRW",
   });
+  const chartSeries = lite ? undefined : buildChartSeries(daily.candles);
 
   return {
     signals,
     fomo,
     ...(taFact ? { taFact } : {}),
     ...(ta ? { ta } : {}),
-    ...(verdict ? { verdict } : {}),
+    verdict,
+    ...(chartSeries ? { chartSeries } : {}),
     sparkline: daily.closes.slice(lite ? -42 : -66),
     ...(basics?.priceText ? { priceText: basics.priceText } : {}),
     ...(basics?.changeText ? { changeText: basics.changeText } : {}),

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -440,6 +440,58 @@ export interface NasdaqSymbolQuote {
 }
 
 /**
+ * 임의 US 심볼의 일봉 OHLCV(WO 1.6 A/B — 덱 verdict 배선용).
+ * api.nasdaq.com historical 재사용(쿼터 무관·Vercel egress 통과, TwelveData 대체 경로).
+ * 실패 시 빈 배열(fail-open) — verdict 는 최소 verdict 로 강등된다.
+ */
+export async function fetchNasdaqDailyCandles(
+  symbol: string,
+  calendarDays = 270
+): Promise<{ candles: DailyOhlcv[]; closes: number[]; volumes: number[] }> {
+  const empty = { candles: [] as DailyOhlcv[], closes: [] as number[], volumes: [] as number[] };
+  const sym = symbol.trim().toUpperCase();
+  if (!sym) return empty;
+  const to = latestUsSessionDate();
+  const fromDate = new Date(`${to}T12:00:00Z`);
+  fromDate.setUTCDate(fromDate.getUTCDate() - calendarDays);
+  const url = new URL(`${NASDAQ_HISTORICAL_URL}/${encodeURIComponent(sym)}/historical`);
+  url.searchParams.set("assetclass", "stocks");
+  url.searchParams.set("fromdate", fromDate.toISOString().slice(0, 10));
+  url.searchParams.set("todate", to);
+  url.searchParams.set("limit", String(Math.max(30, Math.min(300, Math.round(calendarDays * 0.72)))));
+  const res = await fetch(url.toString(), {
+    headers: {
+      accept: "application/json, text/plain, */*",
+      "user-agent": NASDAQ_UA,
+      origin: "https://www.nasdaq.com",
+      referer: "https://www.nasdaq.com/",
+    },
+    signal: AbortSignal.timeout(6_000),
+    next: { revalidate: 1_800 },
+  }).catch(() => null);
+  if (!res || !res.ok) return empty;
+  const data = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+  const rows = ((data?.data as Record<string, unknown> | undefined)?.tradesTable as Record<string, unknown> | undefined)?.rows;
+  if (!Array.isArray(rows)) return empty;
+  const candles = rows
+    .map((row): DailyOhlcv | null => {
+      if (!row || typeof row !== "object") return null;
+      const record = row as Record<string, unknown>;
+      const date = isoFromNasdaqDate(String(record.date ?? ""));
+      const close = num(String(record.close ?? ""));
+      if (!date || typeof close !== "number" || close <= 0) return null;
+      const open = num(String(record.open ?? "")) ?? close;
+      const high = num(String(record.high ?? "")) ?? close;
+      const low = num(String(record.low ?? "")) ?? close;
+      const volume = num(String(record.volume ?? "")) ?? 0;
+      return { date, open, high: Math.max(high, close), low: Math.min(low, close), close, volume };
+    })
+    .filter((row): row is DailyOhlcv => row !== null)
+    .sort((a, b) => (a.date ?? "").localeCompare(b.date ?? ""));
+  return { candles, closes: candles.map((c) => c.close), volumes: candles.map((c) => c.volume) };
+}
+
+/**
  * 임의 US 심볼의 시세(현재가·등락·스파크라인) — api.nasdaq.com historical 재사용.
  * Yahoo egress 차단·TwelveData 쿼터와 무관하게 Vercel 에서 동작(스크리너와 동일 경로).
  * 실패 시 null(fail-open).

--- a/packages/fomo-core/__tests__/verdict.test.ts
+++ b/packages/fomo-core/__tests__/verdict.test.ts
@@ -71,9 +71,22 @@ describe("computeCardVerdict — 결정론 판단 엔진", () => {
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
   });
 
-  it("캔들 30거래일 미만 → 판단 보류(undefined)", () => {
+  it("캔들 30거래일 미만 → 최소 verdict(관망·신호 축적, 무효화 레벨 없음 — 가짜 레벨 금지)", () => {
     const few = mkCandles([{ days: 20, from: 10000, to: 10100, vol: 500_000 }]);
-    expect(computeCardVerdict({ candles: few })).toBeUndefined();
+    const v = computeCardVerdict({ candles: few, insider: { insiderCount: 3, valueUsd: 500_000 } });
+    expect(v).toBeDefined();
+    expect(v.stance).toBe("watch");
+    expect(v.confidence).toBe("low");
+    expect(v.invalidation).toBeUndefined();
+    expect(v.invalidationLevel).toBeUndefined();
+    expect(v.evidence.some((line) => line.includes("내부자"))).toBe(true);
+  });
+
+  it("구조 verdict 엔 무효화 텍스트와 실계산 레벨이 항상 짝으로 붙는다", () => {
+    const v = computeCardVerdict({ candles: accumulationCandles(), foreignNetStreak: 5, currency: "KRW" });
+    expect(v.invalidation).toBeTruthy();
+    expect(typeof v.invalidationLevel).toBe("number");
+    expect(v.invalidation).toContain(formatVerdictLevel(v.invalidationLevel!, "KRW"));
   });
 
   it("60거래일 미만 → 국면(phase) 억지 판정 없음, 판단은 가능", () => {

--- a/packages/fomo-core/src/keyword-cards/verdict.ts
+++ b/packages/fomo-core/src/keyword-cards/verdict.ts
@@ -35,8 +35,10 @@ export interface CardVerdict {
   phase?: WyckoffPhase;
   /** 근거 최대 3개 — 전부 실데이터 문장. */
   evidence: string[];
-  /** 무효화 조건 1개 — 실제 캔들에서 계산한 레벨 기반. */
-  invalidation: string;
+  /** 무효화 조건 — 실제 캔들에서 계산한 레벨 기반. 캔들 자체가 부족한 최소 verdict 엔 없다(가짜 레벨 금지). */
+  invalidation?: string;
+  /** 무효화 레벨 실계산 값 — 차트 무효선(WO 1.6 D) 렌더용. invalidation 과 항상 짝. */
+  invalidationLevel?: number;
   confidence: "high" | "medium" | "low";
 }
 
@@ -195,7 +197,8 @@ interface Factor {
   text: string;
 }
 
-function bullFactors(input: VerdictInput, s: PriceStructure): Factor[] {
+/** 가격 구조 없이도 확인 가능한 강세 신호(내부자·수급·재료·거래량) — 최소 verdict 의 근거이기도 하다. */
+function signalBullFactors(input: VerdictInput): Factor[] {
   const out: Factor[] = [];
   const insiderCount = input.insider?.insiderCount;
   if (num(insiderCount) && insiderCount >= 2) {
@@ -217,13 +220,10 @@ function bullFactors(input: VerdictInput, s: PriceStructure): Factor[] {
   if (num(input.volumeRatio) && input.volumeRatio >= 1.5) {
     out.push({ kind: "volume", text: `거래량이 20일 평균의 ${input.volumeRatio.toFixed(1)}배` });
   }
-  if (num(s.ma20) && num(s.ma60) && s.ma20 > s.ma60 && s.close > s.ma20) {
-    out.push({ kind: "trend", text: "20·60일선 정배열 위에서 가격 유지 중" });
-  }
   return out;
 }
 
-function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undefined): Factor[] {
+function signalBearFactors(input: VerdictInput): Factor[] {
   const out: Factor[] = [];
   if (num(input.foreignNetStreak) && input.foreignNetStreak <= -3) {
     out.push({ kind: "flow", text: `외국인 ${Math.abs(input.foreignNetStreak)}일 연속 순매도` });
@@ -231,6 +231,19 @@ function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undef
   if (num(input.institutionNetStreak) && input.institutionNetStreak <= -3) {
     out.push({ kind: "flow", text: `기관 ${Math.abs(input.institutionNetStreak)}일 연속 순매도` });
   }
+  return out;
+}
+
+function bullFactors(input: VerdictInput, s: PriceStructure): Factor[] {
+  const out = signalBullFactors(input);
+  if (num(s.ma20) && num(s.ma60) && s.ma20 > s.ma60 && s.close > s.ma20) {
+    out.push({ kind: "trend", text: "20·60일선 정배열 위에서 가격 유지 중" });
+  }
+  return out;
+}
+
+function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undefined): Factor[] {
+  const out = signalBearFactors(input);
   if (num(rsi) && rsi >= 70) {
     out.push({ kind: "overheat", text: `RSI ${Math.round(rsi)} — 단기 과열 영역` });
   }
@@ -255,37 +268,57 @@ function phaseEvidence(phase: WyckoffPhase, s: PriceStructure, currency: "KRW" |
   return { kind: "phase", text: PHASE_TEXT[phase] };
 }
 
-function invalidationText(
+function invalidationOf(
   stance: VerdictStance,
   driver: Driver,
   s: PriceStructure,
   currency: "KRW" | "USD"
-): string {
+): { text: string; level: number } {
   if (stance === "enter") {
-    if (driver === "accumulation_inflow") {
-      return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 시 이 관점은 무효예요.`;
+    if (driver === "accumulation_inflow" || !num(s.ma20)) {
+      return {
+        text: `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 시 이 관점은 무효예요.`,
+        level: s.windowLow,
+      };
     }
-    if (num(s.ma20)) {
-      return `20일선 ${formatVerdictLevel(s.ma20, currency)} 아래 마감 시 이 관점은 무효예요.`;
-    }
-    return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 시 이 관점은 무효예요.`;
+    return { text: `20일선 ${formatVerdictLevel(s.ma20, currency)} 아래 마감 시 이 관점은 무효예요.`, level: s.ma20 };
   }
   if (stance === "avoid") {
     if (num(s.ma20)) {
-      return `20일선 ${formatVerdictLevel(s.ma20, currency)} 위 마감 시 약세 관점은 무효예요.`;
+      return { text: `20일선 ${formatVerdictLevel(s.ma20, currency)} 위 마감 시 약세 관점은 무효예요.`, level: s.ma20 };
     }
-    return `${s.windowText} 고점 ${formatVerdictLevel(s.windowHigh, currency)} 회복 시 약세 관점은 무효예요.`;
+    return {
+      text: `${s.windowText} 고점 ${formatVerdictLevel(s.windowHigh, currency)} 회복 시 약세 관점은 무효예요.`,
+      level: s.windowHigh,
+    };
   }
-  return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 여부가 다음 판단 기준이에요.`;
+  return {
+    text: `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 이탈 여부가 다음 판단 기준이에요.`,
+    level: s.windowLow,
+  };
+}
+
+/**
+ * 최소 verdict(WO 1.6 B) — 가격 구조가 부족해도 verdict 박스는 항상 있다.
+ * 억지 enter/avoid 금지: 항상 관망 + 확인된 신호 근거만. 레벨을 계산할 수 없으니 무효화는 생략(가짜 레벨 금지).
+ */
+function minimalVerdict(input: VerdictInput): CardVerdict {
+  const evidence = [...signalBullFactors(input), ...signalBearFactors(input)].slice(0, 3).map((f) => f.text);
+  return {
+    stance: "watch",
+    stanceText: "가격 이력이 짧아 신호가 쌓이는 중이에요 — 지금은 관찰 구간이에요.",
+    evidence,
+    confidence: "low",
+  };
 }
 
 /**
  * 카드 판단 계산 — 결정론(같은 입력 → 같은 출력).
- * 캔들 30거래일 미만이면 undefined(판단 보류 — 가짜 판단 금지).
+ * 캔들 30거래일 미만이면 최소 verdict(관망·신호 축적) — 판단 박스 없는 카드 금지(WO 1.6).
  */
-export function computeCardVerdict(input: VerdictInput): CardVerdict | undefined {
+export function computeCardVerdict(input: VerdictInput): CardVerdict {
   const s = priceStructure(input.candles);
-  if (!s) return undefined;
+  if (!s) return minimalVerdict(input);
   const currency = input.currency ?? "KRW";
   const ta = computeTechnicalAnalysis(input.candles);
   const rsi = ta.latest?.rsi14;
@@ -335,12 +368,14 @@ export function computeCardVerdict(input: VerdictInput): CardVerdict | undefined
   const confidence: CardVerdict["confidence"] =
     phase && sidedCount >= 2 ? "high" : phase || sidedCount >= 2 ? "medium" : "low";
 
+  const invalidation = invalidationOf(stance, driver, s, currency);
   return {
     stance,
     stanceText: stanceText(stance, driver, sided[0]?.kind),
     ...(phase ? { phase } : {}),
     evidence,
-    invalidation: invalidationText(stance, driver, s, currency),
+    invalidation: invalidation.text,
+    invalidationLevel: invalidation.level,
     confidence,
   };
 }


### PR DESCRIPTION
## Spec
WO-PHASE1_6-CARD-STANDARD-CHART — 바이오비쥬 카드가 30장 전부의 표준.

## Summary

| # | 수정 |
|---|---|
| A | **미장·내부자 카드 표준 미달** — `fetchNasdaqDailyCandles` 신규(api.nasdaq.com historical OHLCV, 쿼터 무관·기존 소스 계열). 덱 파이프라인에서 US(내부자 포함) 후보도 캔들이 verdict 엔진까지 흐름 → 등락률·verdict·국면 국/미 무차별 |
| B | **verdict 없는 카드 금지** — 엔진이 항상 verdict 반환: 캔들 부족 시 최소 verdict("관망 · 신호 축적 중" + 확인된 신호 근거). 가짜 enter/avoid·가짜 레벨 0(무효화는 계산 가능할 때만). `invalidationLevel` 실계산 수치 추가(차트 무효선용) |
| C | **렌더 전 30장 검증 게이트** — 가격·등락률·헤드라인·verdict 미달 카드는 30장 제외, 다음 quietScore 후보로 대체. 에러 카드 노출 0 |
| D | **차트분석 탭** — ① 실제 차트: 종가+MA20/60/120+거래량+무효화 레벨 라임 점선(기존 svg 확장, 라이브러리 0 — `chartSeries` 페이로드 non-lite) ② 와이코프 국면 뱃지(억지 없음) ③ 관측 수치 부착(RSI 값·기준, 볼린저 폭, ATR, 52주 대비 %) ④ 잔재 문구 2곳 삭제 → "이 관측들이 위 판단의 근거예요" |

## 검증
- [x] typecheck(core/web/fomo-web) / test **1058**(최소 verdict·invalidationLevel 테스트 추가) / guard:discovery ✅(49장) / 빌드 2종
- [x] LODE Nasdaq OHLCV 186거래일 라이브 확인(국면 판정 가능 길이)
- [ ] 배포 후: 30장 전원 표준 포맷·verdict 누락 0·차트탭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)