### PR TITLE
fix(sec): 폴백 UA를 SEC WAF 통과 형식으로 — 프로덕션 SEC 전멸 원인

### DIFF
--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -24,7 +24,10 @@ const SEC_FORM4_XML_SCAN_LIMIT = 8;
 
 function secUserAgent(): string | undefined {
   // SEC 은 연락처 포함 UA 를 요구 — env 미설정이면 기본 UA 폴백(피드 종목이슈가 env 없이도 동작).
-  return process.env.SEC_EDGAR_USER_AGENT?.trim() || "FomoClub/1.0 (contact: fomo-club@users.noreply.github.com)";
+  // ⚠️ UA 형식 주의(2026-07-15 실측): "이름/버전 email@domain" 평문만 200.
+  // 괄호 "(contact: …)" 형식·users.noreply.github.com 주소는 SEC WAF가 403 — 프로덕션에서
+  // fetchRecentSecFilings가 전부 []로 죽어 US 브리핑 '왜'·stock-issue가 통째로 사라졌던 원인.
+  return process.env.SEC_EDGAR_USER_AGENT?.trim() || "FomoClub/1.0 fomo-club@example.com";
 }
 
 function accessionPath(cik: string, accession: string): string {


### PR DESCRIPTION
실측: SEC data.sec.gov가 "(contact: …)" 괄호 형식·users.noreply.github.com
주소가 든 UA를 403으로 차단(주거용 IP에서도 재현). Vercel에 SEC_EDGAR_USER_AGENT
env가 없어 이 폴백이 쓰였고 → 프로덕션 fetchRecentSecFilings 전부 [] →
US 브리핑 '왜' 공백 + feed-hub US stock-issue 0장이 전부 이 한 줄이 원인.

"이름/버전 email@domain" 평문 형식은 200 확인. 폴백 교체 + 재발 방지 주석.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
