### PR TITLE
fix(feed): 코인 매크로 뉴스·미장 실적 사유·언어 통일·CPI/PPI 캘린더

### DIFF
--- a/apps/web/__tests__/lib/feed-extras.test.ts
+++ b/apps/web/__tests__/lib/feed-extras.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import type { RawArticle } from "@fomo/core";
 
 vi.mock("../../lib/fomo-news-sources", () => ({ fetchAllNews: vi.fn(async () => mockedNews) }));
+vi.mock("../../lib/coin-market-source", () => ({ readCoinMarketSnapshots: vi.fn(async () => []) }));
 
-import { buildEventCard, buildHotIssueCards, buildTermCard, normalizedTitleKey, upcomingMarketEvents } from "../../lib/feed-extras";
+import {
+  buildCoinIssueCards,
+  buildEventCard,
+  buildHotIssueCards,
+  buildTermCard,
+  normalizedTitleKey,
+  upcomingMarketEvents,
+} from "../../lib/feed-extras";
 
 const NOW = new Date().toISOString();
 function article(id: string, title: string, source: string): RawArticle {
@@ -82,5 +90,33 @@ describe("hot-issue 제목 dedup", () => {
     expect(new Set(titles).size).toBe(titles.length);
     // 신디케이트 1건 vs 다매체 사건 3건 — 사건이 이겨야 한다
     expect(ko!.headline).toMatch(/이란|코스피/);
+  });
+});
+
+// 2026-07-15 User Zero: "체인링크 1% 오른 게 뭐가 중요해" — 코인 핫이슈는 매크로/규제 사건 우선.
+describe("coin-issue 매크로 우선", () => {
+  it("코인 전문 매체의 규제·법안 기사가 있으면 헤드라인을 차지한다(가격 무버 무시)", async () => {
+    mockedNews = [
+      article("c1", "국회, 가상자산 클래리티 법안 본회의 통과", "토큰포스트"),
+      article("c2", "비트코인, 오늘 소폭 상승 마감", "블록미디어"),
+    ];
+    const [card] = await buildCoinIssueCards();
+    expect(card).toBeDefined();
+    expect(card!.contentType).toBe("coin-issue");
+    expect(card!.headline).toBe("국회, 가상자산 클래리티 법안 본회의 통과");
+    expect(card!.source).toBe("토큰포스트");
+  });
+
+  it("코인 전문 매체가 아니면(일반 경제지) 매크로 키워드가 있어도 무시한다", async () => {
+    mockedNews = [article("m1", "가상자산 ETF 승인 임박", "매일경제")];
+    const cards = await buildCoinIssueCards();
+    // 스냅샷도 없고(mock=[]) 매크로 기사도 자격 미달 — 정직하게 카드 없음.
+    expect(cards).toEqual([]);
+  });
+
+  it("코인 전문 매체라도 매크로 키워드가 없는 단순 가격 기사는 무시한다", async () => {
+    mockedNews = [article("c3", "리플, 오늘도 조용한 하루", "토큰포스트")];
+    const cards = await buildCoinIssueCards();
+    expect(cards).toEqual([]);
   });
 });

--- a/apps/web/__tests__/lib/sec-edgar.test.ts
+++ b/apps/web/__tests__/lib/sec-edgar.test.ts
@@ -64,4 +64,54 @@ describe("SEC EDGAR Form 4 insider purchases", () => {
       transactionDate: "2026-06-15",
     });
   });
