### PR TITLE
fix(deck): 30장 유지 — 신선도 하드 제외 → 최후순위 폴백

### DIFF
--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -66,3 +66,49 @@ describe("daily-30 freshness (모듈 로드 검증)", () => {
     expect(selectDaily30Candidates([])).toEqual([]);
   });
 });
+
+// 신선도 폴백(30장 유지) — 하드 제외가 주말(문구 불변)에 덱을 말린 회귀(실측 30→20) 방지.
+import { stockCandidate, type FreshnessSnapshot } from "../../lib/daily-30";
+import type { DiscoveryFrontSeed, DiscoveryStockPayload } from "../../lib/discovery-supply";
+
+function stubStock(name: string, headline: string): DiscoveryStockPayload {
+  return {
+    canonical: name,
+    market: "KOSPI",
+    country: "KR",
+    marquee: false,
+    sector: "반도체",
+    naverCode: "000001",
+    headline,
+  } as DiscoveryStockPayload;
+}
+
+function stubFront(): DiscoveryFrontSeed {
+  return {
+    signals: { changePct: 2.1, volumeRatio: 2.4 },
+    fomo: { score: 50 } as unknown as DiscoveryFrontSeed["fomo"],
+    sparkline: [100, 101, 102],
+    priceText: "10,000원",
+    verdict: { stance: "watch", stanceText: "관망", evidence: [], confidence: "low" } as NonNullable<DiscoveryFrontSeed["verdict"]>,
+  };
+}
+
+describe("daily-30 신선도 폴백 (30장 유지 > 신선도)", () => {
+  it("같은 문구 이틀 연속이어도 제외하지 않고 최후순위로 강등한다", () => {
+    const freshness: FreshnessSnapshot = { headlines: new Map([["테스트종목", "거래량 평소 2.4배"]]) };
+    const stale = stockCandidate(stubStock("테스트종목", "거래량 평소 2.4배"), stubFront(), freshness);
+    expect(stale).not.toBeNull(); // 하드 제외 금지 — 30장 채움 폴백으로 살아있어야 한다
+    expect(stale!.quietScore).toBeLessThan(-500); // 신선 후보가 항상 우선하도록 바닥 순위
+
+    const fresh = stockCandidate(stubStock("다른종목", "새 재료가 나온 종목"), stubFront(), freshness);
+    expect(fresh).not.toBeNull();
+    expect(fresh!.quietScore).toBeGreaterThan(stale!.quietScore); // 신선 > 재탕
+  });
+
+  it("문구가 갱신되면(신호 갱신) 감점만 받고 정상 순위를 유지한다", () => {
+    const freshness: FreshnessSnapshot = { headlines: new Map([["테스트종목", "어제 문구"]]) };
+    const updated = stockCandidate(stubStock("테스트종목", "오늘 새 문구"), stubFront(), freshness);
+    expect(updated).not.toBeNull();
+    expect(updated!.quietScore).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -177,20 +177,25 @@ function meetsCardStandard(stock: DiscoveryStockPayload, front: DiscoveryFrontSe
 
 /**
  * 신선도 로테이션(WO 미장·코인 확충) — 어제 30장 스냅샷 대비:
- * 같은 종목·같은 문구 → 이틀 연속 금지(제외, 다음 후보 로테이션).
+ * 같은 종목·같은 문구 → **최후순위 폴백**(신선한 후보가 항상 이기고, 30장을 못 채울 때만 재노출).
  * 같은 종목·다른 문구(신호 갱신) → 감점만(연속 등장은 갱신된 신호일 때만 정당).
+ *
+ * ⚠️ 하드 제외 금지: 주말·휴장일엔 시세·재료가 안 바뀌어 문구가 같을 수밖에 없는데,
+ * 제외해버리면 덱이 마른다(프로덕션 실측 30→20 붕괴). "30장 유지"가 신선도보다 우선.
  */
 export interface FreshnessSnapshot {
   /** canonical → 어제 헤드라인. */
   headlines: Map<string, string>;
 }
 const STALE_REPEAT_PENALTY = 8;
+/** 이틀 연속 같은 문구 — 순위를 바닥으로 보내되 후보에서 빼지 않는다(30장 채움 폴백). */
+const STALE_REPEAT_FLOOR = -1000;
 
 function normalizeHeadline(text: string | undefined): string {
   return (text ?? "").replace(/\s+/g, " ").trim();
 }
 
-function stockCandidate(
+export function stockCandidate(
   stock: DiscoveryStockPayload,
   front: DiscoveryFrontSeed | undefined,
   freshness?: FreshnessSnapshot
@@ -200,12 +205,12 @@ function stockCandidate(
   const yesterdayHeadline = freshness?.headlines.get(stock.canonical);
   const repeatStale =
     typeof yesterdayHeadline === "string" && normalizeHeadline(yesterdayHeadline) === normalizeHeadline(stock.headline);
-  if (repeatStale) return null; // 같은 문구 이틀 연속 금지 — 신호 갱신 없으면 다음 후보로
   const signalScore = computeStockSignal(stock, front);
   const hypePenalty =
     computeHypePenalty(stock, front) + (typeof yesterdayHeadline === "string" ? STALE_REPEAT_PENALTY : 0);
-  const quietScore = signalScore - hypePenalty;
-  if (quietScore < 6) return null;
+  let quietScore = signalScore - hypePenalty;
+  if (!repeatStale && quietScore < 6) return null;
+  if (repeatStale) quietScore = STALE_REPEAT_FLOOR + quietScore; // 신선 후보가 전부 소진된 뒤에만 뽑힘
   return {
     kind: "stock",
     id: stockId(stock),


### PR DESCRIPTION
## 문제 (프로덕션 실측)
서버 daily-30 stocks **30 → 20 붕괴**. 프론트 30장 미달의 직접 원인.

## 원인
#820 신선도 로직의 **하드 제외**: 어제와 같은 문구면 후보에서 완전 제거. 주말·휴장일엔 시세·재료가 안 변해 어제 30장 전원이 같은 문구 → 전원 제외 → 후보 풀이 20장으로 고갈. "같은 문구 금지"가 "30장 유지"를 이겨버린 설계 오류.

(참고: 클라 카피 필터는 오늘 payload 기준 오염 0 — 무죄 확인)

## 수정
- 하드 제외 → **quietScore 바닥 강등**(-1000+원점수): 신선한 후보가 항상 우선, 재탕은 30장을 못 채울 때만 뽑힘. **30장 유지 > 신선도** (User Zero 지시).
- 평일(문구 갱신 있는 날)엔 기존 신선도 동작 그대로 — 로테이션 목표(중복률 ≤50%) 유지.
- 회귀 테스트 3건: stale 미제외·바닥 순위 / 신선>재탕 / 문구 갱신 정상 순위.

## 검증
테스트 98/98 · guard:discovery ✅ · typecheck ✅. 머지 후 프로덕션 daily-30 = 30장 실측 첨부.

🤖 Generated with [Claude Code](https://claude.com/claude-code)