### PR TITLE
fix(us): 프리웜 타임아웃 — 벌크 UPSERT + 슬롯 분할 (#822 후속)

### DIFF
--- a/apps/web/lib/us-market-cache.ts
+++ b/apps/web/lib/us-market-cache.ts
@@ -61,10 +61,16 @@ export async function writeUsMarketQuoteRows(
 ): Promise<UsMarketQuoteCacheStats> {
   await ensureUsMarketQuoteCacheTable();
   const quoteRows = rows.filter((row) => row.country === "US" && hasUsQuote(row));
-  for (const row of quoteRows) {
+  // 벌크 UPSERT(unnest) — 유니버스 500 확장 후 순차 INSERT 500회가 함수 타임아웃의 원인이었다.
+  const CHUNK = 200;
+  for (let i = 0; i < quoteRows.length; i += CHUNK) {
+    const chunk = quoteRows.slice(i, i + CHUNK);
+    const symbols = chunk.map((row) => row.symbol.toUpperCase());
+    const payloads = chunk.map((row) => JSON.stringify(row));
     await prisma.$executeRaw`
       INSERT INTO "UsMarketQuoteCache" ("symbol", "row", "sessionDate", "slot", "updatedAt")
-      VALUES (${row.symbol.toUpperCase()}, ${JSON.stringify(row)}::jsonb, ${options.sessionDate}, ${options.slot}, NOW())
+      SELECT s, p::jsonb, ${options.sessionDate}, ${options.slot}, NOW()
+      FROM unnest(${symbols}::text[], ${payloads}::text[]) AS t(s, p)
       ON CONFLICT ("symbol") DO UPDATE
       SET "row" = EXCLUDED."row",
           "sessionDate" = EXCLUDED."sessionDate",

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -846,7 +846,12 @@ async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}
   const curated = curatedScreenerRows(rawScreenerRows, seeds);
   const curatedSymbols = new Set(curated.map((row) => row.symbol.toUpperCase()));
   const dynamicScreener = rawScreenerRows.filter((row) => !curatedSymbols.has(row.symbol.toUpperCase()));
-  const screenerRows = [...curated, ...dynamicScreener];
+  // 프리웜 슬롯 분할(다이내믹 행) — 500행 전부를 한 슬롯이 쓰면 함수 타임아웃(크론 슬롯 확장 원칙).
+  const slottedDynamic =
+    typeof options.slot === "number" && typeof options.slotCount === "number" && options.slotCount > 1
+      ? dynamicScreener.filter((_, index) => index % options.slotCount! === options.slot)
+      : dynamicScreener;
+  const screenerRows = [...curated, ...slottedDynamic];
   if (screenerRows.length >= 100 || (!key && screenerRows.length > 0)) {
     const nasdaqRows = await fetchNasdaqRows(seeds).catch((): DiscoveryMarketRow[] => []);
     const rows = mergePreferredRows(screenerRows, nasdaqRows);
@@ -856,7 +861,7 @@ async function fetchUsMarketRowsInternal(options: UsMarketRowsSourceOptions = {}
         ...fallbackDiagnostics(rows, "nasdaq-screener"),
         moverSymbols: screenerRows.length,
         quoteSymbols: rows.length,
-        dynamicRows: dynamicScreener.length,
+        dynamicRows: slottedDynamic.length,
       },
     };
   }


### PR DESCRIPTION
500행 프리웜이 순차 INSERT로 60초 초과(실측 FUNCTION_INVOCATION_TIMEOUT). unnest 벌크 UPSERT(청크 200) + 다이내믹 행 슬롯 분할(슬롯당 ~250).

🤖 Generated with [Claude Code](https://claude.com/claude-code)