### PR TITLE
feat(feed): WO 피드 파이프라인 통합 — feed-hub 집계 + 다양성 복원 + 뎁스 전면화

### DIFF
--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -8,10 +8,13 @@ import { NarrativeCard } from "@/components/NarrativeCard";
 import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
 import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
 import { FlickerSpinner } from "@/components/FlickerSpinner";
-import { fetchDaily30, type Daily30Response } from "@/lib/fomoApi";
+import { fetchDaily30, fetchFeedHub, type Daily30Response, type FeedHubItem } from "@/lib/fomoApi";
 import { stockDeckCards, type DeckCard, type DeckStock, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
 import { getDiscoverySeen } from "@/lib/discoveryPerformance";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
+import { FeedDepthPage } from "@/components/FeedDepthPage";
+import { SectorCard } from "@/components/SectorCard";
+import { StockIssueCard, sectorCardData } from "@/components/FeedView";
 
 /**
  * PC(≥1024px) 3컬럼 대시보드 — WO-PC-VERSION.
@@ -127,6 +130,9 @@ export function DesktopDashboard() {
   const [failed, setFailed] = useState(false);
   const [filter, setFilter] = useState<FilterTag>("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // 우측 컬럼(feed-hub) 항목 선택 — 중앙에 해당 뎁스 렌더(WO 피드 통합 §3: 막다른 클릭 0).
+  const [feedItem, setFeedItem] = useState<FeedHubItem | null>(null);
+  const [feedItems, setFeedItems] = useState<FeedHubItem[]>([]);
   const [seenItems] = useState(() => getDiscoverySeen());
 
   useEffect(() => {
@@ -134,6 +140,9 @@ export function DesktopDashboard() {
     fetchDaily30()
       .then((d) => alive && setDaily(d))
       .catch(() => alive && setFailed(true));
+    fetchFeedHub()
+      .then((d) => alive && setFeedItems(d.items))
+      .catch(() => {});
     return () => {
       alive = false;
     };
@@ -238,9 +247,13 @@ export function DesktopDashboard() {
         </div>
       </section>
 
-      {/* ② 중앙 — 선택 카드 뎁스(병렬 보기 = PC 핵심 가치) */}
+      {/* ② 중앙 — 선택 카드 뎁스(병렬 보기 = PC 핵심 가치). 우측 항목 클릭 시 해당 뎁스가 우선. */}
       <section className="min-h-0 overflow-hidden rounded-2xl border border-hairline bg-surface">
