### PR TITLE
feat(verdict): 카드 품질 2차 — stanceText 탈템플릿·근거 수치화·KR 캔들 260일 (WO)

### DIFF
--- a/.github/workflows/kr-candle-prewarm.yml
+++ b/.github/workflows/kr-candle-prewarm.yml
@@ -1,0 +1,33 @@
+name: KR Candle Prewarm
+
+# KR 일봉 260거래일 프리웜 (WO 카드 품질 2차 C) — 52주·MA120·와이코프 phase 판정의 연료.
+# 04:40 KST(화~토) = 전 거래일 마감 데이터 확보 후, 05:00 index 크론·06:00 daily-30 빌드 전.
+# 요청 경로는 캐시만 읽는다(504 원칙). GH cron 지연은 상수 — 몇 시간 늦어도 같은 날 데이터라 무해.
+
+on:
+  schedule:
+    - cron: "40 19 * * 1-5"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kr-candle-prewarm
+  cancel-in-progress: false
+
+jobs:
+  prewarm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call production KR candle prewarm endpoint
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          URL="https://fomo-club-backend.vercel.app/api/fomo/cron/kr-candle-prewarm"
+          if [ -n "${CRON_SECRET:-}" ]; then
+            curl -fsS "$URL" -H "Authorization: Bearer ${CRON_SECRET}"
+          else
+            curl -fsS "$URL"
+          fi

--- a/apps/web/app/api/fomo/cron/kr-candle-prewarm/route.ts
+++ b/apps/web/app/api/fomo/cron/kr-candle-prewarm/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { withCors, kstDate } from "../../../../../lib/fomo";
+import { fetchKrMarketRows } from "../../../../../lib/discovery-supply";
+import { fetchStockDaily } from "../../../../../lib/stock-front";
+import { writeKrCandleCache } from "../../../../../lib/kr-candle-cache";
+
+/**
+ * KR 일봉 260거래일 프리웜 (WO 카드 품질 2차 C) — 네이버 siseJson 420일력을 받아 캐시에 쓴다.
+ * 요청 경로(daily-30 빌드)는 이 캐시만 읽고, 미스면 기존 110일력 직접 fetch 로 폴백(동작 후퇴 없음).
+ * 새벽(04:40 KST) 실행 — 05:00 index 크론·06:00 daily-30 빌드 전에 캐시가 차 있게.
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const UNIVERSE_LIMIT = 450; // 발견 유니버스(시총 상위 400) + 여유 — 덱 후보를 덮는다
+const CONCURRENCY = 8;
+const TIME_BUDGET_MS = 50_000; // maxDuration 60s 안에서 안전 마진
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return true;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return withCors(NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }));
+  }
+  const startedAt = Date.now();
+  const rows = await fetchKrMarketRows().catch(() => []);
+  const codes = [...new Set(rows.map((row) => row.naverCode).filter((code): code is string => !!code))].slice(0, UNIVERSE_LIMIT);
+
+  let stored = 0;
+  let short = 0;
+  let failed = 0;
+  let skippedForBudget = 0;
+  let cursor = 0;
+  async function worker() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= codes.length) return;
+      if (Date.now() - startedAt > TIME_BUDGET_MS) {
+        skippedForBudget += 1;
+        continue; // 카운트만 하고 소진 — 남은 개수를 응답에 정직하게 남긴다(silent cap 금지)
+      }
+      const code = codes[index]!;
+      try {
+        const daily = await fetchStockDaily(code, 420);
+        if (daily.candles.length >= 120) {
+          await writeKrCandleCache(code, daily.candles);
+          stored += 1;
+        } else {
+          short += 1; // 신규 상장 등 이력 자체가 짧음 — 정직하게 캐시 안 함
+        }
+      } catch {
+        failed += 1;
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+
+  return withCors(
+    NextResponse.json({
+      ok: true,
+      asOf: kstDate(),
+      universe: codes.length,
+      stored,
+      short,
+      failed,
+      skippedForBudget,
+      tookMs: Date.now() - startedAt,
+    })
+  );
+}

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -43,6 +43,7 @@ import {
   type DartDisclosureHit,
 } from "./dart-disclosures";
 import { fetchAllNews, fetchNaverCompanyResearch, fetchNaverStockNews, fetchYahooStockNews } from "./fomo-news-sources";
+import { readKrCandleCache } from "./kr-candle-cache";
 import type { DiscoveryCountryScope, DiscoveryMarketRow } from "./market-source-types";
 import { relatedTo, type RelatedNode } from "./relation-graph";
 import { fetchRecentSecFilings } from "./sec-edgar";
@@ -2163,6 +2164,15 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     SPARKLINE_CONCURRENCY,
     async (candidate) => {
       if (candidate.naverCode) {
+        // WO 카드 품질 2차 C: 프리웜 캐시(260거래일)를 우선 — 52주·MA120·와이코프 phase 판정의 연료.
+        // 캐시 미스면 기존 110일력 직접 fetch 폴백(요청 경로에 260일 fetch 추가 금지 — 504 원칙).
+        const cached = await readKrCandleCache(candidate.naverCode).catch(() => null);
+        if (cached) {
+          return {
+            ticker: candidate.ticker,
+            daily: { candles: cached, closes: cached.map((c) => c.close), volumes: cached.map((c) => c.volume) },
+          };
+        }
         return { ticker: candidate.ticker, daily: await fetchStockDaily(candidate.naverCode, 110) };
       }
       // US(내부자 포함) — Nasdaq OHLCV 로 verdict 엔진까지 캔들 공급(WO 1.6 A/B: 국/미 무차별 표준).

--- a/apps/web/lib/kr-candle-cache.ts
+++ b/apps/web/lib/kr-candle-cache.ts
@@ -1,0 +1,44 @@
+import type { DailyOhlcv } from "@fomo/core";
+import { readFeedContent, writeFeedContent } from "./feed-content-store";
+
+/**
+ * KR 일봉 260거래일 캐시 (WO 카드 품질 2차 C) — 프리웜 크론이 쓰고 요청 경로는 읽기만(504 원칙).
+ *
+ * 배경: 덱 카드 verdict 가 네이버 일봉 110일력(≈75거래일)만 받아 52주·MA120·와이코프 phase 판정이
+ * 국장에서 불가능했다("최근 4개월 저점" 문구·phase 55% 판정불가의 뿌리). 프리웜이 420일력(≈280거래일)을
+ * 받아 최근 260거래일을 저장하면 windowLabel ≥240 → "52주" 승격, MA120·정배열 판정이 자동 활성된다.
+ *
+ * 저장소는 기존 FeedContentCache(JSONB) 재사용 — 신규 DDL 없음. 키: "kr-candles:<naverCode>".
+ */
+
+interface KrCandleRow {
+  candles: DailyOhlcv[];
+  asOf: string;
+}
+
+const KEY_PREFIX = "kr-candles:";
+/** 260거래일 = 52주 라벨(windowLabel ≥240) + MA120 여유. */
+export const KR_CANDLE_KEEP_DAYS = 260;
+/** 캐시가 유효하려면 최소 이만큼 — 현행 요청 경로(110일력 ≈ 75거래일)보다 명확히 나은 경우만 사용. */
+const MIN_USEFUL_DAYS = 120;
+/** 이 일수보다 오래된 캐시는 스테일 — 프리웜이 죽었는데 옛 캔들로 verdict 내는 것 방지. */
+const MAX_STALE_DAYS = 7;
+
+function kstDate(now = new Date()): string {
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+export async function writeKrCandleCache(naverCode: string, candles: readonly DailyOhlcv[]): Promise<void> {
+  if (candles.length < MIN_USEFUL_DAYS) return; // 짧은 이력은 캐시하지 않는다 — 폴백(직접 fetch)이 정본
+  const row: KrCandleRow = { candles: candles.slice(-KR_CANDLE_KEEP_DAYS), asOf: kstDate() };
+  await writeFeedContent(`${KEY_PREFIX}${naverCode}`, row);
+}
+
+/** 캐시 읽기 — 유효(길이·신선도)하지 않으면 null(호출부가 기존 경로로 폴백). */
+export async function readKrCandleCache(naverCode: string): Promise<DailyOhlcv[] | null> {
+  const row = await readFeedContent<KrCandleRow>(`${KEY_PREFIX}${naverCode}`).catch(() => null);
+  if (!row?.candles || row.candles.length < MIN_USEFUL_DAYS) return null;
+  const ageDays = (Date.parse(kstDate()) - Date.parse(row.asOf)) / 86_400_000;
+  if (!Number.isFinite(ageDays) || ageDays > MAX_STALE_DAYS) return null;
+  return row.candles;
+}

--- a/packages/fomo-core/__tests__/verdict.test.ts
+++ b/packages/fomo-core/__tests__/verdict.test.ts
@@ -181,3 +181,126 @@ describe("computeCardVerdict — 결정론 판단 엔진", () => {
     expect(allowed.some((level) => v!.invalidation.includes(level))).toBe(true);
   });
 });
