### PR TITLE
feat(depth): WO-22 Phase 0 — 뎁스 정보 우위 복원 (양면·출처·서술화·US 한글화)

### DIFF
--- a/apps/fomo-web/__tests__/depthCopy.test.ts
+++ b/apps/fomo-web/__tests__/depthCopy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { describe52wGap, describeRsi } from "../lib/depthCopy";
+
+// WO-22: "RSI 39" 숫자 단독 나열 금지 — 항상 의미 병기, 판단·매매 지시 금칙어 없음.
+describe("depthCopy 서술화", () => {
+  it("RSI 밴드별 의미가 붙는다", () => {
+    expect(describeRsi(75)).toContain("과열");
+    expect(describeRsi(62)).toContain("탄력");
+    expect(describeRsi(50)).toContain("중립");
+    expect(describeRsi(39)).toContain("눌린");
+    expect(describeRsi(22)).toContain("과매도");
+  });
+
+  it("실수치가 보존된다(가짜 숫자 금지)", () => {
+    expect(describeRsi(39)).toContain("RSI 39");
+    expect(describe52wGap(26.1)).toContain("-26.1%");
+  });
+
+  it("52주 갭 밴드별 의미", () => {
+    expect(describe52wGap(0.3)).toContain("고점권");
+    expect(describe52wGap(7)).toContain("쉬는 자리");
+    expect(describe52wGap(26.1)).toContain("조정");
+    expect(describe52wGap(45)).toContain("깊게");
+  });
+
+  it("판단·매매 지시 금칙어 없음", () => {
+    const all = [describeRsi(75), describeRsi(39), describe52wGap(26.1), describe52wGap(0.3)].join(" ");
+    // "과매도"(지표 용어)는 허용 — 매매 지시형 표현만 금지.
+    expect(all).not.toMatch(/사세요|파세요|매수하|매도하|담아|목표가|반등|급등 예상|기회/);
+  });
+});

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -26,6 +26,7 @@ import {
   type StockFrontResponse,
 } from "@/lib/fomoApi";
 import { isWatched, toggleWatch } from "@/lib/watchlist";
