### PR TITLE
fix(feed): 미장 덱 바닥 확보 + US 콘텐츠 한글화 (User Zero 2026-07-12 크리티컬 2건)

### DIFF
--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -71,6 +71,29 @@ describe("daily-30 freshness (모듈 로드 검증)", () => {
   });
 });
 
+describe("daily-30 자산군 바닥 (2026-07-12 미장 1장 사고)", () => {
+  const cand = (id: string, assetClass: "kr-stock" | "us-stock" | "coin", quietScore: number) =>
+    ({ kind: "stock", id, assetClass, quietScore, signalScore: quietScore, hypePenalty: 0 }) as unknown as Parameters<typeof selectDaily30Candidates>[0][number];
+
+  it("KR이 quietScore 상위를 독식해도 미장은 바닥(8) 만큼 확보된다", () => {
+    // KR 40장(전부 고득점) + US 10장(저득점). 바닥 없으면 US 0~1, 바닥 있으면 8.
+    const kr = Array.from({ length: 40 }, (_, i) => cand(`kr${i}`, "kr-stock", 100 - i));
+    const us = Array.from({ length: 10 }, (_, i) => cand(`us${i}`, "us-stock", 10 - i * 0.1));
+    const deck = selectDaily30Candidates([...kr, ...us], 30);
+    const usInDeck = deck.filter((c) => c.assetClass === "us-stock").length;
+    expect(usInDeck).toBeGreaterThanOrEqual(8);
+    expect(deck).toHaveLength(30);
+  });
+
+  it("US 후보가 바닥보다 적으면 있는 만큼만(억지 생성 없음)", () => {
+    const kr = Array.from({ length: 40 }, (_, i) => cand(`kr${i}`, "kr-stock", 100 - i));
+    const us = [cand("us0", "us-stock", 5), cand("us1", "us-stock", 4)];
+    const deck = selectDaily30Candidates([...kr, ...us], 30);
+    expect(deck.filter((c) => c.assetClass === "us-stock")).toHaveLength(2);
+    expect(deck).toHaveLength(30);
+  });
+});
+
 // 신선도 폴백(30장 유지) — 하드 제외가 주말(문구 불변)에 덱을 말린 회귀(실측 30→20) 방지.
 import { stockCandidate, type FreshnessSnapshot } from "../../lib/daily-30";
 import type { DiscoveryFrontSeed, DiscoveryStockPayload } from "../../lib/discovery-supply";

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -10,6 +10,8 @@ import {
   type FeedBriefingRow,
 } from "../../../../../lib/feed-briefing";
 import { processSearchQueue, rebuildSymbolIndex } from "../../../../../lib/symbol-index";
