### PR TITLE
fix(search): 역방향 포함 매칭 — 긴 쿼리가 not-found 되던 결함 (#826 후속)

### DIFF
--- a/apps/web/lib/symbol-index.ts
+++ b/apps/web/lib/symbol-index.ts
@@ -101,11 +101,13 @@ function parseSymbolDir(text: string, kind: "nasdaq" | "other"): SymbolIndexEntr
       const [symbol, name, , testIssue, , , etf] = cols;
       if (!symbol || !name || testIssue === "Y" || etf === "Y") continue;
       if (/File Creation Time/i.test(symbol)) continue;
+      if (/warrant|right(s)?\b|\bunit(s)?\b/i.test(name)) continue; // 워런트·라이츠·유닛 — 종목 아님(RGTIW 오염 실측)
       out.push({ canonical: cleanUsName(name), englishName: cleanUsName(name), symbol: symbol.trim(), market: "NASDAQ", country: "US" });
     } else {
       const [symbol, name, exchange, , etf, , testIssue] = cols;
       if (!symbol || !name || testIssue === "Y" || etf === "Y") continue;
       if (/File Creation Time/i.test(symbol)) continue;
+      if (/warrant|right(s)?\b|\bunit(s)?\b/i.test(name)) continue; // 워런트·라이츠·유닛 — 종목 아님
       const market = exchange === "N" ? "NYSE" : exchange === "A" ? "NYSE" : "NYSE"; // AMEX·기타는 NYSE 그룹으로 표기
       out.push({ canonical: cleanUsName(name), englishName: cleanUsName(name), symbol: symbol.trim(), market, country: "US" });
     }
@@ -249,6 +251,8 @@ export async function searchSymbols(query: string, limit = 10): Promise<SymbolSe
     for (const key of keys) {
       if (key === q) score = Math.max(score, 3);
       else if (key.startsWith(q)) score = Math.max(score, 2);
+      // 역방향 포함 — 쿼리가 키보다 길 때("리게티컴퓨팅" ⊃ 인덱스 "리게티"). 큐 확정(score≥2)도 통과.
+      else if (key.length >= 2 && q.length > key.length && q.includes(key)) score = Math.max(score, 2);
       else if (q.length >= 2 && key.includes(q)) score = Math.max(score, 1);
     }
     // 본명(표시명/티커) 정확 일치는 별칭 일치보다 위 — "META"에서 코인 별칭이 Meta Platforms 를 이기지 않게.


### PR DESCRIPTION
프로덕션 실측: '리게티컴퓨팅' 요청이 not-found(인덱스 표시명 '리게티'보다 긴 쿼리는 미매칭). 역포함 매칭(score 2 — 큐 확정 통과) + 워런트/라이츠/유닛 인덱스 오염 필터. 로컬 실측: 리게티컴퓨팅→RGTI, 팔란티어테크놀로지스→PLTR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)