### PR TITLE
fix(discovery): US 캐시 읽기 경로 시총 재검증 — 구 마이크로캡 행 즉시 차단

### DIFF
--- a/apps/web/lib/market-source-types.ts
+++ b/apps/web/lib/market-source-types.ts
@@ -10,6 +10,8 @@ export interface DiscoveryMarketRow {
   country: StockCountry;
   marketCapRank?: number;
   marketCapRankSource?: "live" | "curated";
+  /** 시총(USD) — US 다이내믹 행 큐레이션 하한 검증용(2026-07-11). 스크리너 원천값. */
+  marketCapUsd?: number;
   priceText?: string;
   changeText?: string;
   changeDir?: "up" | "down" | "flat";

--- a/apps/web/lib/us-market-cache.ts
+++ b/apps/web/lib/us-market-cache.ts
@@ -1,8 +1,27 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "./prisma";
 import type { DiscoveryMarketRow } from "./market-source-types";
+import { usDiscoveryUniverse } from "./us-symbols";
 
 const US_MARKET_QUOTE_CACHE_MAX_AGE_HOURS = 18;
+
+// 2026-07-11 User Zero: "미장은 시총 높은 걸로 — 상위권 기업 아니면 핫한 기업만".
+// 다이내믹(비큐레이션) 행 시총 하한. 쓰기(스크리너 파스)와 읽기(캐시 재검증) 양쪽에서 적용 —
+// 캐시는 UPSERT-only라 구 마이크로캡 행이 18h 잔존하므로 읽기 재검증이 필수(배포 즉시 효력).
+export const US_DYNAMIC_MIN_MARKET_CAP_USD = Number(process.env.US_DYNAMIC_MIN_MARKET_CAP_USD ?? 20_000_000_000);
+
+let curatedSymbolCache: Set<string> | null = null;
+
+function isCuratedSymbol(symbol: string): boolean {
+  curatedSymbolCache ??= new Set(usDiscoveryUniverse().map((seed) => seed.symbol.toUpperCase()));
+  return curatedSymbolCache.has(symbol.toUpperCase());
+}
+
+/** 큐레이션 시드는 하한 우회, 그 외는 시총 하한 충족 필수(시총 미상 구캐시 행은 보수적 제외). */
+function passesUsCapCuration(row: DiscoveryMarketRow): boolean {
+  if (isCuratedSymbol(row.symbol)) return true;
+  return typeof row.marketCapUsd === "number" && row.marketCapUsd >= US_DYNAMIC_MIN_MARKET_CAP_USD;
+}
 
 export interface UsMarketQuoteCacheWriteOptions {
   sessionDate: string;
@@ -98,7 +117,8 @@ export async function readUsMarketQuoteRows(options: UsMarketQuoteCacheReadOptio
     return records
       .map((record) => record.row)
       .filter(isUsMarketRow)
-      .filter(hasUsQuote);
+      .filter(hasUsQuote)
+      .filter(passesUsCapCuration);
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2010") return [];
     return [];

--- a/apps/web/lib/us-market-source.ts
+++ b/apps/web/lib/us-market-source.ts
@@ -1,6 +1,6 @@
 import type { DiscoveryMarket, DailyOhlcv } from "@fomo/core";
 import type { DiscoveryMarketRow } from "./market-source-types";
-import { readUsMarketQuoteRows } from "./us-market-cache";
+import { readUsMarketQuoteRows, US_DYNAMIC_MIN_MARKET_CAP_USD } from "./us-market-cache";
 import { usDiscoverySeedForSymbol, usDiscoveryUniverse, type UsDiscoverySymbol } from "./us-symbols";
 
 const TWELVE_DATA_URL = "https://api.twelvedata.com/quote";
@@ -15,10 +15,7 @@ const NASDAQ_UA =
 // TwelveData(키 있을 때) 경로는 쿼터 보호를 위해 기존 60 유지.
 const US_SCREENER_UNIVERSE_LIMIT = 500;
 const US_DYNAMIC_UNIVERSE_LIMIT = 60;
-// 2026-07-11 User Zero: "미장은 시총 높은 걸로 — 상위권 기업 아니면 핫한 기업만".
-// 다이내믹(비큐레이션) 스크리너 행에 시총 하한 — 마이크로캡 잡주(EQPT·CREX·FBRX류)가
-// 모멘텀 점수만으로 덱에 오르던 경로 차단. 큐레이션 시드 98종(핫 종목 포함)은 하한 우회.
-const US_DYNAMIC_MIN_MARKET_CAP_USD = Number(process.env.US_DYNAMIC_MIN_MARKET_CAP_USD ?? 20_000_000_000);
+// 시총 하한 상수는 us-market-cache(읽기 경로 재검증)와 공유 — 그쪽이 정의 원본.
 const US_QUOTE_BATCH_SIZE = 60;
 const US_SPARKLINE_LIMIT = 30;
 const US_PREWARM_CACHE_MAX_AGE_HOURS = 18;
@@ -218,6 +215,7 @@ function parseQuote(seed: UsDiscoverySymbol, quote: TwelveQuote | undefined, spa
       : {}),
     changeDir: dir,
     ...(volume ? { tradingValue: volume } : {}),
+    ...(typeof marketCapUsd === "number" && marketCapUsd > 0 ? { marketCapUsd } : {}),
     ...(sparkline && sparkline.length >= 2 ? { sparkline } : {}),
     sectorHint: seed.sector,
     sessionLabel: session.label,
@@ -303,6 +301,7 @@ function parseNasdaqScreenerRow(row: NasdaqScreenerRow): DiscoveryMarketRow | nu
   const pct = num(row.pctchange);
   const change = num(row.netchange);
   const volume = num(row.volume);
+  const marketCapUsd = num(row.marketCap);
   const priceText = money(price);
   const session = latestUsSessionAsOf();
   const canonical = String(row.name ?? symbol)


### PR DESCRIPTION
#828 배포 후에도 EQPT·RPID·FBRX가 미장 덱에 잔존(프로덕션 실측) —
발견 US 유니버스는 UsMarketQuoteCache(UPSERT-only)를 읽는데 프리웜이
구 마이크로캡 행을 지우지 않아 18h 동안 하한 우회로 살아남았다.

- DiscoveryMarketRow.marketCapUsd 신설, 스크리너 파스에서 전파.
- readUsMarketQuoteRows에 시총 재검증: 큐레이션 시드 우회, 그 외
  marketCapUsd >= $20B 필수 — 시총 미상 구캐시 행은 보수적 즉시 제외.
- US_DYNAMIC_MIN_MARKET_CAP_USD 정의를 us-market-cache로 이동(쓰기·읽기 공유).

검증: vitest 1078 통과 · guard:discovery 통과(48장) · typecheck 클린.
배포 후 daily-30 캐시 버스트로 프로덕션 확인 예정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