+import { translateAndStoreUsTitles } from "../../../../../lib/content-i18n";
+import { fetchAllNews } from "../../../../../lib/fomo-news-sources";
 
 /**
  * 피드 콘텐츠 프리웜 크론 (WO 피드 강화) — ?slot=morning|close|weekly
@@ -65,9 +67,13 @@ export async function GET(request: Request) {
     }
     if (slot === "morning") {
       await save(`briefing:us:${date}`, await buildUsBriefing());
+      const translated = await translateAndStoreUsTitles(await fetchAllNews().catch(() => [])).catch(() => 0);
+      if (translated > 0) written.push(`i18n:us-titles(${translated})`);
     } else if (slot === "close") {
       await save(`briefing:kr:${date}`, await buildKrBriefing());
       await save(`buzz:${date}`, await buildBuzzStory());
+      const translated = await translateAndStoreUsTitles(await fetchAllNews().catch(() => [])).catch(() => 0);
+      if (translated > 0) written.push(`i18n:us-titles(${translated})`);
     } else if (slot === "weekly") {
       await save(`recap:${isoWeekOf()}`, await buildWeeklyRecap());
     } else {

--- a/apps/web/lib/content-i18n.ts
+++ b/apps/web/lib/content-i18n.ts
@@ -1,0 +1,119 @@
+/**
+ * US 뉴스 콘텐츠 한글화 (2026-07-12 User Zero: "콘텐츠에 영문만 있는 것도 있고 — 크리티컬").
+ *
+ * 근본 원인: 브리핑·버즈는 Groq로 한글 카피를 생성하지만, narrative(STORY) 트리거와
+ * hot-issue 헤드라인은 US 기사 원문(영어)을 그대로 노출했다. 제품은 한국어 우선인데
+ * 미장 뉴스가 영어로 떴다.
+ *
+ * 설계(제품 헌법 준수 — LLM은 크론에서만, 요청 경로는 캐시 읽기 전용):
+ * - 크론(feed-content): 최신 US 기사 제목을 Groq로 배치 번역해 FeedContentCache에 저장.
+ * - 요청 경로(discovery·feed-hub): `hydrateKoreanTitles()`로 캐시를 모듈 맵에 적재하고
+ *   `koreanTitle(url)`로 동기 조회. 번역이 없으면 원문 폴백(무회귀).
+ */
+
+import { callAI, isAiConfigured } from "@fomo/shared";
+import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { kstDate } from "./fomo";
+
+const CACHE_PREFIX = "i18n:us-titles";
+const MAX_TITLES_PER_RUN = 60;
+const HANGUL = /[가-힣]/;
+
+interface KoreanTitleMap {
+  /** 기사 url → 자연스러운 한국어 제목. */
+  map: Record<string, string>;
+  updatedAt: string;
+}
+
+// 요청 경로에서 동기 조회하기 위한 모듈 캐시(daily-30·feed-hub 는 캐시라 회당 1회만 hydrate).
+const koCache = new Map<string, string>();
+let hydratedAt = 0;
+
+/** 저장된 번역을 모듈 맵으로 적재. 60초 스로틀(중복 DB 읽기 방지). fail-open. */
+export async function hydrateKoreanTitles(): Promise<void> {
+  if (Date.now() - hydratedAt < 60_000 && koCache.size > 0) return;
+  try {
+    const rows = await readFeedContentByPrefix<KoreanTitleMap>(CACHE_PREFIX, 3);
+    for (const { row } of rows) {
+      if (!row?.map) continue;
+      for (const [url, ko] of Object.entries(row.map)) {
+        if (typeof ko === "string" && ko.trim()) koCache.set(url, ko);
+      }
+    }
+    hydratedAt = Date.now();
+  } catch {
+    // 캐시 부재/DB 오류 — 원문 폴백(무회귀).
+  }
+}
+
+/** 동기 조회 — hydrate 이후 사용. 번역 없으면 undefined(호출부가 원문 폴백). */
+export function koreanTitle(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  return koCache.get(url);
+}
+
+/** 이미 한국어면 번역 불필요(한글 포함 여부로 판별). */
+function looksKorean(text: string): boolean {
+  return HANGUL.test(text);
+}
+
+function parseJsonArray(content: string): string[] | null {
+  const start = content.indexOf("[");
+  const end = content.lastIndexOf("]");
+  if (start === -1 || end === -1 || end <= start) return null;
+  try {
+    const parsed = JSON.parse(content.slice(start, end + 1));
+    return Array.isArray(parsed) ? parsed.map((x) => (typeof x === "string" ? x : "")) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 크론 전용 — 미번역 US 기사 제목을 Groq로 배치 번역해 저장한다.
+ * 이미 저장된 url 은 건너뛴다(증분). AI 미설정·실패 시 조용히 no-op(fail-open).
+ * @returns 새로 번역·저장한 제목 수.
+ */
+export async function translateAndStoreUsTitles(articles: ReadonlyArray<{ url: string; title: string; lang?: string }>): Promise<number> {
+  if (!isAiConfigured()) return 0;
+  const date = kstDate();
+  const existing = (await readFeedContent<KoreanTitleMap>(`${CACHE_PREFIX}:${date}`))?.map ?? {};
+  const pending = articles
+    .filter((a) => a.url && a.title && (a.lang ?? "en") === "en" && !looksKorean(a.title) && !existing[a.url])
+    .filter((a, index, arr) => arr.findIndex((x) => x.url === a.url) === index)
+    .slice(0, MAX_TITLES_PER_RUN);
+  if (pending.length === 0) return 0;
+
+  const numbered = pending.map((a, i) => `${i + 1}. ${a.title.replace(/\s+/g, " ").trim()}`).join("\n");
+  const result = await callAI({
+    trace: "content-i18n",
+    temperature: 0.2,
+    messages: [
+      {
+        role: "system",
+        content:
+          "너는 금융 뉴스 헤드라인을 자연스러운 한국어로 번역한다. 티커·기업명·숫자·통화는 그대로 유지하고, " +
+          "직역투가 아닌 한국 경제뉴스체로 옮긴다. 매수/매도/예측 표현을 새로 넣지 말고 사실만 옮긴다. " +
+          '입력과 동일한 개수·순서의 JSON 문자열 배열만 출력한다. 예: ["번역1","번역2"]',
+      },
+      { role: "user", content: numbered },
+    ],
+  });
+  if (!result.ok) return 0;
+  const translated = parseJsonArray(result.content);
+  if (!translated || translated.length !== pending.length) return 0;
+
+  const map: Record<string, string> = { ...existing };
+  let added = 0;
+  for (let i = 0; i < pending.length; i += 1) {
+    const ko = (translated[i] ?? "").replace(/\s+/g, " ").trim();
+    if (ko && looksKorean(ko)) {
+      map[pending[i]!.url] = ko;
+      added += 1;
+    }
+  }
+  if (added > 0) {
+    await writeFeedContent(`${CACHE_PREFIX}:${date}`, { map, updatedAt: new Date().toISOString() } satisfies KoreanTitleMap);
+  }
+  return added;
+}

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -79,6 +79,13 @@ const ASSET_CAPS: Record<Daily30AssetClass, number> = {
   coin: 5,
   macro: 6,
 };
+// 2026-07-12 프로덕션 미장 1장 사고: KR이 quietScore 상위를 독식해(2패스 캡 완화 시 KR 24장)
+// 미장·코인이 굶었다. 자산군 최소 바닥 — 미장 탭이 비지 않도록 US를 우선 확보한다.
+// (후보가 바닥보다 적으면 있는 만큼만 — 억지 생성 없음. 코인 5=캡과 동일.)
+const ASSET_FLOORS: Partial<Record<Daily30AssetClass, number>> = {
+  "us-stock": 8,
+  coin: 5,
+};
 
 function isStockCard(card: DiscoveryDeckCardPayload): card is { kind: "stock" } & DiscoveryStockPayload {
   return !("kind" in card) || card.kind === "stock";
@@ -208,7 +215,8 @@ export function stockCandidate(
   freshness?: FreshnessSnapshot
 ): Daily30Candidate | null {
   if (!meetsCardStandard(stock, front)) return null;
-  if (FAMOUS_STOCKS.has(stock.canonical) && !strongQuietSignal(stock)) return null;
+  // 유명주 강신호 게이트는 국장 발굴 정체성 전용 — 미장은 "시총 높은·아는 기업"이 제품(2026-07-12).
+  if (stock.country !== "US" && FAMOUS_STOCKS.has(stock.canonical) && !strongQuietSignal(stock)) return null;
   const yesterdayHeadline = freshness?.headlines.get(stock.canonical);
   const repeatStale =
     typeof yesterdayHeadline === "string" && normalizeHeadline(yesterdayHeadline) === normalizeHeadline(stock.headline);
@@ -346,6 +354,19 @@ export function selectDaily30Candidates(candidates: readonly Daily30Candidate[],
     return selected.length >= targetCount;
   };
 
+  // 0) 자산군 최소 바닥 — KR 독식 방지(2026-07-12 미장 1장 사고). 바닥은 자산군 캡을 우선하되
+  //    섹터 과밀 캡은 존중. 있는 후보만큼만 채운다(억지 생성 없음).
+  for (const [assetClass, floor] of Object.entries(ASSET_FLOORS) as Array<[Daily30AssetClass, number]>) {
+    let taken = 0;
+    for (const candidate of ranked) {
+      if (taken >= floor) break;
+      if (candidate.assetClass !== assetClass || seen.has(candidate.id)) continue;
+      if (candidate.sector && (sectorCounts.get(candidate.sector) ?? 0) >= 5) continue;
+      const full = tryTake(candidate, false);
+      taken += 1;
+      if (full) return selected;
+    }
+  }
   for (const candidate of ranked) {
     if (tryTake(candidate, true)) return selected;
   }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -1,3 +1,4 @@
+import { hydrateKoreanTitles, koreanTitle } from "./content-i18n";
 import {
   STOCK_VOCAB,
   applyAxisRarity,
@@ -600,7 +601,8 @@ function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEv
 }
 
 function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
-  const label = cleanUsMaterialTitle(article.title);
+  // 한글 번역(크론 캐시) 우선 — 없으면 원문 클린 폴백(무회귀). 제품 한국어 우선(2026-07-12).
+  const label = koreanTitle(article.url) ?? cleanUsMaterialTitle(article.title);
   if (!label) return null;
   const sourceName = article.source || sourceFallback;
   const sourceTitle = decodeHtmlEntities(article.title).replace(/\s+/g, " ").trim();
@@ -1961,6 +1963,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     ? targetedMaterialCandidateLimit(scope, options.targetedMaterialLimit)
     : 0;
   const asOf = discoveryAsOf(scope);
+  // 2026-07-12: US 뉴스 제목 한글 번역 캐시를 모듈 맵에 적재(요청 경로 동기 조회용). fail-open.
+  await hydrateKoreanTitles();
   const discoveryContentPromise =
     scope === "US"
       ? fetchDeckContentCards().catch((err) => {

--- a/apps/web/lib/feed-extras.ts
+++ b/apps/web/lib/feed-extras.ts
@@ -15,6 +15,7 @@ import type { DeckContentCard, DeckContentFact } from "./deck-content";
 import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
 import { computeCoinSignal } from "./coin-discovery";
 import { fetchAllNews } from "./fomo-news-sources";
+import { koreanTitle } from "./content-i18n";
 
 function kstNow(): Date {
   return new Date(Date.now() + 9 * 60 * 60 * 1000);
@@ -116,20 +117,25 @@ export async function buildHotIssueCards(): Promise<DeckContentCard[]> {
     const top = ranked[0]!;
     if (clusterScore(top, tokenFreq) < HOT_ISSUE_MIN_CLUSTER) continue;
     const topTokens = new Set(tokenize(top.title));
+    // en 클러스터는 한글 번역(크론 캐시) 우선 — 미번역 en 헤드라인은 노출 금지(2026-07-12).
+    const koTitle = (article: (typeof ranked)[number]): string | undefined => (lang === "en" ? koreanTitle(article.url) : article.title);
+    const topKo = koTitle(top);
+    if (lang === "en" && !topKo) continue; // 번역 없으면 영문 헤드라인 노출하지 않는다
     const related = ranked
       .slice(1)
       .filter((article) => tokenize(article.title).some((token) => topTokens.has(token)))
+      .filter((article) => lang === "ko" || koTitle(article))
       .slice(0, 3);
-    const facts: DeckContentFact[] = related.map((article) => ({
-      label: article.source,
-      value: article.title.length > 60 ? `${article.title.slice(0, 57)}…` : article.title,
-    }));
+    const facts: DeckContentFact[] = related.map((article) => {
+      const title = koTitle(article) ?? article.title;
+      return { label: article.source, value: title.length > 60 ? `${title.slice(0, 57)}…` : title };
+    });
     cards.push({
       kind: "content",
       id: `content:hot-issue:${lang}:${kstDate()}`,
       contentType: "hot-issue",
       scope: lang === "ko" ? "domestic" : "world",
-      headline: top.title,
+      headline: topKo ?? top.title,
       facts,
       sourceUrl: top.url,
       source: top.source,

--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -10,6 +10,7 @@ import { fetchStockDaily } from "./stock-front";
 import { readTodayFulfilledSearches } from "./symbol-index";
 import { kstDate } from "./fomo";
 import { buildCoinIssueCards, buildEventCard, buildHotIssueCards, buildTermCard } from "./feed-extras";
+import { hydrateKoreanTitles } from "./content-i18n";
 import type { DiscoveryMarketRow } from "./market-source-types";
 
 /**
@@ -330,6 +331,7 @@ export function interleaveFeedItems(items: readonly FeedHubItem[]): FeedHubItem[
 
 export async function buildFeedHubResponse(): Promise<FeedHubResponse> {
   const asOf = kstDate();
+  await hydrateKoreanTitles(); // US 뉴스 제목 한글 번역 캐시 적재(hot-issue·narrative 동기 조회용).
   const [daily30, deckContent, krRows, usRows] = await Promise.all([
     getCachedDaily30Response().catch(() => null),
     fetchDeckContentCards().catch(() => [] as DeckContentCard[]),


### PR DESCRIPTION
프로덕션 모니터링으로 두 원인 확정:

① 미장 카드 1장 — discovery는 US 14장 생성하나 daily-30 셀렉터가 순수
   quietScore 랭킹이라 KR이 상위를 독식(2패스 캡 완화 시 KR 24장) → US 1.
   추가로 FAMOUS_STOCKS 유명주 하드 드롭이 국가 무관이라 미장 메가캡까지 잘림.
   - selectDaily30Candidates에 자산군 바닥(ASSET_FLOORS: us-stock 8·coin 5) —
     KR 독식 전 US·코인을 먼저 확보. 후보가 바닥보다 적으면 있는 만큼만.
   - FAMOUS_STOCKS 강신호 게이트를 country!=="US" 로 한정(미장=아는 기업이 제품).

② 콘텐츠 영문 노출 — 브리핑·버즈는 Groq로 한글화되나 narrative(STORY) 트리거와
   hot-issue 헤드라인은 US 기사 원문(영어)을 그대로 노출.
   - content-i18n.ts: 크론(feed-content morning/close)에서 US 기사 제목을 Groq
     배치 번역해 FeedContentCache에 저장(증분·fail-open). 요청 경로는
     hydrateKoreanTitles()로 모듈 맵 적재 + koreanTitle(url) 동기 조회.
   - materialEventFromUsArticle: 한글 번역 우선, 없으면 원문 폴백(무회귀).
   - hot-issue(en): 번역 없으면 헤드라인 노출 안 함(영문 유출 차단).

검증: vitest 1085(신규 3) · guard:discovery(덱 48) · backend next build 성공 ·
양쪽 typecheck. LLM은 크론에서만(요청 경로 캐시 읽기 전용 원칙 유지).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
