### PR TITLE
feat(fomo): R1 후회 영수증 — 넘긴 카드 성과 복기 + 어제의 영수증

### DIFF
--- a/apps/fomo-web/components/ContentCard.tsx
+++ b/apps/fomo-web/components/ContentCard.tsx
@@ -36,6 +36,8 @@ function typeLabel(type: DeckContent["contentType"]): string {
       return "용어";
     case "event":
       return "일정";
+    case "daily-receipt":
+      return "영수증";
     default:
       return "노트";
   }
@@ -60,6 +62,7 @@ function cardLabel(type: DeckContent["contentType"]): string {
   if (type === "hot-issue") return "HOT ISSUE";
   if (type === "term") return "오늘의 용어";
   if (type === "event") return "MARKET CALENDAR";
+  if (type === "daily-receipt") return "어제의 영수증";
   return "MARKET NOTE";
 }
 

--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -7,6 +7,7 @@ import { ContentCard } from "@/components/ContentCard";
 import { NarrativeCard } from "@/components/NarrativeCard";
 import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
 import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
+import { RegretReceiptPanel } from "@/components/RegretReceiptPanel";
 import { FlickerSpinner } from "@/components/FlickerSpinner";
 import { fetchDaily30, fetchFeedHub, type Daily30Response, type FeedHubItem } from "@/lib/fomoApi";
 import { stockDeckCards, type DeckCard, type DeckStock, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
@@ -314,6 +315,7 @@ export function DesktopDashboard() {
             </button>
           ))}
         <div className="rounded-2xl border border-hairline bg-surface px-4 py-4">
+          <RegretReceiptPanel items={seenItems} />
           <PerformanceProofPanel items={seenItems} />
         </div>
       </section>

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -5,6 +5,7 @@ import { MOCK_KEYWORD_CARDS, scoreToColor, type KeywordCard } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { MyDiscoveryPreview } from "@/components/MyDiscoveryPreview";
 import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
+import { RegretReceiptPanel } from "@/components/RegretReceiptPanel";
 import { getHistory } from "@/lib/keywordHistory";
 import { DISCOVERY_PERFORMANCE_UPDATED_EVENT, getDiscoverySeen } from "@/lib/discoveryPerformance";
 import { getWatchlist, type WatchItem } from "@/lib/watchlist";
