### PR TITLE
fix(feed): SEC 8-K 라벨을 copy-guards 통과 문구로 — IBM '왜' 폐기 회귀 수정

### DIFF
--- a/apps/web/__tests__/lib/sec-edgar.test.ts
+++ b/apps/web/__tests__/lib/sec-edgar.test.ts
@@ -88,7 +88,11 @@ describe("SEC EDGAR Form 4 insider purchases", () => {
 
     const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
     const hits = await fetchRecentSecFilings("IBM", 2);
-    expect(hits[0]?.label).toBe("실적 발표 8-K 공시가 확인됐어요.");
+    expect(hits[0]?.label).toBe("실적 발표 8-K 공시 · 7/14");
+    // 브리핑 detail 경로(safeWhy→hasForbiddenCopy)에서 폐기되지 않아야 한다 —
+    // "공시가 확인됐어요" 시절 라벨이 추상 슬롭 블록리스트에 걸려 IBM '왜'가 통째로 사라졌던 회귀 방지.
+    const { hasForbiddenCopy } = await import("../../lib/copy-guards");
+    expect(hasForbiddenCopy(hits[0]!.label)).toBe(false);
   });
 
   it("items 필드가 없거나 매핑되지 않은 코드면 기존 일반 문구로 폴백한다", async () => {
@@ -112,6 +116,8 @@ describe("SEC EDGAR Form 4 insider purchases", () => {
 
     const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
     const hits = await fetchRecentSecFilings("IBM", 2);
-    expect(hits[0]?.label).toBe("8-K 공시가 확인됐어요.");
+    expect(hits[0]?.label).toBe("8-K 공시 제출 · 7/14");
+    const { hasForbiddenCopy } = await import("../../lib/copy-guards");
+    expect(hasForbiddenCopy(hits[0]!.label)).toBe(false);
   });
 });

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -121,10 +121,14 @@ const SEC_8K_ITEM_LABELS: Record<string, string> = {
 // 급변동 원인으로서의 정보 가치 순 — 실적(2.02)이 최우선(가장 흔한 급변동 원인).
 const SEC_8K_ITEM_PRIORITY = ["2.02", "2.05", "2.06", "1.01", "1.02", "3.01", "5.02", "4.01", "7.01", "8.01"];
 
-function eightKLabel(items: string | undefined): string {
+/**
+ * ⚠️ 문구 제약: "공시가 확인됐어요" 류는 copy-guards의 추상 슬롭 블록리스트(공시…확인됐)에 걸려
+ * 브리핑 detail(safeWhy→hasForbiddenCopy)에서 통째로 폐기된다 — 사실 명사구 형태를 유지할 것.
+ */
+function eightKLabel(items: string | undefined, asOf: string): string {
   const codes = (items ?? "").split(",").map((c) => c.trim()).filter(Boolean);
   const hit = SEC_8K_ITEM_PRIORITY.find((code) => codes.includes(code));
-  return hit ? `${SEC_8K_ITEM_LABELS[hit]} 8-K 공시가 확인됐어요.` : "8-K 공시가 확인됐어요.";
+  return hit ? `${SEC_8K_ITEM_LABELS[hit]} 8-K 공시 · ${mmdd(asOf)}` : `8-K 공시 제출 · ${mmdd(asOf)}`;
 }
 
 function parseForm4InsiderPurchase(symbol: string, xml: string): SecFilingHit["insiderPurchase"] | undefined {
@@ -240,7 +244,7 @@ export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<
       if (!asOf || !accession) continue;
       out.push({
         symbol: symbol.toUpperCase(),
-        label: form === "8-K" ? eightKLabel(recent.items?.[i]) : `${form} 공시가 확인됐어요.`,
+        label: form === "8-K" ? eightKLabel(recent.items?.[i], asOf) : `${form} 공시 제출 · ${mmdd(asOf)}`,
         source: "SEC EDGAR",
         asOf,
         url: accessionPath(cik, accession),


### PR DESCRIPTION
#840 프로덕션 검증에서 발견: "실적 발표 8-K 공시가 확인됐어요." 라벨이
copy-guards 추상 슬롭 블록리스트(공시…확인됐 패턴)에 걸려 브리핑 detail
경로(safeWhy→hasForbiddenCopy)에서 통째로 폐기 — IBM -25% 무버에 "왜"가
여전히 비어 있었다.

라벨을 사실 명사구로 교체: "실적 발표 8-K 공시 · 7/14" / "8-K 공시 제출 · 7/14"
/ "10-Q 공시 제출 · 7/14". 가드 통과를 테스트로 고정(hasForbiddenCopy=false 단언).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
