### PR TITLE
fix(us): 스크리너 다이내믹 행 포함 — 유니버스 500 실현 (#821 후속)

### DIFF
--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -192,7 +192,9 @@ describe("US market source", () => {
 
     const rows = await fetchUsMarketRows();
     expect(rows.map((row) => row.symbol)).toEqual(expect.arrayContaining(["MRVL", "META"]));
-    expect(rows.some((row) => row.symbol === "OPEN")).toBe(false);
+    // WO 미장·코인 확충 — 비큐레이션 정상주(Opendoor)도 유니버스 포함(큐레이션 125 상한 폐기).
+    expect(rows.some((row) => row.symbol === "OPEN")).toBe(true);
+    // 품질 게이트는 유지 — SPAC/블랭크체크(AACB)는 여전히 제외.
     expect(rows.some((row) => row.symbol === "AACB")).toBe(false);
     expect(rows.find((row) => row.symbol === "MRVL")?.changePct).toBe(6.25);
     expect(rows.find((row) => row.symbol === "MRVL")?.canonical).toBe("마벨테크놀로지");

--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -201,7 +201,8 @@ describe("US market source", () => {
 
     const diag = await fetchUsMarketDiagnostics();
     expect(diag.source).toBe("nasdaq-screener");
-    expect(diag.dynamicRows).toBeGreaterThanOrEqual(2);
+    // dynamicRows = 비큐레이션 행 수(의미 정교화) — 픽스처에선 OPEN 1건.
+    expect(diag.dynamicRows).toBeGreaterThanOrEqual(1);
     expect(diag.strongMomentumRows).toBe(0);
   });
 

--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -201,9 +201,9 @@ describe("US market source", () => {
 
     const diag = await fetchUsMarketDiagnostics();
     expect(diag.source).toBe("nasdaq-screener");
-    // dynamicRows = 비큐레이션 행 수(의미 정교화) — 픽스처에선 OPEN 1건.
+    // dynamicRows = 비큐레이션 행 수(의미 정교화) — 픽스처에선 OPEN 1건(+17.65% → 강모멘텀도 1).
     expect(diag.dynamicRows).toBeGreaterThanOrEqual(1);
-    expect(diag.strongMomentumRows).toBe(0);
+    expect(diag.strongMomentumRows).toBe(1);
   });
 
   it("does not wire Yahoo chart endpoints into the US quote adapter", () => {

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -840,7 +840,13 @@ async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}
 
   // 스크리너(무료·전종목·1콜)를 키 유무와 무관하게 1차 소스로(WO 미장·코인 확충) —
   // TwelveData 키가 있으면 keyed 경로(쿼터 60개 안팎)를 타서 유니버스가 말랐다(프리웜 실측 fetched 48).
-  const screenerRows = curatedScreenerRows(await fetchNasdaqScreenerRows().catch((): DiscoveryMarketRow[] => []), seeds);
+  const rawScreenerRows = await fetchNasdaqScreenerRows().catch((): DiscoveryMarketRow[] => []);
+  // 큐레이션 교집합(시드 메타 병합) + **비큐레이션 다이내믹 행**(WO 미장·코인 확충) —
+  // curatedScreenerRows 만 쓰면 전종목 스크리너가 큐레이션 ~125로 다시 말라붙는다(프리웜 실측 48의 실체).
+  const curated = curatedScreenerRows(rawScreenerRows, seeds);
+  const curatedSymbols = new Set(curated.map((row) => row.symbol.toUpperCase()));
+  const dynamicScreener = rawScreenerRows.filter((row) => !curatedSymbols.has(row.symbol.toUpperCase()));
+  const screenerRows = [...curated, ...dynamicScreener];
   if (screenerRows.length >= 100 || (!key && screenerRows.length > 0)) {
     const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
     const rows = mergePreferredRows(screenerRows, nasdaqRows);
@@ -850,7 +856,7 @@ async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}
         ...fallbackDiagnostics(rows, "nasdaq-screener"),
         moverSymbols: screenerRows.length,
         quoteSymbols: rows.length,
-        dynamicRows: screenerRows.length,
+        dynamicRows: dynamicScreener.length,
       },
     };
   }


### PR DESCRIPTION
curatedScreenerRows가 스크리너 전종목을 큐레이션 시드 교집합(~125)만 남기고 폐기 — 프리웜 fetched 48의 실체. 다이내믹 행 포함으로 상위 500 실현, 품질 게이트(SPAC·저유동·비미국 제외)는 유지. 테스트 계약 갱신(OPEN 포함/AACB 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)