### PR TITLE
feat(discovery): 유니버스 큐레이션 — 코인 시총 10위권·미장 대형주만

### DIFF
--- a/apps/web/__tests__/lib/us-market-source.test.ts
+++ b/apps/web/__tests__/lib/us-market-source.test.ts
@@ -171,6 +171,18 @@ describe("US market source", () => {
                 industry: "Computer Software",
               },
               {
+                symbol: "BKNG",
+                name: "Booking Holdings Inc Common Stock",
+                lastsale: "$5200.00",
+                netchange: "403.00",
+                pctchange: "8.40%",
+                volume: "400000",
+                marketCap: "170000000000",
+                country: "United States",
+                sector: "Consumer Discretionary",
+                industry: "Transportation Services",
+              },
+              {
                 symbol: "AACB",
                 name: "Artius II Acquisition Inc Class A Ordinary Shares",
                 lastsale: "$10.49",
@@ -192,8 +204,8 @@ describe("US market source", () => {
 
     const rows = await fetchUsMarketRows();
     expect(rows.map((row) => row.symbol)).toEqual(expect.arrayContaining(["MRVL", "META"]));
-    // WO 미장·코인 확충 — 비큐레이션 정상주(Opendoor)도 유니버스 포함(큐레이션 125 상한 폐기).
-    expect(rows.some((row) => row.symbol === "OPEN")).toBe(true);
+    // 2026-07-11 User Zero — 다이내믹 행 시총 하한($20B): 마이크로캡(Opendoor $2B)은 급등해도 제외.
+    expect(rows.some((row) => row.symbol === "OPEN")).toBe(false);
     // 품질 게이트는 유지 — SPAC/블랭크체크(AACB)는 여전히 제외.
     expect(rows.some((row) => row.symbol === "AACB")).toBe(false);
     expect(rows.find((row) => row.symbol === "MRVL")?.changePct).toBe(6.25);
@@ -201,7 +213,8 @@ describe("US market source", () => {
 
     const diag = await fetchUsMarketDiagnostics();
     expect(diag.source).toBe("nasdaq-screener");
-    // dynamicRows = 비큐레이션 행 수(의미 정교화) — 픽스처에선 OPEN 1건(+17.65% → 강모멘텀도 1).
+    // dynamicRows = 비큐레이션 행 수 — 시총 하한($20B) 통과한 BKNG 1건(+8.40% → 강모멘텀 1).
+    // 마이크로캡 OPEN(+17.65%, $2B)은 하한 미달로 다이내믹 경로에서도 제외(2026-07-11).
     expect(diag.dynamicRows).toBeGreaterThanOrEqual(1);
     expect(diag.strongMomentumRows).toBe(1);
   });

--- a/apps/web/lib/coin-market-source.ts
+++ b/apps/web/lib/coin-market-source.ts
@@ -19,12 +19,12 @@ const UPBIT_DAILY_CANDLES_URL = "https://api.upbit.com/v1/candles/days";
 const UA = "Mozilla/5.0 (compatible; FomoClubBot/1.0)";
 
 /**
- * 유니버스 = 시총 상위 30 고정 (WO 미장·코인 확충 — User Zero 결정).
- * 코인은 발굴이 아니라 커버리지 — CoinGecko 시총 순 ∩ Upbit KRW 상장 상위 30.
- * 상위 30이면 잡코인·유의 방어선 불필요(Phase C 알트 서치 폐기).
- * CoinGecko 실패 시 24h 거래대금 상위 30 폴백(정직한 근사).
+ * 유니버스 = 시총 상위 10 고정 (2026-07-11 User Zero 재결정 — "코인은 시총 10위권만").
+ * 코인은 발굴이 아니라 커버리지 — CoinGecko 시총 순 ∩ Upbit KRW 상장 상위 10.
+ * (30→10 축소: DOT·UNI 등 10위권 밖 코인이 덱에 올라와 잡코인 인상 — 상위 10만.)
+ * CoinGecko 실패 시 24h 거래대금 상위 10 폴백(정직한 근사).
  */
-const COIN_UNIVERSE_LIMIT = 30;
+const COIN_UNIVERSE_LIMIT = 10;
 const COINGECKO_MARKETS_URL =
   "https://api.coingecko.com/api/v3/coins/markets?vs_currency=krw&order=market_cap_desc&per_page=150&page=1";
 /** 스테이블코인 — 가격 고정이라 신호·카드 가치가 없다(잡코인 방어선 아님, 자산 성격상 제외). */

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -796,40 +796,12 @@ function insiderClusterEvent(candidate: InsiderClusterCandidate, asOf: string): 
   };
 }
 
-/** openinsider 영문 업종 → 한글 섹터(INDUSTRY_HINTS 매칭). 못 맞추면 undefined(다운스트림 폴백). */
-function insiderSectorHint(symbol: string, industry: string | undefined): string | undefined {
-  if (!industry) return undefined;
-  const label = inferDiscoverySectorLabel(symbol, [
-    { kind: "market_context", firstSeen: false, strength: 0, source: "", asOf: "", confidence: "L", label: industry },
-  ]);
-  return label === "기타 업종" ? undefined : label;
-}
-
-function insiderClusterRow(candidate: InsiderClusterCandidate): DiscoveryMarketRow {
-  const quote = candidate.quote;
-  const changePct = quote?.changePct;
-  const changeDir: "up" | "down" | "flat" =
-    typeof changePct !== "number" ? "flat" : changePct > 0 ? "up" : changePct < 0 ? "down" : "flat";
-  const priceText = insiderMoney(quote?.price);
-  return {
-    canonical: candidate.symbol,
-    symbol: candidate.symbol,
-    market: "NASDAQ",
-    country: "US",
-    currency: "USD",
-    marketCapRank: 900,
-    ...(priceText ? { priceText } : {}),
-    ...(typeof changePct === "number" ? { changePct, changeDir } : {}),
-    ...(quote?.sparkline && quote.sparkline.length >= 2 ? { sparkline: quote.sparkline } : {}),
-    ...(insiderSectorHint(candidate.symbol, candidate.industry) ? { sectorHint: insiderSectorHint(candidate.symbol, candidate.industry)! } : {}),
-    sessionLabel: latestUsSessionAsOf().label,
-  };
-}
-
 /**
- * US 내부자 클러스터 매수 발굴 — 조용한 종목까지 덱에 주입한다.
- * 이미 유니버스에 있으면 내부자 이벤트만 보강, 없으면 합성 row+event를 직접 주입(eligible 게이트 우회).
- * openinsider 실패 시 조용히 no-op(fail-open).
+ * US 내부자 클러스터 매수 — 유니버스(시총 큐레이션 통과) 종목에 이벤트를 보강한다(attach-only).
+ * 2026-07-11 User Zero: 합성 row 직접 주입(eligible 게이트 우회) 폐기 — openinsider 클러스터는
+ * 마이크로캡이 대부분이라 "아무도 모르는 잡주"(CREX·FCBM·DPC·SWZ 실측)가 미장 덱을 지배했다.
+ * 내부자 신호는 시총 하한(US_DYNAMIC_MIN_MARKET_CAP_USD·큐레이션 시드)을 통과한 종목의
+ * 보강 재료로만 쓴다. openinsider 실패 시 조용히 no-op(fail-open).
  */
 async function hydrateUsInsiderClusterRows(
   byTicker: Map<string, { row: DiscoveryMarketRow; events: DiscoveryEvent[] }>,
@@ -838,17 +810,13 @@ async function hydrateUsInsiderClusterRows(
   const candidates = await fetchInsiderClusterCandidates().catch((): InsiderClusterCandidate[] => []);
   if (candidates.length === 0) return;
   for (const candidate of candidates) {
-    const event = insiderClusterEvent(candidate, asOf);
     const existing = [...byTicker.entries()].find(
       ([, value]) => value.row.country === "US" && value.row.symbol?.toUpperCase() === candidate.symbol
     );
-    if (existing) {
-      const [ticker, current] = existing;
-      if (current.events.some((e) => e.insiderPurchase)) continue;
-      byTicker.set(ticker, { ...current, events: [...current.events, event] });
-      continue;
-    }
-    byTicker.set(candidate.symbol, { row: insiderClusterRow(candidate), events: [event] });
+    if (!existing) continue; // 유니버스 밖(시총 미달 마이크로캡) — 주입하지 않는다.
+    const [ticker, current] = existing;
+    if (current.events.some((e) => e.insiderPurchase)) continue;
+    byTicker.set(ticker, { ...current, events: [...current.events, insiderClusterEvent(candidate, asOf)] });
   }
 }
 

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -15,6 +15,10 @@ const NASDAQ_UA =
 // TwelveData(키 있을 때) 경로는 쿼터 보호를 위해 기존 60 유지.
 const US_SCREENER_UNIVERSE_LIMIT = 500;
 const US_DYNAMIC_UNIVERSE_LIMIT = 60;
+// 2026-07-11 User Zero: "미장은 시총 높은 걸로 — 상위권 기업 아니면 핫한 기업만".
+// 다이내믹(비큐레이션) 스크리너 행에 시총 하한 — 마이크로캡 잡주(EQPT·CREX·FBRX류)가
+// 모멘텀 점수만으로 덱에 오르던 경로 차단. 큐레이션 시드 98종(핫 종목 포함)은 하한 우회.
+const US_DYNAMIC_MIN_MARKET_CAP_USD = Number(process.env.US_DYNAMIC_MIN_MARKET_CAP_USD ?? 20_000_000_000);
 const US_QUOTE_BATCH_SIZE = 60;
 const US_SPARKLINE_LIMIT = 30;
 const US_PREWARM_CACHE_MAX_AGE_HOURS = 18;
@@ -365,8 +369,13 @@ async function fetchNasdaqScreenerRows(): Promise<DiscoveryMarketRow[]> {
     next: { revalidate: 900 },
   });
   if (!res.ok) return [];
+  const seedSymbols = new Set(usDiscoveryUniverse().map((seed) => seed.symbol.toUpperCase()));
   const deduped = new Map<string, DiscoveryMarketRow>();
   for (const row of normalizeNasdaqScreenerRows(await res.json())) {
+    // 다이내믹 행 시총 하한(2026-07-11) — 큐레이션 시드는 우회, 시총 미상은 보수적으로 제외.
+    const cap = num(row.marketCap);
+    const symbol = String(row.symbol ?? "").toUpperCase();
+    if (!seedSymbols.has(symbol) && (typeof cap !== "number" || cap < US_DYNAMIC_MIN_MARKET_CAP_USD)) continue;
     const parsed = parseNasdaqScreenerRow(row);
     if (parsed) deduped.set(parsed.symbol.toUpperCase(), parsed);
   }


### PR DESCRIPTION
## 무엇/왜
User Zero 지시(2026-07-11): "미증 시가 높은걸로 — 상위 기업 아니면 핫한 기업. 코인은 시총 10위권만. 지금 너무 아무도 모르는 잡주 느낌."

프로덕션 실측(daily-30): 코인 = KRW-DOT·KRW-UNI(10위권 밖), 미장 12장 = EQPT·CREX·FBRX·FCBM·DPC·SWZ·MSIF·KYN·GOF 등 내부자 마이크로캡 지배.

## 변경
- **코인**: `COIN_UNIVERSE_LIMIT` 30→10 — CoinGecko 시총순 ∩ Upbit KRW(스테이블 제외) 상위 10만. 캐시 정리 로직이 기존 11~30위 행을 다음 프리웜에 자동 제거.
- **미장 다이내믹 스크리너**: 시총 하한 **$20B** (`US_DYNAMIC_MIN_MARKET_CAP_USD` env 조정 가능). 큐레이션 시드 98종(fameRank·핫 종목)은 하한 우회. 시총 미상 행 보수적 제외.
- **내부자 클러스터**: 합성 row 직접 주입(eligible 게이트 우회) 폐기 → 유니버스 통과 종목에 이벤트 **보강만**(attach-only). `insiderClusterRow`/`insiderSectorHint` 제거.

## 검증 커버리지
- vitest **1078 통과** (옛 결정 박제 테스트 2건을 새 정책으로 갱신: OPEN $2B 제외·BKNG $170B 다이내믹 포함)
- `guard:discovery` **통과** — 덱 48장 ≥ 40 하한 (30장 유지 원칙 무손상, 미장 축소분은 2-pass 셀렉터가 KR로 백필)
- `spec:analyze` 통과 · typecheck/lint 클린
- 배포 후: 프리웜 크론 트리거 → daily-30에서 코인 10위권·미장 대형주 확인 예정

## 주의
- daily-30 unstable_cache는 커밋 SHA 키라 배포로 자동 버스트. 코인/US 프리웜 캐시는 다음 크론(시간당)에 갱신 — 배포 직후 수동 트리거 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)