-        {selected?.type === "stock" ? (
+        {feedItem?.type === "narrative" ? (
+          <NarrativeDepthPage key={feedItem.narrative.id} card={feedItem.narrative} onClose={() => setFeedItem(null)} inline />
+        ) : feedItem ? (
+          <FeedDepthPage key={feedItemId(feedItem)} item={feedItem} onClose={() => setFeedItem(null)} inline />
+        ) : selected?.type === "stock" ? (
           <StockInsightView
             key={selected.data.canonical}
             stock={selected.data.canonical}
@@ -255,29 +268,62 @@ export function DesktopDashboard() {
         )}
       </section>
 
-      {/* ③ 우 — 콘텐츠·시장 + 성과 되짚기 */}
+      {/* ③ 우 — feed-hub(피드 탭과 동일 소스·이원화 금지) + 성과 되짚기. 클릭 → 중앙 뎁스. */}
       <section className="scrollbar-none min-h-0 space-y-3 overflow-y-auto">
-        {contentCards.slice(0, 4).map((card) => (
-          <div key={card.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">
-            <ContentCard card={card.data} />
-          </div>
-        ))}
-        {narrativeCards.slice(0, 2).map((card) => (
-          <button
-            key={card.data.id}
-            type="button"
-            onClick={() => setSelectedId(cardId(card))}
-            aria-pressed={cardId(card) === selectedId}
-            className="block w-full rounded-2xl border bg-surface px-5 py-5 text-left transition-colors hover:border-whiteout/20"
-            style={{ borderColor: cardId(card) === selectedId ? NEON : "var(--hairline, #2a2a2a)" }}
-          >
-            <NarrativeCard card={card.data} />
-          </button>
-        ))}
+        {(feedItems.length > 0 ? feedItems : []).slice(0, 8).map((item) => {
+          const id = feedItemId(item);
+          const active = feedItem ? feedItemId(feedItem) === id : false;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => setFeedItem(item)}
+              aria-pressed={active}
+              className="block w-full rounded-2xl border bg-surface px-5 py-5 text-left transition-colors hover:border-whiteout/20"
+              style={{ borderColor: active ? NEON : "var(--hairline, #2a2a2a)" }}
+            >
+              {item.type === "narrative" ? (
+                <NarrativeCard card={item.narrative} />
+              ) : item.type === "sector" ? (
+                <SectorCard card={sectorCardData(item)} />
+              ) : item.type === "stock-issue" ? (
+                <StockIssueCard item={item} />
+              ) : (
+                <ContentCard card={item.content} />
+              )}
+            </button>
+          );
+        })}
+        {feedItems.length === 0 &&
+          contentCards.slice(0, 4).map((card) => (
+            <div key={card.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">
+              <ContentCard card={card.data} />
+            </div>
+          ))}
+        {feedItems.length === 0 &&
+          narrativeCards.slice(0, 2).map((card) => (
+            <button
+              key={card.data.id}
+              type="button"
+              onClick={() => setSelectedId(cardId(card))}
+              aria-pressed={cardId(card) === selectedId}
+              className="block w-full rounded-2xl border bg-surface px-5 py-5 text-left transition-colors hover:border-whiteout/20"
+              style={{ borderColor: cardId(card) === selectedId ? NEON : "var(--hairline, #2a2a2a)" }}
+            >
+              <NarrativeCard card={card.data} />
+            </button>
+          ))}
         <div className="rounded-2xl border border-hairline bg-surface px-4 py-4">
           <PerformanceProofPanel items={seenItems} />
         </div>
       </section>
     </div>
   );
+}
+
+function feedItemId(item: FeedHubItem): string {
+  if (item.type === "narrative") return item.narrative.id;
+  if (item.type === "sector") return item.sector.id;
+  if (item.type === "stock-issue") return item.stockIssue.id;
+  return item.content.id;
 }

--- a/apps/fomo-web/components/FeedDepthPage.tsx
+++ b/apps/fomo-web/components/FeedDepthPage.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { StockInsightView } from "@/components/KeywordDepthPage";
+import type { FeedHubItem, FeedHubSectorStockRef } from "@/lib/fomoApi";
+import { sparklinePath } from "@fomo/core";
+
+/**
+ * 피드 범용 뎁스 (WO 피드 통합 §3 — "탭했는데 안 가는 항목 0").
+ * 브리핑·회고·버즈·지수·거시·고래·거시이슈·섹터·종목이슈를 한 컴포넌트가 커버:
+ * 사실 전체 + 해석 + (있으면) 추이 미니차트 + 원문 링크, 종목 행 탭 → 종목 뎁스 중첩.
+ * 내러티브는 기존 NarrativeDepthPage 소관.
+ */
+
+const NEON = "#D8FF3A";
+
+function valueTone(value: string): string {
+  const number = Number.parseFloat(value.replace(/,/g, ""));
+  if (!Number.isFinite(number)) return "rgba(250,250,250,0.78)";
+  if (number > 0) return "#FF4D4D";
+  if (number < 0) return "#3B82F6";
+  return "#8A8A86";
+}
+
+function TrendChart({ series }: { series: number[] }) {
+  const pts = series.filter((v) => Number.isFinite(v));
+  if (pts.length < 2) return null;
+  const W = 320;
+  const H = 64;
+  const paths = sparklinePath(pts, W, H);
+  if (!paths) return null;
+  return (
+    <div className="mt-4 rounded-xl border border-hairline bg-white/[0.03] p-3">
+      <p className="font-pixel text-[10px] uppercase tracking-wide text-muted">추이 (최근 구간)</p>
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="mt-2 h-16 w-full" aria-hidden>
+        <path d={paths.line} fill="none" stroke={NEON} strokeWidth={1.8} strokeLinejoin="round" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+}
+
+interface StockRef {
+  name: string;
+  naverCode?: string | undefined;
+  symbol?: string | undefined;
+  market?: string | undefined;
+  country?: string | undefined;
+  reason?: string | undefined;
+}
+
+function sectorStockRef(stock: FeedHubSectorStockRef, note: string): StockRef {
+  return {
+    name: stock.canonical,
+    naverCode: stock.naverCode,
+    symbol: stock.symbol,
+    market: stock.market,
+    country: stock.country,
+    reason: note,
+  };
+}
+
+/** 브리핑/회고 무버 라벨 → 종목 뎁스 컨텍스트(이름만으로 열기 — StockInsightView가 자체 조회). */
+function factStockRef(label: string, detail: string | undefined): StockRef | null {
+  const name = label.replace(/\s+/g, " ").trim();
+  if (!name || /지수$|환율|금리|유가|VIX|시총/.test(name)) return null; // 지수·거시 행은 종목이 아님
+  return { name, reason: detail };
+}
+
+export function FeedDepthPage({ item, onClose, inline = false }: { item: FeedHubItem; onClose: () => void; inline?: boolean }) {
+  const [stockRef, setStockRef] = useState<StockRef | null>(null);
+
+  useEffect(() => {
+    if (inline) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [inline]);
+
+  if (stockRef) {
+    return (
+      <StockInsightView
+        stock={stockRef.name}
+        context={{
+          ...(stockRef.reason ? { reason: stockRef.reason } : {}),
+          ...(stockRef.naverCode ? { naverCode: stockRef.naverCode } : {}),
+          ...(stockRef.symbol ? { symbol: stockRef.symbol } : {}),
+          ...(stockRef.market ? { market: stockRef.market } : {}),
+          ...(stockRef.country ? { country: stockRef.country } : {}),
+        }}
+        onClose={() => setStockRef(null)}
+        inline={inline}
+        inlineBackLabel="피드로"
+      />
+    );
+  }
+
+  const body = (() => {
+    if (item.type === "sector") {
+      const sector = item.sector;
+      return (
+        <>
+          <p className="font-pixel text-[10px] uppercase tracking-wide text-muted">SECTOR DEPTH</p>
+          <h2 className="mt-2 text-2xl font-bold leading-8 text-whiteout">
+            {sector.country === "US" ? "미국 " : ""}
+            {sector.sector}
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted">{sector.stanceNote}</p>
+          <div className="mt-5 grid gap-2">
+            {sector.stocks.map((stock) => (
+              <button
+                key={stock.canonical}
+                type="button"
+                onClick={() => setStockRef(sectorStockRef(stock, sector.stanceNote))}
+                className="flex items-center justify-between rounded-xl border border-hairline bg-white/[0.03] px-4 py-3 text-left transition-colors hover:border-whiteout/25"
+              >
+                <span className="text-sm font-semibold text-whiteout">{stock.canonical}</span>
+                <span className="text-sm font-bold tabular-nums" style={{ color: valueTone(`${stock.changePct ?? ""}`) }}>
+                  {typeof stock.changePct === "number" ? `${stock.changePct > 0 ? "+" : ""}${stock.changePct.toFixed(2)}%` : "—"}
+                </span>
+              </button>
+            ))}
+          </div>
+          <p className="mt-4 text-xs text-muted">종목을 누르면 종목 상세로 이어져요.</p>
+        </>
+      );
+    }
+    if (item.type === "stock-issue") {
+      const issue = item.stockIssue;
+      return (
+        <>
+          <p className="font-pixel text-[10px] uppercase tracking-wide text-muted">STOCK ISSUE</p>
+          <h2 className="mt-2 text-xl font-bold leading-7 text-whiteout">{issue.headline}</h2>
+          <button
+            type="button"
+            onClick={() =>
+              setStockRef({
+                name: issue.stock,
+                naverCode: issue.naverCode,
+                symbol: issue.symbol,
+                market: issue.market,
+                country: issue.country,
+                reason: issue.headline,
+              })
+            }
+            className="mt-4 flex w-full items-center justify-between rounded-xl border border-hairline bg-white/[0.03] px-4 py-3 text-left transition-colors hover:border-whiteout/25"
+          >
+            <span className="text-sm font-semibold text-whiteout">{issue.stock} 상세 보기</span>
+            <span className="text-sm font-bold tabular-nums" style={{ color: valueTone(`${issue.changePct ?? ""}`) }}>
+              {typeof issue.changePct === "number" ? `${issue.changePct > 0 ? "+" : ""}${issue.changePct.toFixed(2)}%` : "→"}
+            </span>
+          </button>
+          <p className="mt-3 font-pixel text-[11px] text-muted">
+            {issue.source} · {issue.asOf}
+          </p>
+          {issue.url && (
+            <a href={issue.url} target="_blank" rel="noreferrer" className="mt-2 inline-block text-xs underline" style={{ color: NEON }}>
+              공시 원문 보기
+            </a>
+          )}
+        </>
+      );
+    }
+    // 내러티브는 NarrativeDepthPage 소관 — 방어적 빈 렌더(호출부가 분기함).
+    if (item.type === "narrative") return null;
+    // content 계열(briefing·recap·buzz·index·macro·whale·macro-issue) — 사실 전체 + 노트 + 추이.
+    const card = item.content;
+    const label =
+      item.type === "briefing" ? "BRIEFING DEPTH" : item.type === "macro-issue" ? "MACRO ISSUE" : item.type === "buzz" ? "BUZZ STORY" : item.type === "recap" ? "WEEKLY RECAP" : "MARKET DEPTH";
+    return (
+      <>
+        <p className="font-pixel text-[10px] uppercase tracking-wide text-muted">{label}</p>
+        <h2 className="mt-2 text-xl font-bold leading-7 text-whiteout">{card.headline}</h2>
+        <div className="mt-5 grid gap-2">
+          {card.facts.map((fact) => {
+            const ref = item.type === "briefing" || item.type === "recap" || item.type === "buzz" ? factStockRef(fact.label, fact.detail) : null;
+            const row = (
+              <>
+                <div className="flex min-w-0 items-center justify-between gap-3">
+                  <span className="min-w-0 truncate text-sm font-semibold text-whiteout">{fact.label}</span>
+                  <span className="shrink-0 text-sm font-bold tabular-nums" style={{ color: valueTone(fact.value) }}>
+                    {fact.value}
+                  </span>
+                </div>
+                {fact.detail && <p className="mt-1 text-xs leading-4 text-muted">{fact.detail}</p>}
+              </>
+            );
+            return ref ? (
+              <button
+                key={`${card.id}:${fact.label}`}
+                type="button"
+                onClick={() => setStockRef(ref)}
+                className="rounded-xl border border-hairline bg-white/[0.03] px-4 py-3 text-left transition-colors hover:border-whiteout/25"
+              >
+                {row}
+              </button>
+            ) : (
+              <div key={`${card.id}:${fact.label}`} className="rounded-xl border border-hairline bg-white/[0.03] px-4 py-3">
+                {row}
+              </div>
+            );
+          })}
+        </div>
+        {card.series && card.series.length >= 2 && <TrendChart series={card.series} />}
+        {card.note && (
+          <div className="mt-4 rounded-xl px-4 py-3" style={{ backgroundColor: "rgba(216,255,58,0.12)" }}>
+            <p className="font-pixel text-[10px] uppercase tracking-wide" style={{ color: NEON }}>
+              Editor&apos;s Note
+            </p>
+            <p className="mt-1 text-sm leading-6 text-whiteout">{card.note}</p>
+          </div>
+        )}
+        <p className="mt-4 font-pixel text-[11px] text-muted">
+          {card.source} · {card.asOf}
+        </p>
+        {card.sourceUrl && (
+          <a href={card.sourceUrl} target="_blank" rel="noreferrer" className="mt-2 inline-block text-xs underline" style={{ color: NEON }}>
+            원문 보기
+          </a>
+        )}
+        {(item.type === "briefing" || item.type === "recap" || item.type === "buzz") && (
+          <p className="mt-3 text-xs text-muted">종목 줄을 누르면 종목 상세로 이어져요.</p>
+        )}
+      </>
+    );
+  })();
+
+  if (inline) {
+    return (
+      <div className="h-full overflow-y-auto px-6 py-6">
+        <button type="button" onClick={onClose} className="mb-4 font-pixel text-xs text-muted underline">
+          ← 피드로
+        </button>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-[70] overflow-y-auto bg-canvas">
+      <div className="mx-auto max-w-xl px-6 pb-16 pt-6">
+        <button type="button" onClick={onClose} className="mb-5 font-pixel text-xs text-muted underline">
+          ← 피드로
+        </button>
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/apps/fomo-web/components/FeedView.tsx
+++ b/apps/fomo-web/components/FeedView.tsx
@@ -1,51 +1,79 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { ContentCard } from "@/components/ContentCard";
 import { NarrativeCard } from "@/components/NarrativeCard";
 import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
+import { SectorCard } from "@/components/SectorCard";
+import { FeedDepthPage } from "@/components/FeedDepthPage";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
-import { fetchDaily30, type Daily30Response } from "@/lib/fomoApi";
-import { stockDeckCards, type DeckCard, type DeckContent, type DeckNarrative, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
+import { fetchFeedHub, type FeedHubItem } from "@/lib/fomoApi";
+import type { DeckCard, DeckNarrative, DeckSectorCardData } from "@/lib/discoveryDeck";
 
 /**
- * 피드 표면(WO-GNB-TWO-SURFACES ②) — 콘텐츠 전용 세로 스크롤.
- * 소스 = daily-30(메인 덱·PC 우측 컬럼과 동일 — 이원화 금지). 종목 카드는 제외, 콘텐츠만 모은다.
- * 내러티브 = 사건→스토리 뎁스→종목 뎁스, 매크로/지수/고래 = 사실 카드.
+ * 피드 표면(WO 피드 통합) — 소스는 feed-hub 단일(브리핑·버즈·회고·내러티브·섹터·지수·거시·고래·종목이슈·거시이슈).
+ * ⚠️ daily-30 만 읽던 배선이 피드 다양성 붕괴의 원인이었다 — feed-hub 외 소스로 되돌리지 말 것.
+ * 모든 항목은 탭 → 뎁스 도달(막다른 탭 0): 내러티브→스토리 뎁스, 나머지→FeedDepthPage.
  */
 
-/** 피드에 담기는 콘텐츠 카드(내러티브·매크로/지수/고래). 종목·섹터 카드는 메인 덱 소관. */
-type FeedItem =
-  | { type: "narrative"; data: DeckNarrative }
-  | { type: "content"; data: DeckContent };
+function valueTone(value: number | undefined): string {
+  if (typeof value !== "number") return "rgba(250,250,250,0.78)";
+  if (value > 0) return "#FF4D4D";
+  if (value < 0) return "#3B82F6";
+  return "#8A8A86";
+}
 
-function feedItemsFromDaily30(discovery: Daily30Response): FeedItem[] {
-  const raw = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
-  // daily-30 cards 순서 = quietScore 랭킹 = 중요도순. 그 순서를 보존하며 콘텐츠만 추린다.
-  const items: FeedItem[] = [];
-  for (const card of stockDeckCards(raw)) {
-    if (card.type === "narrative") items.push({ type: "narrative", data: card.data });
-    else if (card.type === "content") items.push({ type: "content", data: card.data });
-  }
-  return items;
+export function sectorCardData(item: Extract<FeedHubItem, { type: "sector" }>): DeckSectorCardData {
+  return {
+    id: item.sector.id,
+    sector: item.sector.sector,
+    country: item.sector.country,
+    stance: item.sector.stance,
+    stanceNote: item.sector.stanceNote,
+    stocks: item.sector.stocks.map((stock) => ({
+      canonical: stock.canonical,
+      market: stock.market as DeckSectorCardData["stocks"][number]["market"],
+      country: stock.country as DeckSectorCardData["stocks"][number]["country"],
+      ...(stock.naverCode ? { naverCode: stock.naverCode } : {}),
+      ...(stock.symbol ? { symbol: stock.symbol } : {}),
+      ...(typeof stock.changePct === "number" ? { changePct: stock.changePct } : {}),
+    })),
+  };
+}
+
+export function StockIssueCard({ item }: { item: Extract<FeedHubItem, { type: "stock-issue" }> }) {
+  const issue = item.stockIssue;
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <span className="font-pixel text-[10px] uppercase tracking-wide text-muted">
+          STOCK ISSUE · {issue.country === "US" ? "미국" : "국내"}
+        </span>
+        <p className="mt-2 text-base font-bold leading-6 text-whiteout">{issue.stock}</p>
+        <p className="mt-1 text-sm leading-5 text-muted">{issue.headline}</p>
+      </div>
+      <span className="shrink-0 text-sm font-bold tabular-nums" style={{ color: valueTone(issue.changePct) }}>
+        {typeof issue.changePct === "number" ? `${issue.changePct > 0 ? "+" : ""}${issue.changePct.toFixed(2)}%` : ""}
+      </span>
+    </div>
+  );
 }
 
 export function FeedView() {
-  const [items, setItems] = useState<FeedItem[] | null>(null);
+  const [items, setItems] = useState<FeedHubItem[] | null>(null);
   const [failed, setFailed] = useState(false);
-  const [selected, setSelected] = useState<DeckNarrative | null>(null);
+  const [selected, setSelected] = useState<FeedHubItem | null>(null);
+  const [narrative, setNarrative] = useState<DeckNarrative | null>(null);
 
   useEffect(() => {
     let alive = true;
-    fetchDaily30()
-      .then((d) => alive && setItems(feedItemsFromDaily30(d)))
+    fetchFeedHub()
+      .then((d) => alive && setItems(d.items))
       .catch(() => alive && setFailed(true));
     return () => {
       alive = false;
     };
   }, []);
-
-  const content = useMemo(() => items ?? [], [items]);
 
   if (failed) {
     return (
@@ -57,7 +85,7 @@ export function FeedView() {
   if (!items) {
     return <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />;
   }
-  if (content.length === 0) {
+  if (items.length === 0) {
     return (
       <div className="mt-16 px-8 text-center text-sm leading-6 text-whiteout">
         오늘은 콘텐츠가 잠깐 비었어요.
@@ -67,34 +95,47 @@ export function FeedView() {
     );
   }
 
+  const cardShell =
+    "block w-full rounded-2xl border border-hairline bg-surface px-5 py-5 text-left transition-colors hover:border-whiteout/20";
+
   return (
     <div className="space-y-3 pb-4">
-      {content.map((item) => {
+      {items.map((item) => {
         if (item.type === "narrative") {
           return (
-            <button
-              key={item.data.id}
-              type="button"
-              onClick={() => setSelected(item.data)}
-              className="block w-full rounded-2xl border border-hairline bg-surface px-5 py-5 text-left transition-colors hover:border-whiteout/20"
-            >
-              <NarrativeCard card={item.data} />
+            <button key={item.narrative.id} type="button" onClick={() => setNarrative(item.narrative)} className={cardShell}>
+              <NarrativeCard card={item.narrative} />
+            </button>
+          );
+        }
+        if (item.type === "sector") {
+          return (
+            <button key={item.sector.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
+              <SectorCard card={sectorCardData(item)} />
+            </button>
+          );
+        }
+        if (item.type === "stock-issue") {
+          return (
+            <button key={item.stockIssue.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
+              <StockIssueCard item={item} />
             </button>
           );
         }
         return (
-          <div key={item.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">
-            <ContentCard card={item.data} />
-          </div>
+          <button key={item.content.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
+            <ContentCard card={item.content} />
+          </button>
         );
       })}
 
-      {selected && <NarrativeDepthPage card={selected} onClose={() => setSelected(null)} />}
+      {narrative && <NarrativeDepthPage card={narrative} onClose={() => setNarrative(null)} />}
+      {selected && <FeedDepthPage item={selected} onClose={() => setSelected(null)} />}
     </div>
   );
 }
 
-/** 메인 덱 필터(WO-GNB) — daily-30 카드에서 종목 카드만. 콘텐츠·섹터·내러티브는 피드로 이관. */
+/** 메인 덱 필터(WO-GNB) — daily-30 카드에서 종목 카드만. 콘텐츠·섹터·내러티브는 피드(feed-hub) 소관. */
 export function stockOnlyDeckCards(cards: readonly DeckCard[]): DeckCard[] {
   return cards.filter((card) => card.type === "stock");
 }

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -9,7 +9,7 @@ import type {
   MoodSignal,
   ScoredArticle,
 } from "@fomo/core";
-import type { DeckContent } from "./discoveryDeck";
+import type { DeckContent, DeckNarrative } from "./discoveryDeck";
 import { isDiscoveryCopySafe } from "./discoveryCopySafe";
 import { getSessionId } from "@/lib/session";
 import { cachedGet, readCached, refreshCached, setCached } from "./apiCache";
@@ -269,6 +269,51 @@ export interface FeedResponse {
   content?: DeckContent[];
 }
 export const fetchFeed = () => get<FeedResponse>("/api/fomo/feed");
+
+/** 피드 집계(feed-hub, WO 피드 통합) — FeedView·PC 우측 컬럼의 단일 소스. */
+export interface FeedHubSectorStockRef {
+  canonical: string;
+  market: string;
+  country: string;
+  naverCode?: string;
+  symbol?: string;
+  changePct?: number;
+}
+export interface FeedHubSectorCard {
+  id: string;
+  sector: string;
+  country: "KR" | "US";
+  stance: "bull-dominant" | "bear-dominant" | "balanced" | "insufficient";
+  stanceNote: string;
+  stocks: FeedHubSectorStockRef[];
+}
+export interface FeedHubStockIssue {
+  id: string;
+  stock: string;
+  market: string;
+  country: "KR" | "US";
+  naverCode?: string;
+  symbol?: string;
+  changePct?: number;
+  headline: string;
+  source: string;
+  url?: string;
+  asOf: string;
+}
+export type FeedHubItem =
+  | { type: "briefing" | "buzz" | "recap" | "index" | "macro" | "whale" | "macro-issue"; scope: "KR" | "US" | "GLOBAL"; content: DeckContent & { series?: number[] } }
+  | { type: "narrative"; scope: "KR" | "US"; narrative: DeckNarrative }
+  | { type: "sector"; scope: "KR" | "US"; sector: FeedHubSectorCard }
+  | { type: "stock-issue"; scope: "KR" | "US"; stockIssue: FeedHubStockIssue };
+export interface FeedHubResponse {
+  asOf: string;
+  items: FeedHubItem[];
+  typeCounts: Record<string, number>;
+  scopeCounts: { KR: number; US: number; GLOBAL: number };
+  source: string;
+}
+export const fetchFeedHub = () =>
+  cachedGet(`feed-hub:${kstDateKey()}`, () => get<FeedHubResponse>("/api/fomo/feed-hub"), 15 * MINUTE);
 
 /** 뉴스 덱 — 한국 뉴스(점수순) + 차트 카드 인터리브, 스와이프용(피드 탭). */
 export type { ScoredArticle, ChartCard, DeckCard } from "@fomo/core";

--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { FEED_ITEM_TYPES, interleaveFeedItems, type FeedHubItem } from "../../lib/feed-hub";
+
+/**
+ * 타입 레지스트리 회귀 방지 (WO 피드 통합 §4) —
+ * "새 포맷 추가 = 기존 제거"가 피드 다양성 붕괴의 원인이었다.
+ * 타입 제거는 명시 지시 없이 금지. 이 테스트가 그 원칙을 지킨다.
+ */
+describe("feed-hub 타입 레지스트리", () => {
+  it("등록된 타입은 절대 줄지 않는다 (제거는 명시 지시 필요)", () => {
+    const REQUIRED_TYPES = [
+      "briefing",
+      "buzz",
+      "recap",
+      "narrative",
+      "sector",
+      "index",
+      "macro",
+      "whale",
+      "stock-issue",
+      "macro-issue",
+    ];
+    for (const type of REQUIRED_TYPES) {
+      expect(FEED_ITEM_TYPES, `타입 "${type}" 이 레지스트리에서 사라졌다 — 명시 지시 없는 타입 제거는 금지`).toContain(type);
+    }
+    expect(FEED_ITEM_TYPES.length).toBeGreaterThanOrEqual(REQUIRED_TYPES.length);
+  });
+});
+
+function contentItem(type: "index" | "macro" | "whale", id: string): FeedHubItem {
+  return {
+    type,
+    scope: "KR",
+    content: { kind: "content", id, contentType: type, scope: "domestic", headline: "h", facts: [{ label: "l", value: "+1%" }], source: "s", asOf: "2026-07-04" },
+  };
+}
+
+describe("interleaveFeedItems", () => {
+  it("같은 타입 연속 3개 금지", () => {
+    const items: FeedHubItem[] = [
+      contentItem("index", "a"),
+      contentItem("index", "b"),
+      contentItem("index", "c"),
+      contentItem("macro", "d"),
+      contentItem("whale", "e"),
+    ];
+    const ordered = interleaveFeedItems(items);
+    for (let i = 2; i < ordered.length; i += 1) {
+      const same = ordered[i]!.type === ordered[i - 1]!.type && ordered[i]!.type === ordered[i - 2]!.type;
+      expect(same, `${i}번째에서 같은 타입 3연속`).toBe(false);
+    }
+    expect(ordered).toHaveLength(items.length); // 억지 삭제 금지 — 재배열만
+  });
+
+  it("전부 같은 타입이면 그대로 유지(삭제 금지)", () => {
+    const items: FeedHubItem[] = [contentItem("index", "a"), contentItem("index", "b"), contentItem("index", "c")];
+    expect(interleaveFeedItems(items)).toHaveLength(3);
+  });
+});

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -59,8 +59,9 @@ export async function GET(request: Request) {
     } else {
       return withCors(NextResponse.json({ ok: false, error: "slot must be morning|close|weekly" }, { status: 400 }));
     }
-    // daily-30 서버 캐시 즉시 만료 — 다음 요청이 새 콘텐츠를 포함해 재빌드.
+    // daily-30·feed-hub 서버 캐시 즉시 만료 — 다음 요청이 새 콘텐츠를 포함해 재빌드.
     revalidateTag("daily-30", { expire: 0 });
+    revalidateTag("feed-hub", { expire: 0 });
     return withCors(
       NextResponse.json(
         { ok: true, slot, written, elapsedMs: Date.now() - startedAt },

--- a/apps/web/app/api/fomo/daily-30/route.ts
+++ b/apps/web/app/api/fomo/daily-30/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from "next/server";
-import { unstable_cache } from "next/cache";
-import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
-import { buildDaily30Response, type Daily30Response } from "../../../../lib/daily-30";
+import { withCors, kstDate } from "../../../../lib/fomo";
+import { getCachedDaily30Response, type Daily30Response } from "../../../../lib/daily-30";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
-
-const REVALIDATE_S = 60 * 60 * 12;
 
 export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
@@ -14,14 +11,8 @@ export function OPTIONS() {
 
 export async function GET() {
   try {
-    const load = unstable_cache(
-      () => buildDaily30Response(),
-      ["fomo-daily-30", cacheVersion(), kstDate()],
-      // 태그: feed-content 크론(브리핑/버즈/회고 갱신)이 revalidateTag 로 즉시 재빌드 유도.
-      { revalidate: REVALIDATE_S, tags: ["daily-30"] }
-    );
     return withCors(
-      NextResponse.json(await load(), {
+      NextResponse.json(await getCachedDaily30Response(), {
         headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
       })
     );

--- a/apps/web/app/api/fomo/feed-hub/route.ts
+++ b/apps/web/app/api/fomo/feed-hub/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
+import { buildFeedHubResponse, type FeedHubResponse } from "../../../../lib/feed-hub";
+
+/**
+ * 피드 집계 API (WO 피드 파이프라인 통합) — FeedView·PC 우측 컬럼의 단일 소스.
+ * 모든 생산자(브리핑·버즈·회고·내러티브·섹터·지수·거시·고래·종목이슈·거시이슈)를 여기서만 소비한다.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const REVALIDATE_S = 1800; // 30분 — 콘텐츠는 크론 주기로 갱신, revalidateTag 로 즉시 반영
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function GET() {
+  try {
+    const load = unstable_cache(
+      () => buildFeedHubResponse(),
+      ["fomo-feed-hub", cacheVersion(), kstDate()],
+      { revalidate: REVALIDATE_S, tags: ["feed-hub", "daily-30"] }
+    );
+    const response = await load();
+    return withCors(
+      NextResponse.json(response, {
+        headers: { "Cache-Control": "public, s-maxage=900, stale-while-revalidate=86400" },
+      })
+    );
+  } catch (err) {
+    console.warn("[fomo/feed-hub] failed", (err as Error)?.message);
+    return withCors(
+      NextResponse.json(
+        {
+          asOf: kstDate(),
+          items: [],
+          typeCounts: {},
+          scopeCounts: { KR: 0, US: 0, GLOBAL: 0 },
+          source: "feed-hub unavailable",
+        } satisfies FeedHubResponse,
+        { status: 503, headers: { "Cache-Control": "no-store" } }
+      )
+    );
+  }
+}

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -1,4 +1,6 @@
+import { unstable_cache } from "next/cache";
 import type { CardFrontSignals, StockCountry } from "@fomo/core";
+import { cacheVersion, kstDate as kstDateOf } from "./fomo";
 import {
   buildDiscoveryResponse,
   type DiscoveryDeckCardPayload,
@@ -195,6 +197,7 @@ const CONTENT_SIGNAL_SCORE: Record<DeckContentCard["contentType"], number> = {
   briefing: 72,
   buzz: 60,
   recap: 52,
+  "macro-issue": 48,
   index: 42,
   macro: 38,
   whale: 34,
@@ -394,4 +397,17 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
     .slice(0, FEED_CARD_LIMIT);
   const deck = selectDaily30Candidates(stockCandidates, DAILY_CARD_TARGET);
   return responseFromSelected(deck, feedCandidates, [kr, us, coin], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+}
+
+/**
+ * 공유 캐시 getter — daily-30 라우트와 feed-hub 가 같은 캐시 엔트리를 쓴다(중복 빌드 방지).
+ * feed-content 크론이 tags 로 즉시 무효화한다.
+ */
+export async function getCachedDaily30Response(): Promise<Daily30Response> {
+  const load = unstable_cache(
+    () => buildDaily30Response(),
+    ["fomo-daily-30", cacheVersion(), kstDateOf()],
+    { revalidate: 60 * 60 * 12, tags: ["daily-30"] }
+  );
+  return load();
 }

--- a/apps/web/lib/deck-content.ts
+++ b/apps/web/lib/deck-content.ts
@@ -8,8 +8,8 @@ const FRED_WORLD_SERIES = ["DGS10", "VIXCLS"] as const;
 const FRED_CONTENT_TIMEOUT_MS = 4_500;
 
 export type DeckContentScope = "domestic" | "world" | "global";
-/** briefing=데일리 브리핑, buzz=떠들썩 스토리, recap=주간 회고 (WO 피드 강화 — 숫자에 이야기를 붙인다). */
-export type DeckContentType = "macro" | "index" | "whale" | "briefing" | "buzz" | "recap";
+/** briefing=데일리 브리핑, buzz=떠들썩 스토리, recap=주간 회고, macro-issue=거시 이슈(임계 변동). */
+export type DeckContentType = "macro" | "index" | "whale" | "briefing" | "buzz" | "recap" | "macro-issue";
 
 export interface DeckContentFact {
   label: string;
@@ -300,6 +300,8 @@ function contentTypePriority(type: DeckContentType): number {
       return -2;
     case "recap":
       return -1;
+    case "macro-issue":
+      return -1;
     case "index":
       return 0;
     case "macro":
@@ -319,7 +321,7 @@ function factCardId(baseId: string, fact: DeckContentFact, index: number): strin
 
 function splitFactCards(card: DeckContentCard): DeckContentCard[] {
   // 브리핑·버즈·회고는 구성체(무버+지수+노트) — 조각내면 이야기가 깨진다.
-  if (card.contentType === "briefing" || card.contentType === "buzz" || card.contentType === "recap") return [];
+  if (card.contentType === "briefing" || card.contentType === "buzz" || card.contentType === "recap" || card.contentType === "macro-issue") return [];
   if (card.facts.length <= 1) return [];
   return card.facts.map((fact, index) => ({
     ...card,

--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -1,0 +1,361 @@
+import { sectorOf } from "@fomo/core";
+import { getCachedDaily30Response } from "./daily-30";
+import { fetchDeckContentCards, type DeckContentCard } from "./deck-content";
+import { fetchKrMarketRows, type DiscoveryNarrativeCardPayload } from "./discovery-supply";
+import { readUsMarketQuoteRows } from "./us-market-cache";
+import { fetchDartDisclosuresByStock } from "./dart-disclosures";
+import { fetchRecentSecFilings } from "./sec-edgar";
+import { fetchFredSeriesHistory } from "./fred";
+import { fetchStockDaily } from "./stock-front";
+import { kstDate } from "./fomo";
+import type { DiscoveryMarketRow } from "./market-source-types";
+
+/**
+ * 피드 집계 계층 (WO 피드 파이프라인 통합) — 모든 콘텐츠 생산자를 하나의 응답으로.
+ * FeedView(모바일 피드 탭)와 PC 우측 컬럼은 이것만 읽는다(daily-30 은 종목 덱 전용).
+ *
+ * ⚠️ 타입 레지스트리 원칙(회귀 방지): FEED_ITEM_TYPES 에서 타입을 제거하는 것은
+ * **명시 지시 없이 금지**다. "새 포맷 추가 = 기존 제거"가 이번 붕괴의 원인이었다.
+ * feed-hub.test.ts 의 타입별 최소 존재 테스트가 이 원칙을 지킨다.
+ */
+export const FEED_ITEM_TYPES = [
+  "briefing", // 데일리 브리핑(간밤 미장/오늘 국장)
+  "buzz", // 떠들썩 스토리(언급 급증 사건)
+  "recap", // 주간 회고(일주일 전에 샀으면)
+  "narrative", // 사건→연결 종목 스토리
+  "sector", // 섹터 강세·약세(KR+US)
+  "index", // 시장 지수(KR+US)
+  "macro", // FRED 거시(환율·금리·VIX)
+  "whale", // 고래·코인 시장
+  "stock-issue", // 종목 이슈 단신(공시·실적 1줄) — 신규
+  "macro-issue", // 거시 이슈(환율·유가·금리 임계 변동) — 신규
+] as const;
+export type FeedItemType = (typeof FEED_ITEM_TYPES)[number];
+
+/** 피드 항목 — 콘텐츠/내러티브/섹터/종목이슈 payload 중 하나. 전 타입 뎁스 도달 가능해야 한다(막다른 탭 0). */
+export interface FeedSectorStockRef {
+  canonical: string;
+  market: string;
+  country: string;
+  naverCode?: string;
+  symbol?: string;
+  changePct?: number;
+}
+
+export interface FeedSectorCard {
+  id: string;
+  sector: string;
+  country: "KR" | "US";
+  stance: "bull-dominant" | "bear-dominant" | "balanced" | "insufficient";
+  stanceNote: string;
+  stocks: FeedSectorStockRef[];
+}
+
+export interface FeedStockIssue {
+  id: string;
+  stock: string;
+  market: string;
+  country: "KR" | "US";
+  naverCode?: string;
+  symbol?: string;
+  changePct?: number;
+  headline: string;
+  source: string;
+  url?: string;
+  asOf: string;
+}
+
+export type FeedHubItem =
+  | { type: "briefing" | "buzz" | "recap" | "index" | "macro" | "whale" | "macro-issue"; scope: "KR" | "US" | "GLOBAL"; content: DeckContentCard & { series?: number[] } }
+  | { type: "narrative"; scope: "KR" | "US"; narrative: DiscoveryNarrativeCardPayload }
+  | { type: "sector"; scope: "KR" | "US"; sector: FeedSectorCard }
+  | { type: "stock-issue"; scope: "KR" | "US"; stockIssue: FeedStockIssue };
+
+export interface FeedHubResponse {
+  asOf: string;
+  items: FeedHubItem[];
+  /** 실측 타입 카운트 — 수용 기준 검증·모니터링용. */
+  typeCounts: Record<string, number>;
+  scopeCounts: { KR: number; US: number; GLOBAL: number };
+  source: string;
+}
+
+function signedPct(value: number): string {
+  return `${value > 0 ? "+" : ""}${value.toFixed(2)}%`;
+}
+
+function contentScope(card: DeckContentCard): "KR" | "US" | "GLOBAL" {
+  if (card.scope === "domestic") return "KR";
+  if (card.scope === "world") return "US";
+  return "GLOBAL";
+}
+
+// ── 섹터 강세·약세 (KR + US — "미장 미미" 해소축 ①) ─────────────────────────
+
+const SECTOR_MIN_MEMBERS = 4;
+const SECTOR_TOP_STOCKS = 5;
+/** 섹터 집계 유니버스 — 시총 상위만(소형주 노이즈로 섹터 평균이 왜곡되지 않게). */
+const SECTOR_UNIVERSE = 400;
+
+function buildSectorCards(rows: readonly DiscoveryMarketRow[], country: "KR" | "US", asOf: string): FeedSectorCard[] {
+  const bySector = new Map<string, Array<{ row: DiscoveryMarketRow; changePct: number }>>();
+  for (const row of rows.slice(0, SECTOR_UNIVERSE)) {
+    if (typeof row.changePct !== "number" || !Number.isFinite(row.changePct)) continue;
+    const sector = row.sectorHint ?? sectorOf(row.canonical);
+    if (!sector || sector === "기타 업종" || sector === "미국주식") continue;
+    const arr = bySector.get(sector) ?? [];
+    arr.push({ row, changePct: row.changePct });
+    bySector.set(sector, arr);
+  }
+  const ranked = [...bySector.entries()]
+    .filter(([, members]) => members.length >= SECTOR_MIN_MEMBERS)
+    .map(([sector, members]) => {
+      const avg = members.reduce((sum, m) => sum + m.changePct, 0) / members.length;
+      return { sector, members, avg };
+    })
+    .sort((a, b) => Math.abs(b.avg) - Math.abs(a.avg));
+
+  const picks = [
+    ranked.find((entry) => entry.avg > 0.8), // 강세 1
+    ranked.find((entry) => entry.avg < -0.8), // 약세 1
+  ].filter((entry): entry is NonNullable<typeof entry> => !!entry);
+
+  return picks.map((entry) => {
+    const stance: FeedSectorCard["stance"] = entry.avg > 0.8 ? "bull-dominant" : "bear-dominant";
+    const up = entry.members.filter((m) => m.changePct > 0).length;
+    const stocks = [...entry.members]
+      .sort((a, b) => Math.abs(b.changePct) - Math.abs(a.changePct))
+      .slice(0, SECTOR_TOP_STOCKS)
+      .map(({ row, changePct }) => ({
+        canonical: row.canonical,
+        market: row.market,
+        country: row.country,
+        ...(row.naverCode ? { naverCode: row.naverCode } : {}),
+        ...(row.symbol ? { symbol: row.symbol } : {}),
+        changePct: Number(changePct.toFixed(2)),
+      }));
+    return {
+      id: `feed:sector:${country}:${entry.sector}:${asOf}`,
+      sector: entry.sector,
+      country,
+      stance,
+      stanceNote: `${entry.sector} ${entry.members.length}종목 평균 ${signedPct(entry.avg)} · 상승 ${up}·하락 ${entry.members.length - up} — ${entry.avg > 0 ? "오늘 온기가 몰린" : "오늘 힘이 빠진"} 자리예요.`,
+      stocks,
+    };
+  });
+}
+
+// ── 종목 이슈 단신 (신규 ① — 공시·실적 1줄, 수집 재료 재활용) ────────────────
+
+const KR_ISSUE_LIMIT = 3;
+const US_ISSUE_LIMIT = 3;
+const US_ISSUE_MOVER_MIN_PCT = 3;
+
+async function buildKrStockIssues(rows: readonly DiscoveryMarketRow[], asOf: string): Promise<FeedStockIssue[]> {
+  const disclosureMap = await fetchDartDisclosuresByStock(asOf).catch((): Record<string, { label: string; source: string; url?: string }> => ({}));
+  const rowByName = new Map(rows.map((row) => [row.canonical, row]));
+  return Object.entries(disclosureMap)
+    .slice(0, KR_ISSUE_LIMIT)
+    .map(([stock, hit]) => {
+      const row = rowByName.get(stock);
+      return {
+        id: `feed:issue:KR:${stock}:${asOf}`,
+        stock,
+        market: row?.market ?? "KOSPI",
+        country: "KR" as const,
+        ...(row?.naverCode ? { naverCode: row.naverCode } : {}),
+        ...(typeof row?.changePct === "number" ? { changePct: row.changePct } : {}),
+        headline: hit.label,
+        source: hit.source,
+        ...(hit.url ? { url: hit.url } : {}),
+        asOf,
+      };
+    });
+}
+
+async function buildUsStockIssues(rows: readonly DiscoveryMarketRow[], asOf: string): Promise<FeedStockIssue[]> {
+  const movers = rows
+    .filter((row) => typeof row.changePct === "number" && Math.abs(row.changePct) >= US_ISSUE_MOVER_MIN_PCT)
+    .sort((a, b) => Math.abs(b.changePct!) - Math.abs(a.changePct!))
+    .slice(0, US_ISSUE_LIMIT * 2); // 공시 없는 종목 대비 여유
+  const out: FeedStockIssue[] = [];
+  for (const row of movers) {
+    if (out.length >= US_ISSUE_LIMIT) break;
+    const filings = await fetchRecentSecFilings(row.symbol, 3).catch(() => []);
+    const filing = filings[0];
+    if (!filing) continue;
+    out.push({
+      id: `feed:issue:US:${row.symbol}:${asOf}`,
+      stock: row.canonical,
+      market: row.market,
+      country: "US",
+      symbol: row.symbol,
+      ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
+      headline: filing.label,
+      source: filing.source,
+      ...(filing.url ? { url: filing.url } : {}),
+      asOf,
+    });
+  }
+  return out;
+}
+
+// ── 거시 이슈 (신규 ② — 환율·유가·금리 임계 변동, FRED 실데이터) ─────────────
+
+const MACRO_ISSUE_SERIES: Array<{ id: string; label: string; unit: string; thresholdPct: number }> = [
+  { id: "DEXKOUS", label: "원/달러 환율", unit: "원", thresholdPct: 0.7 },
+  { id: "DCOILWTICO", label: "WTI 유가", unit: "달러", thresholdPct: 3 },
+  { id: "DGS10", label: "미 10년물 금리", unit: "%", thresholdPct: 4 },
+  { id: "VIXCLS", label: "VIX 변동성", unit: "", thresholdPct: 12 },
+];
+
+async function buildMacroIssues(asOf: string): Promise<Array<DeckContentCard & { series?: number[] }>> {
+  const out: Array<DeckContentCard & { series?: number[] }> = [];
+  for (const spec of MACRO_ISSUE_SERIES) {
+    const history = await fetchFredSeriesHistory(spec.id).catch(() => []);
+    if (history.length < 20) continue;
+    const last = history[history.length - 1]!;
+    const prev = history[history.length - 2]!;
+    if (prev.value === 0) continue;
+    const changePct = ((last.value - prev.value) / Math.abs(prev.value)) * 100;
+    if (Math.abs(changePct) < spec.thresholdPct) continue; // 임계 미달 — 카드 없음(억지 생성 금지)
+    const values = history.map((h) => h.value);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const position = max > min ? ((last.value - min) / (max - min)) * 100 : 50;
+    const positionText = position >= 80 ? "최근 구간의 상단" : position <= 20 ? "최근 구간의 하단" : "최근 구간의 중간";
+    out.push({
+      kind: "content",
+      id: `content:macro-issue:${spec.id}:${asOf}`,
+      contentType: "macro-issue",
+      scope: "world",
+      headline: `${spec.label}, 하루 만에 ${signedPct(changePct)}`,
+      facts: [
+        { label: spec.label, value: `${last.value.toLocaleString("en-US", { maximumFractionDigits: 2 })}${spec.unit}` },
+        { label: "하루 변동", value: signedPct(changePct) },
+      ],
+      note: `약 5개월 범위에서 ${positionText}이에요(${last.date} 기준, FRED 공식 데이터).`,
+      source: "FRED(미 연준)",
+      asOf,
+      series: values.slice(-60),
+    });
+  }
+  return out;
+}
+
+// ── 지수 추이(매크로 뎁스용) — KR 지수 일봉 시리즈 부착 ─────────────────────
+
+async function attachIndexSeries(cards: Array<DeckContentCard & { series?: number[] }>): Promise<void> {
+  const domesticIndex = cards.find((card) => card.contentType === "index" && card.scope === "domestic");
+  if (!domesticIndex) return;
+  const kospi = await fetchStockDaily("KOSPI", 120).catch(() => ({ closes: [] as number[] }));
+  if (kospi.closes.length >= 10) domesticIndex.series = kospi.closes.slice(-60);
+}
+
+// ── 인터리브 — 같은 타입 연속 3개 금지, 상단은 오늘의 중요도 ──────────────────
+
+const TYPE_PRIORITY: Record<FeedItemType, number> = {
+  briefing: 0,
+  buzz: 1,
+  "macro-issue": 2,
+  recap: 3,
+  narrative: 4,
+  sector: 5,
+  index: 6,
+  "stock-issue": 7,
+  macro: 8,
+  whale: 9,
+};
+
+export function interleaveFeedItems(items: readonly FeedHubItem[]): FeedHubItem[] {
+  const sorted = [...items].sort((a, b) => TYPE_PRIORITY[a.type] - TYPE_PRIORITY[b.type]);
+  const out: FeedHubItem[] = [];
+  const queue = [...sorted];
+  while (queue.length > 0) {
+    const lastTwo = out.slice(-2);
+    const blocked = lastTwo.length === 2 && lastTwo[0]!.type === lastTwo[1]!.type ? lastTwo[0]!.type : undefined;
+    const index = blocked ? queue.findIndex((item) => item.type !== blocked) : 0;
+    if (index === -1) {
+      out.push(...queue); // 남은 게 전부 같은 타입이면 그대로(억지 삭제 금지)
+      break;
+    }
+    out.push(queue.splice(index, 1)[0]!);
+  }
+  return out;
+}
+
+// ── 집계 ────────────────────────────────────────────────────────────────────
+
+export async function buildFeedHubResponse(): Promise<FeedHubResponse> {
+  const asOf = kstDate();
+  const [daily30, deckContent, krRows, usRows] = await Promise.all([
+    getCachedDaily30Response().catch(() => null),
+    fetchDeckContentCards().catch(() => [] as DeckContentCard[]),
+    fetchKrMarketRows().catch((): DiscoveryMarketRow[] => []),
+    readUsMarketQuoteRows().catch((): DiscoveryMarketRow[] => []),
+  ]);
+  const [krIssues, usIssues, macroIssues] = await Promise.all([
+    buildKrStockIssues(krRows, asOf).catch((): FeedStockIssue[] => []),
+    buildUsStockIssues(usRows, asOf).catch((): FeedStockIssue[] => []),
+    buildMacroIssues(asOf).catch((): Array<DeckContentCard & { series?: number[] }> => []),
+  ]);
+
+  const items: FeedHubItem[] = [];
+  const seen = new Set<string>();
+  const push = (item: FeedHubItem, id: string) => {
+    if (seen.has(id)) return;
+    seen.add(id);
+    items.push(item);
+  };
+
+  // 1) daily-30 이 실어온 콘텐츠·내러티브(브리핑·버즈·회고 포함) — 생산된 것은 전부 표면으로.
+  for (const card of daily30?.cards ?? []) {
+    if (!("kind" in card)) continue;
+    if (card.kind === "content") {
+      const type = (card.contentType === "index" ? "index" : card.contentType) as FeedItemType;
+      if (!FEED_ITEM_TYPES.includes(type)) continue;
+      push({ type: type as "briefing", scope: contentScope(card), content: card }, card.id);
+    } else if (card.kind === "narrative") {
+      const narrative = card as DiscoveryNarrativeCardPayload;
+      push({ type: "narrative", scope: narrative.scope, narrative }, narrative.id);
+    }
+  }
+  // 2) 레거시 콘텐츠 엔진(지수·거시·고래) — daily-30 expand 에서 잘린 것 포함 전부.
+  const contentWithSeries = deckContent as Array<DeckContentCard & { series?: number[] }>;
+  await attachIndexSeries(contentWithSeries).catch(() => {});
+  for (const card of contentWithSeries) {
+    const type = (card.contentType === "index" ? "index" : card.contentType) as FeedItemType;
+    if (!FEED_ITEM_TYPES.includes(type)) continue;
+    push({ type: type as "index", scope: contentScope(card), content: card }, card.id);
+  }
+  // 3) 섹터 강세·약세 (KR+US).
+  for (const sector of [...buildSectorCards(krRows, "KR", asOf), ...buildSectorCards(usRows, "US", asOf)]) {
+    push({ type: "sector", scope: sector.country, sector }, sector.id);
+  }
+  // 4) 종목 이슈 단신 (KR DART + US SEC).
+  for (const issue of [...krIssues, ...usIssues]) {
+    push({ type: "stock-issue", scope: issue.country, stockIssue: issue }, issue.id);
+  }
+  // 5) 거시 이슈 (임계 변동일만).
+  for (const card of macroIssues) {
+    push({ type: "macro-issue", scope: "US", content: card }, card.id);
+  }
+
+  const ordered = interleaveFeedItems(items);
+  const typeCounts: Record<string, number> = {};
+  for (const type of FEED_ITEM_TYPES) typeCounts[type] = 0;
+  const scopeCounts = { KR: 0, US: 0, GLOBAL: 0 };
+  for (const item of ordered) {
+    typeCounts[item.type] = (typeCounts[item.type] ?? 0) + 1;
+    scopeCounts[item.scope] += 1;
+  }
+  if (scopeCounts.US < 5) console.warn("[feed-hub] 미장 콘텐츠 목표 미달", scopeCounts);
+
+  return {
+    asOf,
+    items: ordered,
+    typeCounts,
+    scopeCounts,
+    source: "브리핑·버즈·회고·내러티브·섹터·지수·거시·고래·종목이슈·거시이슈 통합(feed-hub)",
+  };
+}

--- a/apps/web/lib/fred.ts
+++ b/apps/web/lib/fred.ts
@@ -105,6 +105,36 @@ async function fetchJsonLatest(seriesId: string): Promise<{ date: string; value:
   }
 }
 
+/** CSV 전체 파싱 — 최근 구간 시계열(과거→최신). 거시 이슈 임계 감지 + 매크로 뎁스 추이차트용. */
+function parseFredCsvSeries(csv: string): Array<{ date: string; value: number }> {
+  if (!csv) return [];
+  const out: Array<{ date: string; value: number }> = [];
+  for (const line of csv.trim().split(/\r?\n/).slice(1)) {
+    const [date, raw] = line.trim().split(",");
+    if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    const v = Number.parseFloat(raw ?? "");
+    if (Number.isFinite(v)) out.push({ date, value: v });
+  }
+  return out;
+}
+
+/** 시리즈 최근 ~150일 시계열(키리스 CSV — 이미 받던 페이로드를 전체 파싱). 실패 시 빈 배열. */
+export async function fetchFredSeriesHistory(seriesId: string): Promise<Array<{ date: string; value: number }>> {
+  try {
+    const url = `https://fred.stlouisfed.org/graph/fredgraph.csv?id=${encodeURIComponent(seriesId)}&cosd=${cosd()}`;
+    const res = await fetch(url, {
+      headers: { "user-agent": UA, accept: "text/csv,*/*" },
+      signal: AbortSignal.timeout(15_000),
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return [];
+    return parseFredCsvSeries(await res.text());
+  } catch (err) {
+    console.warn(`[fred] series ${seriesId} error`, err);
+    return [];
+  }
+}
+
 /** 테마의 FRED 공식 데이터 SourceDoc[]. idStart 부터 id 부여(S{n}). 미매핑/실패 시 빈 배열. */
 export async function fetchFredDocs(theme: string, makeId: () => string): Promise<SourceDoc[]> {
   const series = FRED_THEME_SERIES[theme];


### PR DESCRIPTION
## WO — 피드 파이프라인 통합 + 다양성 복원
> User Zero: "핫이슈만 남고 나머지가 사라졌다. 10장도 안 된다. 미장 미미, 뎁스 사라짐." **원인은 배선(실측)** — FeedView가 daily-30만 읽는데 콘텐츠는 덱에서 뺐고, 레거시 `/api/fomo/feed`가 생산하던 macro·index·whale은 소비자가 없었다.

## §1 배선 통합 (최우선)
- **`feed-hub.ts` + `/api/fomo/feed-hub`**: 모든 생산자를 단일 응답으로 — 브리핑·버즈·회고·내러티브·**섹터(KR+US)**·지수·FRED거시·고래·**종목이슈**·**거시이슈**. 응답에 `typeCounts`/`scopeCounts` 동봉(수용 기준 실측용).
- FeedView(모바일 피드 탭)·PC 우측 컬럼은 **feed-hub만** 읽음(이원화 금지). daily-30은 종목 덱 전용으로 원위치.

## §1 신규 2타입
- **종목 이슈 단신**: KR = DART 오늘 주요 공시(수집 재료 재활용), US = |±3%| 무버의 SEC 최신 공시. 실데이터.
- **거시 이슈**: FRED 환율(0.7%)·유가(3%)·10년물(4%)·VIX(12%) 하루 변동 임계 초과일만 + "최근 5개월 범위 상/하단" 해석(시리즈 퍼센타일 — 실데이터). 임계 미달 = 카드 없음(억지 생성 금지).

## §2 다양성·수량
- 타입 10종 등록, 인터리브(같은 타입 3연속 금지 — 삭제 없이 재배열), 상단 = 브리핑→버즈→거시이슈. 미장 최소 5 미달 시 경고 로그(예상 구성: 미장 브리핑+미장 섹터 2+미장 종목이슈 3+지수+거시 ≈ 7).

## §3 뎁스 전면 복원 (막다른 탭 0)
- **`FeedDepthPage`(신설, 범용)**: 브리핑/회고/버즈 → 무버 전체+왜, **종목 행 탭→종목 뎁스** · 섹터 → 구성 종목 리스트→각 종목 뎁스 · 종목이슈 → 종목 뎁스+공시 원문 링크 · 지수/거시 → **추이 미니차트**(KOSPI 일봉·FRED 150일 시리즈)+해석. 내러티브는 기존 스토리 뎁스.
- PC: 우측 컬럼 어떤 항목 클릭해도 중앙에 해당 뎁스 렌더(inline).

## §4 회귀 방지
- `FEED_ITEM_TYPES` 레지스트리 + 코드 주석 "**타입 제거는 명시 지시 없이 금지**" + `feed-hub.test.ts` 타입별 존재 테스트(10종) + 인터리브 무삭제 테스트.

## 검증
- 테스트 92/92 · guard:discovery ✅(덱 30장 불변) · typecheck(web/fomo-web) ✅ · spec:analyze error 0.
- 로컬 스모크(DB 없는 환경): 구조 정상 — sector/index/macro/whale 생성 확인. **전체 타입 카운트는 머지 후 프로덕션 실측 첨부 예정**(브리핑·US캐시·DART가 prod 리소스).

🤖 Generated with [Claude Code](https://claude.com/claude-code)