### PR TITLE
feat(feed): 주간 판단 캘린더 — 어닝(US)+매크로 일정, 내 카드 조인 개인화

### DIFF
--- a/apps/fomo-web/components/CalendarCard.tsx
+++ b/apps/fomo-web/components/CalendarCard.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useMemo } from "react";
+import type { FeedHubCalendar, FeedHubCalendarStockRef } from "@/lib/fomoApi";
+import { getWatchlist } from "@/lib/watchlist";
+import { getDiscoverySeen } from "@/lib/discoveryPerformance";
+
+/**
+ * 주간 판단 캘린더 (2026-07-15) — 해자: 일정 나열이 아니라 "내 카드의 시험대".
+ * 서버는 발견 유니버스 어닝+매크로 일정만 주고, 이 컴포넌트가 로그인 없이 localStorage
+ * (담은 카드 fomo_watchlist · 본 카드 fomo_discovery_seen)와 조인해 내 종목을 하이라이트한다.
+ * 윤리 가드: 사실 일정만, 공포·재촉·예측 없음 — 프레임은 "미리 알고 보는 복기 준비".
+ */
+
+const NEON = "#D8FF3A";
+
+function dayLabel(dateIso: string, todayIso: string): string {
+  const [, m, d] = dateIso.match(/^\d{4}-(\d{2})-(\d{2})$/) ?? [];
+  const weekday = ["일", "월", "화", "수", "목", "금", "토"][new Date(`${dateIso}T00:00:00+09:00`).getDay()];
+  const diff = Math.round((Date.parse(dateIso) - Date.parse(todayIso)) / 86_400_000);
+  const dday = diff === 0 ? "오늘" : `D-${diff}`;
+  return `${Number(m)}/${Number(d)} ${weekday} · ${dday}`;
+}
+
+function kstToday(): string {
+  return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+export function CalendarCard({ calendar }: { calendar: FeedHubCalendar }) {
+  // 내 카드 조인 — 담은(★) 종목과 본 종목. 렌더 시점 1회면 충분(캘린더는 하루 단위 데이터).
+  const { mineSet, seenSet } = useMemo(() => {
+    const mine = new Set(getWatchlist().map((w) => w.stock));
+    const seen = new Set(getDiscoverySeen().map((s) => s.stock));
+    return { mineSet: mine, seenSet: seen };
+  }, []);
+
+  const today = kstToday();
+  const myUpcoming = useMemo(() => {
+    const names = new Set<string>();
+    for (const day of calendar.days) {
+      for (const event of day.events) {
+        for (const stock of event.stocks ?? []) {
+          if (mineSet.has(stock.canonical) || seenSet.has(stock.canonical)) names.add(stock.canonical);
+        }
+      }
+    }
+    return [...names];
+  }, [calendar, mineSet, seenSet]);
+
+  const stockChip = (stock: FeedHubCalendarStockRef) => {
+    const isMine = mineSet.has(stock.canonical);
+    const isSeen = !isMine && seenSet.has(stock.canonical);
+    return (
+      <span
+        key={stock.symbol}
+        className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]"
+        style={
+          isMine
+            ? { borderColor: NEON, color: NEON }
+            : isSeen
+              ? { borderColor: "rgba(216,255,58,0.35)", color: "rgba(250,250,250,0.9)" }
+              : { borderColor: "var(--hairline, #2a2a2a)", color: "rgba(250,250,250,0.72)" }
+        }
+      >
+        {isMine && <span aria-hidden>★</span>}
+        {stock.canonical}
+        {stock.session && <span className="text-[10px] opacity-70">{stock.session}</span>}
+      </span>
+    );
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <span className="font-pixel text-[10px] uppercase tracking-wide text-muted">WEEKLY CALENDAR</span>
+        <span className="text-[10px] text-muted">발견 유니버스 · 공개 일정</span>
+      </div>
+      <p className="mt-2 text-base font-bold leading-6 text-whiteout">이번 주 시장 일정</p>
+      {myUpcoming.length > 0 ? (
+        <p className="mt-1 text-xs leading-5" style={{ color: NEON }}>
+          내가 본 카드 {myUpcoming.length}장({myUpcoming.slice(0, 3).join("·")}
+          {myUpcoming.length > 3 ? " 외" : ""})의 발표가 이번 주에 있어요.
+        </p>
+      ) : (
+        <p className="mt-1 text-xs leading-5 text-muted">카드를 담아두면 그 종목의 발표 일정이 여기서 표시돼요.</p>
+      )}
+
+      <div className="mt-3 flex flex-col gap-2.5">
+        {calendar.days.map((day) => (
+          <div key={day.date} className="rounded-xl border border-hairline-soft px-3 py-2.5">
+            <p className="text-[11px] font-semibold text-muted">{dayLabel(day.date, today)}</p>
+            <div className="mt-1.5 flex flex-col gap-1.5">
+              {day.events.map((event, idx) =>
+                event.kind === "macro" ? (
+                  <p key={`${day.date}-m-${idx}`} className="text-sm leading-5 text-whiteout">
+                    {event.title}
+                    {event.detail && <span className="text-xs text-muted"> — {event.detail}</span>}
+                  </p>
+                ) : (
+                  <div key={`${day.date}-e-${idx}`} className="flex flex-wrap items-center gap-1.5">
+                    <span className="text-sm text-whiteout">실적 발표</span>
+                    {(event.stocks ?? []).map(stockChip)}
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-[11px] leading-4 text-muted">
+        미국 확정 일정 기준이에요. 국장 실적 일정은 준비 중 — 발표 당일 공시는 피드 종목 이슈로 올라와요.
+      </p>
+    </div>
+  );
+}

--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -16,6 +16,7 @@ import type { FrontEntry } from "@/components/StockSwipeDeck";
 import { FeedDepthPage } from "@/components/FeedDepthPage";
 import { SectorCard } from "@/components/SectorCard";
 import { StockIssueCard, sectorCardData } from "@/components/FeedView";
+import { CalendarCard } from "@/components/CalendarCard";
 
 /**
  * PC(≥1024px) 3컬럼 대시보드 — WO-PC-VERSION.
@@ -289,6 +290,8 @@ export function DesktopDashboard() {
                 <SectorCard card={sectorCardData(item)} />
               ) : item.type === "stock-issue" ? (
                 <StockIssueCard item={item} />
+              ) : item.type === "calendar" ? (
+                <CalendarCard calendar={item.calendar} />
               ) : (
                 <ContentCard card={item.content} />
               )}
@@ -327,5 +330,6 @@ function feedItemId(item: FeedHubItem): string {
   if (item.type === "narrative") return item.narrative.id;
   if (item.type === "sector") return item.sector.id;
   if (item.type === "stock-issue") return item.stockIssue.id;
+  if (item.type === "calendar") return item.calendar.id;
   return item.content.id;
 }

--- a/apps/fomo-web/components/FeedDepthPage.tsx
+++ b/apps/fomo-web/components/FeedDepthPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { CalendarCard } from "@/components/CalendarCard";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import type { FeedHubItem, FeedHubSectorStockRef } from "@/lib/fomoApi";
 import { sparklinePath } from "@fomo/core";
@@ -163,6 +164,8 @@ export function FeedDepthPage({ item, onClose, inline = false }: { item: FeedHub
     }
     // 내러티브는 NarrativeDepthPage 소관 — 방어적 빈 렌더(호출부가 분기함).
     if (item.type === "narrative") return null;
+    // 캘린더는 카드 자체가 완결 정보 — 뎁스에서도 같은 카드를 그대로(PC 우측 클릭 경로).
+    if (item.type === "calendar") return <CalendarCard calendar={item.calendar} />;
     // content 계열(briefing·recap·buzz·index·macro·whale·macro-issue) — 사실 전체 + 노트 + 추이.
     const card = item.content;
     const label =

--- a/apps/fomo-web/components/FeedView.tsx
+++ b/apps/fomo-web/components/FeedView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { CalendarCard } from "@/components/CalendarCard";
 import { ContentCard } from "@/components/ContentCard";
 import { NarrativeCard } from "@/components/NarrativeCard";
 import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
@@ -120,6 +121,14 @@ export function FeedView() {
             <button key={item.stockIssue.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
               <StockIssueCard item={item} />
             </button>
+          );
+        }
+        if (item.type === "calendar") {
+          // 캘린더는 인라인 완결(전체 정보가 카드 안) — 뎁스 불요, 막다른 탭 아님.
+          return (
+            <div key={item.calendar.id} className="w-full rounded-2xl border border-hairline bg-surface px-5 py-5">
+              <CalendarCard calendar={item.calendar} />
+            </div>
           );
         }
         return (

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -327,11 +327,28 @@ export interface FeedHubStockIssue {
   url?: string;
   asOf: string;
 }
+export interface FeedHubCalendarStockRef {
+  canonical: string;
+  symbol: string;
+  session?: "장전" | "장후";
+}
+export interface FeedHubCalendarEvent {
+  kind: "earnings" | "macro";
+  title: string;
+  detail?: string;
+  stocks?: FeedHubCalendarStockRef[];
+}
+export interface FeedHubCalendar {
+  id: string;
+  asOf: string;
+  days: Array<{ date: string; events: FeedHubCalendarEvent[] }>;
+}
 export type FeedHubItem =
   | { type: "briefing" | "buzz" | "recap" | "index" | "macro" | "whale" | "macro-issue"; scope: "KR" | "US" | "GLOBAL"; content: DeckContent & { series?: number[] } }
   | { type: "narrative"; scope: "KR" | "US"; narrative: DeckNarrative }
   | { type: "sector"; scope: "KR" | "US"; sector: FeedHubSectorCard }
-  | { type: "stock-issue"; scope: "KR" | "US"; stockIssue: FeedHubStockIssue };
+  | { type: "stock-issue"; scope: "KR" | "US"; stockIssue: FeedHubStockIssue }
+  | { type: "calendar"; scope: "GLOBAL"; calendar: FeedHubCalendar };
 export interface FeedHubResponse {
   asOf: string;
   items: FeedHubItem[];

--- a/apps/web/__tests__/lib/earnings-calendar.test.ts
+++ b/apps/web/__tests__/lib/earnings-calendar.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { composeWeeklyCalendar, selectDayEarnings, type EarningsRow } from "../../lib/earnings-calendar";
+
+// 2026-07-15 주간 판단 캘린더 — 해자: 발견 유니버스 큐레이션 + 클라 localStorage 조인(개인화는 프론트).
+
+describe("selectDayEarnings (어닝 필터·랭크)", () => {
+  it("발견 유니버스 종목은 시총 무관 포함(한글명), 유니버스 밖은 메가캡($80B+)만", () => {
+    const rows: EarningsRow[] = [
+      { symbol: "TSM", marketCapUsd: 2_000_000_000_000, session: "장전" }, // 유니버스 안(TSMC)
+      { symbol: "OKTA", marketCapUsd: 15_000_000_000, session: "장후" }, // 유니버스 안(옥타)
+      { symbol: "MEGAX", marketCapUsd: 300_000_000_000 }, // 유니버스 밖 메가캡 — 포함(심볼 그대로)
+      { symbol: "ZZZZ", marketCapUsd: 5_000_000_000 }, // 유니버스 밖 소형 — 제외
+    ];
+    const picked = selectDayEarnings(rows);
+    expect(picked.map((p) => p.symbol)).toEqual(["TSM", "MEGAX", "OKTA"]);
+    // 유니버스 종목은 canonical 매핑, 밖은 심볼 그대로(이름을 지어내지 않는다)
+    expect(picked[0]!.canonical).toBe("TSMC");
+    expect(picked.find((p) => p.symbol === "OKTA")!.canonical).not.toBe("OKTA");
+    expect(picked.find((p) => p.symbol === "MEGAX")!.canonical).toBe("MEGAX");
+    expect(picked[0]!.session).toBe("장전");
+  });
+
+  it("하루 상한 4종 — 시총 큰 순", () => {
+    const rows: EarningsRow[] = Array.from({ length: 8 }, (_, i) => ({
+      symbol: `BIG${i}`,
+      marketCapUsd: (10 - i) * 100_000_000_000,
+    }));
+    const picked = selectDayEarnings(rows);
+    expect(picked).toHaveLength(4);
+    expect(picked[0]!.symbol).toBe("BIG0");
+  });
+});
+
+describe("composeWeeklyCalendar (주간 합성)", () => {
+  it("어닝+매크로를 날짜 그룹으로 — 이벤트 없는 날은 생략, 7일 창 밖은 제외", () => {
+    const earnings = new Map([
+      ["2026-07-16", [{ canonical: "넷플릭스", symbol: "NFLX", session: "장후" as const }]],
+    ]);
+    const macro = [
+      { date: "2026-07-15", label: "미국 PPI 발표", detail: "생산자물가지수" },
+      { date: "2026-07-29", label: "FOMC 금리 결정", detail: "창 밖 — 제외돼야 함" },
+    ];
+    const cal = composeWeeklyCalendar("2026-07-15", earnings, macro);
+    expect(cal.days.map((d) => d.date)).toEqual(["2026-07-15", "2026-07-16"]);
+    expect(cal.days[0]!.events[0]).toMatchObject({ kind: "macro", title: "미국 PPI 발표" });
+    expect(cal.days[1]!.events[0]).toMatchObject({ kind: "earnings" });
+    expect(cal.days[1]!.events[0]!.stocks?.[0]?.canonical).toBe("넷플릭스");
+    // 금지 문형 없음(사실 일정만)
+    const text = JSON.stringify(cal);
+    expect(text).not.toMatch(/사세요|파세요|매수하세요|매도하세요|추천|서둘/);
+  });
+
+  it("이벤트가 하나도 없으면 days=[] — feed-hub가 카드를 만들지 않는다(정직)", () => {
+    const cal = composeWeeklyCalendar("2026-07-15", new Map(), []);
+    expect(cal.days).toEqual([]);
+  });
+});

--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -24,6 +24,7 @@ describe("feed-hub 타입 레지스트리", () => {
       "term",
       "event",
       "daily-receipt",
+      "calendar",
     ];
     for (const type of REQUIRED_TYPES) {
       expect(FEED_ITEM_TYPES, `타입 "${type}" 이 레지스트리에서 사라졌다 — 명시 지시 없는 타입 제거는 금지`).toContain(type);

--- a/apps/web/app/api/fomo/cron/feed-content/route.ts
+++ b/apps/web/app/api/fomo/cron/feed-content/route.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../../lib/feed-briefing";
 import { processSearchQueue, rebuildSymbolIndex } from "../../../../../lib/symbol-index";
 import { translateAndStoreUsTitles } from "../../../../../lib/content-i18n";
+import { buildAndStoreWeeklyCalendar } from "../../../../../lib/earnings-calendar";
 import { isAiConfigured } from "@fomo/shared";
 import { fetchAllNews, fetchYahooStockNews } from "../../../../../lib/fomo-news-sources";
 import { readUsMarketQuoteRows } from "../../../../../lib/us-market-cache";
@@ -88,11 +89,13 @@ export async function GET(request: Request) {
       // 심볼 마스터 인덱스 재구축(일 1회) + 검색 알림 신청 큐 처리(WO 검색 ①·④).
       const stats = await rebuildSymbolIndex();
       const queue = await processSearchQueue();
+      // 주간 판단 캘린더(2026-07-15) — Nasdaq 어닝 7일치 + 매크로 일정 프리웜.
+      const calendar = await buildAndStoreWeeklyCalendar().catch(() => null);
       revalidateTag("daily-30", { expire: 0 });
       revalidateTag("feed-hub", { expire: 0 });
       return withCors(
         NextResponse.json(
-          { ok: true, slot, index: stats, queue, elapsedMs: Date.now() - startedAt },
+          { ok: true, slot, index: stats, queue, calendarDays: calendar?.days.length ?? null, elapsedMs: Date.now() - startedAt },
           { headers: { "Cache-Control": "no-store" } }
         )
       );

--- a/apps/web/lib/earnings-calendar.ts
+++ b/apps/web/lib/earnings-calendar.ts
@@ -1,0 +1,161 @@
+/**
+ * 주간 판단 캘린더 (2026-07-15 User Zero: "어닝콜·실적발표 캘린더 — 똑같이 하지 말고 우리만의 해자").
+ *
+ * 해자 설계: 토스류 캘린더 = 전 종목 일정 나열(누구나 같은 화면). FOMO 캘린더 = 발견 덱과 같은
+ * 유니버스(큐레이션 미장 대형주)만 추려서, 클라이언트가 내 행동 기록(담은/본 카드, localStorage)과
+ * 조인해 "이번 주 내 카드의 시험대"로 보여준다 — 로그인 없이 개인화되는 판단 캘린더.
+ *
+ * 데이터: Nasdaq calendar API(어닝, Vercel egress 통과 확인) + BLS/Fed/거래소 규칙 일정(feed-extras).
+ * KR 실적 발표일은 사전 공표 소스가 없어(DART는 사후 공시) 정직하게 미포함 — 후속 과제.
+ * 크론 프리웜 전용(요청 경로 fetch 0) — feed-content?slot=index 가 매일 FeedContentCache에 쓴다.
+ */
+
+import { upcomingMarketEvents } from "./feed-extras";
+import { usDiscoverySeedForSymbol } from "./us-symbols";
+import { readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { kstDate } from "./fomo";
+
+const NASDAQ_CALENDAR_URL = "https://api.nasdaq.com/api/calendar/earnings";
+const NASDAQ_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+/** 유니버스 밖이어도 이 시총 이상이면 포함 — TSMC·유나이티드헬스 같은 메가캡 어닝은 시장 이벤트다. */
+const MEGA_CAP_FLOOR_USD = 80_000_000_000;
+const MAX_EARNINGS_PER_DAY = 4;
+const CALENDAR_WINDOW_DAYS = 7;
+
+export interface CalendarStockRef {
+  canonical: string;
+  symbol: string;
+  /** 장전/장후 — Nasdaq time 필드. 미제공이면 생략. */
+  session?: "장전" | "장후";
+}
+
+export interface CalendarEvent {
+  kind: "earnings" | "macro";
+  title: string;
+  detail?: string;
+  stocks?: CalendarStockRef[];
+}
+
+export interface CalendarDay {
+  date: string; // YYYY-MM-DD
+  events: CalendarEvent[];
+}
+
+export interface WeeklyCalendar {
+  asOf: string;
+  days: CalendarDay[];
+}
+
+export interface EarningsRow {
+  symbol: string;
+  marketCapUsd: number;
+  session?: "장전" | "장후";
+}
+
+function parseMarketCap(text: string | undefined): number {
+  if (!text) return 0;
+  const value = Number(text.replace(/[^0-9.]/g, ""));
+  return Number.isFinite(value) ? value : 0;
+}
+
+function sessionOf(time: string | undefined): "장전" | "장후" | undefined {
+  if (time === "time-pre-market") return "장전";
+  if (time === "time-after-hours") return "장후";
+  return undefined;
+}
+
+/** 하루치 Nasdaq 어닝 캘린더 — 실패는 [](fail-open, 크론 전용). */
+export async function fetchNasdaqEarningsDay(dateIso: string): Promise<EarningsRow[]> {
+  try {
+    const res = await fetch(`${NASDAQ_CALENDAR_URL}?date=${dateIso}`, {
+      headers: { accept: "application/json", "user-agent": NASDAQ_UA },
+      signal: AbortSignal.timeout(6_000),
+      next: { revalidate: 3_600 },
+    });
+    if (!res.ok) return [];
+    const payload = (await res.json()) as {
+      data?: { rows?: Array<{ symbol?: string; marketCap?: string; time?: string }> };
+    };
+    return (payload.data?.rows ?? [])
+      .filter((row): row is { symbol: string; marketCap?: string; time?: string } => !!row.symbol)
+      .map((row) => {
+        const session = sessionOf(row.time);
+        return {
+          symbol: row.symbol.toUpperCase(),
+          marketCapUsd: parseMarketCap(row.marketCap),
+          ...(session ? { session } : {}),
+        };
+      });
+  } catch {
+    return [];
+  }
+}
+
+/** 어닝 필터·랭크(순수) — 발견 유니버스(한글명 보유) 우선, 그 외엔 메가캡만. 시총순 상한. */
+export function selectDayEarnings(rows: readonly EarningsRow[]): CalendarStockRef[] {
+  return rows
+    .map((row) => ({ row, seed: usDiscoverySeedForSymbol(row.symbol) }))
+    .filter(({ row, seed }) => seed || row.marketCapUsd >= MEGA_CAP_FLOOR_USD)
+    .sort((a, b) => b.row.marketCapUsd - a.row.marketCapUsd)
+    .slice(0, MAX_EARNINGS_PER_DAY)
+    .map(({ row, seed }) => ({
+      canonical: seed?.canonical ?? row.symbol,
+      symbol: row.symbol,
+      ...(row.session ? { session: row.session } : {}),
+    }));
+}
+
+function addDays(dateIso: string, days: number): string {
+  const d = new Date(`${dateIso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/** 주간 캘린더 합성(순수) — 어닝 + 매크로 일정을 날짜 그룹으로. 이벤트 없는 날은 생략(정직). */
+export function composeWeeklyCalendar(
+  todayIso: string,
+  earningsByDate: ReadonlyMap<string, readonly CalendarStockRef[]>,
+  macroEvents: ReadonlyArray<{ date: string; label: string; detail: string }>
+): WeeklyCalendar {
+  const days: CalendarDay[] = [];
+  for (let offset = 0; offset < CALENDAR_WINDOW_DAYS; offset += 1) {
+    const date = addDays(todayIso, offset);
+    const events: CalendarEvent[] = [];
+    for (const macro of macroEvents.filter((event) => event.date === date)) {
+      events.push({ kind: "macro", title: macro.label, detail: macro.detail });
+    }
+    const stocks = earningsByDate.get(date) ?? [];
+    if (stocks.length > 0) {
+      events.push({ kind: "earnings", title: "실적 발표", stocks: [...stocks] });
+    }
+    if (events.length > 0) days.push({ date, events });
+  }
+  return { asOf: todayIso, days };
+}
+
+/** 크론 전용 — 7일치 어닝 fetch + 매크로 병합 → FeedContentCache 저장. */
+export async function buildAndStoreWeeklyCalendar(): Promise<WeeklyCalendar> {
+  const today = kstDate();
+  const earningsByDate = new Map<string, CalendarStockRef[]>();
+  for (let offset = 0; offset < CALENDAR_WINDOW_DAYS; offset += 1) {
+    const date = addDays(today, offset);
+    const rows = await fetchNasdaqEarningsDay(date);
+    const selected = selectDayEarnings(rows);
+    if (selected.length > 0) earningsByDate.set(date, selected);
+  }
+  const macro = upcomingMarketEvents(today, 20).filter((event) => event.date < addDays(today, CALENDAR_WINDOW_DAYS));
+  const calendar = composeWeeklyCalendar(today, earningsByDate, macro);
+  await writeFeedContent(`calendar:${today}`, calendar).catch(() => {});
+  return calendar;
+}
+
+/** 요청 경로 read — 캐시만(외부 fetch 0). 오늘 것이 없으면 가장 최근 것(어제 빌드도 7일 창이라 유효). */
+export async function readWeeklyCalendar(): Promise<WeeklyCalendar | null> {
+  const rows = await readFeedContentByPrefix<WeeklyCalendar>("calendar:", 2).catch(
+    () => [] as Array<{ id: string; row: WeeklyCalendar }>
+  );
+  const latest = rows.map((r) => r.row).find((row) => row?.days);
+  return latest ?? null;
+}

--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -12,6 +12,7 @@ import { kstDate } from "./fomo";
 import { buildCoinIssueCards, buildEventCard, buildHotIssueCards, buildTermCard } from "./feed-extras";
 import { hydrateKoreanTitles } from "./content-i18n";
 import { buildDailyReceiptCard } from "./feed-receipt";
+import { readWeeklyCalendar, type WeeklyCalendar } from "./earnings-calendar";
 import type { DiscoveryMarketRow } from "./market-source-types";
 
 /**
@@ -38,6 +39,7 @@ export const FEED_ITEM_TYPES = [
   "term", // 오늘의 경제용어(정적 사전 로테이션) — 2026-07-11 베리에이션
   "event", // 시장 일정(만기·FOMC D-day) — 2026-07-11 베리에이션
   "daily-receipt", // 어제의 영수증(어제 30장 성과) — 2026-07-12 R1 후회 영수증
+  "calendar", // 주간 판단 캘린더(어닝+매크로, 내 카드 조인은 클라 localStorage) — 2026-07-15
 ] as const;
 export type FeedItemType = (typeof FEED_ITEM_TYPES)[number];
 
@@ -82,7 +84,8 @@ export type FeedHubItem =
     }
   | { type: "narrative"; scope: "KR" | "US"; narrative: DiscoveryNarrativeCardPayload }
   | { type: "sector"; scope: "KR" | "US"; sector: FeedSectorCard }
-  | { type: "stock-issue"; scope: "KR" | "US"; stockIssue: FeedStockIssue };
+  | { type: "stock-issue"; scope: "KR" | "US"; stockIssue: FeedStockIssue }
+  | { type: "calendar"; scope: "GLOBAL"; calendar: WeeklyCalendar & { id: string } };
 
 export interface FeedHubResponse {
   asOf: string;
@@ -270,6 +273,7 @@ async function attachIndexSeries(cards: Array<DeckContentCard & { series?: numbe
 const TYPE_PRIORITY: Record<FeedItemType, number> = {
   briefing: 0,
   buzz: 1,
+  calendar: 2, // 주간 판단 캘린더 — 브리핑 다음(이번 주 무엇이 시험대인지)
   "hot-issue": 2,
   "macro-issue": 3,
   recap: 4,
@@ -298,6 +302,7 @@ const TYPE_CAPS: Partial<Record<FeedItemType, number>> = {
   "coin-issue": 1,
   term: 1,
   event: 1,
+  calendar: 1,
 };
 
 export function capFeedItemsByType(items: readonly FeedHubItem[]): FeedHubItem[] {
@@ -398,6 +403,12 @@ export async function buildFeedHubResponse(): Promise<FeedHubResponse> {
   for (const card of buildEventCard()) push({ type: "event", scope: "GLOBAL", content: card }, card.id);
   for (const card of await buildDailyReceiptCard().catch((): DeckContentCard[] => [])) {
     push({ type: "daily-receipt", scope: "GLOBAL", content: card }, card.id);
+  }
+  // 5.6) 주간 판단 캘린더(2026-07-15) — 크론 프리웜 캐시만 읽는다(요청 경로 fetch 0). 없으면 미노출(정직).
+  const weeklyCalendar = await readWeeklyCalendar().catch(() => null);
+  if (weeklyCalendar && weeklyCalendar.days.length > 0) {
+    const calendarId = `feed:calendar:${weeklyCalendar.asOf}`;
+    push({ type: "calendar", scope: "GLOBAL", calendar: { ...weeklyCalendar, id: calendarId } }, calendarId);
   }
   // 6) 검색 알림 신청 처리분(WO 검색 ④) — "요청하신 종목 카드가 준비됐어요". 재방문 노출(무로그인).
   const fulfilled = await readTodayFulfilledSearches().catch(() => []);


### PR DESCRIPTION
User Zero 2026-07-15: "어닝콜·실적발표 캘린더 — 토스처럼 나열하지 말고 우리만의 해자".

해자 설계: 캘린더를 '전 종목 일정 나열'이 아니라 '내 카드의 시험대'로.
- 서버는 발견 덱과 같은 유니버스(큐레이션 미장 대형주 + $80B 메가캡)만 추린 어닝
  일정 + 매크로(CPI/PPI/FOMC/만기)를 날짜 그룹으로 제공.
- 클라이언트가 로그인 없이 localStorage(담은 fomo_watchlist·본 fomo_discovery_seen)와
  조인 — "내가 본 카드 N장(메타·옥타…)의 발표가 이번 주에 있어요" + ★ 하이라이트 칩.
- R1 후회 영수증과 같은 축: 판단 전(캘린더) → 판단(덱) → 복기(영수증).

구현:
- earnings-calendar.ts: Nasdaq calendar API(Vercel egress 통과 확인) 7일치 크론 프리웜
  → FeedContentCache. 요청 경로는 read만(fetch 0). 이벤트 없는 날 생략, 캐시 없으면
  카드 미노출(정직).
- feed-hub calendar 타입(우선순위 2 — 브리핑 다음, 캡 1) + 구조화 payload(days/events/stocks).
- 프론트 CalendarCard: 날짜별 D-day, 실적(장전/장후 칩)·매크로 행, 내 종목 네온 하이라이트.
  모바일 피드 + PC 대시보드 + FeedDepthPage 전부 배선(막다른 탭 0).
- KR 실적 발표일은 사전 공표 소스 부재(DART는 사후) — 카드에 정직 고지, 후속 과제.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
