### PR TITLE
feat(depth): 뎁스 재건 — 원인 연결 엔진·8-K 쉬운말·라벨 택소노미·꼬리색·설명률 (WO)

### DIFF
--- a/apps/fomo-web/__tests__/discoveryPresentation.test.ts
+++ b/apps/fomo-web/__tests__/discoveryPresentation.test.ts
@@ -4,7 +4,7 @@ import { discoveryStatus, verdictBalance } from "../lib/discoveryPresentation";
 describe("discovery presentation", () => {
   it("keeps attention state separate from bearish chart balance", () => {
     expect(discoveryStatus({ label: "warming", fomoScore: 31 })).toMatchObject({
-      label: "관심 붙는 중",
+      label: "거래·언급 느는 중",
       tone: "warming",
     });
     expect(verdictBalance({ stance: "avoid" })).toMatchObject({ label: "약세 신호 우세" });

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -794,8 +794,12 @@ function movementTrigger(
   context: StockContext | undefined
 ): string | undefined {
   if (insight && insight.confidence !== "insufficient" && insight.whyHot.trim()) return cleanText(insight.whyHot);
+  // 원인 연결 엔진(WO 뎁스 재건 A) — 급변동일 때 시간창 매칭된 재료가 일반 재료·대표주 카피보다 우선.
+  if (insight?.cause?.kind === "material") return cleanText(insight.cause.text);
   const material = front?.signals.newsEventLabel ?? (front?.axisHook?.axis === "time" ? front.axisHook.hookText : undefined);
-  return cleanText(material ?? context?.reason ?? "") || undefined;
+  const base = cleanText(material ?? context?.reason ?? "") || undefined;
+  // 재료가 없으면 지수 동반·정직한 미확인(±3% 급변동 한정)이라도 답한다 — 자백 템플릿 금지.
+  return base ?? (insight?.cause ? cleanText(insight.cause.text) : undefined);
 }
 
 function movementFacts(front: StockFrontResponse | null): ChartTooltip[] {
@@ -944,7 +948,8 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
             const bottom = y(Math.min(c.open, c.close));
             return (
               <g key={`c-${i}`}>
-                <line x1={cx} x2={cx} y1={y(c.high)} y2={y(c.low)} stroke={DETAIL_CHART.wick} strokeWidth="0.9" />
+                {/* 꼬리 = 몸통 색(WO 뎁스 재건 D) — 회색 단일 꼬리는 차트 신뢰감을 깎는다. */}
+                <line x1={cx} x2={cx} y1={y(c.high)} y2={y(c.low)} stroke={color} strokeWidth="0.9" />
                 <rect x={cx - bodyW / 2} y={top} width={bodyW} height={Math.max(1.2, bottom - top)} rx="0.7" fill={color} />
               </g>
             );
@@ -1002,8 +1007,13 @@ function WhyMovementTab({
       <div className="rounded-xl border border-hairline bg-surface px-4 py-4">
         <p className="text-[11px] font-bold text-muted">확인된 계기</p>
         <p className="mt-2 text-sm leading-6 text-whiteout">
-          {trigger ?? "가격 움직임과 직접 연결된 뉴스·공시 근거는 아직 확인되지 않았어요."}
+          {trigger ?? "오늘은 큰 재료 없이 흐른 날이에요 — 아래 신호와 차트로 흐름을 확인해요."}
         </p>
+        {insight?.cause?.url && insight.cause.kind === "material" && (
+          <a href={insight.cause.url} target="_blank" rel="noreferrer" className="mt-2 block text-[11px] text-muted hover:text-whiteout">
+            ↳ {insight.cause.sourceLabel ?? "출처"} · 원문 보기 →
+          </a>
+        )}
         {sources.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 border-t border-hairline pt-3">
             {sources.map((source) => (
@@ -1618,7 +1628,8 @@ function AnalysisChart({
           const bottom = y(Math.min(c.open, c.close));
           return (
             <g key={`c-${i}`}>
-              <line x1={cx} x2={cx} y1={y(c.high)} y2={y(c.low)} stroke={CHART_COLOR.wick} strokeWidth="0.9" />
+              {/* 꼬리 = 몸통 색(WO 뎁스 재건 D). */}
+              <line x1={cx} x2={cx} y1={y(c.high)} y2={y(c.low)} stroke={color} strokeWidth="0.9" />
               <rect x={cx - barW / 2} y={top} width={barW} height={Math.max(1.2, bottom - top)} rx="0.7" fill={color} />
             </g>
           );

--- a/apps/fomo-web/lib/discoveryPresentation.ts
+++ b/apps/fomo-web/lib/discoveryPresentation.ts
@@ -18,18 +18,20 @@ const STATUS_BY_LABEL: Record<FomoScoreResult["label"], DiscoveryStatusView> = {
   },
   lone: {
     label: "가격 먼저",
-    summary: "가격이 먼저 움직였고 거래·언급의 확인은 더 필요해요.",
+    // 자백 템플릿("확인은 더 필요해요") 금지(WO 뎁스 재건 A) — 사실 서술로.
+    summary: "가격이 먼저 움직였고, 거래·언급은 아직 잠잠해요.",
     tone: "moving",
     color: "#F59E0B",
   },
   warming: {
-    label: "관심 붙는 중",
+    // "관심 붙는 중"은 의미가 모호(WO 뎁스 재건 C) — 무엇이 늘고 있는지 즉시 읽히게.
+    label: "거래·언급 느는 중",
     summary: "가격이나 거래에서 평소와 다른 움직임이 붙었어요.",
     tone: "warming",
     color: "#D8FF3A",
   },
   incoming: {
-    label: "먼저 포착",
+    label: "수급 먼저",
     summary: "가격보다 수급이나 관심 신호가 먼저 확인됐어요.",
     tone: "early",
     color: "#38BDF8",

--- a/apps/web/__tests__/lib/price-cause.test.ts
+++ b/apps/web/__tests__/lib/price-cause.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { SourceDoc } from "@fomo/core";
+import { computePriceCause, CAUSE_NEWS_PATTERN } from "../../lib/price-cause";
+
+const TODAY = "2026-07-17";
+
+const earningsFiling: SourceDoc = {
+  id: "S1",
+  kind: "official",
+  title: "분기 실적 발표 (공식 공시) · 7/14",
+  body: "2026-07-14 접수 공시",
+  source: "SEC EDGAR",
+  url: "https://www.sec.gov/example",
+  publishedAt: "2026-07-14",
+  tier: "official-high",
+};
+
+const staleFiling: SourceDoc = {
+  ...earningsFiling,
+  id: "S2",
+  title: "대형 계약 체결 공시 · 6/23",
+  publishedAt: "2026-06-23",
+};
+
+const fredDoc: SourceDoc = {
+  id: "S3",
+  kind: "official",
+  title: "나스닥 종합지수 25881.95",
+  source: "FRED(미 연준)",
+  publishedAt: "2026-07-16",
+  tier: "official-high",
+};
+
+// WO 뎁스 재건 A — 치명 모순 재현: 답(실적 공시)을 수집해놓고 "계기 미확인"이라 말하던 것.
+describe("원인 연결 엔진 (price-cause)", () => {
+  it("IBM 케이스 — 시간창(±3일) 안의 실적 공시를 급락 원인으로 연결한다", () => {
+    const cause = computePriceCause({ today: "2026-07-16", changePct: -8.2, docs: [earningsFiling, staleFiling, fredDoc] });
+    expect(cause).toBeDefined();
+    expect(cause!.kind).toBe("material");
+    expect(cause!.text).toContain("분기 실적 발표");
+    expect(cause!.text).toContain("급락(-8.2%)");
+    expect(cause!.url).toBe("https://www.sec.gov/example");
+  });
+
+  it("시간창 밖(3주 전) 공시는 원인으로 잇지 않는다 — 추측 인과 금지", () => {
+    const cause = computePriceCause({ today: TODAY, changePct: -5, docs: [staleFiling] });
+    expect(cause!.kind).not.toBe("material");
+  });
+
+  it("FRED 거시 지표는 종목 원인이 아니다", () => {
+    const cause = computePriceCause({ today: TODAY, changePct: 4, docs: [fredDoc] });
+    expect(cause!.kind).toBe("unknown");
+  });
+
+  it("당일 뉴스가 원인 패턴(잠정실적·가이던스 하향)에 걸리면 제목 그대로 grounded 원인", () => {
+    const news: SourceDoc = {
+      id: "S4",
+      kind: "news",
+      title: "OO전자, 잠정 실적 시장 예상 하회…영업이익 -32%",
+      source: "연합뉴스",
+      url: "https://news.example/1",
+      publishedAt: `${TODAY}T09:10:00+09:00`,
+      tier: "news-mid",
+    };
+    const cause = computePriceCause({ today: TODAY, changePct: -6.4, docs: [news] });
+    expect(cause!.kind).toBe("material");
+    expect(cause!.text).toContain("잠정 실적");
+    expect(cause!.sourceLabel).toBe("연합뉴스");
+  });
+
+  it("재료가 없고 지수가 같은 방향 ±1.5%+면 동반 사실로 설명한다", () => {
+    const cause = computePriceCause({
+      today: TODAY,
+      changePct: -4.1,
+      docs: [],
+      indexMoves: [
+        { label: "코스닥", changePct: -4.5 },
+        { label: "코스피", changePct: -6.4 },
+      ],
+    });
+    expect(cause!.kind).toBe("co-move");
+    expect(cause!.text).toContain("코스피");
+    expect(cause!.text).toContain("-6.4%");
+  });
+
+  it("지수가 반대 방향이면 동반 설명하지 않는다 — 최후의 정직한 미확인", () => {
+    const cause = computePriceCause({
+      today: TODAY,
+      changePct: 5.2,
+      docs: [],
+      indexMoves: [{ label: "코스피", changePct: -2.0 }],
+    });
+    expect(cause!.kind).toBe("unknown");
+    expect(cause!.text).toContain("찾지 못했어요");
+  });
+
+  it("±3% 미만 움직임엔 개입하지 않는다", () => {
+    expect(computePriceCause({ today: TODAY, changePct: 1.2, docs: [earningsFiling] })).toBeUndefined();
+  });
+
+  it("원인 패턴 사전 — 실적하회·가이던스·잠정실적 계열이 명시돼 있다(WO A-2)", () => {
+    for (const title of ["잠정실적 하회", "가이던스 하향 조정", "preliminary results", "misses estimates", "cuts guidance", "profit warning"]) {
+      expect(CAUSE_NEWS_PATTERN.test(title), title).toBe(true);
+    }
+  });
+});

--- a/apps/web/__tests__/lib/sec-edgar.test.ts
+++ b/apps/web/__tests__/lib/sec-edgar.test.ts
@@ -88,7 +88,9 @@ describe("SEC EDGAR Form 4 insider purchases", () => {
 
     const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
     const hits = await fetchRecentSecFilings("IBM", 2);
-    expect(hits[0]?.label).toBe("실적 발표 8-K 공시 · 7/14");
+    // WO 뎁스 재건 B — 규제 용어(8-K) 원문 노출 금지, 쉬운말 라벨.
+    expect(hits[0]?.label).toBe("분기 실적 발표 (공식 공시) · 7/14");
+    expect(hits[0]?.label).not.toMatch(/8-K|10-Q|10-K/);
     // 브리핑 detail 경로(safeWhy→hasForbiddenCopy)에서 폐기되지 않아야 한다 —
     // "공시가 확인됐어요" 시절 라벨이 추상 슬롭 블록리스트에 걸려 IBM '왜'가 통째로 사라졌던 회귀 방지.
     const { hasForbiddenCopy } = await import("../../lib/copy-guards");
@@ -116,7 +118,8 @@ describe("SEC EDGAR Form 4 insider purchases", () => {
 
     const { fetchRecentSecFilings } = await import("../../lib/sec-edgar");
     const hits = await fetchRecentSecFilings("IBM", 2);
-    expect(hits[0]?.label).toBe("8-K 공시 제출 · 7/14");
+    expect(hits[0]?.label).toBe("주요 공시 제출 · 7/14");
+    expect(hits[0]?.label).not.toMatch(/8-K|10-Q|10-K/);
     const { hasForbiddenCopy } = await import("../../lib/copy-guards");
     expect(hasForbiddenCopy(hits[0]!.label)).toBe(false);
   });

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -33,8 +33,8 @@ export interface Daily30Response extends DiscoveryResponse {
     assetCounts: Record<Daily30AssetClass, number>;
     /** 어제 30장 대비 종목 중복률(0~1) — 신선도 수용 지표(≤0.5). */
     repeatRatio?: number;
-    /** 2026-07-12 US 파이프라인 진단(임시). */
-    debug?: Record<string, number>;
+    /** 2026-07-12 US 파이프라인 진단(임시) + 원인 설명률(WO 뎁스 재건 E) causeCoverage. */
+    debug?: Record<string, number | { movers: number; explained: number; ratio: number }>;
   };
 }
 
@@ -516,11 +516,33 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
 
   const response = responseFromSelected(deck, feedCandidates, [kr, us, coin], kr.asOf > us.asOf ? kr.asOf : us.asOf);
   // 2026-07-12 진단: US 파이프라인 각 단계 카운트 — 미장 1장 원인이 discovery/후보/셀렉션 어디인지.
+  // 원인 설명률(WO 뎁스 재건 E — 해자의 측정): ±3% 무버 중 원인(원문 연결·재료 서술)이 붙은 비율.
+  // 북극성 지표 ≥0.9 — 급등락 카드를 눌렀을 때 열에 아홉은 답이 있어야 BM을 붙일 자격이 생긴다.
+  const movers = deck.filter((c) => {
+    const change = frontSignals(c.front).changePct;
+    return !!c.stock && typeof change === "number" && Math.abs(change) >= 3;
+  });
+  const explainedMovers = movers.filter((c) => {
+    const s = c.stock!;
+    return (
+      Boolean(s.sourceUrl) ||
+      /공시|실적|계약|수주|투자|증자|자사주|인수|합병|승인|허가|매출|가이던스|발표|보도|리포트|임상|매수|매도|배당|출시/.test(signalText(s))
+    );
+  });
+  const causeCoverage = {
+    movers: movers.length,
+    explained: explainedMovers.length,
+    ratio: movers.length > 0 ? Math.round((explainedMovers.length / movers.length) * 100) / 100 : 1,
+  };
+  if (causeCoverage.ratio < 0.9) {
+    console.warn("[daily-30] 원인 설명률 미달", JSON.stringify({ ...causeCoverage, unexplained: movers.filter((c) => !explainedMovers.includes(c)).map((c) => c.stock!.canonical) }));
+  }
   const debug = {
     usDiscoveryCards: (us.cards?.length ?? us.stocks.length),
     usStockCandidates: stockCandidates.filter((c) => c.assetClass === "us-stock").length,
     usDeck: deck.filter((c) => c.assetClass === "us-stock").length,
     krStockCandidates: stockCandidates.filter((c) => c.assetClass === "kr-stock").length,
+    causeCoverage,
   };
   // 소스 장애 가드(fail-closed, WO-21 원칙) — 2026-07-17 실사고: 네이버 egress 장애 중 빌드가
   // KR 0장 덱을 12h 캐시에 박았다. KR 시세는 시총 리스트라 휴장일에도 0이 될 수 없다 —

--- a/apps/web/lib/price-cause.ts
+++ b/apps/web/lib/price-cause.ts
@@ -1,0 +1,119 @@
+import type { PriceCause, SourceDoc } from "@fomo/core";
+
+/**
+ * 원인 연결 엔진 (WO 뎁스 재건 A) — "이 종목이 왜 움직였는지에 대한 세상에서 제일 쉬운 답".
+ *
+ * 치명 모순(2026-07-17 실측): IBM 뎁스에 7/14 실적 8-K가 떠 있는데 "계기 미확인"이라 말했다 —
+ * 수집 실패가 아니라 연결(linking) 실패. 이 모듈이 그 연결 층이다:
+ *   ① 이미 수집된 공시·뉴스와 가격 급변동의 시간창 매칭(공시 ±2거래일 ≈ ±3일력, 뉴스 ±1일)
+ *   ② 실적하회/가이던스하향/잠정실적 등 원인 패턴 사전(뉴스 제목 grounded)
+ *   ③ 지수 동반 사실 설명(같은 방향 ±1.5%+)
+ *   ④ 최후에만 정직한 미확인(±3% 카드 중 ≤10% 목표)
+ * 전부 결정론·실데이터 — 추측 인과 지어내기 금지(시간창 + 원문 사실만).
+ */
+
+/** 큰 움직임 문턱 — 당일 ±3%(WO). 이 미만이면 cause 엔진은 개입하지 않는다. */
+export const PRICE_CAUSE_MIN_MOVE_PCT = 3;
+/** 공시 시간창 — 공시일 ±2거래일 ≈ 달력 3일. */
+const OFFICIAL_WINDOW_DAYS = 3;
+/** 뉴스 시간창 — 당일 ±1일(전일 저녁 보도가 다음 날 반영되는 케이스). */
+const NEWS_WINDOW_DAYS = 1;
+/** 지수 동반 판정 — 같은 방향 ±1.5% 이상. */
+const CO_MOVE_MIN_INDEX_PCT = 1.5;
+
+/**
+ * 원인 후보 패턴 — 뉴스 제목에서 급변동 원인으로 읽히는 재료(WO A-2: 실적하회 계열 명시 추가).
+ * 제목이 이 패턴에 걸리면 그 제목 자체가 원인 문장(grounded — 지어내지 않는다).
+ */
+export const CAUSE_NEWS_PATTERN =
+  /(잠정\s*실적|실적\s*(?:하회|부진|쇼크|호조|상회|서프라이즈|발표)|어닝\s*(?:쇼크|서프라이즈)|가이던스\s*(?:하향|상향|하회|철회)|preliminary|misses|beats|cuts?\s+guidance|raises?\s+guidance|profit\s+warning|유상증자|무상증자|자사주|블록딜|수주|공급\s*계약|계약\s*(?:체결|해지)|인수|합병|매각|상장\s*폐지|거래\s*정지|임상|승인|허가|반려|소송|담합|리콜|화재|파업|목표가\s*(?:상향|하향))/i;
+
+interface CauseDateWindowInput {
+  /** 오늘(KST) YYYY-MM-DD. */
+  today: string;
+  /** 당일 등락률(%). */
+  changePct: number;
+  /** 수집된 원문(공시 kind=official + 뉴스 kind=news). */
+  docs: readonly SourceDoc[];
+  /** 지수 동반 판정용 — 종목 국적에 맞는 지수 등락률(%). 예: KR→코스피/코스닥, US→S&P/나스닥. */
+  indexMoves?: ReadonlyArray<{ label: string; changePct: number }>;
+}
+
+function daysBetween(aIso: string, bIso: string): number | undefined {
+  const a = Date.parse(aIso.slice(0, 10));
+  const b = Date.parse(bIso.slice(0, 10));
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return undefined;
+  return Math.abs(a - b) / 86_400_000;
+}
+
+function moveWord(changePct: number): string {
+  return changePct > 0 ? `급등(+${changePct.toFixed(1)}%)` : `급락(${changePct.toFixed(1)}%)`;
+}
+
+function mmdd(iso: string): string {
+  const [, m, d] = iso.slice(0, 10).split("-");
+  return `${Number(m)}/${Number(d)}`;
+}
+
+/**
+ * 원인 계산 — 결정론(같은 입력 → 같은 출력). |changePct| < 3% 면 undefined(엔진 비개입).
+ * 반환된 text 는 그대로 "확인된 계기"에 노출 가능한 완성 문장(쉬운말·사실만).
+ */
+export function computePriceCause(input: CauseDateWindowInput): PriceCause | undefined {
+  const { today, changePct, docs, indexMoves } = input;
+  if (!Number.isFinite(changePct) || Math.abs(changePct) < PRICE_CAUSE_MIN_MOVE_PCT) return undefined;
+
+  // ① 공식 공시 시간창 매칭 — DART·SEC(FRED 거시는 종목 원인이 아님). 최신순.
+  const officials = docs
+    .filter((d) => d.kind === "official" && d.source !== "FRED(미 연준)")
+    .map((d) => ({ doc: d, date: (d.publishedAt ?? "").slice(0, 10) }))
+    .filter((x) => x.date && (daysBetween(x.date, today) ?? Infinity) <= OFFICIAL_WINDOW_DAYS)
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+  const official = officials[0];
+  if (official) {
+    return {
+      text: `이번 ${moveWord(changePct)}과 같은 시기의 공식 공시: ${official.doc.title} (${mmdd(official.date)})`,
+      kind: "material",
+      ...(official.doc.source ? { sourceLabel: official.doc.source } : {}),
+      ...(official.doc.url ? { url: official.doc.url } : {}),
+      asOf: official.date,
+    };
+  }
+
+  // ② 뉴스 원인 패턴 매칭 — 당일 ±1일 보도 중 원인성 제목(grounded — 제목 그대로).
+  const news = docs
+    .filter((d) => d.kind === "news" && d.publishedAt)
+    .filter((d) => (daysBetween(d.publishedAt!, today) ?? Infinity) <= NEWS_WINDOW_DAYS)
+    .filter((d) => CAUSE_NEWS_PATTERN.test(`${d.title} ${d.body ?? ""}`))
+    .sort((a, b) => ((a.publishedAt ?? "") < (b.publishedAt ?? "") ? 1 : -1))[0];
+  if (news) {
+    return {
+      text: `같은 날 보도된 재료: "${news.title.trim()}"`,
+      kind: "material",
+      ...(news.source ? { sourceLabel: news.source } : {}),
+      ...(news.url ? { url: news.url } : {}),
+      ...(news.publishedAt ? { asOf: news.publishedAt.slice(0, 10) } : {}),
+    };
+  }
+
+  // ③ 지수 동반 — 같은 방향으로 지수도 크게 움직였으면 그 사실로 설명(종목 고유 재료 아님을 명시).
+  const coMove = (indexMoves ?? [])
+    .filter((m) => Number.isFinite(m.changePct) && Math.abs(m.changePct) >= CO_MOVE_MIN_INDEX_PCT)
+    .filter((m) => Math.sign(m.changePct) === Math.sign(changePct))
+    .sort((a, b) => Math.abs(b.changePct) - Math.abs(a.changePct))[0];
+  if (coMove) {
+    const sign = coMove.changePct > 0 ? "+" : "";
+    return {
+      text: `이날 ${coMove.label} 지수도 ${sign}${coMove.changePct.toFixed(1)}% — 시장 전반과 같은 방향이에요. 종목 고유 재료는 확인되지 않았어요.`,
+      kind: "co-move",
+      asOf: today,
+    };
+  }
+
+  // ④ 최후 — 정직한 미확인(수집 원문 안에서 답을 못 찾은 사실 그대로).
+  return {
+    text: `오늘 ${moveWord(changePct)}의 원인 후보를 수집 원문(공시·뉴스)에서 찾지 못했어요.`,
+    kind: "unknown",
+    asOf: today,
+  };
+}

--- a/apps/web/lib/sec-edgar.ts
+++ b/apps/web/lib/sec-edgar.ts
@@ -107,22 +107,32 @@ function mmdd(date: string): string {
  * 8-K Item 코드 → 한국어 사유(2026-07-15 User Zero: "IBM 실적 부진 8-K가 왜 그냥 '공시 확인'이냐").
  * SEC submissions.json 의 items 필드(예: "2.02,9.01")를 그대로 쓴다 — 본문 파싱·수치 추정 없음(사실만).
  */
+/**
+ * 쉬운말 라벨(WO 뎁스 재건 B — "8-K가 뭔지 모르겠다"): 규제 용어 원문 노출 금지.
+ * 원문 링크·출처(SEC EDGAR)는 유지하고 표기만 쉬운말로.
+ */
 const SEC_8K_ITEM_LABELS: Record<string, string> = {
-  "1.01": "주요 계약 체결",
-  "1.02": "계약 종료",
-  "2.01": "자산 인수·처분 완료",
-  "2.02": "실적 발표",
-  "2.05": "구조조정 비용 계획",
-  "2.06": "자산 손상",
-  "3.01": "상장 요건 미달",
-  "4.01": "감사인 변경",
-  "5.02": "임원·이사 변경",
-  "5.03": "정관 변경",
-  "7.01": "Reg FD 자료 공개",
-  "8.01": "기타 중요사항",
+  "1.01": "대형 계약 체결 공시",
+  "1.02": "계약 종료 공시",
+  "2.01": "자산 인수·처분 공시",
+  "2.02": "분기 실적 발표 (공식 공시)",
+  "2.05": "구조조정 계획 공시",
+  "2.06": "자산 손상 공시",
+  "3.01": "상장 요건 미달 공시",
+  "4.01": "감사인 변경 공시",
+  "5.02": "임원·이사 변경 공시",
+  "5.03": "정관 변경 공시",
+  "7.01": "투자자 대상 자료 공개 (공식 공시)",
+  "8.01": "기타 중요사항 공시",
 };
 // 급변동 원인으로서의 정보 가치 순 — 실적(2.02)이 최우선(가장 흔한 급변동 원인).
 const SEC_8K_ITEM_PRIORITY = ["2.02", "2.05", "2.06", "1.01", "1.02", "3.01", "5.02", "4.01", "7.01", "8.01"];
+
+/** 8-K 외 폼 → 쉬운말(원문 노출 금지). 미등록 폼은 일반어 폴백. */
+const SEC_FORM_LABELS: Record<string, string> = {
+  "10-Q": "분기 보고서 공시",
+  "10-K": "연간 보고서 공시",
+};
 
 /**
  * ⚠️ 문구 제약: "공시가 확인됐어요" 류는 copy-guards의 추상 슬롭 블록리스트(공시…확인됐)에 걸려
@@ -131,7 +141,7 @@ const SEC_8K_ITEM_PRIORITY = ["2.02", "2.05", "2.06", "1.01", "1.02", "3.01", "5
 function eightKLabel(items: string | undefined, asOf: string): string {
   const codes = (items ?? "").split(",").map((c) => c.trim()).filter(Boolean);
   const hit = SEC_8K_ITEM_PRIORITY.find((code) => codes.includes(code));
-  return hit ? `${SEC_8K_ITEM_LABELS[hit]} 8-K 공시 · ${mmdd(asOf)}` : `8-K 공시 제출 · ${mmdd(asOf)}`;
+  return hit ? `${SEC_8K_ITEM_LABELS[hit]} · ${mmdd(asOf)}` : `주요 공시 제출 · ${mmdd(asOf)}`;
 }
 
 function parseForm4InsiderPurchase(symbol: string, xml: string): SecFilingHit["insiderPurchase"] | undefined {
@@ -247,7 +257,7 @@ export async function fetchRecentSecFilings(symbol: string, limit = 4): Promise<
       if (!asOf || !accession) continue;
       out.push({
         symbol: symbol.toUpperCase(),
-        label: form === "8-K" ? eightKLabel(recent.items?.[i], asOf) : `${form} 공시 제출 · ${mmdd(asOf)}`,
+        label: form === "8-K" ? eightKLabel(recent.items?.[i], asOf) : `${SEC_FORM_LABELS[form] ?? "공식 공시 제출"} · ${mmdd(asOf)}`,
         source: "SEC EDGAR",
         asOf,
         url: accessionPath(cik, accession),

--- a/apps/web/lib/theme-understanding.ts
+++ b/apps/web/lib/theme-understanding.ts
@@ -25,6 +25,10 @@ import { fetchDcStockTitles } from "./dcinside";
 import { fetchDartDisclosuresForCode } from "./dart-disclosures";
 import { fetchRecentSecFilings } from "./sec-edgar";
 import { usSymbolForStock } from "./us-symbols";
+import { computePriceCause, PRICE_CAUSE_MIN_MOVE_PCT } from "./price-cause";
+import { fetchStockDaily } from "./stock-front";
+import { readUsMarketQuoteRows } from "./us-market-cache";
+import { fetchMacro } from "./fomo-market-sources";
 
 /**
  * 이해 레이어 오케스트레이션 — DATA_ENGINE_STRATEGY §4 Track A. (네트워크 + LLM)
@@ -507,7 +511,47 @@ export async function collectThemeStocks(
 
 /** 개별 종목 이해·구조화(작업3, BM 심장) — 테마와 동일 구조/가드. 자료 적으면 정직한 빈 상태. */
 export async function understandStock(stock: string, opts: StockUnderstandingOptions = {}): Promise<ThemeInsight> {
-  return runUnderstanding(stock, await collectStockDocs(stock, opts), "stock");
+  const docs = await collectStockDocs(stock, opts);
+  const insight = await runUnderstanding(stock, docs, "stock");
+  // 원인 연결 엔진(WO 뎁스 재건 A) — 이미 수집한 공시·뉴스와 당일 급변동을 시간창으로 잇는다.
+  // 실패해도 인사이트 본체는 정상(fail-open).
+  const cause = await resolvePriceCause(stock, opts, docs).catch(() => undefined);
+  return cause ? { ...insight, cause } : insight;
+}
+
+/** 당일 등락률·지수 동반을 조회해 cause 엔진에 공급한다. 등락률을 못 구하면 개입하지 않는다(가짜 금지). */
+async function resolvePriceCause(
+  stock: string,
+  opts: StockUnderstandingOptions,
+  docs: readonly SourceDoc[]
+): Promise<import("@fomo/core").PriceCause | undefined> {
+  const def = stockDef(stock);
+  const code = validNaverCode(opts.naverCode) ?? def?.naverCode;
+  const symbol = opts.symbol ?? usSymbolForStock(stock);
+  const country = opts.country ?? def?.country ?? (code ? "KR" : symbol ? "US" : undefined);
+  if (!country || country === "GLOBAL") return undefined;
+
+  let changePct: number | undefined;
+  if (country === "KR" && code) {
+    const daily = await fetchStockDaily(code, 12).catch(() => ({ closes: [] as number[] }));
+    const closes = daily.closes;
+    const last = closes[closes.length - 1];
+    const prev = closes[closes.length - 2];
+    if (typeof last === "number" && typeof prev === "number" && prev > 0) changePct = ((last - prev) / prev) * 100;
+  } else if (country === "US" && symbol) {
+    const rows = await readUsMarketQuoteRows().catch(() => []);
+    const row = rows.find((r) => r.symbol === symbol);
+    if (typeof row?.changePct === "number") changePct = row.changePct;
+  }
+  if (typeof changePct !== "number" || Math.abs(changePct) < PRICE_CAUSE_MIN_MOVE_PCT) return undefined;
+
+  const macro = await fetchMacro().catch(() => []);
+  const indexKeys = country === "KR" ? ["kospi", "kosdaq"] : ["spx", "ndq", "sox"];
+  const indexMoves = macro
+    .filter((q) => indexKeys.includes(q.key) && typeof q.change === "number")
+    .map((q) => ({ label: q.label, changePct: q.change as number }));
+
+  return computePriceCause({ today: todayKst(), changePct, docs, indexMoves });
 }
 
 /**

--- a/packages/fomo-core/src/theme-understanding/condense.ts
+++ b/packages/fomo-core/src/theme-understanding/condense.ts
@@ -64,6 +64,8 @@ export interface CondensedInsight {
   wordingAudit?: import("./types").WordingVerdict[];
   /** 공식 지표 팩트(FRED 등) — 중립 사실 숫자(C-2). 강세/약세와 별개. */
   officialFacts?: import("./types").OfficialFact[];
+  /** 가격 급변동 원인(WO 뎁스 재건 A) — "왜 움직였나"의 답. A의 cause 그대로 통과. */
+  cause?: import("./types").PriceCause;
   /** 숨은 연관주(BM 발굴 엔진) — 대장주 아닌, grounded 연관 근거가 있는 종목. 없으면 빈 배열. */
   relatedStocks: import("./discover").RelatedStock[];
 }
@@ -116,6 +118,7 @@ export function condenseThemeInsight(
     ...(insight.officialFacts && insight.officialFacts.length > 0
       ? { officialFacts: insight.officialFacts }
       : {}),
+    ...(insight.cause ? { cause: insight.cause } : {}),
   };
 
   // 정직한 빈 상태 — A가 근거를 못 뽑았으면 응축도 비운다(가짜 생성 금지).

--- a/packages/fomo-core/src/theme-understanding/types.ts
+++ b/packages/fomo-core/src/theme-understanding/types.ts
@@ -94,4 +94,21 @@ export interface ThemeInsight {
   wordingAudit?: import("./wording-filter").WordingVerdict[];
   /** 공식 지표 팩트(FRED 등) — 강세/약세와 별개로 중립 사실 노출(C-2). */
   officialFacts?: OfficialFact[];
+  /** 가격 급변동 원인(WO 뎁스 재건 A) — 수집 원문·공시와 시간창 매칭한 "왜 움직였나"의 답. */
+  cause?: PriceCause;
+}
+
+/**
+ * 가격 급변동 원인(WO 뎁스 재건 A — "왜 움직였나의 가장 쉬운 답").
+ * 시간창 매칭(±2거래일)·재료 패턴·지수 동반까지 전부 실데이터 — 추측 인과 금지.
+ */
+export interface PriceCause {
+  /** 원인 한 줄(쉬운말). */
+  text: string;
+  /** material=재료 연결 · co-move=지수 동반 사실 · unknown=정직한 미확인(±3% 카드 중 ≤10% 목표). */
+  kind: "material" | "co-move" | "unknown";
+  /** 연결된 원문·공시 출처 라벨(있으면). */
+  sourceLabel?: string;
+  url?: string;
+  asOf?: string;
 }


### PR DESCRIPTION
## WO — 뎁스 재건: "왜 움직였나의 가장 쉬운 답"

치명 모순(실측 확정): IBM 뎁스에 7/14 실적 8-K가 표시돼 있는데 "확인된 계기"는 미확인 — **수집이 아니라 연결(linking) 실패**.

### A. 원인 연결 엔진 — `apps/web/lib/price-cause.ts` (결정론·실데이터만)
±3% 무버에 대해 순서대로 끝까지 답을 찾는다:
1. **자기 데이터 재확인**: 수집된 공시(DART·SEC — FRED 거시 제외)와 시간창 매칭(±3일력 ≈ ±2거래일) → IBM 케이스는 이것만으로 잡힘
2. **원인 패턴 사전**: 당일 ±1일 뉴스 제목에서 잠정실적·실적하회·가이던스하향·`preliminary`·`misses`·`cuts guidance` 등(WO 지적대로 이 계열 명시 추가) — 제목 grounded, 지어내지 않음
3. **지수 동반**: 같은 방향 ±1.5%+ 지수 동반 사실 설명(종목 고유 재료 아님 명시)
4. **최후에만** 정직한 미확인
- `understandStock → ThemeInsight.cause → condense → 뎁스 "확인된 계기"`(원문 링크 포함)
- 자백 템플릿("근거는 아직 확인되지 않았어요"·"확인은 더 필요해요") **전부 삭제**

### B. 규제 용어 쉬운말 (원문 노출 0)
"실적 발표 8-K 공시" → **"분기 실적 발표 (공식 공시)"**, 10-Q/10-K → 분기/연간 보고서 공시, Reg FD → 투자자 대상 자료 공개. 출처(SEC EDGAR)·원문 링크 유지. `8-K|10-Q|10-K` 미노출 테스트 고정. copy-guards 통과 유지(#841 교훈).

### C. 라벨 단일 택소노미
카드·뎁스가 이미 `discoveryPresentation.ts` 단일 사전 공용(#849에서 배지 소스 통일) — 모호 라벨만 교체: "관심 붙는 중"→"거래·언급 느는 중", "먼저 포착"→"수급 먼저". lone summary의 자백 문구도 사실 서술로.

### D. 캔들 꼬리색 = 몸통색 (뎁스 차트 2곳)

### E. 원인 설명률 (해자의 측정)
daily-30 `meta.debug.causeCoverage` = {movers, explained, ratio} — ±3% 무버 중 원인 제시율. **북극성 ≥90%**, 미달 시 미설명 종목 나열 경고 로그.

## 검증
- price-cause 신규 8케이스(IBM 시간창 연결 포함) 등 1137 통과 — index.test 4건은 클린 main에서도 재현되는 심야 네트워크 플레이크(본 변경 무관)
- typecheck(backend·fomo-web) 0 · guard:discovery ✅ · next build ✅
- 머지 후 **프로덕션 급변동 3종 실측 첨부** 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)