### PR TITLE
fix(coin): 코인 뎁스 캔들차트 일봉 제공 (#808 후속)

### DIFF
--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -413,6 +413,8 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     ta,
     verdict,
     ...(chartSeries ? { chartSeries } : {}),
+    // 캔들차트(Phase A) — 국·미와 동일하게 non-lite 에서 실제 일봉 제공.
+    ...(snapshot.candles.length > 0 ? { candles: snapshot.candles.slice(-260) } : {}),
   };
 }
 


### PR DESCRIPTION
#808 머지 직후 병렬 랜딩한 캔들차트(Phase A)의 `StockFrontData.candles` 필드를 코인 분기에도 제공 — 국·미·코인 동일 표준. 캐시 캔들 슬라이스 한 줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)