### PR TITLE
fix(feed): PREOPEN 발행 가드 — 장전 0.00% 브리핑 차단 + self-heal (WO-21 후속)

### DIFF
--- a/apps/web/__tests__/lib/feed-briefing.test.ts
+++ b/apps/web/__tests__/lib/feed-briefing.test.ts
@@ -83,3 +83,32 @@ describe("isStaleSession (거래일 가드)", () => {
     expect(safeInternals.isStaleSession("어제", "2026-07-13")).toBe(false);
   });
 });
+
+// 2026-07-14 실측 사각지대 — PREOPEN 에 네이버가 localTradedAt=오늘(현재시각)·등락률 0.00 껍데기를 준다.
+describe("krPublishBlockReason (발행 가드)", () => {
+  it("PREOPEN → 차단 (거래일이 오늘이어도)", () => {
+    const reason = safeInternals.krPublishBlockReason(
+      [{ label: "코스피", tradedAt: "2026-07-14", marketStatus: "PREOPEN" }],
+      "2026-07-14"
+    );
+    expect(reason).toContain("PREOPEN");
+  });
+  it("스테일 거래일 → 차단", () => {
+    const reason = safeInternals.krPublishBlockReason([{ label: "코스피", tradedAt: "2026-07-10" }], "2026-07-13");
+    expect(reason).toContain("2026-07-10");
+  });
+  it("정상(CLOSE·오늘 거래일) → 통과", () => {
+    expect(
+      safeInternals.krPublishBlockReason(
+        [
+          { label: "코스피", tradedAt: "2026-07-13", marketStatus: "CLOSE" },
+          { label: "코스닥", tradedAt: "2026-07-13", marketStatus: "CLOSE" },
+        ],
+        "2026-07-13"
+      )
+    ).toBeNull();
+  });
+  it("status/거래일 미제공 → 통과(확인 가능한 것만 차단)", () => {
+    expect(safeInternals.krPublishBlockReason([{ label: "코스피" }], "2026-07-13")).toBeNull();
+  });
+});

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -107,11 +107,13 @@ export async function GET(request: Request) {
         `ai=${isAiConfigured()} enNews=${news.filter((a) => (a.lang ?? "en") === "en").length} usDeck=${usDeck.length} translated=${translated}`
       );
     } else if (slot === "close") {
-      await save(`briefing:kr:${date}`, await buildKrBriefing());
+      const kr = await buildKrBriefing();
+      if (kr) await save(`briefing:kr:${date}`, kr);
+      else written.push("briefing:kr=skipped");
       await save(`buzz:${date}`, await buildBuzzStory());
       const usDeck = await fetchUsDeckArticles().catch(() => []);
       const translated = await translateAndStoreUsTitles([...usDeck, ...(await fetchAllNews().catch(() => []))]).catch(() => 0);
-      if (translated > 0) written.push(`i18n:us-titles(${translated})`);
+      written.push(`i18n:usDeck=${usDeck.length} translated=${translated}`);
     } else if (slot === "pulse") {
       // 장중 급변 감지(WO-21 Phase 1) — 임계 미달·휴장·스테일이면 아무것도 쓰지 않는다(결정론·LLM 없음).
       await save(`briefing:kr-pulse:${date}`, await buildKrMarketPulse());

--- a/apps/web/lib/feed-briefing.ts
+++ b/apps/web/lib/feed-briefing.ts
@@ -6,7 +6,7 @@ import { fetchKrMarketRows } from "./discovery-supply";
 import { fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
 import { computeStockAttentionSignals } from "./stock-signal-coverage";
 import { hasForbiddenCopy } from "./copy-guards";
-import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { deleteFeedContent, readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
 import { fetchStockDaily } from "./stock-front";
 import { relatedTo } from "./relation-graph";
 import { kstDate } from "./fomo";
@@ -254,6 +254,22 @@ export function isStaleSession(tradedAt: string | undefined, today: string): boo
   return typeof tradedAt === "string" && /^\d{4}-\d{2}-\d{2}$/.test(tradedAt) && tradedAt !== today;
 }
 
+/**
+ * KR 지수 발행 차단 사유(없으면 null) — 거래일 불일치 + 장 시작 전(PREOPEN).
+ * PREOPEN 사각지대(2026-07-14 실측): 네이버가 localTradedAt=현재시각(오늘)·등락률 0.00 껍데기를 줘서
+ * 거래일 가드만으로는 통과된다 → marketStatus 로 차단. 미제공 status 는 통과(확인 가능한 것만 막는다).
+ */
+export function krPublishBlockReason(
+  quotes: ReadonlyArray<{ label: string; tradedAt?: string; marketStatus?: string }>,
+  today: string
+): string | null {
+  for (const q of quotes) {
+    if (isStaleSession(q.tradedAt, today)) return `${q.label} 거래일(${q.tradedAt}) ≠ 오늘(${today}) — 스테일 데이터`;
+    if (q.marketStatus === "PREOPEN") return `${q.label} 장 시작 전(PREOPEN) — 등락률 0.00 껍데기 데이터`;
+  }
+  return null;
+}
+
 function briefingDateLabel(date: string): string {
   const [, m, d] = date.match(/^\d{4}-(\d{2})-(\d{2})$/) ?? [];
   return m && d ? `${Number(m)}월 ${Number(d)}일` : date;
@@ -315,12 +331,13 @@ export async function buildKrBriefing(): Promise<FeedBriefingRow | null> {
   // fresh: 캐시 우회 — 브리핑은 반드시 크론 시점의 실측이어야 한다(2026-07-13 전 거래일 데이터 사건).
   const macro = await fetchMacro({ fresh: true }).catch(() => []);
   const krQuotes = macro.filter((q) => ["kospi", "kosdaq"].includes(q.key));
-  // 거래일 가드(fail-closed) — 소스 거래일 ≠ 오늘이면 발행하지 않는다. 틀린 카드보다 무카드.
-  const staleQuote = krQuotes.find((q) => isStaleSession(q.tradedAt, date));
-  if (staleQuote) {
-    console.error(
-      `[feed-briefing] KR 브리핑 발행 차단 — ${staleQuote.label} 거래일(${staleQuote.tradedAt}) ≠ 오늘(${date}). 스테일 데이터.`
-    );
+  // 발행 가드(fail-closed) — 스테일 거래일·장 시작 전(PREOPEN)이면 발행하지 않는다. 틀린 카드보다 무카드.
+  const blockReason = krPublishBlockReason(krQuotes, date);
+  if (blockReason) {
+    console.error(`[feed-briefing] KR 브리핑 발행 차단 — ${blockReason}`);
+    // self-heal: 같은 날 앞서 잘못 발행된 행(장전 껍데기 등)이 남아 있으면 걷어낸다.
+    // 가드 차단이 확실할 때만 삭제 — 일시 장애(rows 부족)에는 손대지 않는다.
+    await deleteFeedContent(`briefing:kr:${date}`).catch(() => {});
     return null;
   }
   const rows = await fetchKrMarketRows().catch((): DiscoveryMarketRow[] => []);
@@ -423,10 +440,16 @@ export async function buildKrMarketPulse(): Promise<FeedBriefingRow | null> {
   const macro = await fetchMacro({ fresh: true }).catch(() => []);
   const indices = macro
     .filter((q) => ["kospi", "kosdaq"].includes(q.key) && typeof q.change === "number")
-    .map((q) => ({ key: q.key as "kospi" | "kosdaq", label: q.label, changePct: q.change as number, tradedAt: q.tradedAt }));
+    .map((q) => ({
+      key: q.key as "kospi" | "kosdaq",
+      label: q.label,
+      changePct: q.change as number,
+      ...(q.tradedAt ? { tradedAt: q.tradedAt } : {}),
+      ...(q.marketStatus ? { marketStatus: q.marketStatus } : {}),
+    }));
   if (indices.length === 0) return null;
-  // 거래일 가드 — 휴장/장 시작 전(전 거래일 데이터)이면 발화하지 않는다.
-  if (indices.some((i) => isStaleSession(i.tradedAt, date))) return null;
+  // 발행 가드 — 휴장·장 시작 전(스테일/PREOPEN 껍데기)이면 발화하지 않는다.
+  if (krPublishBlockReason(indices, date)) return null;
   const timeLabel = new Intl.DateTimeFormat("ko-KR", { timeZone: "Asia/Seoul", hour: "2-digit", minute: "2-digit", hour12: false }).format(new Date());
   // 임계 미달이면 시세 페이지 fetch 전에 빠지도록 — 먼저 지수만으로 판정.
   const probe = composeKrMarketPulse({ date, timeLabel, indices, movers: [] });

--- a/apps/web/lib/feed-content-store.ts
+++ b/apps/web/lib/feed-content-store.ts
@@ -35,6 +35,12 @@ export async function writeFeedContent(id: string, row: unknown): Promise<void> 
   `;
 }
 
+/** 행 삭제 — 발행 가드가 차단한 날, 앞서 잘못 발행된 같은 키(장전 껍데기 등)를 걷어내는 self-heal 용. */
+export async function deleteFeedContent(id: string): Promise<void> {
+  await ensureFeedContentTable();
+  await prisma.$executeRaw`DELETE FROM "FeedContentCache" WHERE "id" = ${id}`;
+}
+
 export async function readFeedContent<T>(id: string): Promise<T | null> {
   try {
     const records = await prisma.$queryRaw<Array<{ row: unknown }>>`

--- a/apps/web/lib/fomo-market-sources.ts
+++ b/apps/web/lib/fomo-market-sources.ts
@@ -51,7 +51,7 @@ export async function fetchNaverIndex(
   naver: string,
   scope: NaverScope,
   { fresh = false }: { fresh?: boolean } = {}
-): Promise<{ change: number; close: number; tradedAt?: string } | null> {
+): Promise<{ change: number; close: number; tradedAt?: string; marketStatus?: string } | null> {
   const url =
     scope === "domestic"
       ? `https://m.stock.naver.com/api/index/${encodeURIComponent(naver)}/basic`
@@ -160,6 +160,7 @@ export async function fetchMacro({ fresh = false }: { fresh?: boolean } = {}): P
           change: naver.change,
           close: naver.close,
           ...(naver.tradedAt ? { tradedAt: naver.tradedAt } : {}),
+          ...(naver.marketStatus ? { marketStatus: naver.marketStatus } : {}),
         };
 
       const closes = await fetchIndexCloses(s.symbol);

--- a/packages/fomo-core/src/banner.ts
+++ b/packages/fomo-core/src/banner.ts
@@ -156,6 +156,8 @@ export interface MacroQuote {
   close?: number | null;
   /** 데이터의 거래일 "YYYY-MM-DD" — 소스가 주는 경우만. 발행측 스테일 가드용. */
   tradedAt?: string;
+  /** 장 상태("PREOPEN"/"OPEN"/"CLOSE" 등, 대문자) — PREOPEN 은 0.00% 껍데기라 발행 차단 재료. */
+  marketStatus?: string;
 }
 
 const MACRO_META: Record<MacroQuote["key"], { emoji: string; sourceUrl: string; note: string }> = {

--- a/packages/fomo-core/src/markets.ts
+++ b/packages/fomo-core/src/markets.ts
@@ -49,6 +49,8 @@ export interface NaverIndexRaw {
   compareToPreviousPrice?: string | { code?: string; text?: string; name?: string } | null;
   /** 거래 시각 "2026-07-13T18:59:00+09:00" — 발행측 거래일 검증(스테일 가드)용. */
   localTradedAt?: string;
+  /** "PREOPEN" | "OPEN" | "CLOSE" 등 — PREOPEN 은 등락률 0.00 + 현재시각 localTradedAt 을 주므로 발행 차단 재료. */
+  marketStatus?: string;
 }
 
 function parseLooseNumber(v: unknown): number | null {
@@ -67,6 +69,8 @@ export function parseNaverIndexQuote(raw: NaverIndexRaw | null | undefined): {
   close: number;
   /** 거래일 "YYYY-MM-DD"(KST 문자열 그대로) — 없으면 생략. */
   tradedAt?: string;
+  /** 대문자 정규화된 장 상태("PREOPEN"/"OPEN"/"CLOSE" 등) — 없으면 생략. */
+  marketStatus?: string;
 } | null {
   if (!raw) return null;
   const close = parseLooseNumber(raw.closePrice);
@@ -88,7 +92,13 @@ export function parseNaverIndexQuote(raw: NaverIndexRaw | null | undefined): {
         ? mag
         : ratio;
   const tradedDate = raw.localTradedAt?.slice(0, 10);
-  return { change, close, ...(tradedDate && /^\d{4}-\d{2}-\d{2}$/.test(tradedDate) ? { tradedAt: tradedDate } : {}) };
+  const marketStatus = typeof raw.marketStatus === "string" && raw.marketStatus.trim() ? raw.marketStatus.trim().toUpperCase() : undefined;
+  return {
+    change,
+    close,
+    ...(tradedDate && /^\d{4}-\d{2}-\d{2}$/.test(tradedDate) ? { tradedAt: tradedDate } : {}),
+    ...(marketStatus ? { marketStatus } : {}),
+  };
 }
 
 function macroChange(quotes: MacroQuote[], key: MacroQuote["key"]): number | null {


### PR DESCRIPTION
## 사각지대 실측 (2026-07-14 08:09 KST)

WO-21 거래일 가드 배포 후 장전에 close 슬롯을 수동 실행해보니 **0.00% 껍데기 "오늘의 국장 요약 — 7/14"가 발행**됨. 원인: PREOPEN 시간대 네이버 응답이 `localTradedAt=현재시각(오늘)` + `fluctuationsRatio: 0.00` + `marketStatus: "PREOPEN"` — 거래일 가드만으로는 통과.

## 수정

- `parseNaverIndexQuote` → `marketStatus` 파싱·전달 (fomo-core, 테스트 포함)
- `krPublishBlockReason(quotes, today)` — 스테일 거래일 + **PREOPEN 차단** 통합 가드(브리핑·장중 펄스 공용, status 미제공은 통과 — 확인 가능한 것만 차단)
- **self-heal**: 가드 차단이 확정된 경우에만 같은 날 오발행 행 `deleteFeedContent` — 이번 08:09 껍데기 행도 다음 close 크론(16:10) 또는 즉시 재실행으로 자동 제거
- close 슬롯 로그에 `i18n:usDeck=N translated=N` 상시 기록 — US 한글화 파이프 관측 가능

## 검증

- vitest **1104 passed** (krPublishBlockReason 4케이스 추가) · typecheck 0 · guard:discovery ✅
- 머지·배포 후 close 슬롯 재실행 → `briefing:kr=skipped` + 7/14 껍데기 행 삭제 + usDeck 번역 카운트 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)