+
+  // 2026-07-15 User Zero: "IBM 실적 부진 8-K가 왜 그냥 '공시 확인'이냐" — Item 코드로 실제 사유 표시.
+  it("8-K의 items 필드(2.02=실적 발표)를 한국어 사유로 반영한다", async () => {
+    vi.stubEnv("SEC_EDGAR_USER_AGENT", "fomo-test contact@example.com");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("data.sec.gov/submissions")) {
+        return Response.json({
+          filings: {
+            recent: {
+              form: ["8-K"],
+              filingDate: ["2026-07-14"],
+              primaryDocument: ["form8k.htm"],
+              accessionNumber: ["0001045810-26-000200"],
+              items: ["2.02,9.01"],
+            },
+          },
+        });
+      }
+      return Response.json({});
+    });
+
+    const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
+    const hits = await fetchRecentSecFilings("IBM", 2);
+    expect(hits[0]?.label).toBe("실적 발표 8-K 공시가 확인됐어요.");
+  });
+
+  it("items 필드가 없거나 매핑되지 않은 코드면 기존 일반 문구로 폴백한다", async () => {
+    vi.stubEnv("SEC_EDGAR_USER_AGENT", "fomo-test contact@example.com");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("data.sec.gov/submissions")) {
+        return Response.json({
+          filings: {
+            recent: {
+              form: ["8-K"],
+              filingDate: ["2026-07-14"],
+              primaryDocument: ["form8k.htm"],
+              accessionNumber: ["0001045810-26-000201"],
+            },
+          },
+        });
+      }
+      return Response.json({});
+    });
+
+    const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
+    const hits = await fetchRecentSecFilings("IBM", 2);
+    expect(hits[0]?.label).toBe("8-K 공시가 확인됐어요.");
+  });
 });

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -602,8 +602,11 @@ function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEv
 }
 
 function materialEventFromUsArticle(article: RawArticle, asOf: string, sourceFallback: string): DiscoveryEvent | null {
-  // 한글 번역(크론 캐시) 우선 — 없으면 원문 클린 폴백(무회귀). 제품 한국어 우선(2026-07-12).
-  const label = koreanTitle(article.url) ?? cleanUsMaterialTitle(article.title);
+  // cleanUsMaterialTitle 은 "이 기사가 재료로 쓸 만한가" 품질 게이트로만 쓴다(영문 표시 금지, 2026-07-15).
+  if (!cleanUsMaterialTitle(article.title)) return null;
+  // 한글 번역(크론 캐시) 필수 — 없으면 카드 노출 안 함. 개별 심볼 Yahoo URL은 번역 캐시에 거의 없어
+  // 예전엔 원문 영문이 그대로 새어나갔다("미장 카드 어떤 건 영문·어떤 건 한글" 사건).
+  const label = koreanTitle(article.url);
   if (!label) return null;
   const sourceName = article.source || sourceFallback;
   const sourceTitle = decodeHtmlEntities(article.title).replace(/\s+/g, " ").trim();

--- a/apps/web/lib/feed-briefing.ts
+++ b/apps/web/lib/feed-briefing.ts
@@ -3,7 +3,8 @@ import { sectorOf } from "@fomo/core";
 import { fetchMacro } from "./fomo-market-sources";
 import { readUsMarketQuoteRows } from "./us-market-cache";
 import { fetchKrMarketRows } from "./discovery-supply";
-import { fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
+import { fetchNaverStockNews } from "./fomo-news-sources";
+import { fetchRecentSecFilings } from "./sec-edgar";
 import { computeStockAttentionSignals } from "./stock-signal-coverage";
 import { hasForbiddenCopy } from "./copy-guards";
 import { deleteFeedContent, readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
@@ -204,9 +205,15 @@ function relevantTitle(articles: ReadonlyArray<{ title: string }>, name: string)
   return hit?.title?.trim() || undefined;
 }
 
+/**
+ * SEC EDGAR 전용(2026-07-15 User Zero: "IBM 실적 배경이 전혀 안 보인다").
+ * Yahoo 심볼별 RSS는 프로덕션 egress 차단으로 사실상 항상 빈 배열이라 "왜"가 나올 수 없었다.
+ * SEC는 Yahoo와 무관하고, 8-K Item 코드로 실적/구조조정 등 실제 사유를 구분한다(전부 한국어 — 영문 폴백 없음).
+ */
 async function moverMaterialTitleUs(symbol: string): Promise<string | undefined> {
-  const articles = await fetchYahooStockNews(symbol, 4).catch(() => []);
-  return articles[0]?.title?.trim() || undefined; // Yahoo는 심볼별 RSS라 자체적으로 관련 보장
+  const filings = await fetchRecentSecFilings(symbol, 3).catch(() => []);
+  const hit = filings.find((f) => f.insiderPurchase) ?? filings[0];
+  return hit?.label;
 }
 
 async function moverMaterialTitleKr(naverCode: string | undefined, name: string): Promise<string | undefined> {
@@ -305,7 +312,8 @@ export async function buildUsBriefing(): Promise<FeedBriefingRow | null> {
       contentType: "briefing",
       scope: "world",
       headline: `간밤의 미장 요약 — ${briefingDateLabel(date)}`,
-      facts: [...moverFacts(movers, ai?.whyBySymbol ?? new Map()), ...indexFacts(indices)],
+      // koreanMaterialFallback: true — materialTitle 은 이제 SEC 라벨(한국어)뿐이라 LLM 실패해도 안전.
+      facts: [...moverFacts(movers, ai?.whyBySymbol ?? new Map(), { koreanMaterialFallback: true }), ...indexFacts(indices)],
       note,
       source: "미장 시세·수집 뉴스",
       asOf: date,

--- a/apps/web/lib/feed-extras.ts
+++ b/apps/web/lib/feed-extras.ts
@@ -36,13 +36,55 @@ function krwText(price: number): string {
   return `${price.toLocaleString("ko-KR", { maximumFractionDigits: 2 })}원`;
 }
 
-/** 코인 핫이슈 1장 — 시총 10위권(캐시) 중 오늘 가장 크게 움직인 코인 + 상위 4종 시세표. */
+// 코인 전문 매체(토큰포스트·블록미디어)만 — 일반 경제지의 우연한 코인 언급 잡음 배제.
+// isFresh(아래 hot-issue 절 정의, HOT_ISSUE_WINDOW_HOURS=30h)를 그대로 재사용한다.
+const CRYPTO_NEWS_SOURCES = new Set(["토큰포스트", "블록미디어"]);
+// 규제·법안·ETF·거시 지표 등 "왜 중요한가"가 있는 사건만 — 순수 가격 변동 기사(예: "OO 코인 5% 상승")는 걸러낸다.
+const COIN_MACRO_PATTERN = /(법안|규제|승인|입법|반감기|스테이블코인|클래리티|CLARITY|의회|채택|정책|과세|세제|ETF|연준|금리|물가|CPI|PPI)/;
+
+function priceTableFacts(withSignal: readonly { snapshot: CoinMarketSnapshot }[]): DeckContentFact[] {
+  return [...withSignal]
+    .sort((a, b) => (a.snapshot.marketCapRank ?? 999) - (b.snapshot.marketCapRank ?? 999))
+    .slice(0, 4)
+    .map(({ snapshot }) => ({
+      label: snapshot.koreanName,
+      value: `${signedPct(snapshot.changePct)} · ${krwText(snapshot.price)}`,
+    }));
+}
+
+/**
+ * 코인 핫이슈 1장 — 매크로/규제 사건 우선, 없는 날만 가격·거래대금 무버로 폴백
+ * (2026-07-15 User Zero: "체인링크 1% 오른 게 뭐가 중요해 — 클래리티 법안·반감기 같은 게 핫이슈지").
+ */
 export async function buildCoinIssueCards(): Promise<DeckContentCard[]> {
   const snapshots = await readCoinMarketSnapshots().catch((): CoinMarketSnapshot[] => []);
-  if (snapshots.length === 0) return [];
   const withSignal = snapshots
     .map((snapshot) => ({ snapshot, signal: computeCoinSignal(snapshot) }))
     .filter((x): x is { snapshot: CoinMarketSnapshot; signal: NonNullable<ReturnType<typeof computeCoinSignal>> } => x.signal !== null);
+
+  const now = new Date();
+  const articles = await fetchAllNews().catch((): RawArticle[] => []);
+  const macroArticle = dedupeByTitle(
+    articles.filter((a) => CRYPTO_NEWS_SOURCES.has(a.source) && isFresh(a, now) && COIN_MACRO_PATTERN.test(a.title))
+  ).sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))[0];
+
+  if (macroArticle) {
+    return [
+      {
+        kind: "content",
+        id: `content:coin-issue:${kstDate()}`,
+        contentType: "coin-issue",
+        scope: "global",
+        headline: macroArticle.title,
+        facts: priceTableFacts(withSignal),
+        sourceUrl: macroArticle.url,
+        source: macroArticle.source,
+        asOf: kstDate(),
+      },
+    ];
+  }
+
+  // 매크로 뉴스 없는 조용한 날 — 기존 가격·거래대금 무버 폴백(정직: 없는 사건을 지어내지 않는다).
   if (withSignal.length === 0) return [];
   const mover = [...withSignal].sort(
     (a, b) => Math.abs(b.snapshot.changePct) + b.signal.volumeRatio - (Math.abs(a.snapshot.changePct) + a.signal.volumeRatio)
@@ -50,13 +92,6 @@ export async function buildCoinIssueCards(): Promise<DeckContentCard[]> {
   const headlineParts = [`${mover.snapshot.koreanName} 하루 ${signedPct(mover.snapshot.changePct)}`];
   if (mover.signal.volumeRatio >= 1.3) headlineParts.push(`거래대금 평소 ${mover.signal.volumeRatio.toFixed(1)}배`);
   if (typeof mover.snapshot.marketCapRank === "number") headlineParts.push(`시총 ${mover.snapshot.marketCapRank}위`);
-  const facts: DeckContentFact[] = [...withSignal]
-    .sort((a, b) => (a.snapshot.marketCapRank ?? 999) - (b.snapshot.marketCapRank ?? 999))
-    .slice(0, 4)
-    .map(({ snapshot }) => ({
-      label: snapshot.koreanName,
-      value: `${signedPct(snapshot.changePct)} · ${krwText(snapshot.price)}`,
-    }));
   return [
     {
       kind: "content",
@@ -64,7 +99,7 @@ export async function buildCoinIssueCards(): Promise<DeckContentCard[]> {
       contentType: "coin-issue",
       scope: "global",
       headline: headlineParts.join(" · "),
-      facts,
+      facts: priceTableFacts(withSignal),
       source: "Upbit · CoinGecko",
       asOf: kstDate(),
     },
@@ -258,6 +293,14 @@ export function buildTermCard(): DeckContentCard[] {
  */
 const FOMC_2026_DECISION_DATES = ["2026-01-28", "2026-03-18", "2026-04-29", "2026-06-17", "2026-07-29", "2026-09-16", "2026-10-28", "2026-12-09"];
 
+/**
+ * 미국 CPI/PPI 2026 발표일 — BLS 공개 일정(2026-07-15 User Zero: "오늘 PPI 발표인데 반영이 안 된다").
+ * 출처: bls.gov 2026 release schedule. 고용보고서(NFP)는 2026년 셧다운으로 일정 자체가 재조정된
+ * 이력이 확인돼(예: 1월분 발표가 연기) 정적 표로 못박기엔 리스크가 커서 이번 표에서 제외한다.
+ */
+const CPI_2026_DATES = ["2026-01-13", "2026-02-13", "2026-03-11", "2026-04-10", "2026-05-12", "2026-06-10", "2026-07-14", "2026-08-12", "2026-09-11", "2026-10-14", "2026-11-10", "2026-12-10"];
+const PPI_2026_DATES = ["2026-01-14", "2026-01-30", "2026-02-27", "2026-03-18", "2026-04-14", "2026-06-11", "2026-07-15", "2026-08-13", "2026-09-10", "2026-10-15", "2026-11-13", "2026-12-15"];
+
 function nthWeekdayOfMonth(year: number, month: number, weekday: number, nth: number): Date {
   const first = new Date(Date.UTC(year, month, 1));
   const offset = (weekday - first.getUTCDay() + 7) % 7;
@@ -300,6 +343,12 @@ export function upcomingMarketEvents(todayIso: string, limit = 3): MarketEvent[]
   for (const date of FOMC_2026_DECISION_DATES) {
     events.push({ date, label: "FOMC 금리 결정", detail: "미 연준 통화정책 발표 · 한국시간 새벽" });
   }
+  for (const date of CPI_2026_DATES) {
+    events.push({ date, label: "미국 CPI 발표", detail: "소비자물가지수 · 한국시간 밤 10시 전후" });
+  }
+  for (const date of PPI_2026_DATES) {
+    events.push({ date, label: "미국 PPI 발표", detail: "생산자물가지수 · 한국시간 밤 10시 전후" });
+  }
   return events
     .filter((event) => event.date >= todayIso)
     .sort((a, b) => a.date.localeCompare(b.date))
@@ -328,7 +377,7 @@ export function buildEventCard(): DeckContentCard[] {
         label: `${event.date.slice(5).replace("-", "/")} · ${dDayText(date, event.date)}`,
         value: `${event.label} — ${event.detail}`,
       })),
-      source: "거래소 규칙 · Fed 공개 일정",
+      source: "거래소 규칙 · Fed·BLS 공개 일정",
       asOf: date,
     },
   ];

--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -98,6 +98,13 @@ const KR_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] 
   { id: "einfomax", url: "https://news.einfomax.co.kr/rss/S1N2.xml", source: "연합인포맥스", tier: "news-mid" },
 ];
 
+// 코인 전문 매체 — 코인 핫이슈가 가격 무버 노이즈에 그치지 않고 규제·법안·ETF 등 매크로 사건을
+// 우선 잡도록(2026-07-15 User Zero: "체인링크 1% 오른 게 뭐가 중요해"). Node fetch 200 확인.
+const CRYPTO_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] = [
+  { id: "tokenpost", url: "https://www.tokenpost.kr/rss", source: "토큰포스트", tier: "news-mid" },
+  { id: "blockmedia", url: "https://www.blockmedia.co.kr/feed", source: "블록미디어", tier: "news-mid" },
+];
+
 // ───────────────────────── 네이버 금융 뉴스 (JSON) ─────────────────────────
 // 해외 증시 실시간 뉴스(이미 한국어). api.stock.naver.com/news/worldNews.
 const NAVER_NEWS_URL = "https://api.stock.naver.com/news/worldNews?pageSize=20&page=1";
@@ -265,6 +272,7 @@ export const NEWS_SOURCES: readonly NewsSource[] = [
   yahooSource,
   naverNewsSource,
   ...KR_FEEDS.map(makeKoreanRssSource),
+  ...CRYPTO_FEEDS.map(makeKoreanRssSource),
 ];
 
 /** 모든 enabled 소스를 병렬 수집해 정규화 기사 배열로 합산. */

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -100,6 +100,33 @@ function mmdd(date: string): string {
   return match ? `${Number(match[1])}/${Number(match[2])}` : date;
 }
 
+/**
+ * 8-K Item 코드 → 한국어 사유(2026-07-15 User Zero: "IBM 실적 부진 8-K가 왜 그냥 '공시 확인'이냐").
+ * SEC submissions.json 의 items 필드(예: "2.02,9.01")를 그대로 쓴다 — 본문 파싱·수치 추정 없음(사실만).
+ */
+const SEC_8K_ITEM_LABELS: Record<string, string> = {
+  "1.01": "주요 계약 체결",
+  "1.02": "계약 종료",
+  "2.01": "자산 인수·처분 완료",
+  "2.02": "실적 발표",
+  "2.05": "구조조정 비용 계획",
+  "2.06": "자산 손상",
+  "3.01": "상장 요건 미달",
+  "4.01": "감사인 변경",
+  "5.02": "임원·이사 변경",
+  "5.03": "정관 변경",
+  "7.01": "Reg FD 공시",
+  "8.01": "기타 중요사항",
+};
+// 급변동 원인으로서의 정보 가치 순 — 실적(2.02)이 최우선(가장 흔한 급변동 원인).
+const SEC_8K_ITEM_PRIORITY = ["2.02", "2.05", "2.06", "1.01", "1.02", "3.01", "5.02", "4.01", "7.01", "8.01"];
+
+function eightKLabel(items: string | undefined): string {
+  const codes = (items ?? "").split(",").map((c) => c.trim()).filter(Boolean);
+  const hit = SEC_8K_ITEM_PRIORITY.find((code) => codes.includes(code));
+  return hit ? `${SEC_8K_ITEM_LABELS[hit]} 8-K 공시가 확인됐어요.` : "8-K 공시가 확인됐어요.";
+}
+
 function parseForm4InsiderPurchase(symbol: string, xml: string): SecFilingHit["insiderPurchase"] | undefined {
   const ownerBlock = tagBlocks(xml, "reportingOwner")[0] ?? "";
   const ownerName = tagValue(ownerBlock, "rptOwnerName") ?? tagValue(xml, "rptOwnerName");
@@ -182,7 +209,15 @@ export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<
     });
     if (!res.ok) return [];
     const data = (await res.json()) as {
-      filings?: { recent?: { form?: string[]; filingDate?: string[]; primaryDocument?: string[]; accessionNumber?: string[] } };
+      filings?: {
+        recent?: {
+          form?: string[];
+          filingDate?: string[];
+          primaryDocument?: string[];
+          accessionNumber?: string[];
+          items?: string[];
+        };
+      };
     };
     const recent = data.filings?.recent;
     if (!recent?.form?.length) return [];
@@ -205,7 +240,7 @@ export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<
       if (!asOf || !accession) continue;
       out.push({
         symbol: symbol.toUpperCase(),
-        label: `${form} 공시가 확인됐어요.`,
+        label: form === "8-K" ? eightKLabel(recent.items?.[i]) : `${form} 공시가 확인됐어요.`,
         source: "SEC EDGAR",
         asOf,
         url: accessionPath(cik, accession),


### PR DESCRIPTION
콘텐츠 품질 4건 수정 (User Zero 2026-07-15 피드백: "체인링크 1%가 왜 핫이슈냐,
IBM 실적 배경도 없고, 미장 카드 영문·한글 뒤섞이고, 오늘 PPI 발표도 안 보인다").

1. 코인 핫이슈 — 토큰포스트·블록미디어(코인 전문 매체) 신규 등록, 규제·법안·ETF
   등 매크로 키워드 매치 시 가격 무버보다 우선 노출. 매크로 뉴스 없는 날만 기존
   가격·거래대금 무버로 폴백(정직: 없는 사건을 지어내지 않는다).

2. 미장 실적/구조조정 사유 — SEC EDGAR 8-K의 items 필드(Item 2.02=실적 발표 등)를
   한국어 사유로 매핑. 브리핑 무버 재료도 Yahoo 심볼별 RSS(egress 차단으로 사실상
   항상 빈 배열) 대신 SEC EDGAR 우선으로 교체 — "왜"가 뜨는 빈도 자체가 오른다.

3. 미장 언어 통일 — 개별 심볼 재료(materialEventFromUsArticle)는 번역 캐시(koreanTitle)
   필수로 변경, 없으면 카드 노출 안 함(영문 폴백 제거). hot-issue en 카드와 동일한
   정책으로 통일 — 이제 미장 카드는 항상 한글이거나 아예 안 뜬다.

4. 매크로 캘린더 — BLS 공개 일정으로 CPI/PPI 2026 발표일 추가(오늘 PPI 발표 반영).
   고용보고서(NFP)는 2026년 셧다운으로 일정 자체가 재조정된 이력이 확인돼 정적
   표로 못박기엔 리스크가 커서 이번엔 제외.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
