### PR TITLE
fix(feed): SEC UA 폴백 + 섹터 카드 확대 (#812 후속)

### DIFF
--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -115,10 +115,10 @@ function buildSectorCards(rows: readonly DiscoveryMarketRow[], country: "KR" | "
     })
     .sort((a, b) => Math.abs(b.avg) - Math.abs(a.avg));
 
-  const picks = [
-    ranked.find((entry) => entry.avg > 0.8), // 강세 1
-    ranked.find((entry) => entry.avg < -0.8), // 약세 1
-  ].filter((entry): entry is NonNullable<typeof entry> => !!entry);
+  // 강세 최대 2 + 약세 최대 2, 국가당 총 3 — 다양성·수량 목표(하루 20~30) 기여.
+  const bulls = ranked.filter((entry) => entry.avg > 0.8).slice(0, 2);
+  const bears = ranked.filter((entry) => entry.avg < -0.8).slice(0, 2);
+  const picks = [...bulls, ...bears].slice(0, 3);
 
   return picks.map((entry) => {
     const stance: FeedSectorCard["stance"] = entry.avg > 0.8 ? "bull-dominant" : "bear-dominant";

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -23,7 +23,8 @@ const SEC_RECENT_FORM_SCAN_LIMIT = 80;
 const SEC_FORM4_XML_SCAN_LIMIT = 8;
 
 function secUserAgent(): string | undefined {
-  return process.env.SEC_EDGAR_USER_AGENT?.trim();
+  // SEC 은 연락처 포함 UA 를 요구 — env 미설정이면 기본 UA 폴백(피드 종목이슈가 env 없이도 동작).
+  return process.env.SEC_EDGAR_USER_AGENT?.trim() || "FomoClub/1.0 (contact: fomo-club@users.noreply.github.com)";
 }
 
 function accessionPath(cik: string, accession: string): string {


### PR DESCRIPTION
프로덕션 실측 15항목 → 보강: (1) SEC_EDGAR_USER_AGENT 미설정 시 기본 UA 폴백 — US 종목이슈 단신 활성화, (2) 섹터 카드 국가당 최대 3(강세2+약세2). 주말엔 DART 공시가 실제로 없어 종목이슈 0이 정직한 값 — 평일 +6 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)