### PR TITLE
feat(coin): WO Phase C — 코인 발굴 파이프라인 (Upbit 프리웜 + daily-30 합류)

### DIFF
--- a/.github/workflows/coin-market-prewarm.yml
+++ b/.github/workflows/coin-market-prewarm.yml
@@ -1,0 +1,32 @@
+name: Coin Market Prewarm
+
+# 코인은 24/7 거래 — 시간당 1회 Upbit 일봉·시세를 프리웜해 캐시에 쓴다(WO Phase C).
+# 요청 경로는 캐시만 읽는다(504 원칙). Vercel native cron 미지원 플랜이라 GH Actions 로 트리거.
+
+on:
+  schedule:
+    - cron: "20 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coin-market-prewarm
+  cancel-in-progress: false
+
+jobs:
+  prewarm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call production coin prewarm endpoint
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          URL="https://fomo-club-backend.vercel.app/api/fomo/cron/coin-market-prewarm"
+          if [ -n "${CRON_SECRET:-}" ]; then
+            curl -fsS "$URL" -H "Authorization: Bearer ${CRON_SECRET}"
+          else
+            curl -fsS "$URL"
+          fi

--- a/apps/web/__tests__/lib/coin-discovery.test.ts
+++ b/apps/web/__tests__/lib/coin-discovery.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { computeCoinSignal, hasDiscoverySignal, coinHeadline, type CoinSignal } from "../../lib/coin-discovery";
+import type { CoinMarketSnapshot } from "../../lib/coin-market-source";
+
+function snapshot(overrides: Partial<CoinMarketSnapshot> = {}): CoinMarketSnapshot {
+  const days = 40;
+  return {
+    market: "KRW-TEST",
+    symbol: "TEST",
+    koreanName: "테스트코인",
+    englishName: "Test",
+    price: 1500,
+    changePct: 1.2,
+    accTradePrice24h: 5e9,
+    tradeValueRank: 20,
+    candles: Array.from({ length: days }, (_, i) => ({
+      date: `2026-06-${String((i % 28) + 1).padStart(2, "0")}`,
+      open: 1400, high: 1600, low: 1350, close: 1500, volume: 1000,
+    })),
+    tradeValues: Array.from({ length: days }, () => 5e9),
+    fetchedAt: "2026-07-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("coin discovery signals", () => {
+  it("평소 수준 거래대금은 신호 아님 (정직한 0장)", () => {
+    const s = snapshot(); // 24h == 20일 평균 → ratio 1.0
+    const signal = computeCoinSignal(s)!;
+    expect(signal.volumeRatio).toBeCloseTo(1.0, 1);
+    expect(hasDiscoverySignal(s, signal)).toBe(false);
+  });
+
+  it("거래대금 이상(2배+)이면 발굴 신호", () => {
+    const s = snapshot({ accTradePrice24h: 1.5e10 }); // 평소 3배
+    const signal = computeCoinSignal(s)!;
+    expect(signal.volumeRatio).toBeCloseTo(3.0, 1);
+    expect(hasDiscoverySignal(s, signal)).toBe(true);
+  });
+
+  it("진공 후 유입 — 직전 5일 저조 + 오늘 유입", () => {
+    const values = Array.from({ length: 40 }, () => 5e9);
+    for (let i = 34; i < 39; i += 1) values[i] = 1e9; // 진공(마지막 완결 5일 저조)
+    const s = snapshot({ tradeValues: values, accTradePrice24h: 8e9 });
+    const signal = computeCoinSignal(s)!;
+    expect(signal.vacuumInflow).toBe(true);
+    expect(hasDiscoverySignal(s, signal)).toBe(true);
+  });
+
+  it("이미 급등한 코인(±12%+)은 발굴 제외 — 잡코인 러시 방어", () => {
+    const s = snapshot({ accTradePrice24h: 2e10, changePct: 30.5 });
+    const signal = computeCoinSignal(s)!;
+    expect(signal.volumeRatio).toBeGreaterThan(2);
+    expect(hasDiscoverySignal(s, signal)).toBe(false);
+  });
+
+  it("캔들 부족(25일 미만) 마켓은 신호 계산 불가", () => {
+    const s = snapshot({
+      candles: snapshot().candles.slice(0, 10),
+      tradeValues: snapshot().tradeValues.slice(0, 10),
+    });
+    expect(computeCoinSignal(s)).toBeNull();
+  });
+
+  it("헤드라인은 사실+수치 관측 서술", () => {
+    const signal: CoinSignal = { volumeRatio: 6.24, vacuumInflow: false, quiet: true };
+    const s = snapshot({ athChangePct: -62 });
+    expect(coinHeadline(s, signal)).toBe("24시간 거래대금 평소 6.2배 · 전고점 대비 62% 아래 · 아직 조용한 구간");
+  });
+});

