### PR TITLE
fix: 전체 버그 스윕 — taste 입력 상한 + inflight 날짜 키 + localStorage 누적 정리

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -58,6 +58,32 @@ function kstDateKey(now = new Date()): string {
   return new Date(now.getTime() + 9 * HOUR).toISOString().slice(0, 10);
 }
 
+/**
+ * 날짜 키(fomo:index:*, fomo:keywords:*, fomo:discovery:*)로 매일 새 항목이 쌓이는데
+ * 지우는 곳이 없어 localStorage 가 무한 누적된다(quota 초과 시 이후 모든 저장이 조용히 실패
+ * → 오프라인 캐시·취향 기록 등 영속 기능 사망). 오늘이 아닌 날짜가 박힌 fomo:* 키를 정리한다.
+ * 날짜가 없는 키(fomo:discovery:last-good:* 등)는 건드리지 않는다. 세션당 1회.
+ */
+let stalePruned = false;
+function pruneStaleDatedCache(): void {
+  if (typeof window === "undefined" || stalePruned) return;
+  stalePruned = true;
+  try {
+    const today = kstDateKey();
+    const datedFomoKey = /^fomo:(index|keywords|discovery):.*(\d{4}-\d{2}-\d{2})/;
+    const stale: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i);
+      if (!key) continue;
+      const m = datedFomoKey.exec(key);
+      if (m && m[2] !== today) stale.push(key);
+    }
+    for (const key of stale) window.localStorage.removeItem(key);
+  } catch (err) {
+    console.warn("[fomoApi] stale cache prune failed", err);
+  }
+}
+
 export interface FomoIndexResponse {
   date: string;
   score: number;
@@ -116,6 +142,7 @@ function readStoredIndex(): FomoIndexResponse | null {
 function writeStoredIndex(value: FomoIndexResponse): void {
   if (typeof window === "undefined") return;
   try {
+    pruneStaleDatedCache();
     window.localStorage.setItem(indexStorageKey(), JSON.stringify(value));
   } catch (err) {
     console.warn("[fetchIndex] localStorage write failed", err);
@@ -355,6 +382,7 @@ function readStoredKeywords(): KeywordsResponse | null {
 function writeStoredKeywords(value: KeywordsResponse): void {
   if (typeof window === "undefined") return;
   try {
+    pruneStaleDatedCache();
     window.localStorage.setItem(keywordsStorageKey(), JSON.stringify(value));
   } catch (err) {
     console.warn("[fetchKeywords] localStorage write failed", err);
@@ -730,6 +758,7 @@ function writeStoredDiscovery(value: DiscoveryResponse, country: DiscoveryCountr
   if (typeof window === "undefined") return;
   if (!hasDiscoveryCards(value, country)) return;
   try {
+    pruneStaleDatedCache();
     window.localStorage.setItem(discoveryStorageKey(country), JSON.stringify(value));
     window.localStorage.setItem(lastDiscoveryStorageKey(country), JSON.stringify(value));
   } catch (err) {

--- a/apps/web/app/api/fomo/keywords/route.ts
+++ b/apps/web/app/api/fomo/keywords/route.ts
@@ -43,7 +43,8 @@ interface KeywordsPayload {
 //   이후 모든 인스턴스가 즉시 읽기. DDL/외부 KV 불필요. revalidate 30분(시장 변동 반영) + 익일 자동 새 키.
 // snapshot-first(§4.6)는 그대로 — cron 스냅샷이 있으면 그게 1순위. 이 캐시는 라이브 폴백 경로의 영속화.
 // mock 폴백은 캐시 밖(실패를 굳히지 않게). inflight 로 인스턴스 내 동시 요청 dedup.
-let inflight: Promise<KeywordsPayload> | null = null;
+// 날짜로 키잉 — 자정 넘김 시점에 이전 날짜의 산출 Promise 를 새 날짜 요청이 공유하지 않게.
+let inflight: { date: string; p: Promise<KeywordsPayload> } | null = null;
 
 /** 라이브 산출(공유 파이프라인). 성공분만 Data Cache 에 영속. 실패해도 throw 없이 mock 폴백. */
 async function computeLive(date: string): Promise<KeywordsPayload> {
@@ -111,11 +112,12 @@ async function getSnapshotPayload(date: string): Promise<KeywordsPayload> {
 
 /** 명시적 live=1 확인용 경로 — Data Cache 가 영속 캐시, inflight 가 인스턴스 내 동시 dedup. */
 async function getLivePayload(date: string): Promise<KeywordsPayload> {
-  if (inflight) return inflight;
-  inflight = computeLive(date).finally(() => {
-    inflight = null;
+  if (inflight && inflight.date === date) return inflight.p;
+  const p = computeLive(date).finally(() => {
+    if (inflight?.p === p) inflight = null;
   });
-  return inflight;
+  inflight = { date, p };
+  return p;
 }
 
 export async function GET(request: Request) {

--- a/apps/web/app/api/fomo/taste/route.ts
+++ b/apps/web/app/api/fomo/taste/route.ts
@@ -28,6 +28,10 @@ interface TasteBody {
   sessionId?: string;
 }
 
+// 입력 상한 — 정상 subject(테마/종목명)·sessionId 는 짧다. 초과는 오용(임의 문자열 DB 적재 차단).
+const MAX_SUBJECT_LEN = 80;
+const MAX_SESSION_ID_LEN = 128;
+
 export async function POST(req: NextRequest) {
   // 로그인 유저면 userId, 아니면 익명(sessionId). 둘 다 없으면 폐기(주인 식별 불가).
   const userId = verifyToken(extractBearerToken(req.headers.get("authorization")) ?? "");
@@ -36,11 +40,14 @@ export async function POST(req: NextRequest) {
     const body = (await req.json().catch(() => ({}))) as TasteBody;
     const subjectType = SUBJECT_TYPES[body.subjectType as keyof typeof SUBJECT_TYPES];
     const signal = SIGNALS[body.signal as keyof typeof SIGNALS];
-    const subject = body.subject?.trim();
-    const sessionId = body.sessionId?.trim() || null;
+    const subject = typeof body.subject === "string" ? body.subject.trim() : "";
+    const sessionId = (typeof body.sessionId === "string" ? body.sessionId.trim() : "") || null;
 
     if (!subjectType || !signal || !subject) {
       return corsJson({ error: "subjectType·subject·signal 필요", code: "BAD_INPUT" }, { status: 400 });
+    }
+    if (subject.length > MAX_SUBJECT_LEN || (sessionId && sessionId.length > MAX_SESSION_ID_LEN)) {
+      return corsJson({ error: "입력이 너무 깁니다", code: "BAD_INPUT" }, { status: 400 });
     }
     // 익명 적재라도 주인(userId 또는 sessionId)은 있어야 한다 — 둘 다 없으면 의미 없는 행.
     if (!userId && !sessionId) {


### PR DESCRIPTION
전 영역(core 엔진 / apps/web API·lib / fomo-web 클라 로직) 버그·결함 수색 후, **확인된 3건만** 수정. UI(비주얼·카피·레이아웃) 무변경.

## 수정한 결함
1. **`/api/fomo/taste` 입력 상한 없음** — `subject`/`sessionId`가 검증 없이 임의 길이로 DB(TasteSignal)에 적재됨(오염·오용 벡터). → 길이 상한(80/128) + 비문자열 타입 가드, 초과 시 400. 정상 입력(테마/종목명)은 영향 없음.
2. **`/api/fomo/keywords?live=1` inflight 날짜 미키잉** — 모듈 스코프 단일 Promise라 자정 넘김 시 새 날짜 요청이 이전 날짜 산출을 공유할 수 있었음. → `{date, p}` 키잉.
3. **localStorage 날짜 캐시 무한 누적** — `fomo:index/keywords/discovery:<날짜>` 키가 매일 새로 쌓이고(구버전 캐시 키 포함) 지우는 코드가 없어, 장기 사용 시 quota 초과 → 이후 모든 localStorage 저장이 조용히 실패(오프라인 캐시·기록 등 영속 기능 사망). → 세션당 1회, 오늘이 아닌 날짜가 박힌 `fomo:*` 키 정리(무날짜 키 `last-good:*`는 보존).

## 수색에서 정상 확인(변경 없음 — 오탐 기각)
`Math.max(...빈배열)` 후보 전부 가드됨(verdict/technical-analysis/deck/feed-hub) · localStorage `JSON.parse` 10곳 전부 try/catch · insight 라우트 inflight는 날짜+주제 키 · cron 인증(prewarm=CRON_SECRET, daily-30=공개 라우트 워머 프록시라 신규 공격면 없음) · `SECTORS`↔`THEME_DICTIONARY` 정합 · taste/link(WHERE 전용+인증 필수).

참고: 로컬 typecheck 190건 에러는 `@fomo/shared` 워크스페이스 링크 끊김(컨테이너 문제)이었고 `npm install`로 해소 — 코드 변경 아님.

## 검증
`npm run test` **1070 passed** · typecheck(web/fomo-web) 0 에러 · `build:web`/`build:fomo-web` 통과.

https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC)_