### PR TITLE
fix(depth+feed): 뎁스 품질 3종 — 종목 공식지표 FRED 제외·배지 단일 진실·버즈 KR 앵커

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -368,7 +368,9 @@ function mergeFrontSeed(
   if (!hasUsableFront(fresh)) return seed;
   return {
     signals: { ...seed.signals, ...fresh.signals },
-    fomo: fresh.fomo ?? seed.fomo,
+    // 상태 배지 단일 진실(카드=뎁스 모순 금지) — 카드(seed)의 포모 라벨 우선. 라이브 재계산(fresh)은
+    // 시점·입력이 달라 "카드는 '가격 먼저'인데 뎁스는 '주목 집중'" 불일치를 만든다(2026-07-17 User Zero).
+    fomo: seed.fomo ?? fresh.fomo,
     ...(fresh.taFact ?? seed.taFact ? { taFact: fresh.taFact ?? seed.taFact } : {}),
     ...(fresh.ta ?? seed.ta ? { ta: fresh.ta ?? seed.ta } : {}),
     ...(fresh.candles?.length ? { candles: fresh.candles } : seed.candles?.length ? { candles: seed.candles } : {}),

--- a/apps/web/__tests__/lib/stock-official-facts.test.ts
+++ b/apps/web/__tests__/lib/stock-official-facts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SourceDoc } from "@fomo/core";
+
+// AI 미설정 경로로 고정 — officialFacts 필터만 검증한다(LLM 무관 결정론 경로).
+vi.mock("@fomo/shared", () => ({
+  callAI: vi.fn(),
+  isAiConfigured: () => false,
+}));
+
+import { runUnderstanding } from "../../lib/theme-understanding";
+
+const fredDoc: SourceDoc = {
+  id: "S1",
+  kind: "official",
+  title: "나스닥 종합지수 25881.95",
+  body: "2026-07-16 기준 (미 연준 공식 데이터 · FRED NASDAQCOM)",
+  source: "FRED(미 연준)",
+  url: "https://fred.stlouisfed.org/series/NASDAQCOM",
+  tier: "official-high",
+};
+
+const dartDoc: SourceDoc = {
+  id: "S2",
+  kind: "official",
+  title: "주요사항보고서(유상증자결정)",
+  body: "2026-07-17 접수 공시",
+  source: "DART 공시",
+  tier: "official-high",
+};
+
+// 2026-07-17 User Zero: "신일제약에 (나스닥·미 국채) 공식 지표가 왜 붙어" — 종목 뎁스의
+// "확인된 공식 지표"는 종목 직접 공시(DART·SEC)만. FRED 거시는 종목 무관 배경이라 제외.
+describe("종목 officialFacts — FRED 거시 제외", () => {
+  it("kind=stock 이면 FRED 거시 지표는 officialFacts 에서 빠지고 DART 공시만 남는다", async () => {
+    const insight = await runUnderstanding("신일제약", [fredDoc, dartDoc], "stock");
+    const labels = (insight.officialFacts ?? []).map((f) => f.label);
+    expect(labels).toContain("주요사항보고서(유상증자결정)");
+    expect(labels.join(" ")).not.toContain("나스닥");
+  });
+
+  it("kind=stock 에서 종목 직접 공시가 없으면 officialFacts 자체가 비어 섹션이 뜨지 않는다", async () => {
+    const insight = await runUnderstanding("신일제약", [fredDoc], "stock");
+    expect(insight.officialFacts ?? []).toHaveLength(0);
+  });
+
+  it("kind=theme(금리·거시 키워드)에서는 FRED 가 주제 지표라 유지된다", async () => {
+    const insight = await runUnderstanding("금리", [fredDoc], "theme");
+    expect((insight.officialFacts ?? []).map((f) => f.label)).toContain("나스닥 종합지수 25881.95");
+  });
+});

--- a/apps/web/lib/feed-briefing.ts
+++ b/apps/web/lib/feed-briefing.ts
@@ -1,5 +1,5 @@
 import { callAI, isAiConfigured } from "@fomo/shared";
-import { sectorOf } from "@fomo/core";
+import { sectorOf, stockDef } from "@fomo/core";
 import { fetchMacro } from "./fomo-market-sources";
 import { readUsMarketQuoteRows } from "./us-market-cache";
 import { fetchKrMarketRows } from "./discovery-supply";
@@ -491,6 +491,9 @@ export async function buildBuzzStory(): Promise<FeedBriefingRow | null> {
     return values.reduce((a, b) => a + b, 0) / values.length;
   };
   const candidates = Object.entries(attention)
+    // 버즈는 국장 스토리 — KR 종목 앵커만. 코인 매체 소스(#840) 유입 후 '비트코인'이 언급량으로
+    // 앵커를 차지해 코인 거래소 헤드라인이 버즈로 발행되던 것 차단(2026-07-17 User Zero).
+    .filter(([stock]) => stockDef(stock)?.country === "KR")
     .filter(([, signal]) => (signal.newsEventLabel ?? "").trim().length >= 8)
     .map(([stock, signal]) => {
       const avg = avgFor(stock);

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -281,10 +281,16 @@ async function judgeWordingsSafety(
   return out;
 }
 
-/** 공식 데이터(FRED 등 kind=official) 원문을 중립 팩트 리스트로(방향성 주장 아님 — C-2). */
-function officialFactsFrom(docs: readonly SourceDoc[]): OfficialFact[] {
+/**
+ * 공식 데이터(kind=official) 원문을 중립 팩트 리스트로(방향성 주장 아님 — C-2).
+ * 종목(stock) 뎁스의 "확인된 공식 지표"는 종목 직접 공시(DART·SEC)만 — FRED 거시(나스닥지수·미 국채 등)는
+ * 종목과 무관한 배경 지표라 제외한다(2026-07-17 User Zero: "신일제약에 공식 지표가 왜 붙어").
+ * 테마 뎁스(금리·거시 키워드)에는 FRED 가 그 자체로 주제 지표라 유지.
+ */
+function officialFactsFrom(docs: readonly SourceDoc[], kind: "theme" | "stock" = "theme"): OfficialFact[] {
   return docs
     .filter((d) => d.kind === "official" && d.source && d.tier)
+    .filter((d) => kind !== "stock" || d.source !== "FRED(미 연준)")
     .map((d) => ({
       label: d.title,
       ...(d.body ? { detail: d.body } : {}),
@@ -515,8 +521,9 @@ export async function runUnderstanding(
 ): Promise<ThemeInsight> {
   if (docs.length === 0) return emptyThemeInsight(subject, "수집된 원문이 없음(소스 도달 실패 또는 매칭 0)");
 
-  // 공식 지표 팩트(FRED) — LLM 결과와 별개로 항상 노출(있으면). 강세/약세로 해석하지 않는다.
-  const officialFacts = officialFactsFrom(docs);
+  // 공식 지표 팩트 — LLM 결과와 별개로 항상 노출(있으면). 강세/약세로 해석하지 않는다.
+  // 종목이면 DART·SEC 직접 공시만(FRED 거시 제외).
+  const officialFacts = officialFactsFrom(docs, kind);
   const withFacts = (insight: ThemeInsight): ThemeInsight =>
     officialFacts.length > 0 ? { ...insight, officialFacts } : insight;
 


### PR DESCRIPTION
## User Zero 실측 3건 (2026-07-17 스크린샷)

### 1. 종목 뎁스 "확인된 공식 지표"에 미국 매크로 지표 오부착
- 신일제약(KR 바이오) 뎁스에 나스닥지수 25881.95·미 10년물 4.55%·S&P500 7533.77(FRED)
- 원인: `fetchFredDocsForStock`이 전 종목에 FRED 거시를 `kind:"official"`로 부착 → `officialFactsFrom`이 그대로 노출. DART 공시 없는 날은 미국 지수만 남음
- 수정: `officialFactsFrom(docs, kind)` — **종목은 DART·SEC 직접 공시만**, 직접 공시 없으면 섹션 미노출. 테마 뎁스(금리·거시)는 FRED 유지

### 2. 카드-뎁스 배지 불일치
- 폴레드로 재현: 카드 "가격 먼저" → 뎁스 '오늘 발견 포인트' 배지 "주목 집중"
- 원인: `mergeFrontSeed`가 verdict는 seed(카드) 우선인데 **fomo만 fresh(라이브 재계산) 우선** — 시점·입력 차이로 어긋남
- 수정: `fomo: seed.fomo ?? fresh.fomo` — 카드=뎁스 모순 금지 원칙(WO 1.5 A)과 정합

### 3. 버즈 스토리가 비트코인 앵커
- "코인베이스 어드밴스드 -131 BTC 순유출…"이 국장 버즈로 발행, 뎁스도 빈약
- 원인: #840에서 코인 전문 매체(토큰포스트·블록미디어) 소스 추가 → 언급량 집계에서 '비트코인'(STOCK_VOCAB COIN)이 1위 → 버즈 앵커 차지
- 수정: 버즈 후보를 `stockDef(stock)?.country === "KR"`로 제한(버즈 = 국장 스토리, 관련 종목·종토방 연결도 KR 전제)

## 검증
- 신규 테스트 3케이스(stock-official-facts) 포함 전체 1133 통과, typecheck(backend+fomo-web) 0, guard:discovery ✅
- 머지 후: close 슬롯 재빌드로 오늘 버즈 교체, 프로덕션 뎁스(공식 지표·배지 일치) 브라우저 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)