### PR TITLE
fix: 전수조사 2라운드 — 세션/계정 위조 게이트 + 타임아웃 + NaN 가드 + 타이머 정리

### DIFF
--- a/apps/fomo-web/components/KeywordCardFeed.tsx
+++ b/apps/fomo-web/components/KeywordCardFeed.tsx
@@ -219,7 +219,9 @@ function KeywordDeck({
     return new Set(getHistory().filter((h) => kstDay(h.ts) === today).map((h) => h.id));
   })[0];
   const [replay, setReplay] = useState(false);
-  const personalizedCards = personalizedKeywordCards(cards);
+  // 개인화 순서는 마운트 1회 고정 — 스와이프가 관심 점수를 갱신하는데 매 렌더 재정렬하면
+  // idx(위치 인덱스) 밑에서 덱이 바뀌어 카드가 건너뛰거나 반복된다.
+  const personalizedCards = useState(() => personalizedKeywordCards(cards))[0];
   const sectorCards = replay ? personalizedCards : personalizedCards.filter((c) => !viewedIds.has(c.id));
   const deck = toDeckItems(sectorCards);
 

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -542,6 +542,15 @@ export function StockSwipeDeck({
   const firstCardRecorded = useRef(false);
   const hydratedRecorded = useRef<Set<string>>(new Set());
   const matchTimer = useRef<number | null>(null);
+  // 진행 중 연출 타이머(플링/열기) — 언마운트 후 발화하면 사라진 덱에서 setState/openDepth 가 돈다 → 전부 정리.
+  const pendingTimers = useRef<number[]>([]);
+  useEffect(
+    () => () => {
+      for (const t of pendingTimers.current) window.clearTimeout(t);
+      if (matchTimer.current) window.clearTimeout(matchTimer.current);
+    },
+    []
+  );
 
   // 앞면 FOMO 신호 — ④ 정렬 때 풀 전체를 이미 받아 seed(initialFronts). 빠진 종목만 도달 시 lazy 보강.
   const [front, setFront] = useState<Record<string, FrontEntry>>(initialFronts ?? {});
@@ -703,12 +712,14 @@ export function StockSwipeDeck({
       return;
     }
     setExiting(dir);
-    window.setTimeout(() => {
-      setExiting(null);
-      setDx(0);
-      setDy(0);
-      setIdx((i) => i + 1);
-    }, EXIT_MS);
+    pendingTimers.current.push(
+      window.setTimeout(() => {
+        setExiting(null);
+        setDx(0);
+        setDy(0);
+        setIdx((i) => i + 1);
+      }, EXIT_MS)
+    );
   }, []);
 
   // 매칭 모먼트 — 짧게 띄우고 자동 해제(애니메이션 끔 설정이면 더 짧게).
@@ -806,7 +817,7 @@ export function StockSwipeDeck({
     }
     // 카드 날리는 연출(관심=우로, 슈퍼관심=위로) — 스와이프·버튼 완전 동일. 날아간 뒤 매칭 보고 상세로.
     setExiting(kind === "super" ? "up" : "right");
-    window.setTimeout(openAfter, 760);
+    pendingTimers.current.push(window.setTimeout(openAfter, 760));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idx, deckCards, front, fireMatch, loggedIn, onRequireLogin]);
 

--- a/apps/web/app/api/fomo/auth/login/route.ts
+++ b/apps/web/app/api/fomo/auth/login/route.ts
@@ -7,6 +7,9 @@ import { exceedsBcryptPasswordLimit } from "@/lib/auth/passwordPolicy";
 
 export const dynamic = "force-dynamic";
 
+// 타이밍 균일화용 고정 더미 해시(cost 10) — 실제 계정과 무관, 어떤 비밀번호와도 일치하지 않음.
+const DUMMY_BCRYPT_HASH = "$2b$10$C6UzMDM.H6dfI/f/IKcEeO6cBmOQdD3jH9M4qzYlrx1PBGU0y0e6a";
+
 export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
 }
@@ -31,7 +34,10 @@ export async function POST(req: NextRequest) {
     }
 
     const user = await prisma.user.findUnique({ where: { email } });