+
+// ── WO 카드 품질 2차 (2026-07-17) — stanceText 탈템플릿 + 근거 수치화 반복도 게이트 ──
+describe("stanceText 조합 조립 — 돌려막기 회귀 방지 (WO 2차 A/B)", () => {
+  /** 프로덕션 30장을 흉내 낸 다양한 입력 30개 — 결정론(난수 없음), 시나리오·파라미터 스윕. */
+  function thirtyInputs(): VerdictInput[] {
+    const inputs: VerdictInput[] = [];
+    // 축적 6종 — 수급·내부자 변주
+    for (let i = 0; i < 6; i += 1) {
+      const scale = 1 + i * 0.13;
+      const candles = [
+        ...mkCandles([{ days: 80, from: 20000 * scale, to: 10000 * scale, vol: 1_000_000 }]),
+        ...mkCandles([{ days: 40, from: 10200 * scale, to: 10250 * scale, vol: 800_000 }]),
+        ...mkCandles([{ days: 20, from: 10250 * scale, to: 10200 * scale, vol: 480_000 }]),
+      ];
+      inputs.push(
+        i % 2 === 0
+          ? { candles, foreignNetStreak: 3 + i, currency: "KRW" }
+          : { candles, insider: { insiderCount: 2 + i, valueUsd: 300_000 * (i + 1) }, currency: "KRW" }
+      );
+    }
+    // 상승 6종 — 거래량 배수 변주
+    for (let i = 0; i < 6; i += 1) {
+      const candles: DailyOhlcv[] = [];
+      let close = 8000 + i * 700;
+      for (let d = 0; d < 140; d += 1) {
+        close *= d % 2 === 0 ? 1.014 + i * 0.0004 : 0.992;
+        candles.push({ open: close / 1.01, high: close * 1.01, low: close * 0.99, close, volume: d >= 120 ? 1_400_000 : 1_000_000 });
+      }
+      inputs.push({ candles, volumeRatio: 1.5 + i * 0.17, currency: "KRW" });
+    }
+    // 하락 6종 — 기울기·수급 이탈 변주
+    for (let i = 0; i < 6; i += 1) {
+      const candles = mkCandles([
+        { days: 60, from: 20000 + i * 900, to: 17000 + i * 500, vol: 1_000_000 },
+        { days: 80, from: 17000 + i * 500, to: 9000 + i * 350, vol: 1_000_000 },
+      ]);
+      inputs.push(i % 2 === 0 ? { candles, currency: "KRW" } : { candles, institutionNetStreak: -(3 + i), currency: "KRW" });
+    }
+    // 혼조/조용 6종 — 횡보 이격 변주
+    for (let i = 0; i < 6; i += 1) {
+      const base = 10000 + i * 1300;
+      const candles = mkCandles([
+        { days: 70, from: base, to: base * 1.02, vol: 700_000 },
+        { days: 50, from: base * 1.02, to: base * (0.97 + i * 0.012), vol: 700_000 },
+      ]);
+      inputs.push(i % 2 === 0 ? { candles, foreignNetStreak: 3 + i, institutionNetStreak: -(3 + i), currency: "KRW" } : { candles, currency: "KRW" });
+    }
+    // 분산 3종 + 이력 부족 3종
+    for (let i = 0; i < 3; i += 1) {
+      const scale = 1 + i * 0.21;
+      inputs.push({
+        candles: [
+          ...mkCandles([{ days: 100, from: 10000 * scale, to: 20000 * scale, vol: 900_000 }]),
+          ...mkCandles([{ days: 20, from: 19900 * scale, to: 19800 * scale, vol: 1_000_000 }]),
+          ...mkCandles([{ days: 20, from: 19850 * scale, to: 19900 * scale, vol: 1_600_000 }]),
+        ],
+        foreignNetStreak: -(3 + i),
+        currency: "KRW",
+      });
+      inputs.push({
+        candles: mkCandles([{ days: 15 + i * 5, from: 5000 * scale, to: 5100 * scale, vol: 300_000 }]),
+        ...(i === 0 ? { insider: { insiderCount: 2, valueUsd: 250_000 } } : {}),
+        currency: "KRW",
+      });
+    }
+    return inputs.slice(0, 30);
+  }
+
+  it("30장 기준 동일 stanceText ≤3회, 유니크 ≥10종 (돌려막기 금지 CI 게이트)", () => {
+    const verdicts = thirtyInputs().map((input) => computeCardVerdict(input));
+    expect(verdicts).toHaveLength(30);
+    const counts = new Map<string, number>();
+    for (const v of verdicts) counts.set(v.stanceText, (counts.get(v.stanceText) ?? 0) + 1);
+    const maxRepeat = Math.max(...counts.values());
+    expect(maxRepeat, `가장 많이 반복된 문장 ${maxRepeat}회: "${[...counts.entries()].sort((a, b) => b[1] - a[1])[0]![0]}"`).toBeLessThanOrEqual(3);
+    expect(counts.size, "stanceText 유니크 종수").toBeGreaterThanOrEqual(10);
+  });
+
+  it("모든 근거(evidence) 문장에 실측치(숫자) 포함 — 무수치 일반문 0 (WO 2차 B 게이트)", () => {
+    const verdicts = thirtyInputs().map((input) => computeCardVerdict(input));
+    for (const v of verdicts) {
+      for (const line of v.evidence) {
+        expect(/\d/.test(line), `무수치 근거: "${line}"`).toBe(true);
+      }
+    }
+  });
+
+  it("동일 근거 문장 반복 ≤30% (근거도 돌려막기 금지)", () => {
+    const verdicts = thirtyInputs().map((input) => computeCardVerdict(input));
+    const counts = new Map<string, number>();
+    let total = 0;
+    for (const v of verdicts) {
+      for (const line of v.evidence) {
+        counts.set(line, (counts.get(line) ?? 0) + 1);
+        total += 1;
+      }
+    }
+    const maxRepeat = Math.max(...counts.values());
+    expect(maxRepeat / total, `최다 반복 근거 "${[...counts.entries()].sort((a, b) => b[1] - a[1])[0]![0]}"`).toBeLessThanOrEqual(0.3);
+  });
+
+  it("phase 판정률 — 구조가 뚜렷한 시나리오(축적·상승·하락·분산)에서 판정 누락 없음", () => {
+    const structured = [
+      computeCardVerdict({ candles: accumulationCandles(), foreignNetStreak: 5 }),
+      computeCardVerdict({ candles: markupCandles(), volumeRatio: 1.6 }),
+      computeCardVerdict({ candles: markdownCandles() }),
+      computeCardVerdict({ candles: distributionCandles(), foreignNetStreak: -4 }),
+    ];
+    for (const v of structured) expect(v.phase).toBeDefined();
+  });
+
+  it("완화 폴백 — 거래량 확인 없는 뚜렷한 정배열 추세도 markup 으로 분류(억지 아님·배열 1%+ 이격)", () => {
+    const candles: DailyOhlcv[] = [];
+    let close = 10000;
+    for (let d = 0; d < 140; d += 1) {
+      close *= d % 2 === 0 ? 1.012 : 0.994; // 완만 상승, 거래량 확대 없음
+      candles.push({ open: close / 1.01, high: close * 1.01, low: close * 0.99, close, volume: 1_000_000 });
+    }
+    const v = computeCardVerdict({ candles });
+    expect(v.phase).toBe("markup");
+    expect(v.stance).toBe("watch"); // 유입·거래량 확인 없이는 enter 아님 — 판별 규율 유지
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/verdict.ts
+++ b/packages/fomo-core/src/keyword-cards/verdict.ts
@@ -89,6 +89,8 @@ interface PriceStructure {
   stall10: number;
   /** MA20의 10일 기울기(비율) — 상승 지속(양수 큼) vs 고점 정체(≈0) 판별자. */
   ma20Slope10?: number;
+  /** 20/60일선 배열 연속 일수 — 양수=정배열 N일째, 음수=역배열 N일째. 근거 수치화(WO 2차 B)용. */
+  alignStreak?: number;
   days: number;
 }
 
@@ -112,6 +114,25 @@ function priceStructure(candles: readonly DailyOhlcv[]): PriceStructure | undefi
   const ma120 = sma(closes, 120);
   const ma20Prev10 = closes.length >= 30 ? sma(closes.slice(0, -10), 20) : undefined;
   const ma20Slope10 = num(ma20) && num(ma20Prev10) && ma20Prev10 > 0 ? ma20 / ma20Prev10 - 1 : undefined;
+  // 20/60일선 배열 연속 일수 — 프리픽스합으로 일별 SMA를 계산해 현재 배열이 며칠째인지 센다(결정론).
+  let alignStreak: number | undefined;
+  if (closes.length >= 60) {
+    const prefix: number[] = [0];
+    for (const c of closes) prefix.push(prefix[prefix.length - 1]! + c);
+    const smaAt = (i: number, n: number): number | undefined => (i + 1 >= n ? (prefix[i + 1]! - prefix[i + 1 - n]!) / n : undefined);
+    const alignSign = (i: number): number => {
+      const a = smaAt(i, 20);
+      const b = smaAt(i, 60);
+      if (!num(a) || !num(b) || a === b) return 0;
+      return a > b ? 1 : -1;
+    };
+    const last = alignSign(closes.length - 1);
+    if (last !== 0) {
+      let count = 0;
+      for (let i = closes.length - 1; i >= 0 && alignSign(i) === last; i -= 1) count += 1;
+      alignStreak = last * count;
+    }
+  }
   return {
     close,
     ...(num(ma20) ? { ma20 } : {}),
@@ -124,6 +145,7 @@ function priceStructure(candles: readonly DailyOhlcv[]): PriceStructure | undefi
     recentNewLow: min10Low <= windowLow * 1.005,
     stall10: num(first10Close) && first10Close > 0 ? close / first10Close - 1 : 0,
     ...(num(ma20Slope10) ? { ma20Slope10 } : {}),
+    ...(num(alignStreak) ? { alignStreak } : {}),
     days: clean.length,
   };
 }
@@ -149,15 +171,12 @@ function wyckoffPhase(s: PriceStructure, squeeze: boolean, volumeRatio: number |
   if (nearLow && volumeContracting && flat && !s.recentNewLow) return "accumulation";
   if (nearHigh && volumeExpanding && s.stall10 <= 0.02 && ma20Flat) return "distribution";
   if (bullAligned && s.close > s.ma20 && volumeExpanding) return "markup";
+  // 완화 폴백(WO 2차 D — 판정률 80% 목표): 거래량 확인·저점 갱신이 없어도 배열이 뚜렷하면(≥1% 이격)
+  // 추세 국면으로 분류한다. 배열이 붙어 있는 애매한 중간 지대만 정직하게 "없음"으로 남긴다.
+  if (bullAligned && s.ma20 > s.ma60 * 1.01 && s.close > s.ma20) return "markup";
+  if (bearAligned && s.ma20 < s.ma60 * 0.99 && s.close < s.ma20) return "markdown";
   return undefined;
 }
-
-const PHASE_TEXT: Record<WyckoffPhase, string> = {
-  accumulation: "저점권 횡보에 거래가 수축된 축적형 구조",
-  markup: "이동평균 정배열에 거래량이 붙은 상승 국면",
-  distribution: "고점권에서 거래는 늘고 가격은 정체된 분산형 구조",
-  markdown: "이동평균 역배열에 저점을 갱신 중인 하락 국면",
-};
 
 type Driver =
   | "accumulation_inflow"
@@ -170,55 +189,114 @@ type Driver =
   | "markdown"
   | "signal_drain";
 
-function stanceText(stance: VerdictStance, driver: Driver, primaryEvidenceKind: string | undefined): string {
-  if (stance === "enter") {
-    if (driver === "accumulation_inflow") {
-      return primaryEvidenceKind === "insider"
-        ? "저점 다지기 구간에 내부자 매수가 겹쳐, 분할 진입을 검토할 만한 자리로 보여요."
-        : "저점 다지기 구간에 기관·외국인 유입이 붙어, 분할 진입을 검토할 만한 자리로 보여요.";
-    }
-    if (driver === "markup_confirmed") {
-      return "추세 초입에 거래량 확인이 붙어, 흐름을 따라가 볼 만한 자리로 보여요.";
-    }
-    return "가격 구조보다 신호 조합이 먼저 좋아진 상태 — 가볍게 진입을 검토할 만해요.";
-  }
-  if (stance === "avoid") {
-    if (driver === "phase_exit") return "고점권 분산에 수급 이탈이 겹쳐, 지금 들어갈 자리는 아니에요.";
-    if (driver === "markdown") return "하락 추세가 진행 중이라, 바닥 확인 전엔 피하는 게 맞아요.";
-    return "확인되는 신호가 약세 쪽에 몰려 있어, 지금은 피할 구간이에요.";
-  }
-  if (driver === "overheat") return "추세는 살아 있지만 단기 과열 상태 — 눌림을 기다려 볼 구간이에요.";
-  if (driver === "mixed") return "강세·약세 신호가 상충해, 지금은 지켜볼 구간이에요.";
-  return "판단을 기울일 확인 신호가 아직 부족해요. 관찰 목록에 두는 정도가 맞아요.";
+/** 받침 유무 기반 조사 선택 — 조립 문장의 "이/가"·"은/는" 깨짐 방지. 비한글 끝은 받침 없음으로 처리. */
+function josa(word: string, withBatchim: string, withoutBatchim: string): string {
+  const last = word.trim().at(-1);
+  if (!last) return withoutBatchim;
+  const code = last.charCodeAt(0);
+  if (code < 0xac00 || code > 0xd7a3) return withoutBatchim;
+  return (code - 0xac00) % 28 === 0 ? withoutBatchim : withBatchim;
 }
 
 interface Factor {
   kind: string;
+  /** 근거 문장 — 반드시 실측치(숫자) 포함(WO 2차 B 게이트). */
   text: string;
+  /** stanceText 조립용 짧은 구절 — [주도 신호 실측치]+[반대 신호 실측치] 형태(WO 2차 A). */
+  short: string;
 }
 
-/** 가격 구조 없이도 확인 가능한 강세 신호(내부자·수급·재료·거래량) — 최소 verdict 의 근거이기도 하다. */
+/** 근거 수치화 게이트(WO 2차 B) — 숫자 없는 일반문 근거는 카드에 싣지 않는다. */
+export function hasMeasuredValue(text: string): boolean {
+  return /\d/.test(text);
+}
+
+/**
+ * 판단 1줄 조립(WO 2차 A) — stance별 고정 문장 대신 실제 신호 조합에서 조립한다.
+ * 형태: [주도 신호 실측치] + [반대/부족 신호 실측치] + stance 결론. 결정론(같은 입력→같은 출력).
+ */
+function assembleStanceText(
+  stance: VerdictStance,
+  driver: Driver,
+  bulls: readonly Factor[],
+  bears: readonly Factor[],
+  s: PriceStructure,
+  rsi: number | undefined,
+  currency: "KRW" | "USD"
+): string {
+  const bullLead = bulls[0];
+  const bearLead = bears[0];
+  if (stance === "enter") {
+    if (driver === "accumulation_inflow" && bullLead) {
+      return `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 위 다지기에 ${bullLead.short}${josa(bullLead.short, "이", "가")} 붙어 — 분할 진입을 검토할 자리예요.`;
+    }
+    if (driver === "markup_confirmed" && bullLead) {
+      const trendClause = num(s.alignStreak) && s.alignStreak > 0 ? `정배열 ${s.alignStreak}일째 추세` : "상승 추세";
+      const confirm = bulls.find((f) => f.kind === "volume" || f.kind === "insider" || f.kind === "flow") ?? bullLead;
+      return `${trendClause}에 ${confirm.short} 확인 — 흐름을 따라가 볼 자리예요.`;
+    }
+    if (bulls.length >= 2) {
+      return `${bulls[0]!.short}에 ${bulls[1]!.short}까지 겹쳐 — 가볍게 진입을 검토할 만해요.`;
+    }
+    return `${bullLead?.short ?? "확인 신호"}${josa(bullLead?.short ?? "확인 신호", "이", "가")} 먼저 좋아졌어요 — 가볍게 진입을 검토할 만해요.`;
+  }
+  if (stance === "avoid") {
+    if (driver === "phase_exit") {
+      const highGap = ((1 - s.close / s.windowHigh) * 100).toFixed(1);
+      const tail = bearLead ? `에 ${bearLead.short}${josa(bearLead.short, "이", "가")} 겹쳐` : "라";
+      return `${s.windowText} 고점 대비 -${highGap}% 분산 구간${tail} — 지금 들어갈 자리는 아니에요.`;
+    }
+    if (driver === "markdown") {
+      const streakClause = num(s.alignStreak) && s.alignStreak < 0 ? `역배열 ${Math.abs(s.alignStreak)}일째` : "하락 추세";
+      const extra = bears.find((f) => f.kind !== "trend" && f.kind !== "newlow");
+      return extra
+        ? `${streakClause} 하락에 ${extra.short}까지 — 바닥 확인 전엔 피할 구간이에요.`
+        : `${streakClause}, ${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 부근 — 바닥 확인 전엔 피할 구간이에요.`;
+    }
+    if (bears.length >= 2) {
+      return `${bears[0]!.short}·${bears[1]!.short} — 약세 신호가 쌓여 지금은 피할 구간이에요.`;
+    }
+    return `${bearLead?.short ?? "약세 신호"} 쪽에 무게가 실려 — 지금은 피할 구간이에요.`;
+  }
+  // watch
+  if (driver === "overheat" && num(rsi)) {
+    const trendClause = bullLead ? bullLead.short : num(s.alignStreak) && s.alignStreak > 0 ? `정배열 ${s.alignStreak}일째` : "추세";
+    return `${trendClause}로 추세는 살아 있는데 RSI ${Math.round(rsi)} 과열이 맞서요 — 식는지 볼 구간이에요.`;
+  }
+  if (driver === "mixed" && bullLead && bearLead) {
+    return `${bullLead.short}${josa(bullLead.short, "은", "는")} 강세인데 ${bearLead.short}${josa(bearLead.short, "이", "가")} 맞서요 — 우세가 갈릴 때까지 볼 구간이에요.`;
+  }
+  // quiet — 카드마다 다른 실측치(20일선 이격)로 문장을 만들어 돌려막기를 없앤다.
+  if (num(s.ma20) && s.ma20 > 0) {
+    const gap = ((s.close / s.ma20 - 1) * 100).toFixed(1);
+    return `20일선 대비 ${Number(gap) >= 0 ? "+" : ""}${gap}% 자리, 판단을 기울일 확인 신호는 아직 — 관찰 구간이에요.`;
+  }
+  return `가격 이력 ${s.days}거래일 — 확인 신호가 쌓일 때까지 관찰 구간이에요.`;
+}
+
+/** 가격 구조 없이도 확인 가능한 강세 신호(내부자·수급·재료·거래량) — 최소 verdict 의 근거이기도 하다. 전 문장 실측치 포함. */
 function signalBullFactors(input: VerdictInput): Factor[] {
   const out: Factor[] = [];
   const insiderCount = input.insider?.insiderCount;
   if (num(insiderCount) && insiderCount >= 2) {
     const valueUsd = input.insider?.valueUsd;
     const valueText = num(valueUsd) && valueUsd > 0 ? ` 총 $${Math.round(valueUsd / 1000).toLocaleString("en-US")}k` : "";
-    out.push({ kind: "insider", text: `내부자 ${insiderCount}인이${valueText} 동반 매수(공시 확인)` });
+    out.push({ kind: "insider", text: `내부자 ${insiderCount}인이${valueText} 동반 매수(공시 확인)`, short: `내부자 ${insiderCount}인 동반 매수` });
   } else if (input.insider?.confirmed === true) {
-    out.push({ kind: "insider", text: "내부자 공개시장 매수 공시 확인" });
+    out.push({ kind: "insider", text: "내부자 공개시장 매수 공시 1건 이상 확인", short: "내부자 매수 공시 확인" });
   }
   if (num(input.foreignNetStreak) && input.foreignNetStreak >= 3) {
-    out.push({ kind: "flow", text: `외국인 ${input.foreignNetStreak}일 연속 순매수` });
+    out.push({ kind: "flow", text: `외국인 ${input.foreignNetStreak}일 연속 순매수`, short: `외국인 ${input.foreignNetStreak}일 연속 순매수` });
   }
   if (num(input.institutionNetStreak) && input.institutionNetStreak >= 3) {
-    out.push({ kind: "flow", text: `기관 ${input.institutionNetStreak}일 연속 순매수` });
+    out.push({ kind: "flow", text: `기관 ${input.institutionNetStreak}일 연속 순매수`, short: `기관 ${input.institutionNetStreak}일 연속 순매수` });
   }
   if (num(input.materialStrength) && input.materialStrength >= 0.6) {
-    out.push({ kind: "material", text: "이 종목을 직접 언급한 재료(뉴스·공시)가 확인됨" });
+    const pct = Math.round(input.materialStrength * 100);
+    out.push({ kind: "material", text: `이 종목을 직접 언급한 재료(뉴스·공시) 확인 — 신호 강도 ${pct}%`, short: `직접 재료(강도 ${pct}%)` });
   }
   if (num(input.volumeRatio) && input.volumeRatio >= 1.5) {
-    out.push({ kind: "volume", text: `거래량이 20일 평균의 ${input.volumeRatio.toFixed(1)}배` });
+    out.push({ kind: "volume", text: `거래량이 20일 평균의 ${input.volumeRatio.toFixed(1)}배`, short: `거래량 ${input.volumeRatio.toFixed(1)}배` });
   }
   return out;
 }
@@ -226,32 +304,50 @@ function signalBullFactors(input: VerdictInput): Factor[] {
 function signalBearFactors(input: VerdictInput): Factor[] {
   const out: Factor[] = [];
   if (num(input.foreignNetStreak) && input.foreignNetStreak <= -3) {
-    out.push({ kind: "flow", text: `외국인 ${Math.abs(input.foreignNetStreak)}일 연속 순매도` });
+    const days = Math.abs(input.foreignNetStreak);
+    out.push({ kind: "flow", text: `외국인 ${days}일 연속 순매도`, short: `외국인 ${days}일 연속 순매도` });
   }
   if (num(input.institutionNetStreak) && input.institutionNetStreak <= -3) {
-    out.push({ kind: "flow", text: `기관 ${Math.abs(input.institutionNetStreak)}일 연속 순매도` });
+    const days = Math.abs(input.institutionNetStreak);
+    out.push({ kind: "flow", text: `기관 ${days}일 연속 순매도`, short: `기관 ${days}일 연속 순매도` });
   }
   return out;
 }
 
-function bullFactors(input: VerdictInput, s: PriceStructure): Factor[] {
+function bullFactors(input: VerdictInput, s: PriceStructure, currency: "KRW" | "USD"): Factor[] {
   const out = signalBullFactors(input);
   if (num(s.ma20) && num(s.ma60) && s.ma20 > s.ma60 && s.close > s.ma20) {
-    out.push({ kind: "trend", text: "20·60일선 정배열 위에서 가격 유지 중" });
+    const gap = ((s.close / s.ma20 - 1) * 100).toFixed(1);
+    const streakText = num(s.alignStreak) && s.alignStreak > 0 ? ` — 정배열 ${s.alignStreak}일째` : "";
+    out.push({
+      kind: "trend",
+      text: `20일선 ${formatVerdictLevel(s.ma20, currency)} 위 +${gap}%${streakText}`,
+      short: num(s.alignStreak) && s.alignStreak > 0 ? `정배열 ${s.alignStreak}일째` : `20일선 위 +${gap}%`,
+    });
   }
   return out;
 }
 
-function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undefined): Factor[] {
+function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undefined, currency: "KRW" | "USD"): Factor[] {
   const out = signalBearFactors(input);
   if (num(rsi) && rsi >= 70) {
-    out.push({ kind: "overheat", text: `RSI ${Math.round(rsi)} — 단기 과열 영역` });
+    out.push({ kind: "overheat", text: `RSI ${Math.round(rsi)} — 단기 과열 영역`, short: `RSI ${Math.round(rsi)} 단기 과열` });
   }
   if (num(s.ma20) && num(s.ma60) && s.ma20 < s.ma60 && s.close < s.ma20) {
-    out.push({ kind: "trend", text: "20·60일선 역배열 아래에서 가격 하락 중" });
+    const gap = ((1 - s.close / s.ma20) * 100).toFixed(1);
+    const streakText = num(s.alignStreak) && s.alignStreak < 0 ? ` — 역배열 ${Math.abs(s.alignStreak)}일째` : "";
+    out.push({
+      kind: "trend",
+      text: `20일선 ${formatVerdictLevel(s.ma20, currency)} 아래 -${gap}% 이격${streakText}`,
+      short: num(s.alignStreak) && s.alignStreak < 0 ? `역배열 ${Math.abs(s.alignStreak)}일째` : `20일선 아래 -${gap}%`,
+    });
   }
   if (s.recentNewLow) {
-    out.push({ kind: "newlow", text: `${s.windowText} 저점을 최근 갱신` });
+    out.push({
+      kind: "newlow",
+      text: `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)}을 최근 10일 내 갱신`,
+      short: `${s.windowText} 저점 갱신`,
+    });
   }
   return out;
 }
@@ -259,13 +355,36 @@ function bearFactors(input: VerdictInput, s: PriceStructure, rsi: number | undef
 function phaseEvidence(phase: WyckoffPhase, s: PriceStructure, currency: "KRW" | "USD"): Factor {
   if (phase === "accumulation") {
     const pct = ((s.close / s.windowLow - 1) * 100).toFixed(1);
-    return { kind: "phase", text: `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 대비 +${pct}% — ${PHASE_TEXT[phase]}` };
+    return {
+      kind: "phase",
+      text: `${s.windowText} 저점 ${formatVerdictLevel(s.windowLow, currency)} 대비 +${pct}% — 저점권 횡보에 거래가 수축된 축적형 구조`,
+      short: "저점권 축적 구조",
+    };
   }
   if (phase === "distribution") {
     const pct = ((1 - s.close / s.windowHigh) * 100).toFixed(1);
-    return { kind: "phase", text: `${s.windowText} 고점 ${formatVerdictLevel(s.windowHigh, currency)} 대비 -${pct}% — ${PHASE_TEXT[phase]}` };
+    return {
+      kind: "phase",
+      text: `${s.windowText} 고점 ${formatVerdictLevel(s.windowHigh, currency)} 대비 -${pct}% — 고점권에서 거래는 늘고 가격은 정체된 분산형 구조`,
+      short: "고점권 분산 구조",
+    };
   }
-  return { kind: "phase", text: PHASE_TEXT[phase] };
+  if (phase === "markup") {
+    const gap = num(s.ma20) && s.ma20 > 0 ? ((s.close / s.ma20 - 1) * 100).toFixed(1) : undefined;
+    const streakText = num(s.alignStreak) && s.alignStreak > 0 ? `정배열 ${s.alignStreak}일째` : "이동평균 정배열";
+    return {
+      kind: "phase",
+      text: `${streakText}${gap ? `·20일선 위 +${gap}%` : ""} — 상승 국면`,
+      short: streakText,
+    };
+  }
+  const lowGap = ((s.close / s.windowLow - 1) * 100).toFixed(1);
+  const streakText = num(s.alignStreak) && s.alignStreak < 0 ? `역배열 ${Math.abs(s.alignStreak)}일째` : "이동평균 역배열";
+  return {
+    kind: "phase",
+    text: `${streakText}·${s.windowText} 저점 대비 +${lowGap}% — 하락 국면`,
+    short: streakText,
+  };
 }
 
 function invalidationOf(
@@ -303,10 +422,14 @@ function invalidationOf(
  * 억지 enter/avoid 금지: 항상 관망 + 확인된 신호 근거만. 레벨을 계산할 수 없으니 무효화는 생략(가짜 레벨 금지).
  */
 function minimalVerdict(input: VerdictInput): CardVerdict {
-  const evidence = [...signalBullFactors(input), ...signalBearFactors(input)].slice(0, 3).map((f) => f.text);
+  const evidence = [...signalBullFactors(input), ...signalBearFactors(input)]
+    .slice(0, 3)
+    .map((f) => f.text)
+    .filter(hasMeasuredValue);
+  const days = input.candles.length;
   return {
     stance: "watch",
-    stanceText: "가격 이력이 짧아 신호가 쌓이는 중이에요 — 지금은 관찰 구간이에요.",
+    stanceText: `가격 이력 ${days}거래일뿐이라 신호가 쌓이는 중 — 지금은 관찰 구간이에요.`,
     evidence,
     confidence: "low",
   };
@@ -325,8 +448,8 @@ export function computeCardVerdict(input: VerdictInput): CardVerdict {
   const squeeze = ta.inputs.bollingerSqueeze === true;
   const phase = wyckoffPhase(s, squeeze, input.volumeRatio);
 
-  const bulls = bullFactors(input, s);
-  const bears = bearFactors(input, s, rsi);
+  const bulls = bullFactors(input, s, currency);
+  const bears = bearFactors(input, s, rsi, currency);
   const hasInflow = bulls.some((f) => f.kind === "insider" || f.kind === "flow");
   const hasOutflow = bears.some((f) => f.kind === "flow");
   const overheated = num(rsi) && rsi >= 70;
@@ -361,7 +484,7 @@ export function computeCardVerdict(input: VerdictInput): CardVerdict {
   if (phase) evidence.push(phaseEvidence(phase, s, currency).text);
   for (const f of sided) {
     if (evidence.length >= 3) break;
-    if (!evidence.includes(f.text)) evidence.push(f.text);
+    if (!evidence.includes(f.text) && hasMeasuredValue(f.text)) evidence.push(f.text);
   }
 
   const sidedCount = stance === "enter" ? bulls.length : stance === "avoid" ? bears.length : Math.max(bulls.length, bears.length);
@@ -371,7 +494,7 @@ export function computeCardVerdict(input: VerdictInput): CardVerdict {
   const invalidation = invalidationOf(stance, driver, s, currency);
   return {
     stance,
-    stanceText: stanceText(stance, driver, sided[0]?.kind),
+    stanceText: assembleStanceText(stance, driver, bulls, bears, s, rsi, currency),
     ...(phase ? { phase } : {}),
     evidence,
     invalidation: invalidation.text,


### PR DESCRIPTION
## WO — 카드 품질 2차 (프로덕션 실측 49카드 병목 3개, 재진단 없이 수정)

### A. stanceText 탈템플릿 → 조합 조립
- stance별 고정 문장 상수 폐기. `assembleStanceText`가 실제 신호 조합에서 조립: **[주도 신호 실측치] + [반대/부족 신호 실측치] + stance 결론**
- 예: mixed → "기관 4일 연속 순매수는 강세인데 RSI 77 단기 과열이 맞서요 — 우세가 갈릴 때까지 볼 구간이에요"
- quiet도 카드별 실측치(20일선 이격 %)로 문장 생성 — 돌려막기 원천 차단. 받침 기반 조사(이/가·은/는) 처리. 결정론 유지(LLM 없음)
- **반복도 CI 게이트**: 30장 기준 동일 stanceText ≤3회 · 유니크 ≥10종 · 동일 근거 ≤30% — 위반 시 CI 실패

### B. 근거 수치화 (전 문장 실측치)
- 신규 `alignStreak`(프리픽스합 일별 SMA — 정/역배열 N일째), 20일선 실값·이격%, 재료 강도%, 저점 실값·10일 내 갱신
- "20·60일선 역배열 아래 하락 중" → "20일선 7,120원 아래 -8.0% 이격 — 역배열 12일째"
- `hasMeasuredValue` 게이트 — 무수치 일반문 근거는 카드에 싣지 않음 + 테스트

### C. KR 캔들 260거래일 (phase 실패의 뿌리)
- 덱 verdict가 `fetchStockDaily(code, 110)`(≈75거래일)만 받던 것이 원인 — 뎁스는 이미 420일력
- 신규 `kr-candle-cache`(기존 FeedContentCache JSONB 재사용 — **신규 DDL 없음**) + `kr-candle-prewarm` 크론(04:40 KST 화~토, 유니버스 450, 50s 예산, skippedForBudget 정직 보고)
- 요청 경로는 **캐시 읽기만**, 미스 시 기존 110일력 폴백(504 원칙 — 동작 후퇴 없음)
- 자동 효과: windowLabel ≥240 → "52주" 승격("4개월 저점" 소멸), MA120·정배열 판정 활성

### D. phase 완화 폴백 (판정률 80% 목표)
- 4개 정식 판정 뒤, 배열 1%+ 이격의 뚜렷한 추세는 markup/markdown 분류. 애매한 중간 지대만 정직하게 없음
- 완화 markup은 유입·거래량 확인 없인 enter 아님 — 판별 규율·억지 판정 금지 유지

## 검증
- fomo-core verdict 18케이스(신규 CI 게이트 5개) 포함 전체 **1130 테스트 통과**
- typecheck 에러 0 · `guard:discovery` ✅(덱 45카드 불변) · `next build`(backend) 통과
- 머지 후: kr-candle-prewarm 수동 트리거 → daily-30 리웜 → **프로덕션 실측(stanceText 분포·phase율) 첨부 예정**

🤖 Generated with [Claude Code](https://claude.com/claude-code)