+import { describe52wGap, describeRsi } from "@/lib/depthCopy";
 import { FlickerSpinner } from "@/components/FlickerSpinner";
 
 /**
@@ -1770,15 +1771,15 @@ function buildVerdictSections(
     pushEvidence(evidence, `기관 ${Math.abs(instStreak)}일 연속 ${instStreak > 0 ? "순매수" : "순매도"}`);
   }
 
-  // 4) TA 실수치 — 있는 지표만(가짜 금지).
+  // 4) TA 실수치 — 있는 지표만(가짜 금지) + 의미 병기(WO-22: "RSI 39" 단독 나열 금지).
   const latest = front?.ta?.latest;
-  if (typeof latest?.rsi14 === "number") pushEvidence(evidence, `RSI ${Math.round(latest.rsi14)}`);
+  if (typeof latest?.rsi14 === "number") pushEvidence(evidence, describeRsi(latest.rsi14));
   if (typeof latest?.closeTo52WeekHighPct === "number") {
     const gap = Math.round((100 - latest.closeTo52WeekHighPct) * 10) / 10;
-    pushEvidence(evidence, gap <= 0.5 ? "52주 고점권" : `52주 고점 대비 -${gap}%`);
+    pushEvidence(evidence, describe52wGap(gap));
   }
   if (typeof front?.signals.volumeRatio === "number" && front.signals.volumeRatio >= 1.2) {
-    pushEvidence(evidence, `거래량 20일 평균의 ${front.signals.volumeRatio.toFixed(1)}배`);
+    pushEvidence(evidence, `거래량이 20일 평균의 ${front.signals.volumeRatio.toFixed(1)}배 — 평소보다 눈에 띄게 붙은 상태`);
   }
   const taText = front?.taFact ? translateTaFact(front.taFact) : undefined;
   if (taText) pushEvidence(evidence, taText);
@@ -1858,6 +1859,103 @@ function ConvictionParagraphs({
           <p className="font-pixel text-sm text-whiteout">무효 조건</p>
           <p className="mt-2 text-sm leading-6 text-whiteout">{s.invalidation}</p>
         </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * 무슨 일이 있었나(WO-22) — 크론 LLM 인사이트의 전체 재료를 뎁스에 복원.
+ * whyHot 전문 + 강세/약세 양면(원문 보기 링크) + 공식 지표 + 출처 정직 표기.
+ * PRODUCT_VISION §6: 사실·출처·시점·양면. 데이터 없으면 통째로 생략(보일러플레이트 금지).
+ */
+function StockWhyHappened({ insight }: { insight: CondensedInsight | null }) {
+  if (!insight) return null;
+  // 공식 지표(수급 마감 확정 등)는 LLM 코퍼스와 무관한 객관 사실 — 원문이 얇아도(insufficient) 보여준다.
+  const insufficient = insight.confidence === "insufficient";
+  const officialFacts = insight.officialFacts ?? [];
+  if (insufficient && officialFacts.length === 0) return null;
+  const hasSides = !insufficient && insight.bull.length + insight.bear.length > 0;
+  const why = insufficient ? "" : cleanText(insight.whyHot);
+  if (!why && !hasSides && officialFacts.length === 0) return null;
+
+  const srcOf = (id: string) => insight.sources.find((s) => s.id === id);
+  const kindLabel = (kind?: string) =>
+    kind === "official" ? "공식 데이터" : kind === "community" ? "커뮤니티" : kind === "news" ? "뉴스" : "";
+  const sideList = (title: string, tone: string, points: CondensedInsight["bull"], empty: string) => (
+    <div className="rounded-lg border border-hairline bg-black/20 px-3 py-3">
+      <p className="font-pixel text-xs" style={{ color: tone }}>
+        {title}
+      </p>
+      {points.length > 0 ? (
+        <ul className="mt-2 space-y-2">
+          {points.slice(0, 3).map((p, i) => {
+            const s = srcOf(p.sourceId);
+            const kl = kindLabel(s?.kind);
+            const label = `${s?.source ?? s?.title ?? ""}${kl ? ` · ${kl}` : ""}`;
+            return (
+              <li key={`${title}-${i}`}>
+                <span className="block text-sm leading-6 text-whiteout">{cleanText(p.claim)}</span>
+                {s &&
+                  (s.url ? (
+                    <a href={s.url} target="_blank" rel="noreferrer" className="mt-0.5 block text-[11px] text-muted hover:text-whiteout">
+                      ↳ {label} · 원문 보기 →
+                    </a>
+                  ) : (
+                    <span className="mt-0.5 block text-[11px] text-muted">↳ {label}</span>
+                  ))}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="mt-2 text-sm leading-6 text-muted">{empty}</p>
+      )}
+    </div>
+  );
+
+  return (
+    <section className="mt-4 rounded-2xl border border-hairline bg-surface px-4 py-4">
+      <p className="font-pixel text-sm text-whiteout">{why || hasSides ? "무슨 일이 있었나" : "확인된 공식 지표"}</p>
+      {why && <p className="mt-2 text-sm leading-6 text-whiteout">{why}</p>}
+
+      {hasSides && (
+        <div className="mt-3 grid gap-2">
+          {sideList("강세 쪽 근거", "var(--up, #ff5a5f)", insight.bull, "오늘 원문에서 강세 쪽으로 확인된 근거는 없어요.")}
+          {sideList("약세·주의 근거", "var(--down, #4f8cff)", insight.bear, "오늘 원문에서 약세 쪽으로 확인된 근거는 없어요.")}
+        </div>
+      )}
+
+      {officialFacts.length > 0 && (
+        <ul className="mt-3 space-y-2">
+          {officialFacts.slice(0, 3).map((f, i) => (
+            <li key={`swf-of-${i}`} className="rounded-lg border border-hairline bg-black/20 px-3 py-2">
+              <span className="block text-sm leading-5 text-whiteout">{cleanText(f.label)}</span>
+              {f.url ? (
+                <a href={f.url} target="_blank" rel="noreferrer" className="mt-1 block text-[11px] text-muted hover:text-whiteout">
+                  ↳ {f.source} · 공식 데이터 →
+                </a>
+              ) : (
+                <span className="mt-1 block text-[11px] text-muted">↳ {f.source} · 공식 데이터</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {insight.lean.bullCount + insight.lean.bearCount > 0 && (
+        <p className="mt-3 text-[11px] leading-5 text-muted">
+          오늘 쏠림 · <span style={{ color: "var(--up, #ff5a5f)" }}>강세 {insight.lean.bullCount}</span>
+          {" : "}
+          <span style={{ color: "var(--down, #4f8cff)" }}>약세 {insight.lean.bearCount}</span>
+          {insight.lean.oneSided ? " · 반대 관점 안 보임" : ""}
+        </p>
+      )}
+
+      {insight.singleOutlet && insight.outlets.length > 0 && (
+        <p className="mt-2 text-[11px] leading-5 text-muted">
+          오늘은 <span className="text-whiteout">{insight.outlets[0]}</span> 한 곳 기준이에요 — 한 매체 안의 시각일 수 있어요.
+        </p>
       )}
     </section>
   );
@@ -2062,6 +2160,9 @@ export function StockInsightView({
 
           {/* 뎁스 본문 — 판단/근거/무효 조건(WO 1.5). 카드 verdict 와 단일 진실, 부족 블록은 생략. */}
           <ConvictionParagraphs front={front} insight={insight} />
+
+          {/* 무슨 일이 있었나(WO-22) — 원문 인사이트 전체(양면·출처·공식지표). 카드 대비 뎁스의 정보 우위. */}
+          <StockWhyHappened insight={insight} />
 
           {/* 재무 한눈에(WO 1.5 F) — 근거 아래. KR=네이버·US=Yahoo, 없으면 생략. */}
           <FinanceGlanceBlock basics={basics} />

--- a/apps/fomo-web/lib/depthCopy.ts
+++ b/apps/fomo-web/lib/depthCopy.ts
@@ -1,0 +1,21 @@
+/**
+ * 뎁스 근거 서술화(WO-22) — "RSI 39" 식 숫자 단독 나열 금지.
+ * 밴드 의미를 결정론으로 병기한다. 지표 관례의 사실 서술만 — 판단·예측·매매 지시 아님.
+ */
+
+export function describeRsi(rsi: number): string {
+  const v = Math.round(rsi);
+  if (v >= 70) return `RSI ${v} — 단기 과열 영역(70 이상은 과열로 읽는 게 관례)`;
+  if (v >= 60) return `RSI ${v} — 상승 탄력이 붙은 구간`;
+  if (v >= 45) return `RSI ${v} — 중립 구간(과열도 과매도도 아님)`;
+  if (v >= 30) return `RSI ${v} — 눌린 편이지만 과매도까진 아님`;
+  return `RSI ${v} — 과매도 영역(30 미만, 많이 눌린 상태)`;
+}
+
+/** gap = 52주 고점 대비 하락률(%) 양수. */
+export function describe52wGap(gap: number): string {
+  if (gap <= 0.5) return "52주 고점권 — 1년 최고가 부근";
+  if (gap <= 10) return `52주 고점 대비 -${gap}% — 고점 부근에서 살짝 쉬는 자리`;
+  if (gap <= 30) return `52주 고점 대비 -${gap}% — 고점에서 조정이 진행된 자리`;
+  return `52주 고점 대비 -${gap}% — 고점 대비 깊게 내려온 자리`;
+}

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -13,7 +13,8 @@ import {
 import { processSearchQueue, rebuildSymbolIndex } from "../../../../../lib/symbol-index";
 import { translateAndStoreUsTitles } from "../../../../../lib/content-i18n";
 import { isAiConfigured } from "@fomo/shared";
-import { fetchAllNews } from "../../../../../lib/fomo-news-sources";
+import { fetchAllNews, fetchYahooStockNews } from "../../../../../lib/fomo-news-sources";
+import { readUsMarketQuoteRows } from "../../../../../lib/us-market-cache";
 
 /**
  * 피드 콘텐츠 프리웜 크론 (WO 피드 강화) — ?slot=morning|close|weekly
@@ -29,6 +30,35 @@ function isAuthorized(request: Request): boolean {
   const secret = process.env.CRON_SECRET?.trim();
   if (!secret) return true;
   return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+/**
+ * US 덱 재료 기사 수집(WO-22) — 무버 상위 심볼별 Yahoo RSS 제목을 번역 캐시에 적재해
+ * 발견 카드/뎁스 훅(koreanTitle)이 영어 원문으로 떨어지지 않게 한다. 실패는 [](fail-open).
+ */
+const US_DECK_I18N_SYMBOLS = 25;
+const US_DECK_I18N_PER_SYMBOL = 3;
+const US_DECK_I18N_CONCURRENCY = 6;
+
+async function fetchUsDeckArticles(): Promise<Array<{ url: string; title: string; lang?: string }>> {
+  const rows = await readUsMarketQuoteRows().catch(() => []);
+  const symbols = rows
+    .filter((row) => typeof row.changePct === "number")
+    .sort((a, b) => Math.abs(b.changePct!) - Math.abs(a.changePct!))
+    .slice(0, US_DECK_I18N_SYMBOLS)
+    .map((row) => row.symbol);
+  const out: Array<{ url: string; title: string; lang?: string }> = [];
+  let cursor = 0;
+  async function worker() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= symbols.length) return;
+      const articles = await fetchYahooStockNews(symbols[index]!, US_DECK_I18N_PER_SYMBOL).catch(() => []);
+      for (const a of articles) out.push({ url: a.url, title: a.title, lang: a.lang });
+    }
+  }
+  await Promise.all(Array.from({ length: US_DECK_I18N_CONCURRENCY }, () => worker()));
+  return out;
 }
 
 function isoWeekOf(date = new Date()): string {
@@ -70,12 +100,17 @@ export async function GET(request: Request) {
     if (slot === "morning") {
       await save(`briefing:us:${date}`, await buildUsBriefing());
       const news = await fetchAllNews().catch(() => []);
-      const translated = await translateAndStoreUsTitles(news).catch(() => 0);
-      written.push(`ai=${isAiConfigured()} enNews=${news.filter((a) => (a.lang ?? "en") === "en").length} translated=${translated}`);
+      const usDeck = await fetchUsDeckArticles().catch(() => []);
+      // 덱 훅 제목이 우선(가시 표면) — 번역 상한(MAX_TITLES_PER_RUN)에 걸려도 덱부터 채운다.
+      const translated = await translateAndStoreUsTitles([...usDeck, ...news]).catch(() => 0);
+      written.push(
+        `ai=${isAiConfigured()} enNews=${news.filter((a) => (a.lang ?? "en") === "en").length} usDeck=${usDeck.length} translated=${translated}`
+      );
     } else if (slot === "close") {
       await save(`briefing:kr:${date}`, await buildKrBriefing());
       await save(`buzz:${date}`, await buildBuzzStory());
-      const translated = await translateAndStoreUsTitles(await fetchAllNews().catch(() => [])).catch(() => 0);
+      const usDeck = await fetchUsDeckArticles().catch(() => []);
+      const translated = await translateAndStoreUsTitles([...usDeck, ...(await fetchAllNews().catch(() => []))]).catch(() => 0);
       if (translated > 0) written.push(`i18n:us-titles(${translated})`);
     } else if (slot === "pulse") {
       // 장중 급변 감지(WO-21 Phase 1) — 임계 미달·휴장·스테일이면 아무것도 쓰지 않는다(결정론·LLM 없음).

--- a/docs/WO-22_DEPTH_INFO_EDGE.md
+++ b/docs/WO-22_DEPTH_INFO_EDGE.md
@@ -1,0 +1,63 @@
+# WO-22: 뎁스 정보 우위 — "카드와 뎁스가 다를 게 없다" 해소 (2026-07-13)
+
+> BCG식 진단→처방. 정본: `docs/PRODUCT_VISION.md`(§6 뎁스 = 사실·출처·시점·양면) > `AGENTS.md` > `docs/DATA_ENGINE_STRATEGY.md`. WO-19(원문 제목 그대로 금지)·WO-20(why-first) 정합.
+
+## 0. Executive Summary
+
+유저 불만 3가지 — ① US 종목 훅이 영어 원문 그대로, ② 근거가 "RSI 39" 식 지표 나열(의미 없음), ③ 카드 대비 뎁스의 정보 우위 없음(결제/광고 걸 메리트 부재).
+
+**진단: 새 데이터가 필요한 게 아니라, 이미 만들어 놓은 데이터를 뎁스가 버리고 있다.**
+- `stock-insight`(크론 LLM)가 주는 `CondensedInsight`에는 **whyHot 2~3문장, 강세/약세 양면 근거(bull/bear)+원문 링크, 공식 지표(officialFacts), 출처 다양성 정직 표기, 숨은 연관주**가 전부 있는데 — `StockInsightView`는 **whyHot 첫 문장 하나만** 근거 리스트에 끼워 넣고 나머지를 폐기한다.
+- 양면 컴포넌트 `StockReadGuide`(강세/약세/관전 포인트)는 **정의만 있고 어디서도 렌더 안 되는 죽은 코드**.
+- verdict 엔진은 `insider` 입력을 지원하는데 `assembleStockFront`가 **한 번도 전달하지 않는다** — US 종목은 수급 신호가 0이라 거의 항상 "관망 + 신호 부족".
+- US 훅 영어 노출: 번역 캐시(`koreanTitle`)는 URL 키인데, ①심볼별 Yahoo RSS 기사가 번역 크론 코퍼스(`fetchAllNews`)에 안 들어가고 ②`newsEventLabel` 경로는 URL을 버려서 조회 자체가 불가.
+
+## 1. 이슈 트리 (MECE)
+
+```
+뎁스에 정보 우위가 없다
+├─ A. 이미 있는 인사이트를 안 보여줌 (P0 — 프론트만으로 해결)
+│   ├─ A1. whyHot 전문·bull/bear 양면·원문 링크·officialFacts 미렌더 (StockInsightView)
+│   └─ A2. 출처 정직 표기(singleOutlet·lean) 미렌더 — PRODUCT_VISION "양면" 위반 상태
+├─ B. 근거가 숫자 나열 (P0 — 서술화 사전)
+│   └─ "RSI 39" → 의미 밴드("과열 아님, 많이 눌린 자리") 없이 노출
+├─ C. US 콘텐츠 영어 (P0 — 번역 파이프 2개 구멍)
+│   ├─ C1. 심볼별 Yahoo 기사 번역 코퍼스 미포함 (훅/재료 제목)
+│   └─ C2. newsEventLabel 경로가 URL 폐기 → koreanTitle 조회 불가
+└─ D. 신호 자체의 얇음 (P1~ — 데이터 연결)
+    ├─ D1. insider 미연결 (verdict 지원하는데 전달 0 — US 신호 공백의 주범)
+    ├─ D2. DART/SEC 공시·증권사 리서치가 뎁스 섹션으로 없음 (LLM 코퍼스에만)
+    └─ D3. 숨은 연관주(relatedStocks) 뎁스 미노출
+```
+
+## 2. 처방 — 우선순위 (Impact × Effort)
+
+| WS | 내용 | Impact | Effort | Phase |
+| --- | --- | --- | --- | --- |
+| A | **뎁스 "원문 정리" 섹션 복원** — whyHot 전문 + 강세/약세 양면(원문 보기 링크) + 공식 지표 + 한곳출처 정직 표기 | 카드↔뎁스 차별화 즉시 | S(데이터 이미 도착) | **0** |
+| B | **근거 서술화** — RSI·52주 갭·거래량에 의미 밴드 문구(결정론 사전) | "뭐 어쩌라고" 해소 | S | **0** |
+| C | **US 한글화** — 번역 크론에 US 무버 심볼별 기사 포함 + newsEvent 경로 URL 보존→koreanTitle 적용 | 영어 노출 제거 | M | **0** |
+| D1 | insider → verdict 연결(KR DART·US SEC Form4, 크론 캐시 경유) — US "신호 부족" 해소 | 판단 품질 | M | **1** |
+| D2 | 공시·리서치 타임라인 섹션("무슨 일이 있었나" 확장) | 정보 밀도 | M | **1** |
+| D3 | 숨은 연관주 뎁스 노출(발굴 정체성 — "이걸 본 사람이 놓친 종목") | 차별화·BM | M | **2** |
+| E | 결제 훅 설계(뎁스 프리미엄 구획) — D1~D3 정보 우위 확보 후 | BM | L | **2** |
+
+비범위: 발견 표면 변경 금지, 예측/목표가/매수신호 금지(양면 사실까지만), 새 유료 API 도입 보류.
+
+## 3. Phase 0 구현
+
+| 파일 | 변경 |
+| --- | --- |
+| `apps/fomo-web/components/KeywordDepthPage.tsx` | StockInsightView why-탭에 "원문 정리" 섹션(whyHot 전문+bull/bear evidenceItem 링크+officialFacts+singleOutlet)·근거 서술화 사전 |
+| `apps/web/lib/content-i18n.ts` | (필요시) 번역 대상 수집 헬퍼 |
+| `apps/web/app/api/fomo/cron/feed-content/route.ts` | morning 슬롯: US 무버/덱 상위 심볼별 Yahoo 기사 제목 번역 코퍼스 추가 |
+| `apps/web/lib/stock-signal-coverage.ts` | newsEvent에 URL 보존 → 소비처에서 `koreanTitle(url)` 적용 |
+| `apps/web/lib/stock-front.ts` | axisHook/materialLabel에 한글 제목 우선 적용 |
+
+검증: vitest(신규: 서술화 사전·newsEvent URL 보존), typecheck, guard:discovery(stock-front 접촉), 배포 후 메타 뎁스 실측(영어 훅 소멸 + 원문 정리 섹션).
+
+KPI: ① 뎁스 전용 정보 블록 수 2개(판단/재무) → 4개+(양면·공식지표·출처) ② US 뎁스 영어 훅 노출 0 ③ 근거 문장 중 "숫자 단독" 0.
+
+## 4. 사건 맥락
+
+같은 날 WO-21(브리핑 신선도)과 함께 발생한 신뢰 이슈. 공통 교훈: **수집·생성은 돼 있는데 표면화가 끊긴 곳이 신뢰를 깎는다** — 파이프라인 끝단(렌더)까지 데이터가 흐르는지 정기 점검 필요(Phase 1에서 `pipeline-monitor` 에이전트 항목으로 추가 검토).


### PR DESCRIPTION
## 문제 (User Zero 2026-07-13)

① US 종목 훅이 영어 원문 그대로("Meta Expands AI Data Center…") ② 근거가 "RSI 39" 식 숫자 나열 ③ 카드 대비 뎁스의 정보 우위 없음 — 결제/광고 걸 메리트 부재.

## 진단 (docs/WO-22_DEPTH_INFO_EDGE.md — BCG식 이슈트리·우선순위·KPI)

**새 데이터가 필요한 게 아니라, 이미 만들어 놓은 데이터를 뎁스가 버리고 있었다.**
- `stock-insight`의 `CondensedInsight`에는 whyHot 2~3문장·강세/약세 양면 근거(+원문 링크)·공식 지표·출처 정직 표기가 전부 있는데, `StockInsightView`는 whyHot 첫 문장 하나만 쓰고 폐기
- 양면 컴포넌트 `StockReadGuide`는 정의만 있고 렌더 안 되는 죽은 코드(참고용 진단)
- US 훅 영어: 번역 캐시(`koreanTitle`)는 URL 키인데 심볼별 Yahoo 기사가 번역 크론 코퍼스에 미포함 → 조회 미스 → 영어 폴백

## 변경

- **"무슨 일이 있었나" 섹션 신설** (`KeywordDepthPage.tsx`): whyHot 전문 + 강세/약세 양면(원문 보기 링크, PRODUCT_VISION §6 "양면") + 공식 지표 + 한곳출처·쏠림 정직 표기. insufficient여도 공식 지표(수급 확정·FRED)는 렌더 — LLM 무관 객관 사실
- **근거 서술화** (`apps/fomo-web/lib/depthCopy.ts`): RSI·52주 갭 밴드 의미 병기 — "RSI 62 — 상승 탄력이 붙은 구간", "52주 고점 대비 -26.1% — 고점에서 조정이 진행된 자리" (결정론 사전, 판단·예측·매매 지시 없음)
- **US 한글화 구멍 봉합** (`cron/feed-content`): morning/close 슬롯에서 US 무버 상위 25심볼 × 3기사(Yahoo RSS)를 번역 코퍼스에 추가, 덱 훅 우선 순서(번역 상한 대비)

## 검증

- vitest **1100 passed** (신규: depthCopy 서술화·금칙어) · typecheck 0 · `guard:discovery` ✅ · fomo-web build ✅
- 로컬 프리뷰 실측: 근거에 "RSI 62 — 상승 탄력이 붙은 구간" 등 의미 병기 확인, "확인된 공식 지표" 섹션(FRED 3종+링크) 렌더 확인
- US 한글화는 머지 후 다음 morning/close 크론부터 적용(당일 확인: `gh workflow run feed-content.yml -f slot=close`)

## 후속 (Phase 1~2 — 계획서 §2)

insider→verdict 연결(US "신호 부족" 해소 주범), 공시·리서치 타임라인 섹션, 숨은 연관주 뎁스 노출, 그 위에 결제 훅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)