-    const ok = user?.passwordHash ? await bcrypt.compare(password, user.passwordHash) : false;
+    // 미존재 계정도 동일 비용의 해시 비교를 수행 — 응답시간 차로 계정 존재가 새는 것 방지(계정 열거 차단의 짝).
+    const ok = user?.passwordHash
+      ? await bcrypt.compare(password, user.passwordHash)
+      : (await bcrypt.compare(password, DUMMY_BCRYPT_HASH), false);
     if (!user || !ok) {
       return corsJson({ error: "이메일 또는 비밀번호가 맞지 않아.", code: "BAD_CREDENTIALS" }, { status: 401 });
     }

--- a/apps/web/app/api/fomo/challenges/route.ts
+++ b/apps/web/app/api/fomo/challenges/route.ts
@@ -3,6 +3,7 @@ import { challengePointsFor } from "@fomo/core";
 import { prisma } from "../../../../lib/prisma";
 import { kstDate, corsJson, withCors } from "../../../../lib/fomo";
 import { extractBearerToken, verifyToken } from "@/lib/auth/jwt";
+import { isValidSessionIdFormat, verifySession } from "../../../../lib/session-hmac";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,7 @@ export function OPTIONS() {
 
 interface ChallengeBody {
   sessionId?: string;
+  sessionSignature?: string;
   action?: string;
   userId?: string;
   date?: string;
@@ -52,6 +54,10 @@ export async function GET(req: NextRequest) {
     if (!sessionId) {
       return corsJson({ error: "sessionId 필요", code: "MISSING_SESSION" }, { status: 400 });
     }
+    // vote 와 동일한 형식 게이트 — 임의 문자열로 타 세션 포인트 조회/열거 차단.
+    if (!isValidSessionIdFormat(sessionId)) {
+      return corsJson({ error: "세션 형식이 유효하지 않습니다", code: "INVALID_SESSION_FORMAT" }, { status: 400 });
+    }
 
     const row = await prisma.challengeState.findUnique({
       where: { sessionId_challengeDate: { sessionId, challengeDate: date } },
@@ -78,6 +84,13 @@ export async function POST(req: NextRequest) {
     if (!sessionId) {
       return corsJson({ error: "sessionId 필요", code: "MISSING_SESSION" }, { status: 400 });
     }
+    // vote 와 동일한 게이트(형식 + HMAC) — 임의 sessionId 로 포인트 적립 위조 차단.
+    if (!isValidSessionIdFormat(sessionId)) {
+      return corsJson({ error: "세션 형식이 유효하지 않습니다", code: "INVALID_SESSION_FORMAT" }, { status: 400 });
+    }
+    if (verifySession(sessionId, body.sessionSignature).tampered) {
+      return corsJson({ error: "세션이 유효하지 않습니다", code: "TAMPERED_SESSION" }, { status: 403 });
+    }
     if (action !== "accept" && action !== "complete") {
       return corsJson(
         { error: "action은 accept|complete 중 하나", code: "BAD_ACTION" },
@@ -85,9 +98,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 로그인 상태면 Bearer 토큰의 userId를 우선(클라 위조 방지), 없으면 body.userId 폴백.
+    // userId 는 검증된 Bearer 토큰에서만 — body.userId 는 임의 유저에게 기록을 귀속시킬 수 있어 수용 안 함.
     const tokenUserId = verifyToken(extractBearerToken(req.headers.get("authorization")) ?? "");
-    const userId = tokenUserId ?? body.userId ?? null;
+    const userId = tokenUserId ?? null;
 
     const key = { sessionId_challengeDate: { sessionId, challengeDate: date } };
 

--- a/apps/web/app/api/fomo/emotions/link/route.ts
+++ b/apps/web/app/api/fomo/emotions/link/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "../../../../../lib/prisma";
 import { corsJson, withCors } from "../../../../../lib/fomo";
 import { extractBearerToken, verifyToken } from "@/lib/auth/jwt";
+import { isValidSessionIdFormat, verifySession } from "../../../../../lib/session-hmac";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +12,7 @@ export function OPTIONS() {
 
 interface LinkBody {
   sessionId?: string;
+  sessionSignature?: string;
 }
 
 // POST /api/fomo/emotions/link — 로그인 직후 익명 sessionId 기록을 userId로 연결.
@@ -26,6 +28,13 @@ export async function POST(req: NextRequest) {
     const sessionId = body.sessionId?.trim();
     if (!sessionId) {
       return corsJson({ error: "sessionId 필요", code: "MISSING_SESSION" }, { status: 400 });
+    }
+    // vote 와 동일 게이트 — 임의 sessionId 를 알아내 타 세션 기록을 내 계정으로 흡수하는 것 차단.
+    if (!isValidSessionIdFormat(sessionId)) {
+      return corsJson({ error: "세션 형식이 유효하지 않습니다", code: "INVALID_SESSION_FORMAT" }, { status: 400 });
+    }
+    if (verifySession(sessionId, body.sessionSignature).tampered) {
+      return corsJson({ error: "세션이 유효하지 않습니다", code: "TAMPERED_SESSION" }, { status: 403 });
     }
 
     // 아직 주인 없는(userId null) 익명 기록만 연결. 이미 다른 유저에 묶인 건 건드리지 않음.

--- a/apps/web/app/api/fomo/emotions/vote/route.ts
+++ b/apps/web/app/api/fomo/emotions/vote/route.ts
@@ -55,9 +55,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 로그인 상태면 Bearer 토큰의 userId를 우선(클라 위조 방지), 없으면 body.userId 폴백.
+    // userId 는 검증된 Bearer 토큰에서만 — body.userId 는 임의 유저에게 기록을 귀속시킬 수 있어 수용 안 함.
     const tokenUserId = verifyToken(extractBearerToken(req.headers.get("authorization")) ?? "");
-    const userId = tokenUserId ?? body.userId ?? null;
+    const userId = tokenUserId ?? null;
 
     // M4 구조화 한마디 — 두 키가 모두 유효할 때만 저장(가드레일의 서버측 짝).
     const hasVoice = isSituationKey(body.situationKey) && isResolveKey(body.resolveKey);

--- a/apps/web/app/api/fomo/whale/route.ts
+++ b/apps/web/app/api/fomo/whale/route.ts
@@ -27,10 +27,10 @@ export async function GET() {
   const items: string[] = [];
   try {
     const [globalRes, marketsRes] = await Promise.allSettled([
-      fetch("https://api.coingecko.com/api/v3/global", { next: { revalidate: 300 } }),
+      fetch("https://api.coingecko.com/api/v3/global", { next: { revalidate: 300 }, signal: AbortSignal.timeout(8_000) }),
       fetch(
         "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&price_change_percentage=24h",
-        { next: { revalidate: 300 } }
+        { next: { revalidate: 300 }, signal: AbortSignal.timeout(8_000) }
       ),
     ]);
 

--- a/apps/web/lib/fomo-market-sources.ts
+++ b/apps/web/lib/fomo-market-sources.ts
@@ -166,10 +166,10 @@ export async function fetchMacro(): Promise<MacroQuote[]> {
 export async function fetchWhale(): Promise<WhaleInput> {
   try {
     const [globalRes, marketsRes] = await Promise.allSettled([
-      fetch("https://api.coingecko.com/api/v3/global", { next: { revalidate: 300 } }),
+      fetch("https://api.coingecko.com/api/v3/global", { next: { revalidate: 300 }, signal: AbortSignal.timeout(8_000) }),
       fetch(
         "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=10&page=1&price_change_percentage=24h",
-        { next: { revalidate: 300 } }
+        { next: { revalidate: 300 }, signal: AbortSignal.timeout(8_000) }
       ),
     ]);
 

--- a/packages/fomo-core/src/keyword-cards/fomo-score.ts
+++ b/packages/fomo-core/src/keyword-cards/fomo-score.ts
@@ -105,8 +105,9 @@ export interface FomoScoreResult {
   };
 }
 
-const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
-const clamp100 = (x: number) => (x < 0 ? 0 : x > 100 ? 100 : x);
+// NaN/±Infinity 는 0 으로 — 비유한 입력이 점수로 둔갑("포모 NaN")하는 것 차단(discovery-supply 와 동일 규약).
+const clamp01 = (x: number) => (!Number.isFinite(x) ? 0 : x < 0 ? 0 : x > 1 ? 1 : x);
+const clamp100 = (x: number) => (!Number.isFinite(x) ? 0 : x < 0 ? 0 : x > 100 ? 100 : x);
 
 function volTo100(ratio: number): number {
   return clamp01((ratio - 1) / (FOMO_NORM.volTopX - 1)) * 100;


### PR DESCRIPTION
전수조사 2라운드(1라운드 #818에 이어) — 미감사 백엔드 라우트·인증 / 신규 코어 모듈 / 클라 컴포넌트 로직을 3방향 정밀 수색, **확인된 8건** 수정. UI 비주얼 무변경.

## 수정 (심각도순)
**보안/무결성**
- **emotions/vote·challenges `body.userId` 폴백 제거** — 익명 요청이 body에 타 유저 id를 실어 그 계정에 투표/포인트를 귀속시킬 수 있었음. userId는 검증된 Bearer 토큰에서만(능동 클라이언트는 이 필드를 안 보냄을 확인 — 무파급).
- **challenges GET/POST 세션 게이트** — vote와 동일한 형식검사+HMAC(`isValidSessionIdFormat`+`verifySession`). 임의 sessionId로 포인트 위조·조회 차단. 서명 미제공 시 통과(기존 점진도입 규약)라 기존 클라 안 깨짐.
- **emotions/link 세션 게이트** — 임의 익명 sessionId의 감정 기록을 내 계정으로 흡수하는 것 차단.
- **auth/login 타이밍 균일화** — 미존재 계정도 고정 더미 해시로 `bcrypt.compare` 수행(응답시간 차 계정 열거 방지 — 기존 "계정 열거 방지" 정책의 빠진 짝).

**가용성/정합성**
- **CoinGecko fetch 4곳 타임아웃**(whale 라우트+`fetchWhale`) — 코드베이스 유일의 무타임아웃 외부 호출. 행 걸리면 whale·banner가 maxDuration까지 매달림 → `AbortSignal.timeout(8s)`.
- **fomo-score NaN 가드** — `clamp01/clamp100`이 NaN을 통과시켜 "포모 NaN"이 화면에 둔갑 가능 → `Number.isFinite` 가드(형제 모듈과 동일 규약).

**클라 로직(비주얼 무변경)**
- **StockSwipeDeck 타이머 3곳 언마운트 클린업**(플링·열기 760ms·매칭 1100ms) — 덱 이탈 후 사라진 컴포넌트에서 setState/openDepth 발화 차단.
- **KeywordCardFeed 개인화 정렬 마운트 1회 고정**(잠복 경로) — 스와이프가 관심 점수를 갱신해 매 렌더 재정렬 시 카드 건너뜀/반복.

## 기각(오탐 확인)
- card-front-hook "tension" 죽은 분기 → 수정 시 기존 제품 테스트("순수 TA 모양형은 헤드라인 미점유") 위반. **의도된 설계**로 확인, 원복.

## 정상 확인(변경 없음)
auth/jwt(만료·timingSafeEqual)·register(bcrypt cost10)·account, 지표수학(RSI/MACD/ATR/볼린저/SMA 오프바이원 없음), verdict/discovery-supply/multi-axis/assemble grounding, sanitize, 클라 덱 전반(alive 플래그·seq 가드·CAP 상한).

## 판단 보류(제품 결정 필요 — 코드 미변경)
① calendar 조회가 sessionId만으로 가능(감정=저민감, 게이트 추가 여부) ② search 요청 저장 행 수 상한 없음 ③ `loggedIn={true}` 하드코딩(로그인 게이트 전면 비활성 — 의도로 보임) ④ discovery awakening 임계 80 vs 150 불일치 의도 여부.

## 검증
test **1070 pass** · typecheck(core/web/fomo-web) 0 · build:web/fomo-web 통과.

https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRwEXvEzfBUt2obUP4ZRbC)_