### PR TITLE
feat(deck): WO 미장·코인 확충 — 시총 top30 커버리지 + US 풀 500 + 신선도 로테이션

### DIFF
--- a/apps/web/__tests__/lib/coin-discovery.test.ts
+++ b/apps/web/__tests__/lib/coin-discovery.test.ts
@@ -31,7 +31,7 @@ describe("coin discovery signals", () => {
     expect(hasDiscoverySignal(s, signal)).toBe(false);
   });
 
-  it("거래대금 이상(2배+)이면 발굴 신호", () => {
+  it("거래대금 이상(1.5배+)이면 커버리지 신호", () => {
     const s = snapshot({ accTradePrice24h: 1.5e10 }); // 평소 3배
     const signal = computeCoinSignal(s)!;
     expect(signal.volumeRatio).toBeCloseTo(3.0, 1);
@@ -47,11 +47,11 @@ describe("coin discovery signals", () => {
     expect(hasDiscoverySignal(s, signal)).toBe(true);
   });
 
-  it("이미 급등한 코인(±12%+)은 발굴 제외 — 잡코인 러시 방어", () => {
-    const s = snapshot({ accTradePrice24h: 2e10, changePct: 30.5 });
+  it("급등락(±5%+)은 커버리지 신호 — 시총 상위 30에선 그 자체가 사건(WO: 급등 제외 폐기)", () => {
+    const s = snapshot({ changePct: 7.2 }); // 거래대금 평소 수준이어도
     const signal = computeCoinSignal(s)!;
-    expect(signal.volumeRatio).toBeGreaterThan(2);
-    expect(hasDiscoverySignal(s, signal)).toBe(false);
+    expect(signal.bigMove).toBe(true);
+    expect(hasDiscoverySignal(s, signal)).toBe(true);
   });
 
   it("캔들 부족(25일 미만) 마켓은 신호 계산 불가", () => {
@@ -63,8 +63,14 @@ describe("coin discovery signals", () => {
   });
 
   it("헤드라인은 사실+수치 관측 서술", () => {
-    const signal: CoinSignal = { volumeRatio: 6.24, vacuumInflow: false, quiet: true };
+    const signal: CoinSignal = { volumeRatio: 6.24, vacuumInflow: false, bigMove: false, quiet: true };
     const s = snapshot({ athChangePct: -62 });
     expect(coinHeadline(s, signal)).toBe("24시간 거래대금 평소 6.2배 · 전고점 대비 62% 아래 · 아직 조용한 구간");
+  });
+
+  it("급등락 헤드라인 — 등락 사실이 앞에", () => {
+    const signal: CoinSignal = { volumeRatio: 2.1, vacuumInflow: false, bigMove: true, quiet: false };
+    const s = snapshot({ changePct: 7.23 });
+    expect(coinHeadline(s, signal)).toBe("하루 +7.2% · 24시간 거래대금 평소 2.1배");
   });
 });

--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -57,3 +57,12 @@ describe("interleaveFeedItems", () => {
     expect(interleaveFeedItems(items)).toHaveLength(3);
   });
 });
+
+// 신선도 로테이션(WO 미장·코인 확충) — 어제와 같은 문구는 이틀 연속 금지.
+import { selectDaily30Candidates } from "../../lib/daily-30";
+
+describe("daily-30 freshness (모듈 로드 검증)", () => {
+  it("selectDaily30Candidates 는 빈 후보에서 빈 덱(회귀 안전판)", () => {
+    expect(selectDaily30Candidates([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/coin-discovery.ts
+++ b/apps/web/lib/coin-discovery.ts
@@ -5,35 +5,33 @@ import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-
 import type { DiscoveryFrontSeed, DiscoveryResponse, DiscoveryStockPayload } from "./discovery-supply";
 
 /**
- * 코인 발굴 (WO Phase C) — 캐시된 Upbit 스냅샷에서 신호 계산 → 표준 카드(바이오비쥬 포맷).
+ * 코인 카드 (WO 미장·코인 확충 — Phase C 알트 발굴 폐기, User Zero 결정) —
+ * 코인은 발굴이 아니라 **커버리지**다. 유니버스 = 시총 상위 30 고정(소스에서 선정),
+ * BTC·ETH 등 메이저도 신호 있으면 카드 OK(화제성 감점 없음). 그중 오늘 신호 있는 3~5장.
  *
  * 요청 경로 외부 fetch 0 (캐시만 읽음). 신호 없으면 0장(쿼터 강제 금지 — 정직).
- * 발굴 정체성: BTC·ETH 등 메이저는 marquee 감점으로 자연 탈락, 신호 강한 조용한 알트 우선.
  * 관측 서술만 — 매수·매도 판단/예측 없음(verdict 는 결정론 엔진의 관측 요약).
  */
 
-/** 메이저(누구나 아는 대장) — marquee 지정 → daily-30 화제성 감점(+28). 발굴 대상 아님. */
-const MAJOR_COIN_SYMBOLS = new Set([
-  "BTC", "ETH", "XRP", "SOL", "DOGE", "ADA", "TRX", "USDT", "USDC", "BCH", "LINK", "AVAX", "XLM", "DOT",
-]);
-
-/** 발굴 신호 임계 — 24h 거래대금 / 직전 20일(완결 일봉) 평균. */
-const VOLUME_ANOMALY_RATIO = 2.0;
+/** 신호 임계 — 24h 거래대금 / 직전 20일(완결 일봉) 평균. 커버리지 모드라 발굴(2.0)보다 완화. */
+const VOLUME_ANOMALY_RATIO = 1.5;
 /** 진공 후 유입: 직전 5일 평균이 30일 평균의 55% 미만(진공)이었는데 오늘 유입. */
 const VACUUM_RATIO = 0.55;
-const VACUUM_INFLOW_RATIO = 1.6;
+const VACUUM_INFLOW_RATIO = 1.4;
+/** 급등락 재료 — 하루 등락 절대값(시총 상위 30에선 그 자체가 사건). */
+const BIG_MOVE_PCT = 5;
 /** 조용한 구간 — 등락률 절대값. */
 const QUIET_CHANGE_PCT = 3;
-/** 이미 달린 코인 제외 — 발굴은 "신호는 강한데 조용한" 자리. 급등 중 잡코인 러시는 발굴이 아니다. */
-const ALREADY_MOVED_CHANGE_PCT = 12;
-/** 카드 상한(신호 있어도 최대 N — quietScore 경쟁은 daily-30 이 함) */
-const COIN_CARD_LIMIT = 8;
+/** 카드 상한(WO: 3~5장) — quietScore 경쟁은 daily-30 이 함. */
+const COIN_CARD_LIMIT = 5;
 
 export interface CoinSignal {
   /** 24h 거래대금 / 직전 20일 평균. */
   volumeRatio: number;
   /** 진공(직전 5일 저조) 후 첫 유입 여부. */
   vacuumInflow: boolean;
+  /** 급등락 재료(±5%+) — 시총 상위 30에선 그 자체가 오늘의 사건. */
+  bigMove: boolean;
   quiet: boolean;
 }
 
@@ -55,13 +53,14 @@ export function computeCoinSignal(snapshot: CoinMarketSnapshot): CoinSignal | nu
   return {
     volumeRatio,
     vacuumInflow,
+    bigMove: Math.abs(snapshot.changePct) >= BIG_MOVE_PCT,
     quiet: Math.abs(snapshot.changePct) < QUIET_CHANGE_PCT,
   };
 }
 
-export function hasDiscoverySignal(snapshot: CoinMarketSnapshot, signal: CoinSignal): boolean {
-  if (Math.abs(snapshot.changePct) >= ALREADY_MOVED_CHANGE_PCT) return false; // 이미 달림 — 발굴 아님
-  return signal.volumeRatio >= VOLUME_ANOMALY_RATIO || signal.vacuumInflow;
+/** 커버리지 신호 — 거래량 이상 / 진공 후 유입 / 급등락. 메이저 제외·급등 제외 없음(WO: Phase C 폐기). */
+export function hasDiscoverySignal(_snapshot: CoinMarketSnapshot, signal: CoinSignal): boolean {
+  return signal.volumeRatio >= VOLUME_ANOMALY_RATIO || signal.vacuumInflow || signal.bigMove;
 }
 
 function krw(price: number): string {
@@ -83,9 +82,12 @@ function ratioText(ratio: number): string {
 /** 관측 서술 헤드라인 — 사실+수치만. 예측·판단 없음. */
 export function coinHeadline(snapshot: CoinMarketSnapshot, signal: CoinSignal): string {
   const parts: string[] = [];
+  if (signal.bigMove) {
+    parts.push(`하루 ${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(1)}%`);
+  }
   if (signal.vacuumInflow) {
     parts.push(`거래 진공 뒤 첫 유입 · 24시간 거래대금 평소 ${ratioText(signal.volumeRatio)}`);
-  } else {
+  } else if (signal.volumeRatio >= VOLUME_ANOMALY_RATIO || signal.bigMove) {
     parts.push(`24시간 거래대금 평소 ${ratioText(signal.volumeRatio)}`);
   }
   if (typeof snapshot.athChangePct === "number" && snapshot.athChangePct <= -30) {
@@ -117,20 +119,21 @@ function coinFrontSeed(snapshot: CoinMarketSnapshot, signal: CoinSignal): Discov
 }
 
 function coinStockPayload(snapshot: CoinMarketSnapshot, signal: CoinSignal, headline: string): DiscoveryStockPayload {
-  const marquee = MAJOR_COIN_SYMBOLS.has(snapshot.symbol.toUpperCase()) || snapshot.tradeValueRank <= 3;
-  // 뎁스 보조(재무 블록 미해당) — 거래소·거래대금·순위 사실 표기. 시총은 소스에 없어 표기하지 않는다(지어내기 금지).
-  const reason = `Upbit 원화마켓 · 24시간 거래대금 ${eok(snapshot.accTradePrice24h)} · 거래대금 ${snapshot.tradeValueRank}위`;
+  // 뎁스 보조(재무 블록 미해당) — 거래소·거래대금·시총 순위(CoinGecko) 사실 표기.
+  const capText = typeof snapshot.marketCapRank === "number" ? ` · 시총 ${snapshot.marketCapRank}위` : "";
+  const reason = `Upbit 원화마켓 · 24시간 거래대금 ${eok(snapshot.accTradePrice24h)}${capText}`;
   return {
     canonical: snapshot.koreanName,
     market: "COIN",
     country: "GLOBAL",
-    marquee,
+    // 커버리지 모드(WO) — 메이저 화제성 감점 없음. BTC·ETH도 신호 있으면 카드.
+    marquee: false,
     sector: "코인",
     symbol: snapshot.market,
     headline,
     whyShown: headline,
     reason,
-    insightTag: signal.vacuumInflow ? "₿ 진공 후 유입" : "₿ 거래대금 이상",
+    insightTag: signal.vacuumInflow ? "₿ 진공 후 유입" : signal.bigMove ? "₿ 급등락" : "₿ 거래대금 이상",
     sourceLabel: "Upbit 일봉 · CoinGecko",
     sourceUrl: `https://upbit.com/exchange?code=CRIX.UPBIT.${snapshot.market}`,
   };
@@ -145,10 +148,12 @@ export async function buildCoinDiscoveryResponse(): Promise<DiscoveryResponse> {
   const stocks: DiscoveryStockPayload[] = [];
   const fronts: Record<string, DiscoveryFrontSeed> = {};
 
+  const strength = (x: { snapshot: CoinMarketSnapshot; signal: CoinSignal }): number =>
+    x.signal.volumeRatio + (x.signal.bigMove ? Math.abs(x.snapshot.changePct) / 2 : 0);
   const scored = snapshots
     .map((snapshot) => ({ snapshot, signal: computeCoinSignal(snapshot) }))
     .filter((x): x is { snapshot: CoinMarketSnapshot; signal: CoinSignal } => x.signal !== null && hasDiscoverySignal(x.snapshot, x.signal))
-    .sort((a, b) => b.signal.volumeRatio - a.signal.volumeRatio)
+    .sort((a, b) => strength(b) - strength(a))
     .slice(0, COIN_CARD_LIMIT);
 
   for (const { snapshot, signal } of scored) {

--- a/apps/web/lib/coin-market-source.ts
+++ b/apps/web/lib/coin-market-source.ts
@@ -18,10 +18,17 @@ const UPBIT_TICKER_URL = "https://api.upbit.com/v1/ticker";
 const UPBIT_DAILY_CANDLES_URL = "https://api.upbit.com/v1/candles/days";
 const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
 
-/** 잡코인 방어선 — 24h 거래대금 하한(KRW). 미달 마켓은 발굴 유니버스 제외. */
-const MIN_TRADE_PRICE_24H_KRW = 3_000_000_000; // 30억
-/** 유니버스 상한 — 거래대금 상위 N 마켓만 캔들 수집(비용·집중). */
-const COIN_UNIVERSE_LIMIT = 60;
+/**
+ * 유니버스 = 시총 상위 30 고정 (WO 미장·코인 확충 — User Zero 결정).
+ * 코인은 발굴이 아니라 커버리지 — CoinGecko 시총 순 ∩ Upbit KRW 상장 상위 30.
+ * 상위 30이면 잡코인·유의 방어선 불필요(Phase C 알트 서치 폐기).
+ * CoinGecko 실패 시 24h 거래대금 상위 30 폴백(정직한 근사).
+ */
+const COIN_UNIVERSE_LIMIT = 30;
+const COINGECKO_MARKETS_URL =
+  "https://api.coingecko.com/api/v3/coins/markets?vs_currency=krw&order=market_cap_desc&per_page=150&page=1";
+/** 스테이블코인 — 가격 고정이라 신호·카드 가치가 없다(잡코인 방어선 아님, 자산 성격상 제외). */
+const STABLECOIN_SYMBOLS = new Set(["USDT", "USDC", "USDS", "DAI", "FDUSD", "TUSD", "USDE", "PYUSD", "USD1", "USDP"]);
 /** 일봉 목표 개수(WO: 260) — Upbit 1회 최대 200이라 2회 페이지네이션. */
 const COIN_CANDLE_TARGET = 260;
 /** Upbit quotation 그룹 rate limit ~10 req/s — 동시 2 + 요청당 페이스로 ~4 req/s 유지(429 방지). */
@@ -44,8 +51,10 @@ export interface CoinMarketSnapshot {
   changePct: number;
   /** 24h 누적 거래대금(KRW). */
   accTradePrice24h: number;
-  /** KRW 마켓 내 24h 거래대금 순위(1=최대). 메이저 감점·유동성 참고. */
+  /** KRW 마켓 내 24h 거래대금 순위(1=최대). */
   tradeValueRank: number;
+  /** 시총 순위(CoinGecko, 1=최대) — 유니버스 선정 기준. 폴백(거래대금 선정) 시 없음. */
+  marketCapRank?: number;
   /** 일봉(과거→최신). verdict·TA 엔진 공급용. */
   candles: DailyOhlcv[];
   /** 일봉과 정렬된 일별 거래대금(KRW) — 거래대금 이상·진공 신호용. */
@@ -124,16 +133,24 @@ async function mapLimit<T, R>(items: readonly T[], limit: number, fn: (item: T) 
   return out;
 }
 
-/** KRW 마켓 목록 — 유의 지정(warning) 제외. */
+/** KRW 마켓 전체 — 시총 상위 30 유니버스라 유의/잡코인 방어선 불필요(WO: Phase C 필터 제거). */
 async function fetchKrwMarkets(): Promise<UpbitMarketInfo[]> {
   const all = await fetchJson<UpbitMarketInfo[]>(UPBIT_MARKET_ALL_URL);
   if (!Array.isArray(all)) return [];
-  return all.filter(
-    (m) =>
-      m.market?.startsWith("KRW-") &&
-      m.market_event?.warning !== true &&
-      m.market_warning !== "CAUTION"
-  );
+  return all.filter((m) => m.market?.startsWith("KRW-"));
+}
+
+/** CoinGecko 시총 순 심볼 목록(KRW 기준, 상위 150) — 유니버스 선정용. 실패 시 null(거래대금 폴백). */
+async function fetchMarketCapOrder(): Promise<Map<string, number> | null> {
+  const rows = await fetchJson<Array<{ symbol?: string; market_cap_rank?: number }>>(COINGECKO_MARKETS_URL);
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const out = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.symbol) continue;
+    const symbol = row.symbol.toUpperCase();
+    if (!out.has(symbol)) out.set(symbol, row.market_cap_rank ?? out.size + 1);
+  }
+  return out;
 }
 
 async function fetchTickers(markets: readonly string[]): Promise<Map<string, UpbitTicker>> {
@@ -177,20 +194,31 @@ function toOhlcv(candle: UpbitDayCandle): DailyOhlcv {
 }
 
 /**
- * 크론 전용 — Upbit 유니버스 수집(유의 제외·거래대금 하한·상위 N) + 캔들 260 + CoinGecko 전고점 보강.
+ * 크론 전용 — 시총 상위 30 유니버스(CoinGecko ∩ Upbit) + 캔들 260 + CoinGecko 전고점 보강.
  * 요청 경로에서 절대 호출 금지.
  */
 export async function fetchUpbitCoinSnapshots(): Promise<CoinMarketSnapshot[]> {
   const markets = await fetchKrwMarkets();
   if (markets.length === 0) return [];
   const tickers = await fetchTickers(markets.map((m) => m.market));
+  const capOrder = await fetchMarketCapOrder().catch(() => null);
 
-  const liquid = markets
+  const withTicker = markets
     .map((m) => ({ info: m, ticker: tickers.get(m.market) }))
     .filter((x): x is { info: UpbitMarketInfo; ticker: UpbitTicker } => !!x.ticker)
-    .filter((x) => x.ticker.acc_trade_price_24h >= MIN_TRADE_PRICE_24H_KRW)
-    .sort((a, b) => b.ticker.acc_trade_price_24h - a.ticker.acc_trade_price_24h)
-    .slice(0, COIN_UNIVERSE_LIMIT);
+    .filter((x) => !STABLECOIN_SYMBOLS.has(x.info.market.replace(/^KRW-/, "").toUpperCase()));
+
+  // 시총 상위 30(User Zero 결정). CoinGecko 실패 시 거래대금 상위 30 폴백(정직한 근사).
+  const universe = capOrder
+    ? withTicker
+        .map((x) => ({ ...x, capRank: capOrder.get(x.info.market.replace(/^KRW-/, "").toUpperCase()) }))
+        .filter((x): x is typeof x & { capRank: number } => typeof x.capRank === "number")
+        .sort((a, b) => a.capRank - b.capRank)
+        .slice(0, COIN_UNIVERSE_LIMIT)
+    : withTicker
+        .map((x) => ({ ...x, capRank: undefined as number | undefined }))
+        .sort((a, b) => b.ticker.acc_trade_price_24h - a.ticker.acc_trade_price_24h)
+        .slice(0, COIN_UNIVERSE_LIMIT);
 
   // 전고점 대비(CoinGecko fetchWhale) — 크론 시점에 한 번만. 실패해도 파이프라인 정상(fail-open).
   const whale = await fetchWhale().catch(() => ({ marketCapChange24h: null, coins: [] }));
@@ -200,7 +228,7 @@ export async function fetchUpbitCoinSnapshots(): Promise<CoinMarketSnapshot[]> {
   }
 
   const fetchedAt = new Date().toISOString();
-  const snapshots = await mapLimit(liquid, CANDLE_CONCURRENCY, async (entry): Promise<CoinMarketSnapshot | null> => {
+  const snapshots = await mapLimit(universe, CANDLE_CONCURRENCY, async (entry): Promise<CoinMarketSnapshot | null> => {
     const raw = await fetchDailyCandles(entry.info.market).catch((): UpbitDayCandle[] => []);
     if (raw.length < 30) return null; // verdict 최소 캔들 미달 마켓 제외
     const symbol = entry.info.market.replace(/^KRW-/, "");
@@ -214,6 +242,7 @@ export async function fetchUpbitCoinSnapshots(): Promise<CoinMarketSnapshot[]> {
       changePct: entry.ticker.signed_change_rate * 100,
       accTradePrice24h: entry.ticker.acc_trade_price_24h,
       tradeValueRank: 0, // 아래에서 채움
+      ...(typeof entry.capRank === "number" ? { marketCapRank: entry.capRank } : {}),
       candles: raw.map(toOhlcv),
       tradeValues: raw.map((c) => c.candle_acc_trade_price),
       ...(typeof ath === "number" ? { athChangePct: ath } : {}),
@@ -278,6 +307,13 @@ export async function writeCoinMarketSnapshots(snapshots: readonly CoinMarketSna
       SET "row" = EXCLUDED."row", "updatedAt" = NOW()
     `;
     written += 1;
+  }
+  // 유니버스 재정의(시총 상위 30) 이후 구 유니버스(알트) 잔존 행 정리 — read가 옛 코인을 되살리지 않게.
+  if (written > 0) {
+    const keep = snapshots.map((s) => s.market);
+    await prisma.$executeRaw`
+      DELETE FROM "CoinMarketCache" WHERE NOT ("market" = ANY(${keep}))
+    `.catch(() => {});
   }
   return { rows: written, rowsWithCandles: snapshots.filter((s) => s.candles.length >= 30).length };
 }

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -11,6 +11,7 @@ import {
 import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContentCard } from "./deck-content";
 import { buildCoinDiscoveryResponse } from "./coin-discovery";
 import { readTodayFeedContent, type TodayFeedContent } from "./feed-briefing";
+import { readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
 
 export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
 
@@ -28,6 +29,8 @@ export interface Daily30Response extends DiscoveryResponse {
     targetCount: number;
     cards: Daily30MetaCard[];
     assetCounts: Record<Daily30AssetClass, number>;
+    /** 어제 30장 대비 종목 중복률(0~1) — 신선도 수용 지표(≤0.5). */
+    repeatRatio?: number;
   };
 }
 
@@ -68,10 +71,11 @@ const FAMOUS_STOCKS = new Set([
   "버크셔해서웨이",
 ]);
 
+/** 소프트 목표(WO 미장·코인 확충): KR ~15 / US 8~10 / 코인 3~5 — 쿼터 강제가 아니라 풀 확대로 자연 도달. */
 const ASSET_CAPS: Record<Daily30AssetClass, number> = {
-  "kr-stock": 12,
+  "kr-stock": 15,
   "us-stock": 12,
-  coin: 3,
+  coin: 5,
   macro: 6,
 };
 
@@ -171,11 +175,35 @@ function meetsCardStandard(stock: DiscoveryStockPayload, front: DiscoveryFrontSe
   return true;
 }
 
-function stockCandidate(stock: DiscoveryStockPayload, front: DiscoveryFrontSeed | undefined): Daily30Candidate | null {
+/**
+ * 신선도 로테이션(WO 미장·코인 확충) — 어제 30장 스냅샷 대비:
+ * 같은 종목·같은 문구 → 이틀 연속 금지(제외, 다음 후보 로테이션).
+ * 같은 종목·다른 문구(신호 갱신) → 감점만(연속 등장은 갱신된 신호일 때만 정당).
+ */
+export interface FreshnessSnapshot {
+  /** canonical → 어제 헤드라인. */
+  headlines: Map<string, string>;
+}
+const STALE_REPEAT_PENALTY = 8;
+
+function normalizeHeadline(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
+}
+
+function stockCandidate(
+  stock: DiscoveryStockPayload,
+  front: DiscoveryFrontSeed | undefined,
+  freshness?: FreshnessSnapshot
+): Daily30Candidate | null {
   if (!meetsCardStandard(stock, front)) return null;
   if (FAMOUS_STOCKS.has(stock.canonical) && !strongQuietSignal(stock)) return null;
+  const yesterdayHeadline = freshness?.headlines.get(stock.canonical);
+  const repeatStale =
+    typeof yesterdayHeadline === "string" && normalizeHeadline(yesterdayHeadline) === normalizeHeadline(stock.headline);
+  if (repeatStale) return null; // 같은 문구 이틀 연속 금지 — 신호 갱신 없으면 다음 후보로
   const signalScore = computeStockSignal(stock, front);
-  const hypePenalty = computeHypePenalty(stock, front);
+  const hypePenalty =
+    computeHypePenalty(stock, front) + (typeof yesterdayHeadline === "string" ? STALE_REPEAT_PENALTY : 0);
   const quietScore = signalScore - hypePenalty;
   if (quietScore < 6) return null;
   return {
@@ -240,7 +268,8 @@ function narrativeCandidate(card: DiscoveryDeckCardPayload): Daily30Candidate | 
 function addStockCandidates(
   out: Daily30Candidate[],
   discovery: DiscoveryResponse,
-  seen: Set<string>
+  seen: Set<string>,
+  freshness?: FreshnessSnapshot
 ): void {
   const cards = discovery.cards?.length ? discovery.cards : discovery.stocks.map((stock) => ({ kind: "stock", ...stock }) satisfies DiscoveryDeckCardPayload);
   for (const card of cards) {
@@ -249,7 +278,7 @@ function addStockCandidates(
       const id = stockId(stock);
       if (seen.has(id)) continue;
       seen.add(id);
-      const candidate = stockCandidate(stock, discovery.fronts[stock.canonical]);
+      const candidate = stockCandidate(stock, discovery.fronts[stock.canonical], freshness);
       if (candidate) out.push(candidate);
       continue;
     }
@@ -263,7 +292,7 @@ function addStockCandidates(
     const id = stockId(stock);
     if (seen.has(id)) continue;
     seen.add(id);
-    const candidate = stockCandidate(stock, discovery.fronts[stock.canonical]);
+    const candidate = stockCandidate(stock, discovery.fronts[stock.canonical], freshness);
     if (candidate) out.push(candidate);
   }
 }
@@ -356,17 +385,37 @@ function responseFromSelected(
   };
 }
 
+interface Daily30PicksSnapshot {
+  date: string;
+  picks: Array<{ canonical: string; headline?: string }>;
+}
+
+/** 어제(가장 최근, 오늘 제외) 30장 스냅샷 — 신선도 로테이션 기준. 없으면 빈 맵(첫날). */
+async function readYesterdayPicks(today: string): Promise<FreshnessSnapshot> {
+  const rows = await readFeedContentByPrefix<Daily30PicksSnapshot>("daily30-picks:", 3).catch(
+    () => [] as Array<{ id: string; row: Daily30PicksSnapshot }>
+  );
+  const yesterday = rows.map((r) => r.row).find((row) => row?.date && row.date !== today);
+  const headlines = new Map<string, string>();
+  for (const pick of yesterday?.picks ?? []) {
+    if (pick.canonical) headlines.set(pick.canonical, pick.headline ?? "");
+  }
+  return { headlines };
+}
+
 export async function buildDaily30Response(): Promise<Daily30Response> {
-  const [kr, us, coin, rawContent, feedContent] = await Promise.all([
+  const today = kstDateOf();
+  const [kr, us, coin, rawContent, feedContent, freshness] = await Promise.all([
     buildDiscoveryResponse({ country: "KR", targetedMaterial: true, targetedMaterialLimit: 36 }),
-    buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 12 }),
-    // 코인(WO Phase C) — Upbit 캐시 발굴. 신호 없으면 stocks 0(쿼터 강제 없음 — 정직).
+    buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 16 }),
+    // 코인(WO 미장·코인 확충) — 시총 상위 30 커버리지. 신호 없으면 stocks 0(쿼터 강제 없음 — 정직).
     buildCoinDiscoveryResponse().catch(
       (): DiscoveryResponse => ({ asOf: "", stocks: [], fronts: {}, confidence: "L", source: "coin unavailable" })
     ),
     fetchDeckContentCards().catch(() => [] as DeckContentCard[]),
     // 피드 강화(WO) — 브리핑·버즈·회고. 크론이 채운 캐시만 읽는다(외부 fetch 0).
     readTodayFeedContent().catch((): TodayFeedContent => ({ cards: [], pinnedIds: new Set() })),
+    readYesterdayPicks(kstDateOf()),
   ]);
   // MARKET NOTE 해석 1줄(WO — 숫자만 금지): 국내 지수 카드에 섹터 펄스(실데이터) 주입.
   const enrichedRawContent = feedContent.indexNote
@@ -384,9 +433,9 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
   ];
   const candidates: Daily30Candidate[] = [];
   const seen = new Set<string>();
-  addStockCandidates(candidates, kr, seen);
-  addStockCandidates(candidates, us, seen);
-  addStockCandidates(candidates, coin, seen);
+  addStockCandidates(candidates, kr, seen, freshness);
+  addStockCandidates(candidates, us, seen, freshness);
+  addStockCandidates(candidates, coin, seen, freshness);
   addContentCandidates(candidates, content, seen, feedContent.pinnedIds);
 
   // WO-GNB 두 표면 분리: 덱 = 종목 30장(내러티브·콘텐츠 제외), 피드 = 콘텐츠·내러티브(중요도순).
@@ -396,7 +445,21 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
     .sort((a, b) => b.quietScore - a.quietScore || a.id.localeCompare(b.id))
     .slice(0, FEED_CARD_LIMIT);
   const deck = selectDaily30Candidates(stockCandidates, DAILY_CARD_TARGET);
-  return responseFromSelected(deck, feedCandidates, [kr, us, coin], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+
+  // 신선도 스냅샷 저장 — 내일 빌드의 로테이션 기준. 실패해도 응답은 정상(fail-open).
+  const picks: Daily30PicksSnapshot = {
+    date: today,
+    picks: deck
+      .filter((c) => c.stock)
+      .map((c) => ({ canonical: c.stock!.canonical, ...(c.stock!.headline ? { headline: c.stock!.headline } : {}) })),
+  };
+  await writeFeedContent(`daily30-picks:${today}`, picks).catch(() => {});
+  // 중복률(어제 대비) — 수용 지표(≤50%) 모니터링용.
+  const repeatCount = picks.picks.filter((p) => freshness.headlines.has(p.canonical)).length;
+  const repeatRatio = picks.picks.length > 0 ? Math.round((repeatCount / picks.picks.length) * 100) / 100 : 0;
+
+  const response = responseFromSelected(deck, feedCandidates, [kr, us, coin], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+  return { ...response, meta: { ...response.meta, repeatRatio } };
 }
 
 /**

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -2229,6 +2229,14 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       const headlineEventKind = headlineEvent?.kind;
       const hasSurfaceMaterial = headlineEventKind === "news_mention" || headlineEventKind === "disclosure";
       const hasGroundedMaterial = Boolean(stock.sourceLabel && (stock.sourceUrl || headlineEvent?.url));
+      // 시세 사실 신호(WO 미장·코인 확충) — Nasdaq OHLCV 실측(거래량 이상·신고가)은 그 자체가 근거라
+      // 재료(뉴스·공시) 없이도 카드 진입 허용. 카피 가드·verdict 표준은 그대로(품질 게이트 유지).
+      const hasMarketFactSignal = headlineEventKind === "volume_spike" || headlineEventKind === "new_high";
+      if (hasMarketFactSignal) {
+        stocks.push(stock);
+        fronts[candidate.ticker] = front;
+        continue;
+      }
       if (!hasSurfaceMaterial || !hasGroundedMaterial) {
         if (process.env.DISCOVERY_DEBUG_US_DROPS === "1") {
           console.warn("[US drop ungrounded]", {

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -11,8 +11,10 @@ const NASDAQ_SCREENER_URL = "https://api.nasdaq.com/api/screener/stocks";
 const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
 const NASDAQ_UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
-// WO 미장·코인 확충 — 큐레이션 ~125 + 60 상한이 US 5장의 원인. 스크리너(1콜·전종목)에서 상위 500 유지.
-const US_DYNAMIC_UNIVERSE_LIMIT = 500;
+// WO 미장·코인 확충 — 큐레이션 ~125 + 60 상한이 US 5장의 원인. 스크리너(1콜·전종목)는 상위 500,
+// TwelveData(키 있을 때) 경로는 쿼터 보호를 위해 기존 60 유지.
+const US_SCREENER_UNIVERSE_LIMIT = 500;
+const US_DYNAMIC_UNIVERSE_LIMIT = 60;
 const US_QUOTE_BATCH_SIZE = 60;
 const US_SPARKLINE_LIMIT = 30;
 const US_PREWARM_CACHE_MAX_AGE_HOURS = 18;
@@ -373,7 +375,7 @@ async function fetchNasdaqScreenerRows(): Promise<DiscoveryMarketRow[]> {
       const byScore = nasdaqMoverScore(b) - nasdaqMoverScore(a);
       return byScore !== 0 ? byScore : a.symbol.localeCompare(b.symbol);
     })
-    .slice(0, US_DYNAMIC_UNIVERSE_LIMIT);
+    .slice(0, US_SCREENER_UNIVERSE_LIMIT);
 }
 
 function parseNasdaqRow(seed: UsDiscoverySymbol, points: readonly NasdaqDailyPoint[]): DiscoveryMarketRow | null {

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -11,7 +11,8 @@ const NASDAQ_SCREENER_URL = "https://api.nasdaq.com/api/screener/stocks";
 const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
 const NASDAQ_UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
-const US_DYNAMIC_UNIVERSE_LIMIT = 60;
+// WO 미장·코인 확충 — 큐레이션 ~125 + 60 상한이 US 5장의 원인. 스크리너(1콜·전종목)에서 상위 500 유지.
+const US_DYNAMIC_UNIVERSE_LIMIT = 500;
 const US_QUOTE_BATCH_SIZE = 60;
 const US_SPARKLINE_LIMIT = 30;
 const US_PREWARM_CACHE_MAX_AGE_HOURS = 18;


### PR DESCRIPTION
## WO — 미장·코인 카드 확충 + 신선도 로테이션
> 실측: KR22/US5/코인3, 매일 동일. 원인 = 후보 풀 얕음(크론 정상).

### 1. 코인 재정의 (Phase C 알트 발굴 폐기 — User Zero 결정)
- **유니버스 = 시총 상위 30 고정**: CoinGecko(시총순) ∩ Upbit KRW. 로컬 실측: BTC(1)·ETH(2)·XRP(6)·SOL(7)… 정확. CoinGecko 실패 시 거래대금 상위 30 폴백(정직).
- **메이저 감점 제거**(marquee=false) — 코인은 발굴이 아니라 커버리지. ±12% 급등 제외도 폐기(급등락 5%+는 그 자체가 신호). 유의/유동성 방어선 제거(상위 30이면 불필요). **스테이블코인 제외**(가격 고정 — 신호 불가 자산, 잡코인 방어선 아님).
- 신호: 거래대금 1.5배+ / 진공 후 유입 / 급등락 5%+ → 상위 5장. 캐시 write 시 구 알트 유니버스 행 정리.

### 2. 미장 풀 확대
- `US_DYNAMIC_UNIVERSE_LIMIT` 60→**500** — Nasdaq 스크리너는 이미 전종목 1콜이라 슬롯 증설 불필요(요청 경로 fetch 0 원칙 그대로).
- **US 최종 게이트에 시세 사실 신호 허용**: volume_spike·new_high(Nasdaq OHLCV 실측 — 그 자체가 근거)는 재료(뉴스·공시) 없어도 카드 진입. 카피 가드·verdict 표준 유지 — 저품질 재료로 채우는 것 아님(SEC 남발 없음).
- targetedMaterialLimit 12→16. 쿼터 소프트: KR 15 / US 12 / 코인 5.

### 3. 신선도 로테이션
- 오늘 30장 스냅샷 저장 → 다음 빌드: **같은 종목·같은 문구 = 제외**(이틀 연속 금지), 문구 갱신(새 신호) 시 감점(+8)만 — 연속 등장은 신호 갱신 시만.
- `meta.repeatRatio`(어제 대비 중복률) 응답 동봉 — 수용 지표(≤0.5) 상시 측정.

### 검증
- 로컬 실측: 코인 유니버스 30(시총순 정확), 신호 후보(주말 저변동으로 1개 — 정직). 테스트 전체 통과, guard:discovery ✅(KR 로직 불변), typecheck ✅.
- **머지 후: 1일차 구성 실측 첨부 + repeatRatio는 내일 크론 빌드에서 확인**(이틀치 — 스냅샷이 오늘부터 쌓임).

🤖 Generated with [Claude Code](https://claude.com/claude-code)