### PR TITLE
fix(deck): 카피 오염 1장의 덱 전체 무효 구조 제거 — 서버 게이트 + 클라 카드단위 드랍

### DIFF
--- a/apps/fomo-web/lib/discoveryCopySafe.ts
+++ b/apps/fomo-web/lib/discoveryCopySafe.ts
@@ -1,15 +1,5 @@
 /**
- * 발견 카드 카피 안전성 — 미번역 영문+한글조사 잔여물 등 오염 카피를 걸러내는 클라 2차 필터.
- *
- * 주의: 조사 뒤에 한글이 이어지면 그건 조사가 아니라 고유명사 음절이다
- * (예: "SK이터닉스"의 SK+이터닉스, "SK이노베이션", "LG이노텍") — 부정 후방탐색으로 오탐을 막는다.
- * 2~3자 대문자 시장 약어(IPO·AI·ETF 등)는 정상 한국어 문장에 자주 쓰이므로 조사 결합을 허용한다.
- * 이 오탐이 정상 30장 덱을 통째로 무효 처리해 홈 카드 로딩이 멈춘 적이 있다(회귀 테스트로 고정).
+ * 발견 카드 카피 안전성 — 단일 원본은 @fomo/core(discovery-copy-safe.ts).
+ * 서버(daily-30 표준 게이트)와 같은 패턴을 공유한다 — 여기서 패턴을 따로 수정하지 말 것.
  */
-export const UNSAFE_DISCOVERY_COPY_PATTERN =
-  /\b(?:[Ii][Tt][Ss]|[Tt][Hh][Ee]|[Ww][Ii][Tt][Hh]|[Aa][Nn][Dd])\b\s+[A-Za-z]|(?:[A-Z]{4,}|[A-Za-z]*[a-z][A-Za-z]*)\s*(?:와|과|의|가|이|은|는|을|를|에|에서|로|으로)(?![가-힣])|SHPH\s*,\s*ILLR|설명하긴\s*이른데|아직\s*공개된\s*계기/;
-
-/** 카드 카피 안전성 — 오염 카피면 false. 정상 종목명(SK이터닉스 등)은 통과. */
-export function isDiscoveryCopySafe(text: string): boolean {
-  return !UNSAFE_DISCOVERY_COPY_PATTERN.test(text);
-}
+export { UNSAFE_DISCOVERY_COPY_PATTERN, isDiscoveryCopySafe } from "@fomo/core";

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -723,16 +723,21 @@ function cardCopyFields(card: DiscoveryCardResponse): string[] {
   return stockCopyFields(card);
 }
 
-function hasUnsafeDiscoveryCopy(value: DiscoveryResponse | null | undefined): boolean {
-  if (!value) return false;
-  const fields = [...value.stocks.flatMap(stockCopyFields), ...(value.cards ?? []).flatMap(cardCopyFields)];
-  return fields.some((text) => !isDiscoveryCopySafe(text));
+/**
+ * 오염 카피 카드만 제거(카드 단위 드랍) — 서버도 같은 패턴(@fomo/core)으로 거르므로 평소엔 no-op.
+ * ⚠️ 과거엔 1장 오염이 덱 30장 전체를 무효 처리해 홈이 비었다(SKAI "TSID와" 실측) —
+ * 전체 거부로 되돌리지 말 것. 30장 유지가 우선, 오염은 해당 카드만 잃는다.
+ */
+function sanitizeDiscoveryCopy<T extends DiscoveryResponse>(value: T): T {
+  const stocks = value.stocks.filter((stock) => stockCopyFields(stock).every((text) => isDiscoveryCopySafe(text)));
+  const cards = value.cards?.filter((card) => cardCopyFields(card).every((text) => isDiscoveryCopySafe(text)));
+  if (stocks.length === value.stocks.length && (cards?.length ?? 0) === (value.cards?.length ?? 0)) return value;
+  return { ...value, stocks, ...(cards ? { cards } : {}) };
 }
 
 function hasDiscoveryCards(value: DiscoveryResponse | null | undefined, country: DiscoveryCountryScope = "all"): value is DiscoveryResponse {
   return (
     discoveryMatchesCountry(value, country) &&
-    !hasUnsafeDiscoveryCopy(value) &&
     (value.stocks.length > 0 || (value.cards?.length ?? 0) > 0)
   );
 }
@@ -743,7 +748,7 @@ function readStoredDiscovery(country: DiscoveryCountryScope = "KR"): DiscoveryRe
     const raw = window.localStorage.getItem(discoveryStorageKey(country)) ?? window.localStorage.getItem(lastDiscoveryStorageKey(country));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
-    const discovery = isDiscoveryResponse(parsed) ? parsed : null;
+    const discovery = isDiscoveryResponse(parsed) ? sanitizeDiscoveryCopy(parsed) : null;
     if (hasDiscoveryCards(discovery, country)) return discovery;
     window.localStorage.removeItem(discoveryStorageKey(country));
     window.localStorage.removeItem(lastDiscoveryStorageKey(country));
@@ -830,7 +835,8 @@ export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Pro
         }),
       CACHE_TTL.stockFront
       )
