### PR TITLE
fix(us): 스크리너 1차 소스 승격 (#820 후속)

### DIFF
--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -838,21 +838,23 @@ async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}
     source,
   });
 
+  // 스크리너(무료·전종목·1콜)를 키 유무와 무관하게 1차 소스로(WO 미장·코인 확충) —
+  // TwelveData 키가 있으면 keyed 경로(쿼터 60개 안팎)를 타서 유니버스가 말랐다(프리웜 실측 fetched 48).
+  const screenerRows = curatedScreenerRows(await fetchNasdaqScreenerRows().catch((): DiscoveryMarketRow[] => []), seeds);
+  if (screenerRows.length >= 100 || (!key && screenerRows.length > 0)) {
+    const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
+    const rows = mergePreferredRows(screenerRows, nasdaqRows);
+    return {
+      rows,
+      diagnostics: {
+        ...fallbackDiagnostics(rows, "nasdaq-screener"),
+        moverSymbols: screenerRows.length,
+        quoteSymbols: rows.length,
+        dynamicRows: screenerRows.length,
+      },
+    };
+  }
   if (!key) {
-    const screenerRows = curatedScreenerRows(await fetchNasdaqScreenerRows().catch((): DiscoveryMarketRow[] => []), seeds);
-    if (screenerRows.length > 0) {
-      const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
-      const rows = mergePreferredRows(screenerRows, nasdaqRows);
-      return {
-        rows,
-        diagnostics: {
-          ...fallbackDiagnostics(rows, "nasdaq-screener"),
-          moverSymbols: screenerRows.length,
-          quoteSymbols: rows.length,
-          dynamicRows: screenerRows.length,
-        },
-      };
-    }
     const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
     const rows = nasdaqRows.length > 0 ? nasdaqRows : seedRows();
     return { rows, diagnostics: fallbackDiagnostics(rows, nasdaqRows.length > 0 ? "nasdaq-fallback" : "seed") };


### PR DESCRIPTION
프로덕션 실측 fetched 48 — TWELVE_DATA_API_KEY가 있으면 쿼터 죽은 keyed 경로를 타 유니버스가 60개로 말랐음. 스크리너(전종목 1콜)를 키 유무 무관 1차 소스로(100행+일 때). 기존 테스트 6/6 통과(키 경로 캡 60 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)