--- a/apps/web/app/api/fomo/cron/coin-market-prewarm/route.ts
+++ b/apps/web/app/api/fomo/cron/coin-market-prewarm/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../../lib/fomo";
+import { fetchUpbitCoinSnapshots, writeCoinMarketSnapshots } from "../../../../../lib/coin-market-source";
+
+/**
+ * 코인 시세·캔들 프리웜 크론 (WO Phase C) — us-market-prewarm 패턴.
+ * Upbit KRW 마켓(유의 제외·거래대금 하한·상위 60) 일봉 260 + 시세를 캐시에 쓴다.
+ * 요청 경로는 캐시만 읽으므로(504 원칙) 이 크론이 유일한 외부 fetch 지점.
+ * 코인은 24/7 — GH Actions 시간당 1회 트리거.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return true;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return withCors(NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }));
+  }
+  const startedAt = Date.now();
+  try {
+    const snapshots = await fetchUpbitCoinSnapshots();
+    const stats = await writeCoinMarketSnapshots(snapshots);
+    return withCors(
+      NextResponse.json(
+        {
+          ok: true,
+          universe: snapshots.length,
+          written: stats.rows,
+          withCandles: stats.rowsWithCandles,
+          elapsedMs: Date.now() - startedAt,
+        },
+        { headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  } catch (err) {
+    console.warn("[fomo/cron/coin-market-prewarm] failed", (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        { ok: false, error: (err as Error)?.message ?? "coin prewarm failed", elapsedMs: Date.now() - startedAt },
+        { status: 500, headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/lib/coin-discovery.ts
+++ b/apps/web/lib/coin-discovery.ts
@@ -1,0 +1,169 @@
+import { computeCardVerdict, computeFomoScore, isFrontHookSafe } from "@fomo/core";
+import type { CardFrontSignals } from "@fomo/core";
+import { kstDate } from "./fomo";
+import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
+import type { DiscoveryFrontSeed, DiscoveryResponse, DiscoveryStockPayload } from "./discovery-supply";
+
+/**
+ * 코인 발굴 (WO Phase C) — 캐시된 Upbit 스냅샷에서 신호 계산 → 표준 카드(바이오비쥬 포맷).
+ *
+ * 요청 경로 외부 fetch 0 (캐시만 읽음). 신호 없으면 0장(쿼터 강제 금지 — 정직).
+ * 발굴 정체성: BTC·ETH 등 메이저는 marquee 감점으로 자연 탈락, 신호 강한 조용한 알트 우선.
+ * 관측 서술만 — 매수·매도 판단/예측 없음(verdict 는 결정론 엔진의 관측 요약).
+ */
+
+/** 메이저(누구나 아는 대장) — marquee 지정 → daily-30 화제성 감점(+28). 발굴 대상 아님. */
+const MAJOR_COIN_SYMBOLS = new Set([
+  "BTC", "ETH", "XRP", "SOL", "DOGE", "ADA", "TRX", "USDT", "USDC", "BCH", "LINK", "AVAX", "XLM", "DOT",
+]);
+
+/** 발굴 신호 임계 — 24h 거래대금 / 직전 20일(완결 일봉) 평균. */
+const VOLUME_ANOMALY_RATIO = 2.0;
+/** 진공 후 유입: 직전 5일 평균이 30일 평균의 55% 미만(진공)이었는데 오늘 유입. */
+const VACUUM_RATIO = 0.55;
+const VACUUM_INFLOW_RATIO = 1.6;
+/** 조용한 구간 — 등락률 절대값. */
+const QUIET_CHANGE_PCT = 3;
+/** 이미 달린 코인 제외 — 발굴은 "신호는 강한데 조용한" 자리. 급등 중 잡코인 러시는 발굴이 아니다. */
+const ALREADY_MOVED_CHANGE_PCT = 12;
+/** 카드 상한(신호 있어도 최대 N — quietScore 경쟁은 daily-30 이 함) */
+const COIN_CARD_LIMIT = 8;
+
+export interface CoinSignal {
+  /** 24h 거래대금 / 직전 20일 평균. */
+  volumeRatio: number;
+  /** 진공(직전 5일 저조) 후 첫 유입 여부. */
+  vacuumInflow: boolean;
+  quiet: boolean;
+}
+
+function average(values: readonly number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** 마지막 캔들은 진행 중(부분 일봉)이라 신호 계산에서 제외 — 완결 일봉만 비교. */
+export function computeCoinSignal(snapshot: CoinMarketSnapshot): CoinSignal | null {
+  const full = snapshot.tradeValues.slice(0, -1); // 완결 일봉 거래대금
+  if (full.length < 25) return null;
+  const avg20 = average(full.slice(-20));
+  if (!avg20 || avg20 <= 0) return null;
+  const volumeRatio = snapshot.accTradePrice24h / avg20;
+  const avg30 = average(full.slice(-30)) ?? avg20;
+  const recent5 = average(full.slice(-6, -1)) ?? avg20;
+  const vacuumInflow = recent5 < avg30 * VACUUM_RATIO && volumeRatio >= VACUUM_INFLOW_RATIO;
+  return {
+    volumeRatio,
+    vacuumInflow,
+    quiet: Math.abs(snapshot.changePct) < QUIET_CHANGE_PCT,
+  };
+}
+
+export function hasDiscoverySignal(snapshot: CoinMarketSnapshot, signal: CoinSignal): boolean {
+  if (Math.abs(snapshot.changePct) >= ALREADY_MOVED_CHANGE_PCT) return false; // 이미 달림 — 발굴 아님
+  return signal.volumeRatio >= VOLUME_ANOMALY_RATIO || signal.vacuumInflow;
+}
+
+function krw(price: number): string {
+  if (price >= 1000) return `${Math.round(price).toLocaleString("ko-KR")}원`;
+  if (price >= 1) return `${price.toLocaleString("ko-KR", { maximumFractionDigits: 2 })}원`;
+  return `${price.toLocaleString("ko-KR", { maximumFractionDigits: 4 })}원`;
+}
+
+function eok(valueKrw: number): string {
+  const eokValue = valueKrw / 1e8;
+  if (eokValue >= 10_000) return `${(eokValue / 10_000).toFixed(1)}조`;
+  return `${Math.round(eokValue).toLocaleString("ko-KR")}억`;
+}
+
+function ratioText(ratio: number): string {
+  return ratio >= 10 ? `${Math.round(ratio)}배` : `${ratio.toFixed(1)}배`;
+}
+
+/** 관측 서술 헤드라인 — 사실+수치만. 예측·판단 없음. */
+export function coinHeadline(snapshot: CoinMarketSnapshot, signal: CoinSignal): string {
+  const parts: string[] = [];
+  if (signal.vacuumInflow) {
+    parts.push(`거래 진공 뒤 첫 유입 · 24시간 거래대금 평소 ${ratioText(signal.volumeRatio)}`);
+  } else {
+    parts.push(`24시간 거래대금 평소 ${ratioText(signal.volumeRatio)}`);
+  }
+  if (typeof snapshot.athChangePct === "number" && snapshot.athChangePct <= -30) {
+    parts.push(`전고점 대비 ${Math.round(Math.abs(snapshot.athChangePct))}% 아래`);
+  }
+  if (signal.quiet) parts.push("아직 조용한 구간");
+  return parts.join(" · ");
+}
+
+function coinFrontSeed(snapshot: CoinMarketSnapshot, signal: CoinSignal): DiscoveryFrontSeed {
+  const changePct = Number(snapshot.changePct.toFixed(2));
+  const volumeRatio = Number(signal.volumeRatio.toFixed(2));
+  const signals: CardFrontSignals = { changePct, volumeRatio };
+  const closes = snapshot.candles.map((c) => c.close);
+  const changeDir: "up" | "down" | "flat" = snapshot.changePct > 0 ? "up" : snapshot.changePct < 0 ? "down" : "flat";
+  return {
+    signals,
+    fomo: computeFomoScore({ changePct, volumeRatio, asOf: kstDate() }),
+    sparkline: closes.slice(-30),
+    priceText: krw(snapshot.price),
+    changeText: `${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(2)}%`,
+    changeDir,
+    verdict: computeCardVerdict({
+      candles: snapshot.candles,
+      volumeRatio: signal.volumeRatio,
+      currency: "KRW",
+    }),
+  };
+}
+
+function coinStockPayload(snapshot: CoinMarketSnapshot, signal: CoinSignal, headline: string): DiscoveryStockPayload {
+  const marquee = MAJOR_COIN_SYMBOLS.has(snapshot.symbol.toUpperCase()) || snapshot.tradeValueRank <= 3;
+  // 뎁스 보조(재무 블록 미해당) — 거래소·거래대금·순위 사실 표기. 시총은 소스에 없어 표기하지 않는다(지어내기 금지).
+  const reason = `Upbit 원화마켓 · 24시간 거래대금 ${eok(snapshot.accTradePrice24h)} · 거래대금 ${snapshot.tradeValueRank}위`;
+  return {
+    canonical: snapshot.koreanName,
+    market: "COIN",
+    country: "GLOBAL",
+    marquee,
+    sector: "코인",
+    symbol: snapshot.market,
+    headline,
+    whyShown: headline,
+    reason,
+    insightTag: signal.vacuumInflow ? "₿ 진공 후 유입" : "₿ 거래대금 이상",
+    sourceLabel: "Upbit 일봉 · CoinGecko",
+    sourceUrl: `https://upbit.com/exchange?code=CRIX.UPBIT.${snapshot.market}`,
+  };
+}
+
+/**
+ * 코인 발굴 응답 — daily-30 의 addStockCandidates 에 그대로 합류하는 DiscoveryResponse 형.
+ * 캐시 비었거나 신호 없으면 stocks 0(정직) — 파이프라인은 정상.
+ */
+export async function buildCoinDiscoveryResponse(): Promise<DiscoveryResponse> {
+  const snapshots = await readCoinMarketSnapshots().catch((): CoinMarketSnapshot[] => []);
+  const stocks: DiscoveryStockPayload[] = [];
+  const fronts: Record<string, DiscoveryFrontSeed> = {};
+
+  const scored = snapshots
+    .map((snapshot) => ({ snapshot, signal: computeCoinSignal(snapshot) }))
+    .filter((x): x is { snapshot: CoinMarketSnapshot; signal: CoinSignal } => x.signal !== null && hasDiscoverySignal(x.snapshot, x.signal))
+    .sort((a, b) => b.signal.volumeRatio - a.signal.volumeRatio)
+    .slice(0, COIN_CARD_LIMIT);
+
+  for (const { snapshot, signal } of scored) {
+    const headline = coinHeadline(snapshot, signal);
+    if (!isFrontHookSafe(headline)) continue; // 카피 가드 — 발굴 문구도 예외 없음
+    const payload = coinStockPayload(snapshot, signal, headline);
+    stocks.push(payload);
+    fronts[payload.canonical] = coinFrontSeed(snapshot, signal);
+  }
+
+  return {
+    asOf: kstDate(),
+    stocks,
+    fronts,
+    confidence: stocks.length > 0 ? "H" : "L",
+    source: "Upbit 일봉·거래대금 캐시 · CoinGecko",
+  };
+}

--- a/apps/web/lib/coin-market-source.ts
+++ b/apps/web/lib/coin-market-source.ts
@@ -1,0 +1,300 @@
+import { Prisma } from "@prisma/client";
+import type { DailyOhlcv } from "@fomo/core";
+import { prisma } from "./prisma";
+import { fetchWhale } from "./fomo-market-sources";
+
+/**
+ * 코인 시세·캔들 수집 (WO Phase C) — Upbit 공개 API(KRW 마켓, 무키).
+ *
+ * 크론 프리웜 전용: fetchUpbitCoinSnapshots() 는 크론에서만 호출해 캐시에 쓰고,
+ * 요청 경로는 readCoinMarketSnapshots() 로 캐시만 읽는다(요청 경로 외부 fetch 0 — 504 원칙).
+ *
+ * 잡코인 방어선: 유의 지정(market_event.warning) 제외 + 일 거래대금 하한.
+ * 발굴과 잡코인 러시는 다르다 — 유동성 없는 마켓은 유니버스에 넣지 않는다.
+ */
+
+const UPBIT_MARKET_ALL_URL = "https://api.upbit.com/v1/market/all?isDetails=true";
+const UPBIT_TICKER_URL = "https://api.upbit.com/v1/ticker";
+const UPBIT_DAILY_CANDLES_URL = "https://api.upbit.com/v1/candles/days";
+const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
+
+/** 잡코인 방어선 — 24h 거래대금 하한(KRW). 미달 마켓은 발굴 유니버스 제외. */
+const MIN_TRADE_PRICE_24H_KRW = 3_000_000_000; // 30억
+/** 유니버스 상한 — 거래대금 상위 N 마켓만 캔들 수집(비용·집중). */
+const COIN_UNIVERSE_LIMIT = 60;
+/** 일봉 목표 개수(WO: 260) — Upbit 1회 최대 200이라 2회 페이지네이션. */
+const COIN_CANDLE_TARGET = 260;
+/** Upbit quotation 그룹 rate limit ~10 req/s — 동시 2 + 요청당 페이스로 ~4 req/s 유지(429 방지). */
+const CANDLE_CONCURRENCY = 2;
+const CANDLE_PAUSE_MS = 250;
+const FETCH_TIMEOUT_MS = 10_000;
+const COIN_CACHE_MAX_AGE_HOURS = 26; // 시간당 크론 + 여유
+
+/** 캐시에 저장되는 코인 스냅샷 — 캔들·거래대금 시리즈 포함(요청 경로는 이것만 읽음). */
+export interface CoinMarketSnapshot {
+  /** Upbit 마켓 코드 — 예 "KRW-BTC". */
+  market: string;
+  /** 심볼 — 예 "BTC". */
+  symbol: string;
+  koreanName: string;
+  englishName: string;
+  /** 현재가(KRW). */
+  price: number;
+  /** 전일 대비 등락률(%). */
+  changePct: number;
+  /** 24h 누적 거래대금(KRW). */
+  accTradePrice24h: number;
+  /** KRW 마켓 내 24h 거래대금 순위(1=최대). 메이저 감점·유동성 참고. */
+  tradeValueRank: number;
+  /** 일봉(과거→최신). verdict·TA 엔진 공급용. */
+  candles: DailyOhlcv[];
+  /** 일봉과 정렬된 일별 거래대금(KRW) — 거래대금 이상·진공 신호용. */
+  tradeValues: number[];
+  /** CoinGecko 전고점 대비(%) — 크론 시점 fetchWhale 로 채움(top 코인만). */
+  athChangePct?: number;
+  /** 수집 시각(ISO). */
+  fetchedAt: string;
+}
+
+interface UpbitMarketInfo {
+  market: string;
+  korean_name: string;
+  english_name: string;
+  market_event?: { warning?: boolean };
+  market_warning?: string;
+}
+
+interface UpbitTicker {
+  market: string;
+  trade_price: number;
+  signed_change_rate: number;
+  acc_trade_price_24h: number;
+}
+
+interface UpbitDayCandle {
+  candle_date_time_utc: string;
+  opening_price: number;
+  high_price: number;
+  low_price: number;
+  trade_price: number;
+  candle_acc_trade_price: number;
+  candle_acc_trade_volume: number;
+}
+
+async function fetchJson<T>(url: string, retryOn429 = true): Promise<T | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json", "User-Agent": UA }, signal: controller.signal });
+    if (res.status === 429 && retryOn429) {
+      clearTimeout(timer);
+      await sleep(700); // rate limit — 한 번 물러났다 재시도
+      return fetchJson<T>(url, false);
+    }
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function chunks<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size) as T[]);
+  return out;
+}
+
+async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  async function worker() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      out[index] = await fn(items[index] as T);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return out;
+}
+
+/** KRW 마켓 목록 — 유의 지정(warning) 제외. */
+async function fetchKrwMarkets(): Promise<UpbitMarketInfo[]> {
+  const all = await fetchJson<UpbitMarketInfo[]>(UPBIT_MARKET_ALL_URL);
+  if (!Array.isArray(all)) return [];
+  return all.filter(
+    (m) =>
+      m.market?.startsWith("KRW-") &&
+      m.market_event?.warning !== true &&
+      m.market_warning !== "CAUTION"
+  );
+}
+
+async function fetchTickers(markets: readonly string[]): Promise<Map<string, UpbitTicker>> {
+  const out = new Map<string, UpbitTicker>();
+  for (const batch of chunks(markets, 100)) {
+    const url = `${UPBIT_TICKER_URL}?markets=${encodeURIComponent(batch.join(","))}`;
+    const tickers = await fetchJson<UpbitTicker[]>(url);
+    if (Array.isArray(tickers)) for (const t of tickers) out.set(t.market, t);
+    await sleep(CANDLE_PAUSE_MS);
+  }
+  return out;
+}
+
+/** 일봉 260개 — count 최대 200이라 to 파라미터로 2회 페이지네이션(최신→과거 응답을 과거→최신으로 뒤집음). */
+async function fetchDailyCandles(market: string, target = COIN_CANDLE_TARGET): Promise<UpbitDayCandle[]> {
+  const first = await fetchJson<UpbitDayCandle[]>(`${UPBIT_DAILY_CANDLES_URL}?market=${encodeURIComponent(market)}&count=200`);
+  await sleep(CANDLE_PAUSE_MS); // rate limit 페이스 유지(요청당)
+  if (!Array.isArray(first) || first.length === 0) return [];
+  let rows = [...first];
+  const remaining = target - rows.length;
+  if (remaining > 0 && rows.length === 200) {
+    const oldest = rows[rows.length - 1]!.candle_date_time_utc;
+    const more = await fetchJson<UpbitDayCandle[]>(
+      `${UPBIT_DAILY_CANDLES_URL}?market=${encodeURIComponent(market)}&count=${Math.min(200, remaining)}&to=${encodeURIComponent(`${oldest}Z`)}`
+    );
+    await sleep(CANDLE_PAUSE_MS);
+    if (Array.isArray(more)) rows = [...rows, ...more];
+  }
+  return rows.reverse(); // 과거→최신
+}
+
+function toOhlcv(candle: UpbitDayCandle): DailyOhlcv {
+  return {
+    date: candle.candle_date_time_utc.slice(0, 10),
+    open: candle.opening_price,
+    high: candle.high_price,
+    low: candle.low_price,
+    close: candle.trade_price,
+    volume: candle.candle_acc_trade_volume,
+  };
+}
+
+/**
+ * 크론 전용 — Upbit 유니버스 수집(유의 제외·거래대금 하한·상위 N) + 캔들 260 + CoinGecko 전고점 보강.
+ * 요청 경로에서 절대 호출 금지.
+ */
+export async function fetchUpbitCoinSnapshots(): Promise<CoinMarketSnapshot[]> {
+  const markets = await fetchKrwMarkets();
+  if (markets.length === 0) return [];
+  const tickers = await fetchTickers(markets.map((m) => m.market));
+
+  const liquid = markets
+    .map((m) => ({ info: m, ticker: tickers.get(m.market) }))
+    .filter((x): x is { info: UpbitMarketInfo; ticker: UpbitTicker } => !!x.ticker)
+    .filter((x) => x.ticker.acc_trade_price_24h >= MIN_TRADE_PRICE_24H_KRW)
+    .sort((a, b) => b.ticker.acc_trade_price_24h - a.ticker.acc_trade_price_24h)
+    .slice(0, COIN_UNIVERSE_LIMIT);
+
+  // 전고점 대비(CoinGecko fetchWhale) — 크론 시점에 한 번만. 실패해도 파이프라인 정상(fail-open).
+  const whale = await fetchWhale().catch(() => ({ marketCapChange24h: null, coins: [] }));
+  const athBySymbol = new Map<string, number>();
+  for (const coin of whale.coins ?? []) {
+    if (coin.symbol && typeof coin.athChange === "number") athBySymbol.set(coin.symbol.toUpperCase(), coin.athChange);
+  }
+
+  const fetchedAt = new Date().toISOString();
+  const snapshots = await mapLimit(liquid, CANDLE_CONCURRENCY, async (entry): Promise<CoinMarketSnapshot | null> => {
+    const raw = await fetchDailyCandles(entry.info.market).catch((): UpbitDayCandle[] => []);
+    if (raw.length < 30) return null; // verdict 최소 캔들 미달 마켓 제외
+    const symbol = entry.info.market.replace(/^KRW-/, "");
+    const ath = athBySymbol.get(symbol.toUpperCase());
+    return {
+      market: entry.info.market,
+      symbol,
+      koreanName: entry.info.korean_name,
+      englishName: entry.info.english_name,
+      price: entry.ticker.trade_price,
+      changePct: entry.ticker.signed_change_rate * 100,
+      accTradePrice24h: entry.ticker.acc_trade_price_24h,
+      tradeValueRank: 0, // 아래에서 채움
+      candles: raw.map(toOhlcv),
+      tradeValues: raw.map((c) => c.candle_acc_trade_price),
+      ...(typeof ath === "number" ? { athChangePct: ath } : {}),
+      fetchedAt,
+    };
+  });
+
+  const valid = snapshots.filter((s): s is CoinMarketSnapshot => s !== null);
+  valid.sort((a, b) => b.accTradePrice24h - a.accTradePrice24h);
+  valid.forEach((s, i) => {
+    s.tradeValueRank = i + 1;
+  });
+  return valid;
+}
+
+// ── 캐시 (UsMarketQuoteCache 패턴 미러) ─────────────────────────────────────
+
+let ensured = false;
+
+async function ensureCoinMarketCacheTable(): Promise<void> {
+  if (ensured) return;
+  await prisma.$executeRaw`
+    CREATE TABLE IF NOT EXISTS "CoinMarketCache" (
+      "market" TEXT PRIMARY KEY,
+      "row" JSONB NOT NULL,
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+  await prisma.$executeRaw`
+    CREATE INDEX IF NOT EXISTS "CoinMarketCache_updatedAt_idx"
+    ON "CoinMarketCache" ("updatedAt" DESC)
+  `;
+  ensured = true;
+}
+
+function isCoinSnapshot(value: unknown): value is CoinMarketSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<CoinMarketSnapshot>;
+  return (
+    typeof row.market === "string" &&
+    row.market.startsWith("KRW-") &&
+    typeof row.price === "number" &&
+    Array.isArray(row.candles) &&
+    row.candles.length >= 30
+  );
+}
+
+export interface CoinMarketCacheStats {
+  rows: number;
+  rowsWithCandles: number;
+}
+
+export async function writeCoinMarketSnapshots(snapshots: readonly CoinMarketSnapshot[]): Promise<CoinMarketCacheStats> {
+  await ensureCoinMarketCacheTable();
+  let written = 0;
+  for (const snapshot of snapshots) {
+    if (!isCoinSnapshot(snapshot)) continue;
+    await prisma.$executeRaw`
+      INSERT INTO "CoinMarketCache" ("market", "row", "updatedAt")
+      VALUES (${snapshot.market}, ${JSON.stringify(snapshot)}::jsonb, NOW())
+      ON CONFLICT ("market") DO UPDATE
+      SET "row" = EXCLUDED."row", "updatedAt" = NOW()
+    `;
+    written += 1;
+  }
+  return { rows: written, rowsWithCandles: snapshots.filter((s) => s.candles.length >= 30).length };
+}
+
+/** 요청 경로 전용 — 캐시만 읽는다(외부 fetch 0). 캐시 없음/만료 시 빈 배열(fail-open). */
+export async function readCoinMarketSnapshots(maxAgeHours = COIN_CACHE_MAX_AGE_HOURS): Promise<CoinMarketSnapshot[]> {
+  const since = new Date(Date.now() - Math.max(1, Math.min(72, maxAgeHours)) * 60 * 60 * 1000);
+  try {
+    const records = await prisma.$queryRaw<Array<{ market: string; row: unknown }>>`
+      SELECT "market", "row"
+      FROM "CoinMarketCache"
+      WHERE "updatedAt" >= ${since}
+      ORDER BY COALESCE(("row"->>'tradeValueRank')::int, 9999) ASC
+    `;
+    return records.map((record) => record.row).filter(isCoinSnapshot);
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2010") return [];
+    return [];
+  }
+}

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -7,6 +7,7 @@ import {
   type DiscoveryStockPayload,
 } from "./discovery-supply";
 import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContentCard } from "./deck-content";
+import { buildCoinDiscoveryResponse } from "./coin-discovery";
 
 export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
 
@@ -335,9 +336,13 @@ function responseFromSelected(
 }
 
 export async function buildDaily30Response(): Promise<Daily30Response> {
-  const [kr, us, rawContent] = await Promise.all([
+  const [kr, us, coin, rawContent] = await Promise.all([
     buildDiscoveryResponse({ country: "KR", targetedMaterial: true, targetedMaterialLimit: 36 }),
     buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 12 }),
+    // 코인(WO Phase C) — Upbit 캐시 발굴. 신호 없으면 stocks 0(쿼터 강제 없음 — 정직).
+    buildCoinDiscoveryResponse().catch(
+      (): DiscoveryResponse => ({ asOf: "", stocks: [], fronts: {}, confidence: "L", source: "coin unavailable" })
+    ),
     fetchDeckContentCards().catch(() => [] as DeckContentCard[]),
   ]);
   const content = [
@@ -349,6 +354,7 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
   const seen = new Set<string>();
   addStockCandidates(candidates, kr, seen);
   addStockCandidates(candidates, us, seen);
+  addStockCandidates(candidates, coin, seen);
   addContentCandidates(candidates, content, seen);
 
   // WO-GNB 두 표면 분리: 덱 = 종목 30장(내러티브·콘텐츠 제외), 피드 = 콘텐츠·내러티브(중요도순).
@@ -358,5 +364,5 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
     .sort((a, b) => b.quietScore - a.quietScore || a.id.localeCompare(b.id))
     .slice(0, FEED_CARD_LIMIT);
   const deck = selectDaily30Candidates(stockCandidates, DAILY_CARD_TARGET);
-  return responseFromSelected(deck, feedCandidates, [kr, us], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+  return responseFromSelected(deck, feedCandidates, [kr, us, coin], kr.asOf > us.asOf ? kr.asOf : us.asOf);
 }

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -24,6 +24,7 @@ import { fetchStockBasics, fetchStockBasicsLite } from "./stock-basics";
 import { fetchUsDailyCandles } from "./us-market-source";
 import type { DiscoveryMarketRow } from "./market-source-types";
 import { readUsMarketQuoteRows } from "./us-market-cache";
+import { readCoinMarketSnapshots } from "./coin-market-source";
 import { usSymbolForStock } from "./us-symbols";
 import { readSupplyDemandHistory } from "./supply-demand-store";
 import type { StockAttentionSignal, ThemeRelativeSignal } from "./stock-signal-coverage";
@@ -355,6 +356,65 @@ async function assembleUsCachedStockFront(
 }
 
 /**
+ * 코인 카드 앞면·뎁스(WO Phase C) — Upbit 프리웜 캐시만 읽어 조립(요청 경로 외부 fetch 0).
+ * 주식과 같은 표준: TA·verdict·chartSeries 전부 같은 엔진에 캔들만 공급. 재무는 코인 미해당.
+ */
+async function assembleCoinStockFront(market: string, lite: boolean): Promise<StockFrontData> {
+  const snapshots = await readCoinMarketSnapshots().catch(() => []);
+  const snapshot = snapshots.find((s) => s.market.toUpperCase() === market);
+  if (!snapshot) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
+
+  const fullValues = snapshot.tradeValues.slice(0, -1);
+  const avg20 = fullValues.length >= 5 ? fullValues.slice(-20).reduce((a, b) => a + b, 0) / Math.min(20, fullValues.length) : 0;
+  const volRatio = avg20 > 0 ? snapshot.accTradePrice24h / avg20 : undefined;
+  const signals: CardFrontSignals = {
+    changePct: Number(snapshot.changePct.toFixed(2)),
+    ...(typeof volRatio === "number" ? { volumeRatio: Number(volRatio.toFixed(2)) } : {}),
+  };
+  const closes = snapshot.candles.map((c) => c.close);
+  const sparkline = closes.slice(-66);
+  const priceText =
+    snapshot.price >= 1000
+      ? `${Math.round(snapshot.price).toLocaleString("ko-KR")}원`
+      : `${snapshot.price.toLocaleString("ko-KR", { maximumFractionDigits: 4 })}원`;
+  const changeText = `${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(2)}%`;
+  const changeDir: "up" | "down" | "flat" = snapshot.changePct > 0 ? "up" : snapshot.changePct < 0 ? "down" : "flat";
+  const base = {
+    signals,
+    sparkline,
+    priceText,
+    changeText,
+    changeDir,
+  };
+  if (lite) {
+    return { ...base, fomo: computeFomoScore({ ...signals }) };
+  }
+  const ta = computeTechnicalAnalysis(snapshot.candles);
+  const trend = ta.inputs.trendStrength ?? trendStrength(sparkline);
+  const fomo = computeFomoScore({
+    ...signals,
+    ...(typeof trend === "number" ? { trendStrength: trend } : {}),
+    ...(ta.inputs.accumulationDivergence ? { accumulationDivergence: true } : {}),
+    ...(ta.inputs.bollingerSqueeze ? { bollingerSqueeze: true } : {}),
+  });
+  const taFact = selectTaFact(fomo, ta);
+  const verdict = computeCardVerdict({
+    candles: snapshot.candles,
+    ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
+    currency: "KRW",
+  });
+  const chartSeries = buildChartSeries(snapshot.candles);
+  return {
+    ...base,
+    fomo,
+    ...(taFact ? { taFact } : {}),
+    ta,
+    verdict,
+    ...(chartSeries ? { chartSeries } : {}),
+  };
+}
+
+/**
  * 한 종목의 카드 앞면 데이터 조립 + 포모 점수 산출(척추 단일 출처).
  * baseline(가격·52주) + 라이브 수급 streak + 거래량 회전·추세 + 시총순위 + 스파크라인 → computeFomoScore.
  * rankMap 은 비싸므로 호출부에서 받아 재사용(없으면 순위 생략).
@@ -365,6 +425,11 @@ export async function assembleStockFront(
   coverage: { attention?: StockAttentionSignal; themeRelative?: ThemeRelativeSignal } = {},
   options: StockFrontOptions = {}
 ): Promise<StockFrontData> {
+  // 코인(WO Phase C) — symbol 이 Upbit 마켓 코드("KRW-*")면 코인 캐시 경로(요청 경로 외부 fetch 0).
+  const coinMarket = options.symbol?.trim().toUpperCase();
+  if (coinMarket?.startsWith("KRW-")) {
+    return assembleCoinStockFront(coinMarket, options.lite === true);
+  }
   const def = resolveStock(stock);
   const code = options.naverCode ?? def?.naverCode;
   if (!code) {


### PR DESCRIPTION
## WO Phase C — 코인 발굴 파이프라인
> User Zero 확인: 30장 코인 필터 = "해당하는 카드가 오늘은 없어요" — 코인 영역이 비어 있었다. 30장 통합 철학(국·미·코인 경계 없음)의 빈 조각을 채운다.

## 무엇을
### 1. 수집 (크론 프리웜 — 요청 경로 fetch 0)
- **`coin-market-source.ts`**: Upbit 공개 API(무키) — KRW 마켓 **유의 지정 제외** + **일 거래대금 30억 하한**(잡코인 방어선) → 상위 60 마켓 **일봉 260개**(1회 200 제한이라 `to` 페이지네이션, rate limit ~4req/s 페이스 + 429 재시도). CoinGecko(`fetchWhale`) 전고점 대비 보강(크론 시점).
- **`CoinMarketCache`**(JSONB, `CREATE TABLE IF NOT EXISTS`) — UsMarketQuoteCache 패턴 미러, 마이그레이션 0.
- **크론**: `/api/fomo/cron/coin-market-prewarm` + GH Actions 시간당(코인 24/7). CRON_SECRET 동일. **요청 경로는 캐시만 읽음(504 원칙)**.

### 2. 발굴 신호 (quietScore 입력)
- **거래대금 이상**: 24h 거래대금 / 직전 20일(완결 일봉) 평균 ≥ 2배.
- **진공 후 첫 유입**: 직전 5일 평균 < 30일 평균 55% + 유입 1.6배+.
- **이미 급등(±12%+) 제외** — 발굴 ≠ 잡코인 러시.
- **메이저 감점**: BTC·ETH·XRP 등 + 거래대금 top3 = marquee → daily-30 화제성 감점(+28)으로 자연 탈락.
- **쿼터 강제 없음** — 신호 없으면 0장(정직).

### 3. 카드·뎁스 (같은 표준)
- daily-30 quietScore 경쟁에 합류(기존 coin 쿼터 3장). 표준 게이트(가격·등락·헤드라인·**verdict**) 그대로 적용.
- verdict: **같은 엔진**(`computeCardVerdict`) — 와이코프 국면·무효선 계산값, 캔들만 공급(자산 무관·currency KRW).
- 뎁스: `stock-front`에 `KRW-*` 심볼 코인 분기 — 캐시 캔들로 **TA·verdict·chartSeries**(차트분석 탭 동일). 재무 블록 미해당 → 거래소·24h 거래대금·순위 사실 표기(시총은 소스에 없어 표기 안 함 — 지어내기 금지).
- 태그 ₿ (`insightTag: "₿ 거래대금 이상" / "₿ 진공 후 유입"`). 프론트 코인 필터는 `market === "COIN"` 클라 분류라 **백엔드 카드만 넣으면 자동 작동**.

## 검증 (실측)
- 실데이터: 유니버스 **52개**(유의 제외·30억+·캔들 260), 신호 후보 **15개 — 전부 조용한 알트**(BTC·ETH·XRP 0), 예: `미라네트워크 "24시간 거래대금 평소 8.6배"`, `무브먼트 "거래 진공 뒤 첫 유입 · 평소 1.9배 · 아직 조용한 구간"`.
- 카피: 전부 `isFrontHookSafe` 통과. verdict: phase(markdown 등)·무효선·confidence 완비 — 하락장 정직 관측.
- 유닛테스트 6/6 (신호·진공·급등 제외·캔들 부족·헤드라인).
- `guard:discovery` ✅ (KR/US 덱 불변 — 금지: 기존 카드 로직 불건드림), typecheck ✅, spec:analyze error 0.

## 배포 후 순서 (머지 후 진행)
1. `gh workflow run coin-market-prewarm.yml` — 첫 캐시 적재
2. `daily-30` 응답에 코인 카드 확인 (프로덕션 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)