@@ -65,6 +66,7 @@ export function KeywordHistory() {
 
   return (
     <div className="w-full">
+      <RegretReceiptPanel items={seenItems} />
       <PerformanceProofPanel items={seenItems} />
       <MyDiscoveryPreview items={watchlist} onOpen={setStockSel} />
 

--- a/apps/fomo-web/components/RegretReceiptPanel.tsx
+++ b/apps/fomo-web/components/RegretReceiptPanel.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { fetchDiscoveryPerformancePrices, type DiscoveryPerformancePrice } from "@/lib/fomoApi";
+import { daysSince, formatReturnPct, type DiscoverySeenItem } from "@/lib/discoveryPerformance";
+
+/**
+ * R1 후회 영수증 — "넘긴 카드"(2026-07-12 User Zero 성장 로드맵 R1).
+ *
+ * 내가 X로 넘긴 카드에 실제 성과를 붙여 손실회피를 "판단 규율"로 전환한다.
+ * 정직 규약: 오른 카드는 "그 후 +N%"(놓친 상승), 내린 카드는 "넘기길 잘함 −N%"(옳은 판단) —
+ * 양쪽을 똑같이 보여준다. 소급 조작 없음(넘긴 시점 발견가 vs 현재 실시세).
+ * 윤리 가드(AGENTS.md): 공포·카운트다운·매매 재촉 금지. 프레임 = "다음 판단을 위한 복기".
+ */
+
+const GAIN = "#D8FF3A"; // 놓친 상승(중립적 하이라이트)
+const AVOID = "#8FA0A3"; // 넘기길 잘함(차분한 톤)
+const WEEK_MS = 7 * 86_400_000;
+
+interface SkipRow {
+  item: DiscoverySeenItem;
+  returnPct?: number;
+}
+
+function asPrice(value: number, country?: string): string {
+  if (country === "KR") return `${Math.round(value).toLocaleString("ko-KR")}원`;
+  return `$${value.toLocaleString("en-US", { maximumFractionDigits: value >= 100 ? 2 : 3 })}`;
+}
+
+export function RegretReceiptPanel({ items }: { items: readonly DiscoverySeenItem[] }) {
+  const [prices, setPrices] = useState<Record<string, DiscoveryPerformancePrice>>({});
+  const [loading, setLoading] = useState(false);
+
+  const skipped = useMemo(
+    () =>
+      items
+        .filter((item) => item.action === "skip" && typeof item.firstSeenPrice === "number")
+        .sort((a, b) => (b.actionAt ?? b.firstSeenAt) - (a.actionAt ?? a.firstSeenAt))
+        .slice(0, 40),
+    [items]
+  );
+
+  useEffect(() => {
+    if (skipped.length === 0) return;
+    let cancelled = false;
+    setLoading(true);
+    fetchDiscoveryPerformancePrices(skipped)
+      .then((res) => {
+        if (!cancelled) setPrices(res.prices);
+      })
+      .catch((err) => {
+        if (process.env.NODE_ENV !== "production") console.warn("[RegretReceiptPanel] price fetch failed", err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skipped]);
+
+  const rows: SkipRow[] = useMemo(
+    () =>
+      skipped.map((item) => {
+        const current = prices[item.stock];
+        const start = item.firstSeenPrice;
+        const returnPct =
+          typeof start === "number" && start > 0 && typeof current?.currentPrice === "number"
+            ? ((current.currentPrice - start) / start) * 100
+            : undefined;
+        return { item, ...(typeof returnPct === "number" ? { returnPct } : {}) };
+      }),
+    [skipped, prices]
+  );
+
+  // 주간 요약: 최근 7일 넘긴 카드(성과 확인분).
+  const weekly = useMemo(() => {
+    const now = Date.now();
+    const inWeek = rows.filter(
+      (r) => typeof r.returnPct === "number" && now - (r.item.actionAt ?? r.item.firstSeenAt) <= WEEK_MS
+    );
+    if (inWeek.length === 0) return null;
+    const returns = inWeek.map((r) => r.returnPct as number);
+    const avg = returns.reduce((sum, v) => sum + v, 0) / returns.length;
+    const top = inWeek.reduce((best, r) => ((r.returnPct as number) > (best.returnPct as number) ? r : best), inWeek[0]!);
+    return { count: inWeek.length, avg, top };
+  }, [rows]);
+
+  if (skipped.length === 0) return null;
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-center justify-between px-1">
+        <p className="text-xs text-muted">넘긴 카드 복기</p>
+        <span className="text-[10px] font-medium text-muted">
+          {rows.filter((r) => typeof r.returnPct === "number").length}/{skipped.length}
+        </span>
+      </div>
+
+      {weekly && (
+        <div className="mb-3 rounded-2xl border border-hairline bg-surface-raised px-4 py-4">
+          <p className="text-sm leading-6 text-whiteout">
+            이번 주 넘긴 <span className="font-bold">{weekly.count}장</span> 평균{" "}
+            <span className="font-bold" style={{ color: weekly.avg >= 0 ? GAIN : AVOID }}>
+              {formatReturnPct(weekly.avg)}
+            </span>
+            {typeof weekly.top.returnPct === "number" && weekly.top.returnPct > 0 && (
+              <>
+                {" · "}가장 아까운 <span className="font-semibold">{weekly.top.item.stock}</span>{" "}
+                <span className="font-bold" style={{ color: GAIN }}>
+                  {formatReturnPct(weekly.top.returnPct)}
+                </span>
+              </>
+            )}
+          </p>
+          <p className="mt-2 text-[11px] leading-5 text-muted">
+            넘긴 시점 가격과 현재가를 비교한 복기예요. 다음 카드를 조금 더 진지하게 보기 위한 기록입니다.
+          </p>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2.5">
+        {rows.slice(0, 12).map((row) => {
+          const pct = row.returnPct;
+          const up = typeof pct === "number" && pct > 0;
+          const days = daysSince(row.item.actionAt ?? row.item.firstSeenAt);
+          const badge =
+            typeof pct !== "number"
+              ? loading
+                ? "확인 중"
+                : "현재가 없음"
+              : up
+              ? `그 후 ${formatReturnPct(pct)}`
+              : `넘기길 잘함 ${formatReturnPct(pct)}`;
+          return (
+            <article
+              key={`${row.item.stock}-${row.item.actionAt ?? row.item.firstSeenAt}`}
+              className="rounded-xl border border-hairline bg-surface px-4 py-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="min-w-0 truncate text-base font-semibold text-whiteout">{row.item.stock}</span>
+                    {row.item.sector && <span className="shrink-0 text-[11px] text-muted"># {row.item.sector}</span>}
+                  </div>
+                  <p className="mt-1 text-xs text-muted">
+                    {days === 0 ? "오늘 넘김" : `${days}일 전 넘김`}
+                    {typeof row.item.firstSeenPrice === "number" && (
+                      <span> · 넘긴 가격 {row.item.firstSeenPriceText ?? asPrice(row.item.firstSeenPrice, row.item.country)}</span>
+                    )}
+                  </p>
+                </div>
+                <span
+                  className="shrink-0 rounded-full border border-hairline-soft px-2.5 py-1 text-sm font-bold tabular-nums"
+                  style={{ color: typeof pct === "number" ? (up ? GAIN : AVOID) : "#A3A3A0" }}
+                >
+                  {badge}
+                </span>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -18,7 +18,7 @@ import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
 import { SectorCard } from "@/components/SectorCard";
 import { fetchStockFront, recordTaste } from "@/lib/fomoApi";
 import type { FeedSignalPoint, StockFrontResponse } from "@/lib/fomoApi";
-import { recordDiscoverySeen } from "@/lib/discoveryPerformance";
+import { recordDiscoverySeen, markDiscoverySeenAction } from "@/lib/discoveryPerformance";
 import { recordStockInterest } from "@/lib/stockInterest";
 import { upsertWatch } from "@/lib/watchlist";
 import type { DeckNarrative, DeckStock } from "@/lib/discoveryDeck";
@@ -743,6 +743,8 @@ export function StockSwipeDeck({
       }
       const stock = card.data;
       setUndoEntry({ idx, dir, card });
+      // R1 후회 영수증: 스와이프 결과 기록(넘긴 카드 성과 복기용). 발견가는 recordDiscoverySeen 이 캡처.
+      markDiscoverySeenAction(stock.canonical, dir === "right" ? "save" : "skip");
       if (dir === "right") saveDiscovery(stock);
       recordDiscoveryEvent("swipe", { direction: dir, hydrated: !!front[stock.canonical] });
       recordStockInterest(stock.canonical, dir === "right" ? "more" : "less", Date.now());

--- a/apps/fomo-web/lib/discoveryDeck.ts
+++ b/apps/fomo-web/lib/discoveryDeck.ts
@@ -82,7 +82,7 @@ export interface DeckThemeBundle {
   items: DeckThemeBundleItem[];
 }
 
-export type DeckContentType = "macro" | "index" | "whale" | "briefing" | "buzz" | "recap" | "macro-issue" | "coin-issue" | "hot-issue" | "term" | "event";
+export type DeckContentType = "macro" | "index" | "whale" | "briefing" | "buzz" | "recap" | "macro-issue" | "coin-issue" | "hot-issue" | "term" | "event" | "daily-receipt";
 export type DeckContentScope = "domestic" | "world" | "global";
 
 export interface DeckContentFact {

--- a/apps/fomo-web/lib/discoveryPerformance.ts
+++ b/apps/fomo-web/lib/discoveryPerformance.ts
@@ -21,6 +21,9 @@ export interface DiscoverySeenItem {
   country?: StockCountry;
   sector?: string;
   reason?: string;
+  /** R1 후회 영수증(2026-07-12): 스와이프 결과. undefined=봤다만, skip=넘김(X), save=담음(★). */
+  action?: "skip" | "save";
+  actionAt?: number;
 }
 
 export interface DiscoverySeenInput {
@@ -71,6 +74,8 @@ function read(): DiscoverySeenItem[] {
           ...(typeof candidate.country === "string" ? { country: candidate.country as StockCountry } : {}),
           ...(typeof candidate.sector === "string" ? { sector: candidate.sector } : {}),
           ...(typeof candidate.reason === "string" ? { reason: candidate.reason } : {}),
+          ...(candidate.action === "skip" || candidate.action === "save" ? { action: candidate.action } : {}),
+          ...(typeof candidate.actionAt === "number" ? { actionAt: candidate.actionAt } : {}),
         };
       })
       .filter((row): row is DiscoverySeenItem => row !== null);
@@ -140,6 +145,30 @@ export function recordDiscoverySeen(
     return;
   }
   write([next, ...items]);
+}
+
+/**
+ * R1 후회 영수증: 카드의 스와이프 결과를 기록한다(발견가는 recordDiscoverySeen 이 이미 캡처).
+ * view → skip/save 는 확정이므로 항상 갱신. 대상이 없으면(관측 누락) 최소 항목 생성.
+ */
+export function markDiscoverySeenAction(stockName: string, action: "skip" | "save", nowMs = Date.now()): void {
+  if (typeof window === "undefined" || !stockName) return;
+  const items = read();
+  const index = items.findIndex((item) => item.stock === stockName);
+  if (index >= 0) {
+    items[index] = { ...items[index]!, action, actionAt: nowMs };
+    write(items);
+  } else {
+    write([{ stock: stockName, firstSeenAt: nowMs, action, actionAt: nowMs }, ...items]);
+  }
+  if (typeof window !== "undefined") window.dispatchEvent(new Event(DISCOVERY_PERFORMANCE_UPDATED_EVENT));
+}
+
+/** 넘긴(X) 카드만 — 발견가가 있는 것만(성과 계산 가능). 최신순. */
+export function getSkippedSeen(): DiscoverySeenItem[] {
+  return read()
+    .filter((item) => item.action === "skip" && typeof item.firstSeenPrice === "number")
+    .sort((a, b) => (b.actionAt ?? b.firstSeenAt) - (a.actionAt ?? a.firstSeenAt));
 }
 
 export function daysSince(ts: number, nowMs = Date.now()): number {

--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -23,6 +23,7 @@ describe("feed-hub 타입 레지스트리", () => {
       "hot-issue",
       "term",
       "event",
+      "daily-receipt",
     ];
     for (const type of REQUIRED_TYPES) {
       expect(FEED_ITEM_TYPES, `타입 "${type}" 이 레지스트리에서 사라졌다 — 명시 지시 없는 타입 제거는 금지`).toContain(type);

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -2,6 +2,7 @@ import { unstable_cache } from "next/cache";
 import { isDiscoveryCopySafe } from "@fomo/core";
 import type { CardFrontSignals, StockCountry } from "@fomo/core";
 import { cacheVersion, kstDate as kstDateOf } from "./fomo";
+import { parsePriceText } from "./quote-prices";
 import {
   buildDiscoveryResponse,
   type DiscoveryDeckCardPayload,
@@ -256,6 +257,7 @@ const CONTENT_SIGNAL_SCORE: Record<DeckContentCard["contentType"], number> = {
   "hot-issue": 58,
   term: 20,
   event: 46,
+  "daily-receipt": 66, // 후회 영수증 = 데일리 습관 훅(브리핑 다음). 덱 합류 없음(피드 전용)
 };
 const PINNED_SCORE_BONUS = 30;
 
@@ -427,7 +429,9 @@ function responseFromSelected(
 
 interface Daily30PicksSnapshot {
   date: string;
-  picks: Array<{ canonical: string; headline?: string }>;
+  // R1 후회 영수증(2026-07-12): 발견가·식별자 추가 — 다음날 "어제의 영수증"이 발견가 대비 성과를
+  // 계산한다(전향적, 소급 조작 없음). 구버전 스냅샷(price 없음)은 영수증에서 자연 제외.
+  picks: Array<{ canonical: string; headline?: string; price?: number; symbol?: string; naverCode?: string; market?: string; country?: string }>;
 }
 
 /** 어제(가장 최근, 오늘 제외) 30장 스냅샷 — 신선도 로테이션 기준. 없으면 빈 맵(첫날). */
@@ -491,7 +495,19 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
     date: today,
     picks: deck
       .filter((c) => c.stock)
-      .map((c) => ({ canonical: c.stock!.canonical, ...(c.stock!.headline ? { headline: c.stock!.headline } : {}) })),
+      .map((c) => {
+        const stock = c.stock!;
+        const price = parsePriceText(c.front?.priceText);
+        return {
+          canonical: stock.canonical,
+          ...(stock.headline ? { headline: stock.headline } : {}),
+          ...(typeof price === "number" ? { price } : {}),
+          ...(stock.symbol ? { symbol: stock.symbol } : {}),
+          ...(stock.naverCode ? { naverCode: stock.naverCode } : {}),
+          ...(stock.market ? { market: stock.market } : {}),
+          ...(stock.country ? { country: stock.country } : {}),
+        };
+      }),
   };
   await writeFeedContent(`daily30-picks:${today}`, picks).catch(() => {});
   // 중복률(어제 대비) — 수용 지표(≤50%) 모니터링용.

--- a/apps/web/lib/deck-content.ts
+++ b/apps/web/lib/deck-content.ts
@@ -21,7 +21,8 @@ export type DeckContentType =
   | "coin-issue"
   | "hot-issue"
   | "term"
-  | "event";
+  | "event"
+  | "daily-receipt"; // R1 후회 영수증(2026-07-12)
 
 export interface DeckContentFact {
   label: string;
@@ -329,6 +330,8 @@ function contentTypePriority(type: DeckContentType): number {
       return 4;
     case "term":
       return 5;
+    case "daily-receipt":
+      return -2; // 후회 영수증 = 데일리 습관 훅, 상단 근처(브리핑 다음)
   }
 }
 

--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -11,6 +11,7 @@ import { readTodayFulfilledSearches } from "./symbol-index";
 import { kstDate } from "./fomo";
 import { buildCoinIssueCards, buildEventCard, buildHotIssueCards, buildTermCard } from "./feed-extras";
 import { hydrateKoreanTitles } from "./content-i18n";
+import { buildDailyReceiptCard } from "./feed-receipt";
 import type { DiscoveryMarketRow } from "./market-source-types";
 
 /**
@@ -36,6 +37,7 @@ export const FEED_ITEM_TYPES = [
   "hot-issue", // 미장·국장 뉴스 핫이슈(다수 소스 겹침 사건) — 2026-07-11 베리에이션
   "term", // 오늘의 경제용어(정적 사전 로테이션) — 2026-07-11 베리에이션
   "event", // 시장 일정(만기·FOMC D-day) — 2026-07-11 베리에이션
+  "daily-receipt", // 어제의 영수증(어제 30장 성과) — 2026-07-12 R1 후회 영수증
 ] as const;
 export type FeedItemType = (typeof FEED_ITEM_TYPES)[number];
 
@@ -74,7 +76,7 @@ export interface FeedStockIssue {
 
 export type FeedHubItem =
   | {
-      type: "briefing" | "buzz" | "recap" | "index" | "macro" | "whale" | "macro-issue" | "coin-issue" | "hot-issue" | "term" | "event";
+      type: "briefing" | "buzz" | "recap" | "index" | "macro" | "whale" | "macro-issue" | "coin-issue" | "hot-issue" | "term" | "event" | "daily-receipt";
       scope: "KR" | "US" | "GLOBAL";
       content: DeckContentCard & { series?: number[] };
     }
@@ -280,6 +282,7 @@ const TYPE_PRIORITY: Record<FeedItemType, number> = {
   macro: 11,
   whale: 12,
   term: 13,
+  "daily-receipt": 3, // 데일리 습관 훅 — 상단 근처(hot-issue 인접)
 };
 
 // 2026-07-11 타입별 상한(User Zero: "매번 지수 얘기뿐") — 지수·거시가 팩트 분할로
@@ -393,6 +396,9 @@ export async function buildFeedHubResponse(): Promise<FeedHubResponse> {
   for (const card of hotIssues) push({ type: "hot-issue", scope: card.scope === "domestic" ? "KR" : "US", content: card }, card.id);
   for (const card of buildTermCard()) push({ type: "term", scope: "GLOBAL", content: card }, card.id);
   for (const card of buildEventCard()) push({ type: "event", scope: "GLOBAL", content: card }, card.id);
+  for (const card of await buildDailyReceiptCard().catch((): DeckContentCard[] => [])) {
+    push({ type: "daily-receipt", scope: "GLOBAL", content: card }, card.id);
+  }
   // 6) 검색 알림 신청 처리분(WO 검색 ④) — "요청하신 종목 카드가 준비됐어요". 재방문 노출(무로그인).
   const fulfilled = await readTodayFulfilledSearches().catch(() => []);
   const rowByName = new Map([...krRows, ...usRows].map((row) => [row.canonical, row]));

--- a/apps/web/lib/feed-receipt.ts
+++ b/apps/web/lib/feed-receipt.ts
@@ -1,0 +1,100 @@
+/**
+ * R1 후회 영수증 — "어제의 영수증"(2026-07-12 User Zero 성장 로드맵 R1).
+ *
+ * 어제 30장 중 오늘 ±10% 이상 움직인 카드를 하이라이트 — "봤나요?". 손실회피를 판단 규율로:
+ * 놓친 상승을 실데이터로 보여줘 다음 카드를 진지하게 보게 한다.
+ *
+ * 윤리 가드(AGENTS.md + R1 지시서): 실계산만(소급 조작 0 — 어제 스냅샷의 발견가 vs 오늘 실시세),
+ * 공포·카운트다운·매매 재촉 문구 금지. 프레임은 "다음 판단을 위한 복기". LLM 없음(결정론).
+ *
+ * 개인화된 "넘긴 카드"(유저별 스와이프 성과)는 클라이언트 localStorage 기반(apps/fomo-web) —
+ * 서버는 유저 스와이프를 모르므로, 공유 자산인 "어제 30장"만 서버 피드 카드로 만든다.
+ */
+
+import type { DeckContentCard, DeckContentFact } from "./deck-content";
+import { readFeedContentByPrefix } from "./feed-content-store";
+import { fetchCurrentPrices, type QuoteRequestItem } from "./quote-prices";
+import { kstDate } from "./fomo";
+
+interface PickSnapshot {
+  canonical: string;
+  headline?: string;
+  price?: number;
+  symbol?: string;
+  naverCode?: string;
+  market?: string;
+  country?: string;
+}
+interface Daily30PicksSnapshot {
+  date: string;
+  picks: PickSnapshot[];
+}
+
+const RECEIPT_MOVE_THRESHOLD_PCT = 10; // ±10% 이상만 하이라이트(R1 지시서)
+const RECEIPT_MAX_FACTS = 5;
+
+function signedPct(value: number): string {
+  return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
+}
+
+/**
+ * "어제의 영수증" 피드 카드 1장. 어제 스냅샷(발견가 포함)이 없거나 ±10% 무버가 없으면 [](노출 안 함).
+ * 전향적 데이터 규약: 발견가는 어제 스냅샷에 저장된 값만 — 스냅샷에 price 없던 구버전 픽스는 자연 제외.
+ */
+export async function buildDailyReceiptCard(): Promise<DeckContentCard[]> {
+  const today = kstDate();
+  const rows = await readFeedContentByPrefix<Daily30PicksSnapshot>("daily30-picks:", 3).catch(
+    () => [] as Array<{ id: string; row: Daily30PicksSnapshot }>
+  );
+  const yesterday = rows.map((r) => r.row).find((row) => row?.date && row.date !== today);
+  const priced = (yesterday?.picks ?? []).filter(
+    (p): p is PickSnapshot & { price: number } => typeof p.price === "number" && p.price > 0
+  );
+  if (priced.length === 0) return [];
+
+  const items: QuoteRequestItem[] = priced.map((p) => ({
+    key: p.canonical,
+    stock: p.canonical,
+    ...(p.symbol ? { symbol: p.symbol } : {}),
+    ...(p.naverCode ? { naverCode: p.naverCode } : {}),
+    ...(p.market ? { market: p.market } : {}),
+    ...(p.country ? { country: p.country } : {}),
+  }));
+  const current = await fetchCurrentPrices(items).catch(() => new Map<string, number>());
+
+  const moves = priced
+    .map((p) => {
+      const now = current.get(p.canonical);
+      if (typeof now !== "number" || now <= 0) return null;
+      return { canonical: p.canonical, returnPct: ((now - p.price) / p.price) * 100 };
+    })
+    .filter((m): m is { canonical: string; returnPct: number } => m !== null)
+    .filter((m) => Math.abs(m.returnPct) >= RECEIPT_MOVE_THRESHOLD_PCT)
+    .sort((a, b) => b.returnPct - a.returnPct); // 상승 큰 순(FOMO 프레임) → 하락 순
+
+  if (moves.length === 0) return [];
+
+  const gainers = moves.filter((m) => m.returnPct > 0).length;
+  const facts: DeckContentFact[] = moves.slice(0, RECEIPT_MAX_FACTS).map((m) => ({
+    label: m.canonical,
+    value: signedPct(m.returnPct),
+  }));
+  const headline =
+    gainers > 0
+      ? `어제 30장 중 오늘 +10% 넘은 카드 ${gainers}장 — 봤나요?`
+      : `어제 30장 중 오늘 10% 이상 움직인 카드 ${moves.length}장`;
+
+  return [
+    {
+      kind: "content",
+      id: `content:daily-receipt:${today}`,
+      contentType: "daily-receipt",
+      scope: "global",
+      headline,
+      facts,
+      note: "어제 발견 시점 가격 대비 오늘 실시세입니다. 다음 카드를 위한 복기예요.",
+      source: "FOMO 발견 기록",
+      asOf: today,
+    },
+  ];
+}

--- a/apps/web/lib/quote-prices.ts
+++ b/apps/web/lib/quote-prices.ts
@@ -1,0 +1,109 @@
+/**
+ * 서버 현재가 페처 (2026-07-12 R1 후회 영수증) — Yahoo(KR/US) + Upbit(코인).
+ * performance-prices 라우트의 Yahoo 로직을 재사용 가능한 형태로 추출. 코인은 캐시 스냅샷 가격.
+ * 어제의 영수증 등 서버 콘텐츠가 "발견가 대비 지금" 성과를 계산할 때 쓴다. 소급 조작 없음(실시세만).
+ */
+
+import type { StockCountry, StockMarket } from "@fomo/core";
+import { readCoinMarketSnapshots } from "./coin-market-source";
+
+const YAHOO_HOSTS = ["https://query1.finance.yahoo.com", "https://query2.finance.yahoo.com"];
+const YAHOO_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+export interface QuoteRequestItem {
+  key: string; // 결과 맵 키 (canonical 등)
+  stock: string;
+  symbol?: string;
+  naverCode?: string;
+  market?: StockMarket | string;
+  country?: StockCountry | string;
+}
+
+function yahooSymbolFor(item: QuoteRequestItem): string | null {
+  const rawSymbol = item.symbol?.trim().toUpperCase();
+  if (item.country === "US" || item.market === "NASDAQ" || item.market === "NYSE") {
+    return rawSymbol || item.stock.trim().toUpperCase().replace(/[^A-Z0-9.-]/g, "");
+  }
+  const code = item.naverCode?.trim() || (/^\d{6}$/.test(rawSymbol ?? "") ? rawSymbol : "");
+  if (code && item.market === "KOSDAQ") return `${code}.KQ`;
+  if (code && item.market === "KOSPI") return `${code}.KS`;
+  return null;
+}
+
+async function fetchYahooPrice(yahooSymbol: string): Promise<number | null> {
+  for (const host of YAHOO_HOSTS) {
+    try {
+      const url = `${host}/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?range=5d&interval=1d`;
+      const res = await fetch(url, {
+        headers: { accept: "application/json", "user-agent": YAHOO_UA },
+        signal: AbortSignal.timeout(7_000),
+        next: { revalidate: 600 },
+      });
+      if (!res.ok) continue;
+      const payload = (await res.json()) as {
+        chart?: { result?: { meta?: { regularMarketPrice?: number }; indicators?: { quote?: { close?: (number | null)[] }[] } }[] };
+      };
+      const result = payload.chart?.result?.[0];
+      const closes = result?.indicators?.quote?.[0]?.close?.filter(
+        (v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0
+      );
+      const price =
+        typeof result?.meta?.regularMarketPrice === "number" && result.meta.regularMarketPrice > 0
+          ? result.meta.regularMarketPrice
+          : closes?.at(-1);
+      if (typeof price === "number" && Number.isFinite(price) && price > 0) return price;
+    } catch {
+      // 다음 호스트 시도.
+    }
+  }
+  return null;
+}
+
+function isCoin(item: QuoteRequestItem): boolean {
+  return item.market === "COIN" || item.country === "GLOBAL";
+}
+
+async function mapLimit<T, R>(items: readonly T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    out.push(...(await Promise.all(items.slice(i, i + limit).map(worker))));
+  }
+  return out;
+}
+
+/**
+ * key → 현재가 맵. Yahoo(KR/US) + Upbit 캐시(코인). 실패분은 맵에서 빠진다(폴백 없음, 정직).
+ */
+export async function fetchCurrentPrices(items: readonly QuoteRequestItem[]): Promise<Map<string, number>> {
+  const prices = new Map<string, number>();
+  const coinItems = items.filter(isCoin);
+  const stockItems = items.filter((item) => !isCoin(item));
+
+  if (coinItems.length > 0) {
+    const snapshots = await readCoinMarketSnapshots().catch(() => []);
+    const byName = new Map(snapshots.map((s) => [s.koreanName, s.price] as const));
+    const bySymbol = new Map(snapshots.map((s) => [s.symbol.toUpperCase(), s.price] as const));
+    for (const item of coinItems) {
+      const price = byName.get(item.stock) ?? (item.symbol ? bySymbol.get(item.symbol.toUpperCase()) : undefined);
+      if (typeof price === "number" && price > 0) prices.set(item.key, price);
+    }
+  }
+
+  const jobs = stockItems
+    .map((item) => ({ item, yahooSymbol: yahooSymbolFor(item) }))
+    .filter((job): job is { item: QuoteRequestItem; yahooSymbol: string } => !!job.yahooSymbol);
+  await mapLimit(jobs, 5, async ({ item, yahooSymbol }) => {
+    const price = await fetchYahooPrice(yahooSymbol);
+    if (typeof price === "number" && price > 0) prices.set(item.key, price);
+  });
+  return prices;
+}
+
+export function parsePriceText(text: string | undefined): number | null {
+  if (!text) return null;
+  const raw = text.replace(/,/g, "").match(/-?\d+(?:\.\d+)?/u)?.[0];
+  if (!raw) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}


### PR DESCRIPTION
손실회피를 판단 규율로 전환. 유저 행동(봤다/넘겼다/담았다)에 실제 성과를 붙인다.

서버 — 어제의 영수증(공유 자산):
- quote-prices.ts: 재사용 현재가 페처(Yahoo KR/US + Upbit 코인)
- feed-receipt.ts: 어제 daily-30 스냅샷(발견가) vs 오늘 실시세, ±10% 무버 하이라이트
- daily-30 picks 스냅샷에 price/식별자 캡처, daily-receipt 콘텐츠 타입 등록(피드 상단 1장)

클라이언트 — 넘긴 카드(개인 스와이프 성과):
- discoveryPerformance: action(skip/save) 기록 + getSkippedSeen
- StockSwipeDeck: 좌/우 스와이프 시 markDiscoverySeenAction
- RegretReceiptPanel: 오른 카드 "그 후 +N%" / 내린 카드 "넘기길 잘함 −N%" 양쪽 정직 표기,
  주간 후회 요약(넘긴 N장 평균 +X% · 가장 아까운 종목)

윤리 가드: 소급 조작 금지(넘긴 시점 가격만), 공포·카운트다운·매매 재촉 금지.
프레임 = "다음 판단을 위한 복기". LLM 없음(결정론).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
