### PR TITLE
feat(feed): WO 피드 콘텐츠 강화 — 데일리 브리핑·버즈 스토리·주간 회고

### DIFF
--- a/.github/workflows/feed-content.yml
+++ b/.github/workflows/feed-content.yml
@@ -1,0 +1,76 @@
+name: Feed Content Prewarm
+
+# 피드 콘텐츠 강화(WO) — 브리핑/버즈/회고를 크론이 빌드해 캐시에 쓴다(요청 경로 LLM/fetch 0).
+# - morning 20:30 UTC = 05:30 KST: 간밤의 미장 브리핑 (06:00 KST daily-30 빌드 전에)
+# - close   07:10 UTC = 16:10 KST: 오늘의 국장 브리핑 + 버즈 스토리 (장마감 후)
+# - weekly  금 07:40 UTC = 16:40 KST: "일주일 전에 샀으면" 주간 회고
+# 빌드 후 daily-30 을 다시 워밍해 새 콘텐츠가 응답에 실리게 한다.
+
+on:
+  schedule:
+    - cron: "30 20 * * *"
+    - cron: "10 7 * * 1-5"
+    - cron: "40 7 * * 5"
+  workflow_dispatch:
+    inputs:
+      slot:
+        description: "Slot to run (morning | close | weekly). Defaults by schedule time."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: feed-content
+  cancel-in-progress: false
+
+jobs:
+  prewarm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve slot
+        id: slot
+        env:
+          INPUT_SLOT: ${{ github.event.inputs.slot }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_SLOT:-}" ]; then
+            SLOT="$INPUT_SLOT"
+          else
+            HOUR="$(date -u +%H)"; MINUTE="$(date -u +%M)"
+            if [ "$HOUR" = "20" ]; then
+              SLOT="morning"
+            elif [ "$HOUR" = "07" ] && [ "$MINUTE" -ge 30 ]; then
+              SLOT="weekly"
+            else
+              SLOT="close"
+            fi
+          fi
+          case "$SLOT" in morning|close|weekly) ;; *) echo "invalid slot: $SLOT" >&2; exit 1;; esac
+          echo "slot=$SLOT" >> "$GITHUB_OUTPUT"
+
+      - name: Build feed content
+        env:
+          SLOT: ${{ steps.slot.outputs.slot }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          URL="https://fomo-club-backend.vercel.app/api/fomo/cron/feed-content?slot=${SLOT}"
+          if [ -n "${CRON_SECRET:-}" ]; then
+            curl -fsS "$URL" -H "Authorization: Bearer ${CRON_SECRET}"
+          else
+            curl -fsS "$URL"
+          fi
+
+      - name: Rewarm daily-30 with fresh content
+        run: |
+          set -euo pipefail
+          curl -fsS "https://fomo-club-backend.vercel.app/api/fomo/daily-30" > /tmp/daily30.json
+          node -e '
+            const fs = require("fs");
+            const json = JSON.parse(fs.readFileSync("/tmp/daily30.json", "utf8"));
+            const contents = (json.cards || []).filter((c) => c.kind === "content");
+            const kinds = contents.map((c) => c.contentType);
+            console.log(JSON.stringify({ cards: json.cards?.length || 0, contents: contents.length, kinds }));
+          '

--- a/apps/fomo-web/components/ContentCard.tsx
+++ b/apps/fomo-web/components/ContentCard.tsx
@@ -20,6 +20,12 @@ function typeLabel(type: DeckContent["contentType"]): string {
       return "거시";
     case "whale":
       return "고래";
+    case "briefing":
+      return "브리핑";
+    case "buzz":
+      return "버즈";
+    case "recap":
+      return "주간";
   }
 }
 
@@ -34,6 +40,13 @@ function scopeLabel(scope: DeckContent["scope"]): string {
   }
 }
 
