### PR TITLE
feat(search): WO 검색 — 심볼 인덱스 + 온디맨드 카드 + 미존재 분기

### DIFF
--- a/.github/workflows/feed-content.yml
+++ b/.github/workflows/feed-content.yml
@@ -11,6 +11,7 @@ on:
     - cron: "30 20 * * *"
     - cron: "10 7 * * 1-5"
     - cron: "40 7 * * 5"
+    - cron: "0 20 * * *" # index 05:00 KST — 심볼 인덱스 재구축 + 검색 큐 처리(WO 검색)
   workflow_dispatch:
     inputs:
       slot:
@@ -39,7 +40,9 @@ jobs:
             SLOT="$INPUT_SLOT"
           else
             HOUR="$(date -u +%H)"; MINUTE="$(date -u +%M)"
-            if [ "$HOUR" = "20" ]; then
+            if [ "$HOUR" = "20" ] && [ "$MINUTE" -lt 15 ]; then
+              SLOT="index"
+            elif [ "$HOUR" = "20" ]; then
               SLOT="morning"
             elif [ "$HOUR" = "07" ] && [ "$MINUTE" -ge 30 ]; then
               SLOT="weekly"
@@ -47,7 +50,7 @@ jobs:
               SLOT="close"
             fi
           fi
-          case "$SLOT" in morning|close|weekly) ;; *) echo "invalid slot: $SLOT" >&2; exit 1;; esac
+          case "$SLOT" in morning|close|weekly|index) ;; *) echo "invalid slot: $SLOT" >&2; exit 1;; esac
           echo "slot=$SLOT" >> "$GITHUB_OUTPUT"
 
       - name: Build feed content

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -3,9 +3,10 @@
 import { useState } from "react";
 import { scoreToColor, type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
-import { CaretUpIcon, CaretDownIcon, XMarkIcon } from "@/components/icons";
+import { CaretUpIcon, CaretDownIcon, SearchIcon, XMarkIcon } from "@/components/icons";
 import { KeywordHistory } from "@/components/KeywordHistory";
 import { FeedView } from "@/components/FeedView";
+import { SearchOverlay } from "@/components/SearchOverlay";
 import { DesktopDashboard, useIsDesktop } from "@/components/DesktopDashboard";
 import type {
   FomoIndexResponse,
@@ -44,6 +45,7 @@ export function HomeView({
 }) {
   const [tab, setTab] = useState<Tab>("main");
   const [indexHelpOpen, setIndexHelpOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const isDesktop = useIsDesktop();
   const color = index ? scoreToColor(index.score) : undefined;
 
@@ -67,25 +69,37 @@ export function HomeView({
         <main className="fomo-phase-in mx-auto flex h-screen max-w-[1400px] flex-col gap-4 px-6 py-5">
           <div className="flex shrink-0 items-center justify-between">
             <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-            <button
-              type="button"
-              onClick={() => setIndexHelpOpen(true)}
-              className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
-              aria-label="오늘의 시장 온도 계산 방식 보기"
-            >
-              <span>온도</span>
-              {index ? (
-                <span className="font-number text-sm font-bold leading-none" style={{ color }}>
-                  {index.score}
-                </span>
-              ) : (
-                <span>—</span>
-              )}
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setSearchOpen(true)}
+                className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
+                aria-label="종목 검색"
+              >
+                <SearchIcon size={13} />
+                <span>검색</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setIndexHelpOpen(true)}
+                className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
+                aria-label="오늘의 시장 온도 계산 방식 보기"
+              >
+                <span>온도</span>
+                {index ? (
+                  <span className="font-number text-sm font-bold leading-none" style={{ color }}>
+                    {index.score}
+                  </span>
+                ) : (
+                  <span>—</span>
+                )}
+              </button>
+            </div>
           </div>
           <DesktopDashboard />
         </main>
         {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
+        {searchOpen && <SearchOverlay onClose={() => setSearchOpen(false)} />}
       </>
     );
   }
@@ -96,29 +110,39 @@ export function HomeView({
         {/* 상단 얇은 띠: 로고 + 시장 온도 축약 배지(WO 1.5 E — 큰 바는 몰입 방해라 접었다. 탭하면 설명 시트). */}
         <div className="flex items-center justify-between">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-          <button
-            type="button"
-            onClick={() => setIndexHelpOpen(true)}
-            className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
-            aria-label="오늘의 시장 온도 계산 방식 보기"
-          >
-            <span>온도</span>
-            {index ? (
-              <>
-                <span className="font-number text-sm font-bold leading-none" style={{ color }}>
-                  {index.score}
-                </span>
-                {!isFullFallback && index.prevDayDelta !== 0 && (
-                  <span className="inline-flex items-center" style={{ color }}>
-                    {index.prevDayDelta > 0 ? <CaretUpIcon size={9} /> : <CaretDownIcon size={9} />}
-                    {Math.abs(index.prevDayDelta)}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              className="flex items-center rounded-full border border-hairline p-1.5 text-muted transition-colors hover:border-whiteout/20"
+              aria-label="종목 검색"
+            >
+              <SearchIcon size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setIndexHelpOpen(true)}
+              className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
+              aria-label="오늘의 시장 온도 계산 방식 보기"
+            >
+              <span>온도</span>
+              {index ? (
+                <>
+                  <span className="font-number text-sm font-bold leading-none" style={{ color }}>
+                    {index.score}
                   </span>
-                )}
-              </>
-            ) : (
-              <span>—</span>
-            )}
-          </button>
+                  {!isFullFallback && index.prevDayDelta !== 0 && (
+                    <span className="inline-flex items-center" style={{ color }}>
+                      {index.prevDayDelta > 0 ? <CaretUpIcon size={9} /> : <CaretDownIcon size={9} />}
+                      {Math.abs(index.prevDayDelta)}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <span>—</span>
+              )}
+            </button>
+          </div>
         </div>
 
         <div className={`mt-3 flex min-h-0 flex-1 flex-col ${tab === "feed" ? "overflow-y-auto scrollbar-none" : ""}`}>
@@ -142,6 +166,7 @@ export function HomeView({
       </nav>
 
       {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
+      {searchOpen && <SearchOverlay onClose={() => setSearchOpen(false)} />}
     </>
   );
 }

--- a/apps/fomo-web/components/SearchOverlay.tsx
+++ b/apps/fomo-web/components/SearchOverlay.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { StockInsightView } from "@/components/KeywordDepthPage";
+import { FlickerSpinner } from "@/components/FlickerSpinner";
+import { SearchIcon, XMarkIcon } from "@/components/icons";
+import { fetchDaily30, fetchStockFront } from "@/lib/fomoApi";
+import { getDiscoverySeen } from "@/lib/discoveryPerformance";
+
+/**
+ * 검색 오버레이 (WO 검색) — 심볼 인덱스 자동완성 + 3분기.
+ * ① 오늘 카드 있음 → 표준 뎁스 그대로 ② 인덱스 있음 → 온디맨드 단건 조립(프로브 실패 시 ③)
+ * ③ 미존재/실패 → "알림 신청하면 내일 카드로" 큐. 무한 로딩·에러 화면 금지.
+ */
+
+const NEON = "#D8FF3A";
+const API_BASE = process.env.NEXT_PUBLIC_FOMO_API_BASE?.replace(/\/$/, "") || "https://fomo-club-backend.vercel.app";
+const REQUESTS_KEY = "fomo_search_requests";
+/** 온디맨드 프로브 타임아웃 — 넘으면 ③ 분기(무한 로딩 금지). */
+const PROBE_TIMEOUT_MS = 9_000;
+
+interface SearchResultItem {
+  canonical: string;
+  englishName?: string;
+  symbol: string;
+  market: string;
+  country: "KR" | "US" | "GLOBAL";
+  naverCode?: string;
+  sector?: string;
+  todayCard: boolean;
+}
+
+function marketTag(item: Pick<SearchResultItem, "market" | "country">): string {
+  if (item.market === "COIN") return "₿ 코인";
+  if (item.country === "US") return `🇺🇸 ${item.market}`;
+  return `🇰🇷 ${item.market}`;
+}
+
+function savedRequests(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(REQUESTS_KEY) ?? "[]") as string[];
+  } catch {
+    return [];
+  }
+}
+
+function rememberRequest(query: string): void {
+  try {
+    const list = [...new Set([query, ...savedRequests()])].slice(0, 20);
+    localStorage.setItem(REQUESTS_KEY, JSON.stringify(list));
+  } catch {
+    // 저장 실패는 치명 아님
+  }
+}
+
+type Branch =
+  | { kind: "list" }
+  | { kind: "depth"; item: SearchResultItem }
+  | { kind: "probing"; item: SearchResultItem }
+  | { kind: "request"; query: string; reason: "not-found" | "quote-failed"; sent: boolean };
+
+export function SearchOverlay({ onClose }: { onClose: () => void }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResultItem[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [branch, setBranch] = useState<Branch>({ kind: "list" });
+  const [popular, setPopular] = useState<Array<{ stock: string; naverCode?: string; symbol?: string }>>([]);
+  const [recent] = useState(() =>
+    getDiscoverySeen()
+      .slice(0, 6)
+      .map((item) => ({ stock: item.stock, naverCode: item.naverCode, symbol: item.symbol }))
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+  const seqRef = useRef(0);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    document.body.style.overflow = "hidden";
+    // 인기 = 오늘 30장 상위(캐시된 daily-30 — 추가 비용 0).
+    fetchDaily30()
+      .then((d) =>
+        setPopular(
+          (d.stocks ?? []).slice(0, 6).map((s) => ({
+            stock: s.canonical,
+            ...(s.naverCode ? { naverCode: s.naverCode } : {}),
+            ...(s.symbol ? { symbol: s.symbol } : {}),
+          }))
+        )
+      )
+      .catch(() => {});
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  // 자동완성 — 디바운스 200ms, 캐시된 인덱스 조회라 <1초.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 1) {
+      setResults(null);
+      return;
+    }
+    setSearching(true);
+    const seq = (seqRef.current += 1);
+    const timer = setTimeout(() => {
+      fetch(`${API_BASE}/api/fomo/search?q=${encodeURIComponent(q)}`, { signal: AbortSignal.timeout(5_000) })
+        .then((res) => res.json())
+        .then((data: { results?: SearchResultItem[] }) => {
+          if (seqRef.current !== seq) return;
+          setResults(data.results ?? []);
+          setSearching(false);
+        })
+        .catch(() => {
+          if (seqRef.current !== seq) return;
+          setResults([]);
+          setSearching(false);
+        });
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  /** ②분기 프로브 — 단건 stock-front(캐시됨). 시세도 캔들도 없으면 ③으로(무한 로딩·에러 금지). */
+  const openItem = async (item: SearchResultItem) => {
+    if (item.todayCard || item.market === "COIN" || item.naverCode) {
+      // 오늘 카드·코인(캐시)·KR(네이버 무료)은 조립 신뢰도 높음 — 바로 뎁스.
+      setBranch({ kind: "depth", item });
+      return;
+    }
+    setBranch({ kind: "probing", item });
+    try {
+      const probe = await Promise.race([
+        fetchStockFront(item.canonical, { lite: true, ...(item.symbol ? { symbol: item.symbol } : {}) }),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), PROBE_TIMEOUT_MS)),
+      ]);
+      const priced = Boolean(probe?.priceText) || (probe?.sparkline?.length ?? 0) >= 2;
+      setBranch(priced ? { kind: "depth", item } : { kind: "request", query: item.canonical, reason: "quote-failed", sent: false });
+    } catch {
+      setBranch({ kind: "request", query: item.canonical, reason: "quote-failed", sent: false });
+    }
+  };
+
+  const submitRequest = async (q: string) => {
+    rememberRequest(q);
+    setBranch((prev) => (prev.kind === "request" ? { ...prev, sent: true } : prev));
+    try {
+      await fetch(`${API_BASE}/api/fomo/search/request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: q }),
+        signal: AbortSignal.timeout(6_000),
+      });
+    } catch {
+      // 저장 실패해도 UI 는 접수 상태 유지 — 다음 방문 시 재시도 여지(무한 대기·에러 화면 금지)
+    }
+  };
+
+  if (branch.kind === "depth") {
+    const item = branch.item;
+    return (
+      <StockInsightView
+        stock={item.canonical}
+        context={{
+          ...(item.naverCode ? { naverCode: item.naverCode } : {}),
+          ...(item.symbol && item.country !== "KR" ? { symbol: item.symbol } : {}),
+          market: item.market,
+          country: item.country,
+          reason: "검색으로 찾은 종목이에요.",
+        }}
+        onClose={() => setBranch({ kind: "list" })}
+      />
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-[80] flex flex-col bg-canvas">
+      <div className="mx-auto flex w-full max-w-md flex-1 flex-col px-6 pt-5">
+        {/* 검색 입력 */}
+        <div className="flex items-center gap-3">
+          <div className="flex min-w-0 flex-1 items-center gap-2 rounded-2xl border border-hairline bg-white/[0.04] px-4 py-3">
+            <SearchIcon size={16} className="shrink-0 text-muted" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setBranch({ kind: "list" });
+              }}
+              placeholder="종목명·티커로 검색 (예: 메타, META)"
+              className="min-w-0 flex-1 bg-transparent text-sm text-whiteout outline-none placeholder:text-muted"
+            />
+          </div>
+          <button type="button" onClick={onClose} aria-label="검색 닫기" className="shrink-0 text-muted">
+            <XMarkIcon size={22} />
+          </button>
+        </div>
+
+        <div className="scrollbar-none mt-4 min-h-0 flex-1 overflow-y-auto pb-10">
+          {branch.kind === "probing" && (
+            <div className="mt-14 flex flex-col items-center gap-3">
+              <FlickerSpinner size={20} />
+              <p className="text-sm text-muted">{branch.item.canonical} 데이터를 모으고 있어요…</p>
+            </div>
+          )}
+
+          {branch.kind === "request" && (
+            <div className="mt-10 rounded-2xl border border-hairline bg-surface px-5 py-6 text-center">
+              <p className="text-base font-bold text-whiteout">
+                {branch.reason === "not-found" ? "아직 준비 안 된 검색어예요" : "지금 실시간 분석이 안 돼요"}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                알림 신청하면 <span className="text-whiteout">다음날 카드로 만들어드려요</span>.
+                <br />
+                준비되면 피드 상단에서 알려드릴게요.
+              </p>
+              {branch.sent ? (
+                <p className="mt-4 font-pixel text-sm" style={{ color: NEON }}>
+                  접수됐어요 — 내일 피드에서 만나요
+                </p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => submitRequest(branch.query)}
+                  className="mt-4 rounded-full px-5 py-2.5 text-sm font-bold text-black"
+                  style={{ backgroundColor: NEON }}
+                >
+                  알림 신청
+                </button>
+              )}
+            </div>
+          )}
+
+          {branch.kind === "list" && results !== null && (
+            <>
+              {results.map((item) => (
+                <button
+                  key={`${item.symbol}:${item.canonical}`}
+                  type="button"
+                  onClick={() => void openItem(item)}
+                  className="flex w-full items-center justify-between gap-3 border-b border-hairline-soft px-1 py-3.5 text-left"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-bold text-whiteout">
+                      {item.canonical}
+                      {item.englishName && <span className="ml-1.5 font-normal text-muted">{item.englishName}</span>}
+                    </span>
+                    <span className="mt-0.5 block text-[11px] text-muted">
+                      {marketTag(item)} · {item.symbol}
+                    </span>
+                  </span>
+                  {item.todayCard && (
+                    <span className="shrink-0 rounded-full px-2.5 py-1 text-[10px] font-bold text-black" style={{ backgroundColor: NEON }}>
+                      오늘의 30장
+                    </span>
+                  )}
+                </button>
+              ))}
+              {results.length === 0 && !searching && (
+                <div className="mt-10 text-center">
+                  <p className="text-sm text-muted">
+                    &ldquo;{query.trim()}&rdquo; 결과를 찾지 못했어요.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setBranch({ kind: "request", query: query.trim(), reason: "not-found", sent: false })}
+                    className="mt-3 rounded-full border border-hairline px-4 py-2 text-sm text-whiteout"
+                  >
+                    알림 신청하면 내일 카드로 만들어드려요
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+
+          {branch.kind === "list" && results === null && (
+            <>
+              {popular.length > 0 && (
+                <section className="mt-2">
+                  <p className="font-pixel text-[11px] uppercase tracking-wide text-muted">오늘의 30장에서</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {popular.map((p) => (
+                      <button
+                        key={p.stock}
+                        type="button"
+                        onClick={() => setQuery(p.stock)}
+                        className="rounded-full border border-hairline px-3 py-1.5 text-sm text-whiteout"
+                      >
+                        {p.stock}
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              )}
+              {recent.length > 0 && (
+                <section className="mt-6">
+                  <p className="font-pixel text-[11px] uppercase tracking-wide text-muted">최근 본 종목</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {recent.map((r) => (
+                      <button
+                        key={r.stock}
+                        type="button"
+                        onClick={() => setQuery(r.stock)}
+                        className="rounded-full border border-hairline px-3 py-1.5 text-sm text-muted"
+                      >
+                        {r.stock}
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/fomo-web/components/icons.tsx
+++ b/apps/fomo-web/components/icons.tsx
@@ -77,3 +77,13 @@ export function UndoIcon({ size = 18, className }: IconProps) {
     </svg>
   );
 }
+
+/** 🔍 대체 — 검색(WO 검색). */
+export function SearchIcon({ size = 18, className }: IconProps) {
+  return (
+    <svg {...base(size)} className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <circle cx="10.5" cy="10.5" r="6.5" />
+      <path d="M20 20l-4.7-4.7" />
+    </svg>
+  );
+}

--- a/apps/web/__tests__/lib/symbol-index.test.ts
+++ b/apps/web/__tests__/lib/symbol-index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/prisma", () => ({ prisma: { $executeRaw: vi.fn(), $queryRaw: vi.fn().mockResolvedValue([]) } }));
+
+const { searchSymbols, saveSearchRequest } = await import("../../lib/symbol-index");
+
+describe("symbol-index (요청 경로 안전판)", () => {
+  it("인덱스 미구축(캐시 없음) 시 빈 결과 — 재구축·외부 fetch 없이 fail-open", async () => {
+    const results = await searchSymbols("삼성전자");
+    expect(results).toEqual([]);
+  });
+
+  it("검색 요청 저장은 쿼리를 60자로 자르고 pending 상태로 만든다", async () => {
+    const row = await saveSearchRequest("  존재하지  않는   종목  ");
+    expect(row.status).toBe("pending");
+    expect(row.query).toBe("존재하지 않는 종목");
+  });
+});

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -9,6 +9,7 @@ import {
   buildWeeklyRecap,
   type FeedBriefingRow,
 } from "../../../../../lib/feed-briefing";
+import { processSearchQueue, rebuildSymbolIndex } from "../../../../../lib/symbol-index";
 
 /**
  * 피드 콘텐츠 프리웜 크론 (WO 피드 강화) — ?slot=morning|close|weekly
@@ -49,6 +50,19 @@ export async function GET(request: Request) {
       await writeFeedContent(id, row);
       written.push(id);
     };
+    if (slot === "index") {
+      // 심볼 마스터 인덱스 재구축(일 1회) + 검색 알림 신청 큐 처리(WO 검색 ①·④).
+      const stats = await rebuildSymbolIndex();
+      const queue = await processSearchQueue();
+      revalidateTag("daily-30", { expire: 0 });
+      revalidateTag("feed-hub", { expire: 0 });
+      return withCors(
+        NextResponse.json(
+          { ok: true, slot, index: stats, queue, elapsedMs: Date.now() - startedAt },
+          { headers: { "Cache-Control": "no-store" } }
+        )
+      );
+    }
     if (slot === "morning") {
       await save(`briefing:us:${date}`, await buildUsBriefing());
     } else if (slot === "close") {
@@ -57,7 +71,7 @@ export async function GET(request: Request) {
     } else if (slot === "weekly") {
       await save(`recap:${isoWeekOf()}`, await buildWeeklyRecap());
     } else {
-      return withCors(NextResponse.json({ ok: false, error: "slot must be morning|close|weekly" }, { status: 400 }));
+      return withCors(NextResponse.json({ ok: false, error: "slot must be morning|close|weekly|index" }, { status: 400 }));
     }
     // daily-30·feed-hub 서버 캐시 즉시 만료 — 다음 요청이 새 콘텐츠를 포함해 재빌드.
     revalidateTag("daily-30", { expire: 0 });

--- a/apps/web/app/api/fomo/search/request/route.ts
+++ b/apps/web/app/api/fomo/search/request/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../../lib/fomo";
+import { readSearchRequests, saveSearchRequest } from "../../../../../lib/symbol-index";
+
+/**
+ * 검색 알림 신청 큐 (WO 검색 ③ 분기) — 무로그인이라 푸시 대신 재방문 시 피드 노출.
+ * POST {query} → 큐 저장. GET → 최근 요청 상태(클라가 localStorage 의 자기 요청과 대조).
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 10;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as { query?: string };
+    const query = body.query?.replace(/\s+/g, " ").trim();
+    if (!query || query.length < 1 || query.length > 60) {
+      return withCors(NextResponse.json({ ok: false, error: "query required (1~60자)" }, { status: 400 }));
+    }
+    const row = await saveSearchRequest(query);
+    return withCors(NextResponse.json({ ok: true, request: row }, { headers: { "Cache-Control": "no-store" } }));
+  } catch (err) {
+    console.warn("[fomo/search/request] failed", (err as Error)?.message);
+    return withCors(NextResponse.json({ ok: false, error: "저장에 실패했어요" }, { status: 500 }));
+  }
+}
+
+export async function GET() {
+  try {
+    const requests = await readSearchRequests(30);
+    return withCors(NextResponse.json({ requests }, { headers: { "Cache-Control": "no-store" } }));
+  } catch {
+    return withCors(NextResponse.json({ requests: [] }));
+  }
+}

--- a/apps/web/app/api/fomo/search/route.ts
+++ b/apps/web/app/api/fomo/search/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../lib/fomo";
+import { searchSymbols, symbolIndexReady } from "../../../../lib/symbol-index";
+import { getCachedDaily30Response } from "../../../../lib/daily-30";
+
+/**
+ * 검색 자동완성 (WO 검색 §2) — 캐시된 심볼 인덱스만 조회(<1초, 재구축·외부 fetch 0).
+ * 상위 10개 + 오늘의 30장 포함 여부(todayCard) 반환.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 10;
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function GET(req: Request) {
+  const q = new URL(req.url).searchParams.get("q")?.trim() ?? "";
+  if (!q) return withCors(NextResponse.json({ results: [], indexReady: await symbolIndexReady() }));
+  try {
+    const [results, daily30] = await Promise.all([
+      searchSymbols(q, 10),
+      getCachedDaily30Response().catch(() => null),
+    ]);
+    const todayStocks = new Set((daily30?.stocks ?? []).map((s) => s.canonical));
+    const todaySymbols = new Set((daily30?.stocks ?? []).map((s) => s.symbol?.toUpperCase()).filter(Boolean));
+    return withCors(
+      NextResponse.json(
+        {
+          indexReady: results.length > 0 || (await symbolIndexReady()),
+          results: results.map((r) => ({
+            canonical: r.canonical,
+            ...(r.englishName && r.englishName !== r.canonical ? { englishName: r.englishName } : {}),
+            symbol: r.symbol,
+            market: r.market,
+            country: r.country,
+            ...(r.naverCode ? { naverCode: r.naverCode } : {}),
+            ...(r.sector ? { sector: r.sector } : {}),
+            todayCard: todayStocks.has(r.canonical) || todaySymbols.has(r.symbol.toUpperCase()),
+          })),
+        },
+        { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600" } }
+      )
+    );
+  } catch (err) {
+    console.warn("[fomo/search] failed", (err as Error)?.message);
+    return withCors(NextResponse.json({ results: [], indexReady: false }, { status: 200 }));
+  }
+}

--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -7,6 +7,7 @@ import { fetchDartDisclosuresByStock } from "./dart-disclosures";
 import { fetchRecentSecFilings } from "./sec-edgar";
 import { fetchFredSeriesHistory } from "./fred";
 import { fetchStockDaily } from "./stock-front";
+import { readTodayFulfilledSearches } from "./symbol-index";
 import { kstDate } from "./fomo";
 import type { DiscoveryMarketRow } from "./market-source-types";
 
@@ -339,6 +340,26 @@ export async function buildFeedHubResponse(): Promise<FeedHubResponse> {
   // 5) 거시 이슈 (임계 변동일만).
   for (const card of macroIssues) {
     push({ type: "macro-issue", scope: "US", content: card }, card.id);
+  }
+  // 6) 검색 알림 신청 처리분(WO 검색 ④) — "요청하신 종목 카드가 준비됐어요". 재방문 노출(무로그인).
+  const fulfilled = await readTodayFulfilledSearches().catch(() => []);
+  const rowByName = new Map([...krRows, ...usRows].map((row) => [row.canonical, row]));
+  for (const entry of fulfilled) {
+    if (entry.country === "GLOBAL") continue; // 코인 요청은 코인 파이프라인 소관
+    const row = rowByName.get(entry.canonical);
+    const issue: FeedStockIssue = {
+      id: `feed:requested:${entry.symbol}:${asOf}`,
+      stock: entry.canonical,
+      market: entry.market,
+      country: entry.country,
+      ...(entry.naverCode ? { naverCode: entry.naverCode } : {}),
+      ...(entry.country === "US" ? { symbol: entry.symbol } : {}),
+      ...(typeof row?.changePct === "number" ? { changePct: row.changePct } : {}),
+      headline: "요청하신 종목 카드가 준비됐어요 — 눌러서 시세·차트·판단을 확인하세요.",
+      source: "검색 요청",
+      asOf,
+    };
+    push({ type: "stock-issue", scope: entry.country, stockIssue: issue }, issue.id);
   }
 
   const ordered = interleaveFeedItems(items);

--- a/apps/web/lib/symbol-index.ts
+++ b/apps/web/lib/symbol-index.ts
@@ -1,0 +1,328 @@
+import { STOCK_VOCAB, sectorOf } from "@fomo/core";
+import { usDiscoveryUniverse, usSymbolForStock } from "./us-symbols";
+import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { kstDate } from "./fomo";
+
+/**
+ * 심볼 마스터 인덱스 (WO 검색) — 검색의 기반.
+ * KR = 네이버 전종목(코스피+코스닥) · US = Nasdaq Trader 심볼 디렉토리(NYSE 포함) · 코인 = Upbit KRW 마켓.
+ * 크론 일 1회 재구축(rebuildSymbolIndex) → FeedContentCache 저장. **요청 경로에서 재구축 금지** —
+ * searchSymbols 는 캐시(모듈 메모리 10분 + DB)만 조회한다(<1초).
+ * 스키마는 히스토리 성과추적과 동일 필드: canonical·symbol·market·country·naverCode·sector.
+ */
+
+export interface SymbolIndexEntry {
+  /** 표시명 — KR/코인은 한글, US 는 vocab 한글명(있으면) 또는 영문. */
+  canonical: string;
+  englishName?: string;
+  symbol: string;
+  market: string;
+  country: "KR" | "US" | "GLOBAL";
+  naverCode?: string;
+  sector?: string;
+  /** 상호검색용 별칭(한글↔영문↔티커) — vocab aliases 재활용. */
+  aliases?: string[];
+}
+
+interface SymbolIndexDoc {
+  entries: SymbolIndexEntry[];
+  builtAt: string;
+}
+
+const INDEX_CACHE_ID = "symbol-index";
+const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
+const NAVER_PAGE_SIZE = 100;
+const NAVER_MAX_PAGES = 40;
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json", "User-Agent": UA }, signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ── KR: 네이버 전종목 (이미 쓰는 무료 API — 시총 페이지 전체 순회) ───────────
+
+interface NaverListedStock {
+  itemCode?: string;
+  stockName?: string;
+  stockEndType?: string;
+}
+
+async function fetchKrListed(market: "KOSPI" | "KOSDAQ"): Promise<SymbolIndexEntry[]> {
+  const out: SymbolIndexEntry[] = [];
+  for (let page = 1; page <= NAVER_MAX_PAGES; page += 1) {
+    const data = await fetchJson<{ stocks?: NaverListedStock[]; totalCount?: number }>(
+      `https://m.stock.naver.com/api/stocks/marketValue/${market}?page=${page}&pageSize=${NAVER_PAGE_SIZE}`
+    );
+    const stocks = data?.stocks ?? [];
+    if (stocks.length === 0) break;
+    for (const stock of stocks) {
+      if (!stock.itemCode || !stock.stockName) continue;
+      if (stock.stockEndType && stock.stockEndType !== "stock") continue; // ETF/ETN/리츠 외 파생 제외
+      const sector = sectorOf(stock.stockName);
+      out.push({
+        canonical: stock.stockName,
+        symbol: stock.itemCode,
+        market,
+        country: "KR",
+        naverCode: stock.itemCode,
+        ...(sector ? { sector } : {}),
+      });
+    }
+    if (stocks.length < NAVER_PAGE_SIZE) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return out;
+}
+
+// ── US: Nasdaq Trader 심볼 디렉토리 (무료 공식, NYSE 포함) ───────────────────
+
+async function fetchText(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": UA }, signal: AbortSignal.timeout(15_000) });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+function parseSymbolDir(text: string, kind: "nasdaq" | "other"): SymbolIndexEntry[] {
+  const lines = text.split(/\r?\n/);
+  const out: SymbolIndexEntry[] = [];
+  for (const line of lines.slice(1)) {
+    const cols = line.split("|");
+    if (cols.length < 5) continue;
+    if (kind === "nasdaq") {
+      const [symbol, name, , testIssue, , , etf] = cols;
+      if (!symbol || !name || testIssue === "Y" || etf === "Y") continue;
+      if (/File Creation Time/i.test(symbol)) continue;
+      out.push({ canonical: cleanUsName(name), englishName: cleanUsName(name), symbol: symbol.trim(), market: "NASDAQ", country: "US" });
+    } else {
+      const [symbol, name, exchange, , etf, , testIssue] = cols;
+      if (!symbol || !name || testIssue === "Y" || etf === "Y") continue;
+      if (/File Creation Time/i.test(symbol)) continue;
+      const market = exchange === "N" ? "NYSE" : exchange === "A" ? "NYSE" : "NYSE"; // AMEX·기타는 NYSE 그룹으로 표기
+      out.push({ canonical: cleanUsName(name), englishName: cleanUsName(name), symbol: symbol.trim(), market, country: "US" });
+    }
+  }
+  return out;
+}
+
+function cleanUsName(name: string): string {
+  return name
+    .replace(/\s*-\s*(Common Stock|Class [A-Z] (Common Stock|Ordinary Shares?)|American Depositary Shares?.*|Ordinary Shares?|Common Shares?|Depositary Shares?.*)$/i, "")
+    .replace(/,?\s*Inc\.?$|,?\s*Corp(oration)?\.?$|,?\s*Ltd\.?$|,?\s*plc\.?$/i, "")
+    .trim();
+}
+
+async function fetchUsListed(): Promise<SymbolIndexEntry[]> {
+  const [nasdaq, other] = await Promise.all([
+    fetchText("https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"),
+    fetchText("https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt"),
+  ]);
+  return [...(nasdaq ? parseSymbolDir(nasdaq, "nasdaq") : []), ...(other ? parseSymbolDir(other, "other") : [])];
+}
+
+// ── 코인: Upbit KRW 마켓 ─────────────────────────────────────────────────────
+
+interface UpbitMarketInfo {
+  market: string;
+  korean_name: string;
+  english_name: string;
+  market_event?: { warning?: boolean };
+}
+
+async function fetchCoinListed(): Promise<SymbolIndexEntry[]> {
+  const markets = await fetchJson<UpbitMarketInfo[]>("https://api.upbit.com/v1/market/all?isDetails=true");
+  if (!Array.isArray(markets)) return [];
+  return markets
+    .filter((m) => m.market.startsWith("KRW-") && m.market_event?.warning !== true)
+    .map((m) => ({
+      canonical: m.korean_name,
+      englishName: m.english_name,
+      symbol: m.market, // "KRW-BTC" — stock-front 코인 분기와 동일 식별자
+      market: "COIN",
+      country: "GLOBAL" as const,
+      sector: "코인",
+      aliases: [m.english_name, m.market.replace(/^KRW-/, "")],
+    }));
+}
+
+// ── 병합 + vocab 별칭(한글↔영문↔티커 상호검색) ──────────────────────────────
+
+function mergeVocabAliases(entries: SymbolIndexEntry[]): SymbolIndexEntry[] {
+  const bySymbol = new Map<string, SymbolIndexEntry>();
+  const byCode = new Map<string, SymbolIndexEntry>();
+  for (const entry of entries) {
+    bySymbol.set(entry.symbol.toUpperCase(), entry);
+    if (entry.naverCode) byCode.set(entry.naverCode, entry);
+  }
+  // 미국 발굴 시드(us-symbols)의 한글명 병합 — "메타"→META 상호검색의 본체.
+  for (const seed of usDiscoveryUniverse()) {
+    const hit = bySymbol.get(seed.symbol.toUpperCase());
+    if (!hit || !/[가-힣]/.test(seed.canonical)) continue;
+    const aliases = new Set(hit.aliases ?? []);
+    if (hit.englishName === undefined) hit.englishName = hit.canonical;
+    aliases.add(hit.canonical);
+    aliases.add(seed.canonical);
+    hit.canonical = seed.canonical;
+    hit.aliases = [...aliases];
+    if (!hit.sector && seed.sector) hit.sector = seed.sector;
+  }
+  for (const def of STOCK_VOCAB) {
+    const usSymbol = def.country === "US" ? usSymbolForStock(def.canonical) : undefined;
+    const hit = (def.naverCode && byCode.get(def.naverCode)) || (usSymbol && bySymbol.get(usSymbol.toUpperCase()));
+    if (!hit) continue;
+    const aliases = new Set(hit.aliases ?? []);
+    aliases.add(def.canonical);
+    for (const alias of def.aliases) aliases.add(alias);
+    if (def.country === "US") {
+      // 미국 종목: 표시명을 vocab 한글명으로("메타"→META 검색·표시 둘 다).
+      if (hit.englishName === undefined) hit.englishName = hit.canonical;
+      aliases.add(hit.canonical);
+      hit.canonical = def.canonical;
+    }
+    hit.aliases = [...aliases];
+    if (!hit.sector) {
+      const sector = sectorOf(def.canonical);
+      if (sector) hit.sector = sector;
+    }
+  }
+  return entries;
+}
+
+/** 크론 전용 — 인덱스 재구축(+저장). 요청 경로 호출 금지. */
+export async function rebuildSymbolIndex(): Promise<{ total: number; kr: number; us: number; coin: number }> {
+  const [kospi, kosdaq, us, coin] = await Promise.all([
+    fetchKrListed("KOSPI"),
+    fetchKrListed("KOSDAQ"),
+    fetchUsListed(),
+    fetchCoinListed(),
+  ]);
+  const merged = mergeVocabAliases([...kospi, ...kosdaq, ...us, ...coin]);
+  const doc: SymbolIndexDoc = { entries: merged, builtAt: new Date().toISOString() };
+  indexMemo = { doc, loadedAt: Date.now() }; // 메모리 먼저 — 저장 실패해도 이 인스턴스는 검색 가능
+  await writeFeedContent(INDEX_CACHE_ID, doc);
+  return { total: merged.length, kr: kospi.length + kosdaq.length, us: us.length, coin: coin.length };
+}
+
+// ── 검색 (요청 경로 — 캐시만) ────────────────────────────────────────────────
+
+let indexMemo: { doc: SymbolIndexDoc; loadedAt: number } | null = null;
+const INDEX_MEMO_TTL_MS = 10 * 60 * 1000;
+
+async function loadIndex(): Promise<SymbolIndexDoc | null> {
+  if (indexMemo && Date.now() - indexMemo.loadedAt < INDEX_MEMO_TTL_MS) return indexMemo.doc;
+  const doc = await readFeedContent<SymbolIndexDoc>(INDEX_CACHE_ID);
+  if (doc?.entries?.length) {
+    indexMemo = { doc, loadedAt: Date.now() };
+    return doc;
+  }
+  return null;
+}
+
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/[\s·.,'"-]+/g, "");
+}
+
+export interface SymbolSearchResult extends SymbolIndexEntry {
+  score: number;
+}
+
+/** 자동완성 — 정확 > 접두 > 부분. 캐시된 인덱스만(재구축·외부 fetch 0). */
+export async function searchSymbols(query: string, limit = 10): Promise<SymbolSearchResult[]> {
+  const q = normalize(query);
+  if (q.length < 1) return [];
+  const doc = await loadIndex();
+  if (!doc) return [];
+  const results: SymbolSearchResult[] = [];
+  for (const entry of doc.entries) {
+    const keys = [entry.canonical, entry.englishName ?? "", entry.symbol, entry.naverCode ?? "", ...(entry.aliases ?? [])]
+      .filter(Boolean)
+      .map(normalize);
+    let score = 0;
+    for (const key of keys) {
+      if (key === q) score = Math.max(score, 3);
+      else if (key.startsWith(q)) score = Math.max(score, 2);
+      else if (q.length >= 2 && key.includes(q)) score = Math.max(score, 1);
+    }
+    // 본명(표시명/티커) 정확 일치는 별칭 일치보다 위 — "META"에서 코인 별칭이 Meta Platforms 를 이기지 않게.
+    if (score === 3 && (normalize(entry.canonical) === q || normalize(entry.symbol) === q)) score = 3.5;
+    if (score > 0) results.push({ ...entry, score });
+  }
+  return results
+    .sort((a, b) => b.score - a.score || a.canonical.length - b.canonical.length || a.canonical.localeCompare(b.canonical))
+    .slice(0, limit);
+}
+
+export async function symbolIndexReady(): Promise<boolean> {
+  return (await loadIndex()) !== null;
+}
+
+// ── 알림 신청 큐 (③ 분기 — 무로그인: 재방문 시 피드 노출) ─────────────────────
+
+export interface SearchRequestRow {
+  query: string;
+  status: "pending" | "fulfilled" | "not-found";
+  requestedAt: string;
+  resolved?: SymbolIndexEntry;
+  processedAt?: string;
+}
+
+function requestId(query: string): string {
+  return `searchreq:${normalize(query).slice(0, 60)}`;
+}
+
+export async function saveSearchRequest(query: string): Promise<SearchRequestRow> {
+  const clean = query.replace(/\s+/g, " ").trim().slice(0, 60);
+  const existing = await readFeedContent<SearchRequestRow>(requestId(clean));
+  if (existing) return existing;
+  const row: SearchRequestRow = { query: clean, status: "pending", requestedAt: new Date().toISOString() };
+  await writeFeedContent(requestId(clean), row);
+  return row;
+}
+
+export async function readSearchRequests(limit = 30): Promise<SearchRequestRow[]> {
+  const rows = await readFeedContentByPrefix<SearchRequestRow>("searchreq:", limit);
+  return rows.map((r) => r.row).filter((r) => r && typeof r.query === "string");
+}
+
+/**
+ * 크론 전용 — pending 큐를 (새로 재구축된) 인덱스로 해석.
+ * 실존 → fulfilled(+오늘의 검색 요청 카드 목록에 합류), 미실존(오타 등) → not-found 종료(무한 대기 금지).
+ */
+export async function processSearchQueue(): Promise<{ fulfilled: number; notFound: number }> {
+  const rows = await readFeedContentByPrefix<SearchRequestRow>("searchreq:", 50);
+  let fulfilled = 0;
+  let notFound = 0;
+  const fulfilledEntries: SymbolIndexEntry[] = [];
+  for (const { id, row } of rows) {
+    if (row.status !== "pending") continue;
+    const matches = await searchSymbols(row.query, 1);
+    const top = matches[0];
+    const processedAt = new Date().toISOString();
+    if (top && top.score >= 2) {
+      await writeFeedContent(id, { ...row, status: "fulfilled", resolved: top, processedAt } satisfies SearchRequestRow);
+      fulfilledEntries.push(top);
+      fulfilled += 1;
+    } else {
+      await writeFeedContent(id, { ...row, status: "not-found", processedAt } satisfies SearchRequestRow);
+      notFound += 1;
+    }
+  }
+  if (fulfilledEntries.length > 0) {
+    await writeFeedContent(`search-fulfilled:${kstDate()}`, { date: kstDate(), entries: fulfilledEntries });
+  }
+  return { fulfilled, notFound };
+}
+
+/** feed-hub 소비용 — 오늘 처리된 검색 요청 카드 대상. */
+export async function readTodayFulfilledSearches(): Promise<SymbolIndexEntry[]> {
+  const doc = await readFeedContent<{ entries: SymbolIndexEntry[] }>(`search-fulfilled:${kstDate()}`);
+  return doc?.entries ?? [];
+}


### PR DESCRIPTION
## WO — 검색 기능 (3계층 분기)
검색 → ①오늘 30장에 있음: 그 카드/뎁스 그대로 ②인덱스엔 있는데 카드 없음: 온디맨드 단건 조립 → 표준 뎁스+verdict ③인덱스에도 없음/시세 실패: "알림 신청하면 내일 카드로" → 큐 → 다음날 크론 생성 → 재방문 시 피드 노출.

## §1 심볼 마스터 인덱스 (크론 일 1회)
- KR 네이버 전종목(보통주 필터) + US **Nasdaq Trader 심볼 디렉토리**(NYSE 포함, ETF·테스트 제외) + Upbit KRW 마켓 — 전부 무료 소스, 스키마 {canonical·symbol·market·country·naverCode·sector}(히스토리 성과추적 호환).
- **한글↔영문↔티커 상호검색** 실측: "메타"↔META, "엔비디아"↔NVDA, "SMMT"→서밋 테라퓨틱스. 본명 정확일치 가중치(코인 별칭 KRW-META가 Meta Platforms를 못 이김).
- 요청 경로 재구축 금지 — 캐시(모듈 메모리 10분+DB)만 조회. **실측 7쿼리 50ms**.

## §2 검색 API + UI
- `GET /api/fomo/search?q=` top10 + `todayCard` 뱃지. 오버레이: 인기(오늘 30장 상위)+최근 본(히스토리), 시장 태그(🇰🇷/🇺🇸/₿). 1차는 종목만(콘텐츠·테마 검색은 2차 — 범위 명시).

## §3 온디맨드 뎁스 (②)
- KR(naverCode)·코인(KRW-*)·오늘카드 → 바로 표준 뎁스(StockInsightView — 기존 stock-front 재사용: 시세·캔들·TA·verdict·chartSeries. 캔들 부족 시 최소 verdict는 1.6 엔진 소관).
- US 동적 심볼 → 단건 프로브(stock-front lite, 클라 10분 캐시, 9초 타임아웃) → 성공 시 뎁스 / 실패 시 ③분기 문구. **무한 로딩·에러 화면 0**.

## §4 미존재/실패 분기 (③)
- 알림 신청 → `searchreq:` 큐(무로그인 — localStorage로 자기 요청 기억). 다음날 크론(slot=index, 05:00 KST): 인덱스 재구축 후 큐 해석 — 실존 → **feed-hub "요청하신 종목 카드가 준비됐어요"**(재방문 노출), 오타 등 미실존 → not-found 종료(무한 대기 금지).

## 검증
- 테스트 94/94 · guard:discovery ✅ · typecheck ✅ · spec:analyze error 0.
- 로컬 실측: 인덱스 KR+US+코인 구축, 수용 검색어 전부 자동완성 통과.
- **머지 후 프로덕션 시나리오 3개 실측 첨부 예정**(존재+카드있음 / 존재+카드없음 / 미존재→큐).

🤖 Generated with [Claude Code](https://claude.com/claude-code)