### PR TITLE
fix(i18n): US 제목 번역 청크 분할 — 대량 배치 전체 폐기 해소

### DIFF
--- a/apps/web/lib/content-i18n.ts
+++ b/apps/web/lib/content-i18n.ts
@@ -74,17 +74,12 @@ function parseJsonArray(content: string): string[] | null {
  * 이미 저장된 url 은 건너뛴다(증분). AI 미설정·실패 시 조용히 no-op(fail-open).
  * @returns 새로 번역·저장한 제목 수.
  */
-export async function translateAndStoreUsTitles(articles: ReadonlyArray<{ url: string; title: string; lang?: string }>): Promise<number> {
-  if (!isAiConfigured()) return 0;
-  const date = kstDate();
-  const existing = (await readFeedContent<KoreanTitleMap>(`${CACHE_PREFIX}:${date}`))?.map ?? {};
-  const pending = articles
-    .filter((a) => a.url && a.title && (a.lang ?? "en") === "en" && !looksKorean(a.title) && !existing[a.url])
-    .filter((a, index, arr) => arr.findIndex((x) => x.url === a.url) === index)
-    .slice(0, MAX_TITLES_PER_RUN);
-  if (pending.length === 0) return 0;
+/** 청크 크기 — 한 콜 60개는 개수 불일치로 전체 폐기되기 쉬움(2026-07-14 usDeck=75→translated=0 실측). */
+const TRANSLATE_CHUNK_SIZE = 15;
 
-  const numbered = pending.map((a, i) => `${i + 1}. ${a.title.replace(/\s+/g, " ").trim()}`).join("\n");
+async function translateChunk(chunk: ReadonlyArray<{ url: string; title: string }>): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const numbered = chunk.map((a, i) => `${i + 1}. ${a.title.replace(/\s+/g, " ").trim()}`).join("\n");
   const result = await callAI({
     trace: "content-i18n",
     temperature: 0.2,
@@ -98,17 +93,36 @@ export async function translateAndStoreUsTitles(articles: ReadonlyArray<{ url: s
       },
       { role: "user", content: numbered },
     ],
-  });
-  if (!result.ok) return 0;
+  }).catch(() => ({ ok: false as const, content: "" }));
+  if (!result.ok || !result.content) return out;
   const translated = parseJsonArray(result.content);
-  if (!translated || translated.length !== pending.length) return 0;
+  // 개수 불일치면 이 청크만 폐기 — 순서 어긋난 매핑(다른 기사 제목이 붙는 오염)은 절대 금지.
+  if (!translated || translated.length !== chunk.length) return out;
+  for (let i = 0; i < chunk.length; i += 1) {
+    const ko = (translated[i] ?? "").replace(/\s+/g, " ").trim();
+    if (ko && looksKorean(ko)) out.set(chunk[i]!.url, ko);
+  }
+  return out;
+}
 
+export async function translateAndStoreUsTitles(articles: ReadonlyArray<{ url: string; title: string; lang?: string }>): Promise<number> {
+  if (!isAiConfigured()) return 0;
+  const date = kstDate();
+  const existing = (await readFeedContent<KoreanTitleMap>(`${CACHE_PREFIX}:${date}`))?.map ?? {};
+  const pending = articles
+    .filter((a) => a.url && a.title && (a.lang ?? "en") === "en" && !looksKorean(a.title) && !existing[a.url])
+    .filter((a, index, arr) => arr.findIndex((x) => x.url === a.url) === index)
+    .slice(0, MAX_TITLES_PER_RUN);
+  if (pending.length === 0) return 0;
+
+  // 청크 순차 번역 — 한 청크 실패가 나머지를 깎아먹지 않는다(부분 성공 허용).
   const map: Record<string, string> = { ...existing };
   let added = 0;
-  for (let i = 0; i < pending.length; i += 1) {
-    const ko = (translated[i] ?? "").replace(/\s+/g, " ").trim();
-    if (ko && looksKorean(ko)) {
-      map[pending[i]!.url] = ko;
+  for (let start = 0; start < pending.length; start += TRANSLATE_CHUNK_SIZE) {
+    const chunk = pending.slice(start, start + TRANSLATE_CHUNK_SIZE);
+    const translated = await translateChunk(chunk);
+    for (const [url, ko] of translated) {
+      map[url] = ko;
       added += 1;
     }
   }


### PR DESCRIPTION
## 실측

close 슬롯 로그 `i18n:usDeck=75 translated=0` — 수집은 되는데 번역 0. 원인: 60개 제목을 단일 LLM 콜로 보내고 출력 배열 개수가 하나라도 어긋나면 **전체 폐기**하는 구조(개수 검증 자체는 순서 오염 방지용으로 올바름).

## 수정

15개 청크 순차 번역 — 한 청크 실패가 나머지를 깎아먹지 않음(부분 성공). 개수 불일치 시 해당 청크만 폐기해 "다른 기사 제목이 붙는" 오염 방지는 유지.

## 검증

vitest 1104 passed · typecheck 0 · 머지 후 close 슬롯 재실행으로 translated>0 실측 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)