+function cardLabel(type: DeckContent["contentType"]): string {
+  if (type === "briefing") return "DAILY BRIEFING";
+  if (type === "buzz") return "BUZZ STORY";
+  if (type === "recap") return "WEEKLY RECAP";
+  return "MARKET NOTE";
+}
+
 function valueTone(value: string): string {
   const number = Number.parseFloat(value.replace(/,/g, ""));
   if (!Number.isFinite(number)) return "rgba(250,250,250,0.78)";
@@ -43,13 +56,14 @@ function valueTone(value: string): string {
 }
 
 export function ContentCard({ card, progress }: { card: DeckContent; progress?: string | undefined }) {
+  const rich = card.contentType === "briefing" || card.contentType === "buzz" || card.contentType === "recap";
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="shrink-0">
-        <span className="font-pixel text-[10px] uppercase tracking-wide text-muted">MARKET NOTE</span>
+        <span className="font-pixel text-[10px] uppercase tracking-wide text-muted">{cardLabel(card.contentType)}</span>
         <div className="mt-3 flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <h3 className="text-2xl font-bold leading-8 text-whiteout" style={clampStyle(3)}>
+            <h3 className={`${rich ? "text-xl leading-7" : "text-2xl leading-8"} font-bold text-whiteout`} style={clampStyle(3)}>
               {card.headline}
             </h3>
             <p className="mt-1 font-pixel text-xs text-muted">
@@ -63,7 +77,7 @@ export function ContentCard({ card, progress }: { card: DeckContent; progress?: 
       </div>
 
       <div className="mt-5 grid min-h-0 gap-2 overflow-hidden">
-        {card.facts.slice(0, 5).map((fact) => (
+        {card.facts.slice(0, rich ? 7 : 5).map((fact) => (
           <div key={`${card.id}:${fact.label}`} className="border-b border-hairline-soft pb-2.5 last:border-b-0">
             <div className="flex min-w-0 items-center justify-between gap-3">
               <span className="min-w-0 truncate text-sm font-semibold text-whiteout">{fact.label}</span>
@@ -71,9 +85,25 @@ export function ContentCard({ card, progress }: { card: DeckContent; progress?: 
                 {fact.value}
               </span>
             </div>
+            {fact.detail && (
+              <p className="mt-1 text-xs leading-4 text-muted" style={clampStyle(2)}>
+                {fact.detail}
+              </p>
+            )}
           </div>
         ))}
       </div>
+
+      {card.note && (
+        <div className="mt-3 shrink-0 rounded-xl px-3.5 py-3" style={{ backgroundColor: "rgba(216,255,58,0.12)" }}>
+          <p className="font-pixel text-[10px] uppercase tracking-wide" style={{ color: "#D8FF3A" }}>
+            Editor&apos;s Note
+          </p>
+          <p className="mt-1 text-sm leading-5 text-whiteout" style={clampStyle(4)}>
+            {card.note}
+          </p>
+        </div>
+      )}
 
       <div className="mt-auto flex shrink-0 items-center justify-between pt-3">
         <span className="font-pixel text-[11px] text-muted">

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -82,12 +82,14 @@ export interface DeckThemeBundle {
   items: DeckThemeBundleItem[];
 }
 
-export type DeckContentType = "macro" | "index" | "whale";
+export type DeckContentType = "macro" | "index" | "whale" | "briefing" | "buzz" | "recap";
 export type DeckContentScope = "domestic" | "world" | "global";
 
 export interface DeckContentFact {
   label: string;
   value: string;
+  /** "왜" 1줄 — 무버의 재료(브리핑·회고·버즈). */
+  detail?: string;
 }
 
 export interface DeckContent {
@@ -97,6 +99,10 @@ export interface DeckContent {
   scope: DeckContentScope;
   headline: string;
   facts: DeckContentFact[];
+  /** Editor's Note / 해석 — 사실 기반 관측·해석(WO 피드 강화). */
+  note?: string;
+  /** 원문 링크(버즈 스토리). */
+  sourceUrl?: string;
   source: string;
   asOf: string;
 }
@@ -644,6 +650,12 @@ function scopeMatchesCountry(scope: DeckContentScope, country: StockCountry): bo
 
 function contentPriority(type: DeckContentType): number {
   switch (type) {
+    case "briefing":
+      return -3; // 피드 최상단(WO 피드 강화)
+    case "buzz":
+      return -2;
+    case "recap":
+      return -1;
     case "index":
       return 0;
     case "macro":

--- a/apps/web/__tests__/lib/feed-briefing.test.ts
+++ b/apps/web/__tests__/lib/feed-briefing.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/prisma", () => ({ prisma: { $executeRaw: vi.fn(), $queryRaw: vi.fn().mockResolvedValue([]) } }));
+
+const { safeInternals } = await (async () => {
+  const mod = await import("../../lib/feed-briefing");
+  return { safeInternals: mod };
+})();
+
+// 내부 함수는 export 안 됐으므로 공개 계약으로 검증 — 카드 빌더의 안전판이 핵심.
+describe("feed-briefing 안전판", () => {
+  it("모듈이 로드되고 read 경로는 캐시 실패 시 빈 컨텐츠(fail-open)", async () => {
+    const content = await safeInternals.readTodayFeedContent();
+    expect(content.cards).toEqual([]);
+    expect(content.pinnedIds.size).toBe(0);
+  });
+});

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { withCors, kstDate } from "../../../../../lib/fomo";
+import { writeFeedContent } from "../../../../../lib/feed-content-store";
+import {
+  buildBuzzStory,
+  buildKrBriefing,
+  buildUsBriefing,
+  buildWeeklyRecap,
+  type FeedBriefingRow,
+} from "../../../../../lib/feed-briefing";
+
+/**
+ * 피드 콘텐츠 프리웜 크론 (WO 피드 강화) — ?slot=morning|close|weekly
+ * - morning: 간밤의 미장 브리핑
+ * - close: 오늘의 국장 브리핑 + 버즈 스토리(언급 스냅샷 포함)
+ * - weekly: "일주일 전에 샀으면" 주간 회고
+ * LLM은 여기(크론)에서만 — 요청 경로는 캐시 읽기 전용. 빌드 후 daily-30 캐시 태그 무효화.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return true;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+function isoWeekOf(date = new Date()): string {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return withCors(NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }));
+  }
+  const slot = new URL(request.url).searchParams.get("slot") ?? "";
+  const startedAt = Date.now();
+  const date = kstDate();
+  const written: string[] = [];
+  try {
+    const save = async (id: string, row: FeedBriefingRow | null) => {
+      if (!row) return;
+      await writeFeedContent(id, row);
+      written.push(id);
+    };
+    if (slot === "morning") {
+      await save(`briefing:us:${date}`, await buildUsBriefing());
+    } else if (slot === "close") {
+      await save(`briefing:kr:${date}`, await buildKrBriefing());
+      await save(`buzz:${date}`, await buildBuzzStory());
+    } else if (slot === "weekly") {
+      await save(`recap:${isoWeekOf()}`, await buildWeeklyRecap());
+    } else {
+      return withCors(NextResponse.json({ ok: false, error: "slot must be morning|close|weekly" }, { status: 400 }));
+    }
+    // daily-30 서버 캐시 즉시 만료 — 다음 요청이 새 콘텐츠를 포함해 재빌드.
+    revalidateTag("daily-30", { expire: 0 });
+    return withCors(
+      NextResponse.json(
+        { ok: true, slot, written, elapsedMs: Date.now() - startedAt },
+        { headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  } catch (err) {
+    console.warn("[fomo/cron/feed-content] failed", slot, (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        { ok: false, slot, written, error: (err as Error)?.message ?? "feed content failed" },
+        { status: 500, headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/app/api/fomo/daily-30/route.ts
+++ b/apps/web/app/api/fomo/daily-30/route.ts
@@ -17,7 +17,8 @@ export async function GET() {
     const load = unstable_cache(
       () => buildDaily30Response(),
       ["fomo-daily-30", cacheVersion(), kstDate()],
-      { revalidate: REVALIDATE_S }
+      // 태그: feed-content 크론(브리핑/버즈/회고 갱신)이 revalidateTag 로 즉시 재빌드 유도.
+      { revalidate: REVALIDATE_S, tags: ["daily-30"] }
     );
     return withCors(
       NextResponse.json(await load(), {

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -8,6 +8,7 @@ import {
 } from "./discovery-supply";
 import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContentCard } from "./deck-content";
 import { buildCoinDiscoveryResponse } from "./coin-discovery";
+import { readTodayFeedContent, type TodayFeedContent } from "./feed-briefing";
 
 export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
 
@@ -189,9 +190,21 @@ function stockCandidate(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed 
   };
 }
 
-function contentCandidate(card: DeckContentCard): Daily30Candidate | null {
+/** 피드 정렬(WO 피드 강화): 브리핑 상단 → 버즈 → 회고 → 기존(지수·거시·고래). 핀(급변동일)은 그 위. */
+const CONTENT_SIGNAL_SCORE: Record<DeckContentCard["contentType"], number> = {
+  briefing: 72,
+  buzz: 60,
+  recap: 52,
+  index: 42,
+  macro: 38,
+  whale: 34,
+};
+const PINNED_SCORE_BONUS = 30;
+
+function contentCandidate(card: DeckContentCard, pinnedIds?: ReadonlySet<string>): Daily30Candidate | null {
   if (!card.headline.trim() || card.facts.length === 0) return null;
-  const signalScore = card.contentType === "index" ? 42 : card.contentType === "macro" ? 38 : 34;
+  const pinned = pinnedIds?.has(card.id) === true;
+  const signalScore = CONTENT_SIGNAL_SCORE[card.contentType] + (pinned ? PINNED_SCORE_BONUS : 0);
   const hypePenalty = card.contentType === "whale" ? 6 : 2;
   return {
     kind: "content",
@@ -252,9 +265,14 @@ function addStockCandidates(
   }
 }
 
-function addContentCandidates(out: Daily30Candidate[], content: readonly DeckContentCard[], seen: Set<string>): void {
+function addContentCandidates(
+  out: Daily30Candidate[],
+  content: readonly DeckContentCard[],
+  seen: Set<string>,
+  pinnedIds?: ReadonlySet<string>
+): void {
   for (const card of content) {
-    const candidate = contentCandidate(card);
+    const candidate = contentCandidate(card, pinnedIds);
     if (!candidate || seen.has(candidate.id)) continue;
     seen.add(candidate.id);
     out.push(candidate);
@@ -336,7 +354,7 @@ function responseFromSelected(
 }
 
 export async function buildDaily30Response(): Promise<Daily30Response> {
-  const [kr, us, coin, rawContent] = await Promise.all([
+  const [kr, us, coin, rawContent, feedContent] = await Promise.all([
     buildDiscoveryResponse({ country: "KR", targetedMaterial: true, targetedMaterialLimit: 36 }),
     buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 12 }),
     // 코인(WO Phase C) — Upbit 캐시 발굴. 신호 없으면 stocks 0(쿼터 강제 없음 — 정직).
@@ -344,18 +362,29 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
       (): DiscoveryResponse => ({ asOf: "", stocks: [], fronts: {}, confidence: "L", source: "coin unavailable" })
     ),
     fetchDeckContentCards().catch(() => [] as DeckContentCard[]),
+    // 피드 강화(WO) — 브리핑·버즈·회고. 크론이 채운 캐시만 읽는다(외부 fetch 0).
+    readTodayFeedContent().catch((): TodayFeedContent => ({ cards: [], pinnedIds: new Set() })),
   ]);
+  // MARKET NOTE 해석 1줄(WO — 숫자만 금지): 국내 지수 카드에 섹터 펄스(실데이터) 주입.
+  const enrichedRawContent = feedContent.indexNote
+    ? rawContent.map((card) =>
+        card.contentType === "index" && card.scope === "domestic" && !card.note
+          ? { ...card, note: feedContent.indexNote! }
+          : card
+      )
+    : rawContent;
   const content = [
-    ...expandDeckContentCardsForScope(rawContent, "domestic", 3),
-    ...expandDeckContentCardsForScope(rawContent, "world", 3),
-    ...expandDeckContentCardsForScope(rawContent, "global", 2),
+    ...feedContent.cards,
+    ...expandDeckContentCardsForScope(enrichedRawContent, "domestic", 3),
+    ...expandDeckContentCardsForScope(enrichedRawContent, "world", 3),
+    ...expandDeckContentCardsForScope(enrichedRawContent, "global", 2),
   ];
   const candidates: Daily30Candidate[] = [];
   const seen = new Set<string>();
   addStockCandidates(candidates, kr, seen);
   addStockCandidates(candidates, us, seen);
   addStockCandidates(candidates, coin, seen);
-  addContentCandidates(candidates, content, seen);
+  addContentCandidates(candidates, content, seen, feedContent.pinnedIds);
 
   // WO-GNB 두 표면 분리: 덱 = 종목 30장(내러티브·콘텐츠 제외), 피드 = 콘텐츠·내러티브(중요도순).
   const stockCandidates = candidates.filter((c) => c.kind === "stock");

--- a/apps/web/lib/deck-content.ts
+++ b/apps/web/lib/deck-content.ts
@@ -8,11 +8,14 @@ const FRED_WORLD_SERIES = ["DGS10", "VIXCLS"] as const;
 const FRED_CONTENT_TIMEOUT_MS = 4_500;
 
 export type DeckContentScope = "domestic" | "world" | "global";
-export type DeckContentType = "macro" | "index" | "whale";
+/** briefing=데일리 브리핑, buzz=떠들썩 스토리, recap=주간 회고 (WO 피드 강화 — 숫자에 이야기를 붙인다). */
+export type DeckContentType = "macro" | "index" | "whale" | "briefing" | "buzz" | "recap";
 
 export interface DeckContentFact {
   label: string;
   value: string;
+  /** "왜" 1줄 — 무버의 재료(수집 기사에서). 브리핑·회고 무버 행에만. */
+  detail?: string;
 }
 
 export interface DeckContentCard {
@@ -22,6 +25,10 @@ export interface DeckContentCard {
   scope: DeckContentScope;
   headline: string;
   facts: DeckContentFact[];
+  /** Editor's Note / 해석 1~2문장 — 크론 시점 LLM 1콜 캐시(수치는 실데이터만) 또는 규칙 폴백. */
+  note?: string;
+  /** 원문 링크(버즈 스토리). */
+  sourceUrl?: string;
   source: string;
   asOf: string;
 }
@@ -287,6 +294,12 @@ function contentScopeMatches(scope: DeckContentScope, target: DeckContentScope):
 
 function contentTypePriority(type: DeckContentType): number {
   switch (type) {
+    case "briefing":
+      return -3; // 피드 최상단(WO 피드 강화)
+    case "buzz":
+      return -2;
+    case "recap":
+      return -1;
     case "index":
       return 0;
     case "macro":
@@ -305,6 +318,8 @@ function factCardId(baseId: string, fact: DeckContentFact, index: number): strin
 }
 
 function splitFactCards(card: DeckContentCard): DeckContentCard[] {
+  // 브리핑·버즈·회고는 구성체(무버+지수+노트) — 조각내면 이야기가 깨진다.
+  if (card.contentType === "briefing" || card.contentType === "buzz" || card.contentType === "recap") return [];
   if (card.facts.length <= 1) return [];
   return card.facts.map((fact, index) => ({
     ...card,

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -294,7 +294,7 @@ async function fetchMarketPage(market: DiscoveryMarket, page: number): Promise<D
   return (data.stocks ?? []).map((row) => parseMarketRow(row, market)).filter((row): row is DiscoveryMarketRow => row !== null);
 }
 
-async function fetchKrMarketRows(): Promise<DiscoveryMarketRow[]> {
+export async function fetchKrMarketRows(): Promise<DiscoveryMarketRow[]> {
   const settled = await Promise.allSettled(
     MARKETS.flatMap((market) => Array.from({ length: PAGES_PER_MARKET }, (_, i) => fetchMarketPage(market, i + 1)))
   );

--- a/apps/web/lib/feed-briefing.ts
+++ b/apps/web/lib/feed-briefing.ts
@@ -1,0 +1,516 @@
+import { callAI, isAiConfigured } from "@fomo/shared";
+import { sectorOf } from "@fomo/core";
+import { fetchMacro } from "./fomo-market-sources";
+import { readUsMarketQuoteRows } from "./us-market-cache";
+import { fetchKrMarketRows } from "./discovery-supply";
+import { fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
+import { computeStockAttentionSignals } from "./stock-signal-coverage";
+import { hasForbiddenCopy } from "./copy-guards";
+import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { fetchStockDaily } from "./stock-front";
+import { relatedTo } from "./relation-graph";
+import { kstDate } from "./fomo";
+import type { DiscoveryMarketRow } from "./market-source-types";
+import type { DeckContentCard, DeckContentFact } from "./deck-content";
+
+/**
+ * 피드 콘텐츠 강화 (WO) — 숫자에 이야기를 붙인다.
+ * ① 데일리 브리핑(간밤 미장/오늘 국장): 무버+왜 1줄+지수+Editor's Note.
+ * ② 버즈 스토리: 언급 급증 사건 요약 + 연결 종목.
+ * ③ 주간 회고: "일주일 전에 샀으면" UP3/DOWN3.
+ *
+ * 전부 크론에서 빌드→FeedContentCache 저장. 요청 경로는 read* 만(외부 fetch/LLM 0 — 504 원칙).
+ * 수치·사건·연결종목은 실데이터만. Editor's Note 는 크론 LLM 1콜(수치 언급 금지 프롬프트+가드) 또는 규칙 폴백.
+ */
+
+const MOVER_COUNT = 4;
+/** 코스피 급변동 임계(%) — 넘으면 브리핑 최상단 고정 + 원인 확장(WO). */
+const BIG_MOVE_PCT = 3;
+/** 버즈: 언급 스냅샷 대비 급증 배수(스냅샷 3일치 이상일 때). */
+const BUZZ_SPIKE_RATIO = 2.5;
+/** 버즈: 스냅샷 부족 시 절대 언급 하한. */
+const BUZZ_MIN_MENTIONS = 6;
+const LLM_TIMEOUT_MS = 20_000;
+
+/** 캐시 행 — 카드 + 정렬 힌트. */
+export interface FeedBriefingRow {
+  card: DeckContentCard;
+  /** 급변동일 최상단 고정. */
+  pinned?: boolean;
+  /** MARKET NOTE 해석 1줄(지수 카드에 주입) — 실데이터 섹터 펄스. */
+  sectorPulse?: string;
+}
+
+function signedPct(value: number): string {
+  return `${value > 0 ? "+" : ""}${value.toFixed(2)}%`;
+}
+
+/** LLM 출력 안전판 — 금지 카피/숫자(지어낸 수치 방지) 있으면 버린다. */
+function safeNote(text: string | undefined): string | undefined {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  if (!clean || clean.length < 8 || clean.length > 180) return undefined;
+  if (/\d/.test(clean)) return undefined; // 수치는 실데이터(facts)에만 — 노트가 숫자를 만들면 폐기
+  if (hasForbiddenCopy(clean)) return undefined;
+  return clean;
+}
+
+function safeWhy(text: string | undefined): string | undefined {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  if (!clean || clean.length < 4 || clean.length > 60) return undefined;
+  if (hasForbiddenCopy(clean)) return undefined;
+  if (/[A-Za-z]{4,}\s+[A-Za-z]{4,}\s+[A-Za-z]{4,}/.test(clean)) return undefined; // 영어 문장 그대로면 폐기
+  return clean;
+}
+
+function parseJsonBlock<T>(content: string): T | null {
+  const match = content.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[0]) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface MoverInput {
+  name: string;
+  symbol?: string;
+  changePct: number;
+  /** 수집된 재료 헤드라인(원문) — LLM이 한국어 1줄로 눌러쓴다. */
+  materialTitle?: string;
+}
+
+/** 무버 유니버스 상한 — 시총 상위만(상한가 소형주가 브리핑을 점령하지 않게, GMC도 대형주 무버). */
+const MOVER_UNIVERSE = 400;
+
+/** 무버 선택 — |등락| 상위, 상승·하락 최소 1개씩 섞는다(시장의 양면). */
+function pickMovers(rows: readonly DiscoveryMarketRow[], count = MOVER_COUNT): DiscoveryMarketRow[] {
+  const priced = rows
+    .slice(0, MOVER_UNIVERSE)
+    .filter((row) => typeof row.changePct === "number" && Number.isFinite(row.changePct));
+  const byAbs = [...priced].sort((a, b) => Math.abs(b.changePct!) - Math.abs(a.changePct!));
+  const top = byAbs.slice(0, count);
+  const hasUp = top.some((row) => row.changePct! > 0);
+  const hasDown = top.some((row) => row.changePct! < 0);
+  if (!hasDown) {
+    const worst = [...priced].sort((a, b) => a.changePct! - b.changePct!)[0];
+    if (worst && worst.changePct! < 0) top.splice(count - 1, 1, worst);
+  } else if (!hasUp) {
+    const best = [...priced].sort((a, b) => b.changePct! - a.changePct!)[0];
+    if (best && best.changePct! > 0) top.splice(count - 1, 1, best);
+  }
+  return top;
+}
+
+/**
+ * LLM 1콜 — 무버 "왜" 1줄(수집 재료 압축)과 Editor's Note 를 함께 받는다(크론 전용).
+ * 실패/미설정 시 null — 호출부가 규칙 폴백.
+ */
+async function synthesizeBriefingCopy(
+  market: "미국" | "한국",
+  movers: readonly MoverInput[],
+  indices: ReadonlyArray<{ label: string; changePct: number }>,
+  sectorPulse?: string
+): Promise<{ whyBySymbol: Map<string, string>; note?: string } | null> {
+  if (!isAiConfigured()) return null;
+  const data = {
+    market,
+    movers: movers.map((m) => ({
+      name: m.name,
+      changePct: Number(m.changePct.toFixed(2)),
+      material: m.materialTitle ?? null,
+    })),
+    indices: indices.map((i) => ({ label: i.label, changePct: Number(i.changePct.toFixed(2)) })),
+    ...(sectorPulse ? { sectorPulse } : {}),
+  };
+  const res = await callAI({
+    messages: [
+      {
+        role: "system",
+        content:
+          "너는 시장 브리핑 에디터다. 입력 JSON의 실데이터만 근거로 답한다. " +
+          "각 무버의 material(기사 제목)을 한국어 한 줄(24자 이내, 사실 서술)로 눌러써라. material이 null이면 빈 문자열. " +
+          "note는 오늘 시장 전체의 해석 1~2문장(한국어) — 숫자·퍼센트 언급 금지(수치는 카드가 보여준다), 입력에 없는 종목·사실 언급 금지, 매수·매도 권유 금지. " +
+          'JSON만 출력: {"movers":[{"name":"...","why":"..."}],"note":"..."}',
+      },
+      { role: "user", content: JSON.stringify(data) },
+    ],
+    temperature: 0.4,
+    timeoutMs: LLM_TIMEOUT_MS,
+    trace: "feed-briefing",
+  });
+  if (!res.ok || !res.content) return null;
+  const parsed = parseJsonBlock<{ movers?: Array<{ name?: string; why?: string }>; note?: string }>(res.content);
+  if (!parsed) return null;
+  const whyBySymbol = new Map<string, string>();
+  for (const item of parsed.movers ?? []) {
+    const why = safeWhy(item.why);
+    if (item.name && why) whyBySymbol.set(item.name, why);
+  }
+  const note = safeNote(parsed.note);
+  return { whyBySymbol, ...(note ? { note } : {}) };
+}
+
+/** 규칙 폴백 노트 — 실데이터 breadth 만으로 정직하게. */
+function ruleNote(rows: readonly DiscoveryMarketRow[], market: "미국" | "한국"): string {
+  const priced = rows.filter((row) => typeof row.changePct === "number");
+  const up = priced.filter((row) => row.changePct! > 0).length;
+  const down = priced.filter((row) => row.changePct! < 0).length;
+  if (up === 0 && down === 0) return `${market} 시장의 큰 방향은 없었어요.`;
+  if (up > down * 1.5) return `${market} 시장은 오른 종목이 뚜렷하게 많았던 하루예요.`;
+  if (down > up * 1.5) return `${market} 시장은 내린 종목이 많았던 하루예요.`;
+  return `${market} 시장은 오르고 내린 종목이 팽팽했어요.`;
+}
+
+/** 섹터 펄스 — 지수 기여 최대 섹터 1줄(실데이터). 종목수×|평균|로 랭크(소수 섹터의 착시 방지). */
+function computeSectorPulse(rows: readonly DiscoveryMarketRow[]): string | undefined {
+  const bySector = new Map<string, number[]>();
+  for (const row of rows.slice(0, MOVER_UNIVERSE)) {
+    if (typeof row.changePct !== "number") continue;
+    const sector = row.sectorHint ?? sectorOf(row.canonical);
+    if (!sector || sector === "기타 업종") continue;
+    const arr = bySector.get(sector) ?? [];
+    arr.push(row.changePct);
+    bySector.set(sector, arr);
+  }
+  let best: { sector: string; avg: number; count: number; weight: number } | undefined;
+  for (const [sector, changes] of bySector) {
+    if (changes.length < 5) continue; // 소수 섹터가 지수 원인 행세하지 않게
+    const avg = changes.reduce((a, b) => a + b, 0) / changes.length;
+    const weight = changes.length * Math.abs(avg);
+    if (!best || weight > best.weight) best = { sector, avg, count: changes.length, weight };
+  }
+  if (!best || Math.abs(best.avg) < 1) return undefined;
+  return `${best.sector} ${best.count}종목이 평균 ${signedPct(best.avg)} — 오늘 지수를 ${best.avg > 0 ? "끌어올린" : "누른"} 쪽이에요.`;
+}
+
+/** 종목과 무관한 기사가 "왜"로 붙는 오염 방지 — 제목에 종목명(또는 앞 토큰)이 있어야 재료로 인정. */
+function relevantTitle(articles: ReadonlyArray<{ title: string }>, name: string): string | undefined {
+  const normalized = name.replace(/\s+/g, "");
+  const token = normalized.slice(0, 4);
+  const shortName = normalized.length <= 3; // "SK"가 "SK하이닉스" 기사에 붙는 오염 방지 — 짧은 이름은 경계 필수
+  const hit = articles.find((a) => {
+    const title = a.title.replace(/\s+/g, "");
+    const idx = title.indexOf(token);
+    if (idx < 0) return false;
+    if (!shortName) return true;
+    const next = title[idx + token.length];
+    return !next || !/[가-힣A-Za-z0-9]/.test(next);
+  });
+  return hit?.title?.trim() || undefined;
+}
+
+async function moverMaterialTitleUs(symbol: string): Promise<string | undefined> {
+  const articles = await fetchYahooStockNews(symbol, 4).catch(() => []);
+  return articles[0]?.title?.trim() || undefined; // Yahoo는 심볼별 RSS라 자체적으로 관련 보장
+}
+
+async function moverMaterialTitleKr(naverCode: string | undefined, name: string): Promise<string | undefined> {
+  if (!naverCode) return undefined;
+  const articles = await fetchNaverStockNews(naverCode, 5).catch(() => []);
+  return relevantTitle(articles, name);
+}
+
+function moverFacts(
+  movers: readonly MoverInput[],
+  whyByName: ReadonlyMap<string, string>,
+  { koreanMaterialFallback = false } = {}
+): DeckContentFact[] {
+  return movers.map((m) => {
+    // LLM 압축이 1순위, 없으면(미설정·실패) 한국어 재료 제목을 그대로 — 영어 제목은 폴백 금지.
+    const fallback = koreanMaterialFallback ? safeWhy(m.materialTitle) : undefined;
+    const why = whyByName.get(m.name) ?? fallback;
+    return {
+      label: m.name,
+      value: signedPct(m.changePct),
+      ...(why ? { detail: why } : {}),
+    };
+  });
+}
+
+function indexFacts(indices: ReadonlyArray<{ label: string; changePct: number }>): DeckContentFact[] {
+  return indices.map((i) => ({ label: `${i.label} 지수`, value: signedPct(i.changePct) }));
+}
+
+function briefingDateLabel(date: string): string {
+  const [, m, d] = date.match(/^\d{4}-(\d{2})-(\d{2})$/) ?? [];
+  return m && d ? `${Number(m)}월 ${Number(d)}일` : date;
+}
+
+/** ① 간밤의 미장 브리핑 — 아침 크론. US 프리웜 캐시 + Yahoo RSS 재료(크론 시점) + LLM 1콜. */
+export async function buildUsBriefing(): Promise<FeedBriefingRow | null> {
+  const rows = await readUsMarketQuoteRows();
+  if (rows.length === 0) return null;
+  const moverRows = pickMovers(rows);
+  const movers: MoverInput[] = [];
+  for (const row of moverRows) {
+    const materialTitle = await moverMaterialTitleUs(row.symbol);
+    movers.push({
+      name: row.canonical,
+      symbol: row.symbol,
+      changePct: row.changePct!,
+      ...(materialTitle ? { materialTitle } : {}),
+    });
+  }
+  const macro = await fetchMacro().catch(() => []);
+  const indices = macro
+    .filter((q) => ["spx", "ndq", "sox"].includes(q.key) && typeof q.change === "number")
+    .map((q) => ({ label: q.label, changePct: q.change as number }));
+  const ai = await synthesizeBriefingCopy("미국", movers, indices).catch(() => null);
+  const note = ai?.note ?? ruleNote(rows, "미국");
+  const date = kstDate();
+  return {
+    card: {
+      kind: "content",
+      id: `content:briefing:us:${date}`,
+      contentType: "briefing",
+      scope: "world",
+      headline: `간밤의 미장 요약 — ${briefingDateLabel(date)}`,
+      facts: [...moverFacts(movers, ai?.whyBySymbol ?? new Map()), ...indexFacts(indices)],
+      note,
+      source: "미장 시세·수집 뉴스",
+      asOf: date,
+    },
+  };
+}
+
+/** ① 오늘의 국장 브리핑 — 장마감 크론. 네이버 시세 + 종목뉴스 재료 + LLM 1콜. 급변동일 고정. */
+export async function buildKrBriefing(): Promise<FeedBriefingRow | null> {
+  const rows = await fetchKrMarketRows().catch((): DiscoveryMarketRow[] => []);
+  if (rows.length === 0) return null;
+  const moverRows = pickMovers(rows);
+  const movers: MoverInput[] = [];
+  for (const row of moverRows) {
+    const materialTitle = await moverMaterialTitleKr(row.naverCode, row.canonical);
+    movers.push({
+      name: row.canonical,
+      changePct: row.changePct!,
+      ...(materialTitle ? { materialTitle } : {}),
+    });
+  }
+  const macro = await fetchMacro().catch(() => []);
+  const indices = macro
+    .filter((q) => ["kospi", "kosdaq"].includes(q.key) && typeof q.change === "number")
+    .map((q) => ({ label: q.label, changePct: q.change as number }));
+  const kospiChange = indices.find((i) => i.label.includes("코스피") || i.label.toUpperCase().includes("KOSPI"))?.changePct;
+  const bigMove = typeof kospiChange === "number" && Math.abs(kospiChange) >= BIG_MOVE_PCT;
+  const sectorPulse = computeSectorPulse(rows);
+  const ai = await synthesizeBriefingCopy("한국", movers, indices, sectorPulse).catch(() => null);
+  const baseNote = ai?.note ?? ruleNote(rows, "한국");
+  // 급변동일 — 원인(섹터 펄스) 확장. 전부 실데이터.
+  const note = bigMove && sectorPulse ? `크게 출렁인 날이에요. ${sectorPulse} ${baseNote}` : baseNote;
+  const date = kstDate();
+  return {
+    card: {
+      kind: "content",
+      id: `content:briefing:kr:${date}`,
+      contentType: "briefing",
+      scope: "domestic",
+      headline: `오늘의 국장 요약 — ${briefingDateLabel(date)}`,
+      facts: [...moverFacts(movers, ai?.whyBySymbol ?? new Map(), { koreanMaterialFallback: true }), ...indexFacts(indices)],
+      note,
+      source: "네이버 시세·종목뉴스",
+      asOf: date,
+    },
+    ...(bigMove ? { pinned: true } : {}),
+    ...(sectorPulse ? { sectorPulse } : {}),
+  };
+}
+
+interface MentionSnapshot {
+  date: string;
+  counts: Record<string, number>;
+}
+
+/** ② 버즈 스토리 — 언급 급증 사건. 장마감 크론에서 스냅샷 저장 + 카드 빌드. */
+export async function buildBuzzStory(): Promise<FeedBriefingRow | null> {
+  const attention = await computeStockAttentionSignals().catch(() => ({}) as Record<string, { mentionCount: number; mentionScore: number; newsEventLabel?: string; newsEventSource?: string }>);
+  const date = kstDate();
+  const counts: Record<string, number> = {};
+  for (const [stock, signal] of Object.entries(attention)) counts[stock] = signal.mentionCount;
+  await writeFeedContent(`mention-snapshot:${date}`, { date, counts } satisfies MentionSnapshot).catch(() => {});
+
+  // 급증 판정 — 지난 스냅샷 평균 대비. 히스토리 부족하면 절대 언급 하한(정직한 폴백).
+  const history = (await readFeedContentByPrefix<MentionSnapshot>("mention-snapshot:", 8)).filter((s) => s.row.date !== date);
+  const avgFor = (stock: string): number | undefined => {
+    const values = history.map((s) => s.row.counts[stock] ?? 0);
+    if (values.length < 3) return undefined;
+    return values.reduce((a, b) => a + b, 0) / values.length;
+  };
+  const candidates = Object.entries(attention)
+    .filter(([, signal]) => (signal.newsEventLabel ?? "").trim().length >= 8)
+    .map(([stock, signal]) => {
+      const avg = avgFor(stock);
+      const spike = typeof avg === "number" ? (avg > 0 ? signal.mentionCount / avg : signal.mentionCount) : undefined;
+      return { stock, signal, spike };
+    })
+    .filter((c) =>
+      typeof c.spike === "number" ? c.spike >= BUZZ_SPIKE_RATIO && c.signal.mentionCount >= 4 : c.signal.mentionCount >= BUZZ_MIN_MENTIONS
+    )
+    .sort((a, b) => b.signal.mentionCount - a.signal.mentionCount);
+  const top = candidates[0];
+  if (!top) return null; // 오늘 떠든 사건 없음 — 카드 0(정직)
+
+  const rows = await fetchKrMarketRows().catch((): DiscoveryMarketRow[] => []);
+  const rowByName = new Map(rows.map((row) => [row.canonical, row]));
+  const anchorRow = rowByName.get(top.stock);
+  const sector = sectorOf(top.stock);
+  const related = relatedTo({ kind: "event", ticker: top.stock, ...(sector ? { theme: sector } : {}) })
+    .filter((node) => node.ticker !== top.stock && node.country === "KR")
+    .slice(0, 3);
+  const facts: DeckContentFact[] = [
+    {
+      label: top.stock,
+      value: typeof anchorRow?.changePct === "number" ? signedPct(anchorRow.changePct) : `언급 ${top.signal.mentionCount}건`,
+      detail: "사건의 중심",
+    },
+    ...related.map((node) => {
+      const row = rowByName.get(node.ticker);
+      return {
+        label: node.label,
+        value: typeof row?.changePct === "number" ? signedPct(row.changePct) : "—",
+        detail: node.reason,
+      };
+    }),
+  ];
+
+  // 사건 요약 — 수집 기사 기반 LLM 2~3문장(크론 1콜), 폴백은 사건 헤드라인 그대로.
+  let note: string | undefined;
+  if (isAiConfigured()) {
+    const articles = anchorRow?.naverCode ? await fetchNaverStockNews(anchorRow.naverCode, 5).catch(() => []) : [];
+    const res = await callAI({
+      messages: [
+        {
+          role: "system",
+          content:
+            "아래 기사 제목·요약(실데이터)만 근거로 이 사건이 무슨 일인지, 왜 시장이 떠드는지 한국어 2~3문장으로 정리하라. " +
+            "입력에 없는 수치·사실 금지, 추측 인과 금지(기사에 있는 사실만), 매수·매도 권유 금지. 문장만 출력.",
+        },
+        {
+          role: "user",
+          content: JSON.stringify({
+            event: top.signal.newsEventLabel,
+            articles: articles.slice(0, 4).map((a) => ({ title: a.title, summary: a.summary ?? null })),
+          }),
+        },
+      ],
+      temperature: 0.3,
+      timeoutMs: LLM_TIMEOUT_MS,
+      trace: "feed-buzz",
+    }).catch(() => ({ ok: false as const, content: "" }));
+    if (res.ok && res.content) {
+      const clean = res.content.replace(/\s+/g, " ").trim();
+      if (clean.length >= 20 && clean.length <= 300 && !hasForbiddenCopy(clean)) note = clean;
+    }
+  }
+
+  return {
+    card: {
+      kind: "content",
+      id: `content:buzz:${date}`,
+      contentType: "buzz",
+      scope: "domestic",
+      headline: top.signal.newsEventLabel!,
+      facts,
+      ...(note ? { note } : {}),
+      source: top.signal.newsEventSource ?? "수집 뉴스 · 언급량",
+      asOf: date,
+    },
+  };
+}
+
+function isoWeek(date = new Date()): string {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+const RECAP_UNIVERSE = 120;
+const RECAP_CONCURRENCY = 6;
+
+/** ③ 주간 회고 "일주일 전에 샀으면" — 주 1회 크론. KR 상위 유니버스 5거래일 등락 UP3/DOWN3. */
+export async function buildWeeklyRecap(): Promise<FeedBriefingRow | null> {
+  const rows = (await fetchKrMarketRows().catch((): DiscoveryMarketRow[] => [])).filter((row) => row.naverCode);
+  if (rows.length === 0) return null;
+  const universe = rows.slice(0, RECAP_UNIVERSE);
+  const changes: Array<{ row: DiscoveryMarketRow; weeklyPct: number }> = [];
+  let cursor = 0;
+  async function worker() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= universe.length) return;
+      const row = universe[index]!;
+      const daily = await fetchStockDaily(row.naverCode!, 16).catch(() => ({ closes: [] as number[] }));
+      const closes = daily.closes;
+      if (closes.length < 6) continue;
+      const last = closes[closes.length - 1]!;
+      const weekAgo = closes[closes.length - 6]!;
+      if (weekAgo <= 0) continue;
+      changes.push({ row, weeklyPct: ((last - weekAgo) / weekAgo) * 100 });
+    }
+  }
+  await Promise.all(Array.from({ length: RECAP_CONCURRENCY }, () => worker()));
+  if (changes.length < 20) return null;
+
+  const sorted = [...changes].sort((a, b) => b.weeklyPct - a.weeklyPct);
+  const winners = sorted.slice(0, 3);
+  const losers = sorted.slice(-3).reverse();
+  const factFor = async (entry: { row: DiscoveryMarketRow; weeklyPct: number }): Promise<DeckContentFact> => {
+    const title = await moverMaterialTitleKr(entry.row.naverCode, entry.row.canonical);
+    const why = title && title.length <= 60 && !hasForbiddenCopy(title) ? title : undefined;
+    return {
+      label: entry.row.canonical,
+      value: signedPct(entry.weeklyPct),
+      ...(why ? { detail: why } : {}),
+    };
+  };
+  const facts: DeckContentFact[] = [];
+  for (const entry of [...winners, ...losers]) facts.push(await factFor(entry));
+
+  const week = isoWeek();
+  return {
+    card: {
+      kind: "content",
+      id: `content:recap:${week}`,
+      contentType: "recap",
+      scope: "domestic",
+      headline: "일주일 전에 샀으면, 지금 내 계좌는",
+      facts,
+      note: "지난 5거래일 등락이에요. 이미 지나간 수익률은 다음 기회의 근거가 아니라 복기 재료예요.",
+      source: "네이버 일봉 · 주간 등락",
+      asOf: kstDate(),
+    },
+  };
+}
+
+// ── 요청 경로 read (캐시만) ──────────────────────────────────────────────────
+
+export interface TodayFeedContent {
+  cards: DeckContentCard[];
+  pinnedIds: Set<string>;
+  /** MARKET NOTE(국내 지수 카드) 해석 1줄. */
+  indexNote?: string;
+}
+
+/** daily-30 빌드 시 호출 — DB 캐시만 읽는다(외부 fetch 0). */
+export async function readTodayFeedContent(): Promise<TodayFeedContent> {
+  const date = kstDate();
+  const week = isoWeek();
+  const [us, kr, buzz, recap] = await Promise.all([
+    readFeedContent<FeedBriefingRow>(`briefing:us:${date}`),
+    readFeedContent<FeedBriefingRow>(`briefing:kr:${date}`),
+    readFeedContent<FeedBriefingRow>(`buzz:${date}`),
+    readFeedContent<FeedBriefingRow>(`recap:${week}`),
+  ]);
+  const rowsFound = [us, kr, buzz, recap].filter((row): row is FeedBriefingRow => !!row?.card);
+  const pinnedIds = new Set(rowsFound.filter((row) => row.pinned).map((row) => row.card.id));
+  const indexNote = kr?.sectorPulse;
+  return {
+    cards: rowsFound.map((row) => row.card),
+    pinnedIds,
+    ...(indexNote ? { indexNote } : {}),
+  };
+}

--- a/apps/web/lib/feed-content-store.ts
+++ b/apps/web/lib/feed-content-store.ts
@@ -1,0 +1,64 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "./prisma";
+
+/**
+ * 피드 콘텐츠 캐시 (WO 피드 강화) — 크론이 쓰고 요청 경로는 읽기만(504 원칙).
+ * 브리핑·버즈·주간회고·언급 스냅샷을 id 단위 JSONB 로 저장. UsMarketQuoteCache 패턴 미러.
+ * id 규약: "briefing:us:<date>" | "briefing:kr:<date>" | "buzz:<date>" | "recap:<isoweek>" | "mention-snapshot:<date>"
+ */
+
+let ensured = false;
+
+async function ensureFeedContentTable(): Promise<void> {
+  if (ensured) return;
+  await prisma.$executeRaw`
+    CREATE TABLE IF NOT EXISTS "FeedContentCache" (
+      "id" TEXT PRIMARY KEY,
+      "row" JSONB NOT NULL,
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+  await prisma.$executeRaw`
+    CREATE INDEX IF NOT EXISTS "FeedContentCache_updatedAt_idx"
+    ON "FeedContentCache" ("updatedAt" DESC)
+  `;
+  ensured = true;
+}
+
+export async function writeFeedContent(id: string, row: unknown): Promise<void> {
+  await ensureFeedContentTable();
+  await prisma.$executeRaw`
+    INSERT INTO "FeedContentCache" ("id", "row", "updatedAt")
+    VALUES (${id}, ${JSON.stringify(row)}::jsonb, NOW())
+    ON CONFLICT ("id") DO UPDATE
+    SET "row" = EXCLUDED."row", "updatedAt" = NOW()
+  `;
+}
+
+export async function readFeedContent<T>(id: string): Promise<T | null> {
+  try {
+    const records = await prisma.$queryRaw<Array<{ row: unknown }>>`
+      SELECT "row" FROM "FeedContentCache" WHERE "id" = ${id} LIMIT 1
+    `;
+    return (records[0]?.row as T | undefined) ?? null;
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2010") return null;
+    return null;
+  }
+}
+
+/** 접두사로 여러 개 읽기(최신순) — 언급 스냅샷 7일치 등. */
+export async function readFeedContentByPrefix<T>(prefix: string, limit = 10): Promise<Array<{ id: string; row: T }>> {
+  try {
+    const records = await prisma.$queryRaw<Array<{ id: string; row: unknown }>>`
+      SELECT "id", "row" FROM "FeedContentCache"
+      WHERE "id" LIKE ${`${prefix}%`}
+      ORDER BY "updatedAt" DESC
+      LIMIT ${Math.max(1, Math.min(50, limit))}
+    `;
+    return records.map((record) => ({ id: record.id, row: record.row as T }));
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2010") return [];
+    return [];
+  }
+}


### PR DESCRIPTION
## WO — 피드 콘텐츠 강화 (GMC·박대리 수준)
> User Zero: "메타로 시끌벅적했고 코스피가 출렁였는데, 그런 걸 찾아서 요약해주는 느낌이 없다." 진단: 피드는 숫자만 있고 이야기가 없다. **메인 덱=발굴 / 피드=오늘 시장이 떠든 것** — 역할 분리 유지.

## 신설 3포맷 (전부 크론 프리웜 — 요청 경로 LLM/fetch 0)
### ① 데일리 브리핑 (`feed-briefing.ts`)
- **간밤의 미장**(아침 05:30 KST) / **오늘의 국장**(마감 16:10 KST): 무버 4종목(각 **"왜" 1줄** — 수집 재료, 종목명 관련성 검증·짧은 이름 경계 체크) + 지수 + **Editor's Note**.
- Editor's Note = 크론 LLM 1콜(Groq): **수치 언급 금지 프롬프트 + safeNote 가드**(숫자·금지카피 출력 시 폐기) → 규칙 폴백(실데이터 breadth). 수치는 facts(실데이터)에만.
- **코스피 ±3% 급변동일**: 최상단 고정(pinned +30점) + 섹터 펄스 원인 확장(종목수×|평균| 기여 랭크 — 소수 섹터 착시 방지).

### ② 버즈 스토리
- 언급 스냅샷(매일 저장) 대비 **급증 2.5배+** 사건 감지(히스토리 3일 미만이면 절대 하한 6건 폴백 — 정직). 사건 헤드라인 + 기사 기반 요약(LLM 크론 1콜, 추측 인과 금지) + **연결 종목**(relation graph) + 원문 출처.

### ③ 주간 "일주일 전에 샀으면" (금 16:40 KST)
- KR 시총 상위 120 **실제 5거래일 등락** UP3/DOWN3 + 왜 1줄. "먼저 짚음" 배지는 **서버 아카이브 부재로 보류**(소급 조작 금지 — 클라 localStorage뿐이라 정직하게 뺌).

## 기존 수정
- **MARKET NOTE**(국내 지수 카드)에 해석 1줄 — 섹터 펄스(실데이터) 주입. 숫자만 금지 해소.
- 피드 정렬: 브리핑(72) → 버즈(60) → 회고(52) → 지수·거시·고래. PC/모바일 동일 소스(daily-30 cards).
- `revalidateTag("daily-30", {expire:0})` — 마감 브리핑이 12h 캐시를 기다리지 않고 즉시 반영.

## 검증 (실측 — 오늘 실데이터)
- 국장 브리핑: **코스피 +5.76% 급변동일 → pinned**, 무버 대형주(파라다이스 -11.77% "카지노 매출 감소", SK하이닉스 +10.88% "1.3조 CP 인수"), **펄스 "반도체 5종목 평균 +6.33% — 지수를 끌어올린 쪽"** (정확한 원인 귀속).
- 버즈: "미래에셋증권, SK하이닉스서 1.26조 조달" 사건 + 연결 종목.
- 회고: 가온전선 +51.79%("K-전력기기 수주잔고 50조") 등 실등락+재료.
- guard:discovery ✅(덱 30장 불변) · 테스트 89/89 · typecheck(web/fomo-web) ✅ · spec:analyze error 0.

## 배포 후 (머지 후 진행)
`gh workflow run feed-content.yml -f slot=close` → daily-30 응답에 briefing/buzz 카드 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)