-      .then((fresh) => {
+      .then((raw) => {
+        const fresh = sanitizeDiscoveryCopy(raw);
         if (!hasDiscoveryCards(fresh, country)) return;
         writeStoredDiscovery(fresh, country);
         emitDiscoveryUpdated(country, fresh);
@@ -843,7 +849,7 @@ export async function fetchDiscovery(country: DiscoveryCountryScope = "KR"): Pro
     return stored;
   }
 
-  const fresh = await fetchDiscoveryNetwork({ country });
+  const fresh = sanitizeDiscoveryCopy(await fetchDiscoveryNetwork({ country }));
   if (!hasDiscoveryCards(fresh, country)) throw new Error(`GET /api/fomo/discovery returned invalid ${country} deck`);
   setCached(key, fresh, CACHE_TTL.stockFront);
   writeStoredDiscovery(fresh, country);
@@ -896,7 +902,7 @@ export async function fetchDaily30(): Promise<Daily30Response> {
   return cachedGet(
     key,
     async () => {
-      const fresh = await fetchDaily30Network();
+      const fresh = sanitizeDiscoveryCopy(await fetchDaily30Network());
       if (!hasDaily30Cards(fresh)) throw new Error("GET /api/fomo/daily-30 returned invalid deck");
       return fresh;
     },

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { isDiscoveryCopySafe } from "@fomo/core";
 import type { CardFrontSignals, StockCountry } from "@fomo/core";
 import { cacheVersion, kstDate as kstDateOf } from "./fomo";
 import {
@@ -172,6 +173,12 @@ function meetsCardStandard(stock: DiscoveryStockPayload, front: DiscoveryFrontSe
   if (typeof frontSignals(front).changePct !== "number") return false;
   if (!(stock.headline ?? "").trim()) return false;
   if (!front?.verdict) return false;
+  // 카피 세이프(클라와 동일 패턴, @fomo/core 단일 원본) — 오염 카드 1장이 클라에서
+  // 덱 30장 전체를 무효 처리한 사고(SKAI "TSID와" 실측) 재발 방지. 탈락분은 다음 후보가 채운다.
+  const copyFields = [stock.canonical, stock.headline, stock.whyShown, stock.reason, stock.insightTag, stock.sourceLabel];
+  for (const field of copyFields) {
+    if (typeof field === "string" && field.trim() && !isDiscoveryCopySafe(field)) return false;
+  }
   return true;
 }
 

--- a/packages/fomo-core/src/keyword-cards/discovery-copy-safe.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-copy-safe.ts
@@ -1,0 +1,18 @@
+/**
+ * 발견 카드 카피 안전성 — 미번역 영문+한글조사 잔여물 등 오염 카피 판정.
+ * **서버(daily-30 표준 게이트)와 클라(fomo-web 2차 필터)가 공유하는 단일 원본.**
+ * 서버가 이 패턴으로 후보를 거르면 탈락분은 다음 quietScore 후보가 채워 30장이 유지되고,
+ * 클라에는 오염 카드가 도달하지 않는다(클라 필터는 방어 2선).
+ *
+ * 주의: 조사 뒤에 한글이 이어지면 그건 조사가 아니라 고유명사 음절이다
+ * (예: "SK이터닉스"의 SK+이터닉스, "SK이노베이션", "LG이노텍") — 부정 후방탐색으로 오탐을 막는다.
+ * 2~3자 대문자 시장 약어(IPO·AI·ETF 등)는 정상 한국어 문장에 자주 쓰이므로 조사 결합을 허용한다.
+ * 이 오탐이 정상 30장 덱을 통째로 무효 처리해 홈 카드 로딩이 멈춘 적이 있다(회귀 테스트로 고정).
+ */
+export const UNSAFE_DISCOVERY_COPY_PATTERN =
+  /\b(?:[Ii][Tt][Ss]|[Tt][Hh][Ee]|[Ww][Ii][Tt][Hh]|[Aa][Nn][Dd])\b\s+[A-Za-z]|(?:[A-Z]{4,}|[A-Za-z]*[a-z][A-Za-z]*)\s*(?:와|과|의|가|이|은|는|을|를|에|에서|로|으로)(?![가-힣])|SHPH\s*,\s*ILLR|설명하긴\s*이른데|아직\s*공개된\s*계기/;
+
+/** 카드 카피 안전성 — 오염 카피면 false. 정상 종목명(SK이터닉스 등)은 통과. */
+export function isDiscoveryCopySafe(text: string): boolean {
+  return !UNSAFE_DISCOVERY_COPY_PATTERN.test(text);
+}

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -7,6 +7,7 @@ export * from "./comment";
 export * from "./josa";
 export * from "./stocks";
 export * from "./card-front-hook";
+export * from "./discovery-copy-safe";
 export * from "./multi-axis-hook";
 export * from "./discovery-supply";
 export * from "./fomo-score";


### PR DESCRIPTION
## 문제 (프로덕션 실측 — 프론트 30장 미표시 2번째 축)
#824로 서버 30장은 복구됐지만, SKAI 카드 헤드라인 \"...TSID와 보안 강화...\"가 클라 오염 패턴(4자+ 대문자+조사)에 걸림. 클라 `hasUnsafeDiscoveryCopy`는 **1장 오염 = 덱 30장 전체 무효**(fetch throw → 홈 미표시/구캐시 폴백).

## 수정
1. **패턴 단일 원본화**: `@fomo/core` discovery-copy-safe.ts — 서버·클라 공유(fomo-web은 re-export, 기존 테스트 4/4 그대로).
2. **서버 게이트**: daily-30 `meetsCardStandard`에 동일 패턴 — 오염 후보 탈락 시 **다음 후보가 채워 30장 유지**. 클라엔 오염 카드 미도달.
3. **클라 방어 2선**: 전체 거부 → `sanitizeDiscoveryCopy`(오염 카드만 드랍). fetch·revalidate·localStorage 전 경로. \"전체 거부 금지\" 주석 고정.

## 검증
테스트 전체 통과(fomo-web copySafe 4/4 포함) · guard:discovery ✅ · typecheck(web/fomo-web) ✅. 머지 후 캐시 버스트 → 서버 30장+오염 0 실측 첨부.

🤖 Generated with [Claude Code](https://claude.com/claude-code)