### PR TITLE
feat(gnb): WO-GNB — 메인/피드/히스토리 3탭 (두 표면 분리)

### DIFF
--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -35,12 +35,12 @@ export function useIsDesktop(): boolean {
 
 type FilterTag = "all" | "kr" | "us" | "coin" | "macro";
 
+// 좌 리스트는 종목 전용(WO-GNB) — 매크로는 우측 콘텐츠 컬럼 소관이라 필터에서 뺀다.
 const FILTER_TABS: Array<{ key: FilterTag; label: string }> = [
   { key: "all", label: "전체" },
   { key: "kr", label: "국장" },
   { key: "us", label: "미장" },
   { key: "coin", label: "코인" },
-  { key: "macro", label: "매크로" },
 ];
 
 /** 카드 → 필터 태그 분류(daily-30 assetClass 규칙과 동일 기준, 클라 재계산). */
@@ -138,11 +138,14 @@ export function DesktopDashboard() {
     };
   }, []);
 
-  const cards = useMemo<DeckCard[]>(() => {
+  const allCards = useMemo<DeckCard[]>(() => {
     if (!daily) return [];
     const raw = ((daily.cards?.length ? daily.cards : daily.stocks) ?? []) as DiscoveryDeckCard[];
-    return stockDeckCards(raw).slice(0, 30);
+    return stockDeckCards(raw);
   }, [daily]);
+
+  // 좌 리스트 = 종목 30장(WO-GNB 메인과 동일). 우 컬럼 = 콘텐츠·내러티브(피드와 동일 소스).
+  const cards = useMemo(() => allCards.filter((card) => card.type === "stock").slice(0, 30), [allCards]);
 
   const fronts = (daily?.fronts ?? {}) as Record<string, FrontEntry>;
   const filtered = useMemo(
@@ -158,8 +161,8 @@ export function DesktopDashboard() {
   }, [filtered, selectedId]);
 
   const selected = filtered.find((card) => cardId(card) === selectedId) ?? filtered[0];
-  const contentCards = cards.filter((card): card is Extract<DeckCard, { type: "content" }> => card.type === "content");
-  const narrativeCards = cards.filter((card): card is Extract<DeckCard, { type: "narrative" }> => card.type === "narrative");
+  const contentCards = allCards.filter((card): card is Extract<DeckCard, { type: "content" }> => card.type === "content");
+  const narrativeCards = allCards.filter((card): card is Extract<DeckCard, { type: "narrative" }> => card.type === "narrative");
 
   const depthContext = (stock: DeckStock) => ({
     fromTheme: stock.sector,
@@ -243,16 +246,8 @@ export function DesktopDashboard() {
             onClose={() => undefined}
             inline
           />
-        ) : selected?.type === "content" ? (
-          <div className="mx-auto h-full max-w-lg px-8 py-8">
-            <ContentCard card={selected.data} />
-          </div>
-        ) : selected?.type === "narrative" ? (
-          <div className="mx-auto h-full max-w-lg px-8 py-8">
-            <NarrativeCard card={selected.data} />
-          </div>
         ) : (
-          <div className="flex h-full items-center justify-center text-sm text-muted">카드를 선택해 주세요.</div>
+          <div className="flex h-full items-center justify-center text-sm text-muted">종목을 선택해 주세요.</div>
         )}
       </section>
 

--- a/apps/fomo-web/components/FeedView.tsx
+++ b/apps/fomo-web/components/FeedView.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { StockInsightView, type StockContext } from "@/components/KeywordDepthPage";
+import { ContentCard } from "@/components/ContentCard";
+import { NarrativeCard } from "@/components/NarrativeCard";
+import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
+import { fetchDaily30, type Daily30Response } from "@/lib/fomoApi";
+import { stockDeckCards, type DeckCard, type DeckContent, type DeckNarrative, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
+
+/**
+ * 피드 표면(WO-GNB-TWO-SURFACES ②) — 콘텐츠 전용 세로 스크롤.
+ * 소스 = daily-30(메인 덱·PC 우측 컬럼과 동일 — 이원화 금지). 종목 카드는 제외, 콘텐츠만 모은다.
+ * 내러티브 = 사건→종목 스토리(탭 시 앵커 종목 뎁스), 매크로/지수/고래 = 사실 카드.
+ */
+
+/** 피드에 담기는 콘텐츠 카드(내러티브·매크로/지수/고래). 종목·섹터 카드는 메인 덱 소관. */
+type FeedItem =
+  | { type: "narrative"; data: DeckNarrative }
+  | { type: "content"; data: DeckContent };
+
+function feedItemsFromDaily30(discovery: Daily30Response): FeedItem[] {
+  const raw = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
+  // daily-30 cards 순서 = quietScore 랭킹 = 중요도순. 그 순서를 보존하며 콘텐츠만 추린다.
+  const items: FeedItem[] = [];
+  for (const card of stockDeckCards(raw)) {
+    if (card.type === "narrative") items.push({ type: "narrative", data: card.data });
+    else if (card.type === "content") items.push({ type: "content", data: card.data });
+  }
+  return items;
+}
+
+function narrativeAnchorContext(card: DeckNarrative): { stock: string; context: StockContext } | null {
+  // 트리거 앵커 티커 우선, 없으면 첫 종목. 뎁스 진입에 필요한 식별자(코드/심볼)를 넘긴다.
+  const anchor =
+    card.stocks.find((s) => s.ticker === card.trigger.anchorTicker) ?? card.stocks[0];
+  if (!anchor) return null;
+  return {
+    stock: anchor.name,
+    context: {
+      reason: card.headline,
+      sourceLabel: card.source,
+      ...(card.trigger.url ? { sourceUrl: card.trigger.url } : {}),
+      ...(anchor.naverCode ? { naverCode: anchor.naverCode } : {}),
+      ...(anchor.symbol ? { symbol: anchor.symbol } : {}),
+      market: anchor.market,
+      country: anchor.country,
+    },
+  };
+}
+
+export function FeedView() {
+  const [items, setItems] = useState<FeedItem[] | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [selected, setSelected] = useState<{ stock: string; context: StockContext } | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchDaily30()
+      .then((d) => alive && setItems(feedItemsFromDaily30(d)))
+      .catch(() => alive && setFailed(true));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const content = useMemo(() => items ?? [], [items]);
+
+  if (failed) {
+    return (
+      <div className="mt-16 px-8 text-center text-sm leading-6 text-muted">
+        오늘 피드를 불러오지 못했어요. 잠시 후 다시 열어주세요.
+      </div>
+    );
+  }
+  if (!items) {
+    return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
+  }
+  if (content.length === 0) {
+    return (
+      <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout">
+        오늘은 콘텐츠가 잠깐 비었어요.
+        <br />
+        조용한 날도 있는 거예요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 pb-4">
+      {content.map((item) => {
+        if (item.type === "narrative") {
+          const anchor = narrativeAnchorContext(item.data);
+          return (
+            <button
+              key={item.data.id}
+              type="button"
+              onClick={() => anchor && setSelected(anchor)}
+              disabled={!anchor}
+              className="block w-full rounded-2xl border border-hairline bg-surface px-5 py-5 text-left transition-colors enabled:hover:border-whiteout/20 disabled:cursor-default"
+            >
+              <NarrativeCard card={item.data} />
+            </button>
+          );
+        }
+        return (
+          <div key={item.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">
+            <ContentCard card={item.data} />
+          </div>
+        );
+      })}
+
+      {selected && (
+        <StockInsightView stock={selected.stock} context={selected.context} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
+}
+
+/** 메인 덱 필터(WO-GNB) — daily-30 카드에서 종목 카드만. 콘텐츠·섹터·내러티브는 피드로 이관. */
+export function stockOnlyDeckCards(cards: readonly DeckCard[]): DeckCard[] {
+  return cards.filter((card) => card.type === "stock");
+}

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -5,6 +5,7 @@ import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
 import { CaretUpIcon, CaretDownIcon, XMarkIcon } from "@/components/icons";
 import { KeywordHistory } from "@/components/KeywordHistory";
+import { FeedView } from "@/components/FeedView";
 import { DesktopDashboard, useIsDesktop } from "@/components/DesktopDashboard";
 import type {
   FomoIndexResponse,
@@ -22,7 +23,7 @@ import type {
  * 열면 바로 카드(스와이프 덱). 큰 마스코트 제거, 지수는 상단 얇은 띠. 본 카드는 히스토리 탭에.
  * (감정 게이트/캘린더/한마디 props는 보존 차원에서 시그니처에 남기되 미사용 — flag로 숨김 유지.)
  */
-type Tab = "card" | "history";
+type Tab = "main" | "feed" | "history";
 const NEON = "#D8FF3A";
 
 export function HomeView({
@@ -41,7 +42,7 @@ export function HomeView({
   loggedIn: boolean;
   onLoggedIn: () => void;
 }) {
-  const [tab, setTab] = useState<Tab>("card");
+  const [tab, setTab] = useState<Tab>("main");
   const [indexHelpOpen, setIndexHelpOpen] = useState(false);
   const isDesktop = useIsDesktop();
   const color = index ? scoreToColor(index.score) : undefined;
@@ -120,19 +121,22 @@ export function HomeView({
           </button>
         </div>
 
-        <div className="mt-3 flex min-h-0 flex-1 flex-col">
-          {tab === "card" ? (
+        <div className={`mt-3 flex min-h-0 flex-1 flex-col ${tab === "feed" ? "overflow-y-auto scrollbar-none" : ""}`}>
+          {tab === "main" ? (
             <KeywordCardFeed loggedIn={true} />
+          ) : tab === "feed" ? (
+            <FeedView />
           ) : (
             <KeywordHistory />
           )}
         </div>
       </main>
 
-      {/* 하단 탭: 카드 / 히스토리 */}
+      {/* 하단 GNB: 메인 / 피드 / 히스토리 (WO-GNB — 두 표면 분리) */}
       <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-[#1E1E1E] bg-black">
         <div className="mx-auto flex max-w-md">
-          <TabButton active={tab === "card"} onClick={() => setTab("card")} label="카드" />
+          <TabButton active={tab === "main"} onClick={() => setTab("main")} label="메인" />
+          <TabButton active={tab === "feed"} onClick={() => setTab("feed")} label="피드" />
           <TabButton active={tab === "history"} onClick={() => setTab("history")} label="히스토리" />
         </div>
       </nav>

--- a/apps/fomo-web/components/UnifiedDailyDeck.tsx
+++ b/apps/fomo-web/components/UnifiedDailyDeck.tsx
@@ -5,6 +5,7 @@ import { StockSwipeDeck } from "@/components/StockSwipeDeck";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import { fetchDaily30, type Daily30Response } from "@/lib/fomoApi";
 import { stockDeckCards, type DeckCard, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
+import { stockOnlyDeckCards } from "@/components/FeedView";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
 
 interface UnifiedDailyDeckProps {
@@ -38,7 +39,8 @@ function Daily30Empty({ onRetry }: { onRetry: () => void }) {
 function cardsFromDaily30(discovery: Daily30Response): { cards: DeckCard[]; fronts: Record<string, FrontEntry> } {
   const rawCards = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
   const fronts = discovery.fronts as Record<string, FrontEntry>;
-  return { cards: stockDeckCards(rawCards).slice(0, 30), fronts };
+  // 메인 덱 = 종목 발굴 전용(WO-GNB). 콘텐츠·내러티브는 피드 표면으로 이관.
+  return { cards: stockOnlyDeckCards(stockDeckCards(rawCards)).slice(0, 30), fronts };
 }
 
 export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDailyDeckProps) {

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -287,8 +287,12 @@ export function selectDaily30Candidates(candidates: readonly Daily30Candidate[],
   return selected;
 }
 
+/** 피드 표면(WO-GNB)용 콘텐츠·내러티브 최대치 — 덱 30장과 별개로 응답에 함께 싣는다. */
+const FEED_CARD_LIMIT = 16;
+
 function responseFromSelected(
-  selected: readonly Daily30Candidate[],
+  deck: readonly Daily30Candidate[],
+  feed: readonly Daily30Candidate[],
   discoveries: readonly DiscoveryResponse[],
   asOf: string
 ): Daily30Response {
@@ -298,25 +302,27 @@ function responseFromSelected(
   for (const discovery of discoveries) {
     for (const [ticker, front] of Object.entries(discovery.fronts)) fronts[ticker] = front;
   }
-  for (const candidate of selected) {
+  for (const candidate of deck) {
     if (!candidate.stock) continue;
     if (stockById.has(candidate.id)) continue;
     stockById.set(candidate.id, candidate.stock);
     stocks.push(candidate.stock);
   }
+  // cards = 덱(종목 30장) + 피드(콘텐츠·내러티브). 클라가 표면별로 필터: 메인=stock, 피드=content/narrative.
+  const all = [...deck, ...feed];
   const assetCounts: Record<Daily30AssetClass, number> = { "kr-stock": 0, "us-stock": 0, coin: 0, macro: 0 };
-  for (const candidate of selected) assetCounts[candidate.assetClass] += 1;
+  for (const candidate of all) assetCounts[candidate.assetClass] += 1;
   return {
     asOf,
     country: "all",
     stocks,
-    cards: selected.map((candidate) => candidate.card),
+    cards: all.map((candidate) => candidate.card),
     fronts,
-    confidence: selected.length >= DAILY_CARD_TARGET ? "H" : selected.length >= 20 ? "M" : "L",
+    confidence: deck.length >= DAILY_CARD_TARGET ? "H" : deck.length >= 20 ? "M" : "L",
     source: "KR/US discovery·수급·내부자·거래량·고래·매크로 통합 quietScore",
     meta: {
       targetCount: DAILY_CARD_TARGET,
-      cards: selected.map((candidate) => ({
+      cards: all.map((candidate) => ({
         id: candidate.id,
         assetClass: candidate.assetClass,
         quietScore: Number(candidate.quietScore.toFixed(2)),
@@ -344,6 +350,13 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
   addStockCandidates(candidates, kr, seen);
   addStockCandidates(candidates, us, seen);
   addContentCandidates(candidates, content, seen);
-  const selected = selectDaily30Candidates(candidates, DAILY_CARD_TARGET);
-  return responseFromSelected(selected, [kr, us], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+
+  // WO-GNB 두 표면 분리: 덱 = 종목 30장(내러티브·콘텐츠 제외), 피드 = 콘텐츠·내러티브(중요도순).
+  const stockCandidates = candidates.filter((c) => c.kind === "stock");
+  const feedCandidates = candidates
+    .filter((c) => c.kind === "content" || c.kind === "narrative")
+    .sort((a, b) => b.quietScore - a.quietScore || a.id.localeCompare(b.id))
+    .slice(0, FEED_CARD_LIMIT);
+  const deck = selectDaily30Candidates(stockCandidates, DAILY_CARD_TARGET);
+  return responseFromSelected(deck, feedCandidates, [kr, us], kr.asOf > us.asOf ? kr.asOf : us.asOf);
 }


### PR DESCRIPTION
## Spec
WO-GNB-TWO-SURFACES — 콘텐츠가 30장 덱에 묻히니 두 표면으로 분리. 하단 GNB 메인/피드/히스토리 3탭.

## Summary
- **① 메인** = 종목 발굴 덱(틴더, 기존). `UnifiedDailyDeck` 에 `stockOnlyDeckCards` 필터 — 콘텐츠·내러티브 덱에서 제거. 스와이프 UX 불변.
- **② 피드**(신설 `FeedView`) = 콘텐츠 전용 세로 스크롤. 내러티브(사건→종목, 탭 시 앵커 종목 뎁스) + 매크로/지수/고래 `ContentCard`. **소스 = daily-30**(메인·PC 우측과 동일, 이원화 금지).
- **③ 히스토리** = 기존 + `PerformanceProofPanel` 성과 되짚기.
- **daily-30 서버**: 덱은 종목 30장 선정, 콘텐츠·내러티브는 quietScore순 16장까지 별도 포함 → 클라가 표면별 필터(메인 30장 유지 + 피드 콘텐츠 확보). 새 API·새 소스 0.
- **PC 정합**: 좌 리스트=종목 30장, 우 컬럼=콘텐츠·내러티브(같은 daily-30). 좌 필터 매크로 탭 제거, 중앙 뎁스 종목 전용.

## 검증
- [x] typecheck / test 1058 / guard:discovery ✅(49장) / 빌드 2종
- [x] 로컬(375px): GNB 3탭, 메인 종목 틴더(회피 verdict), 피드 STORY+MARKET NOTE 세로스크롤, 내러티브 탭→뎁스 열림
- [ ] 배포 후 프로덕션 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)