### PR TITLE
fix(depth): 원인 뉴스 시간창 1→3일 — 실측 회귀(제닉스로보틱스 unknown)

### DIFF
--- a/apps/web/__tests__/lib/price-cause.test.ts
+++ b/apps/web/__tests__/lib/price-cause.test.ts
@@ -68,6 +68,33 @@ describe("원인 연결 엔진 (price-cause)", () => {
     expect(cause!.sourceLabel).toBe("연합뉴스");
   });
 
+  it("제닉스로보틱스 케이스 — 3일 전 재료 보도(자사주 신탁)도 원인으로 잇는다(실측 회귀)", () => {
+    const news: SourceDoc = {
+      id: "S5",
+      kind: "news",
+      title: "제닉스로보틱스, 10억원 규모 자사주 취득 신탁계약",
+      source: "이데일리",
+      publishedAt: "2026-07-15T07:49:00.000Z",
+      tier: "news-mid",
+    };
+    const cause = computePriceCause({ today: "2026-07-18", changePct: 5.58, docs: [news] });
+    expect(cause!.kind).toBe("material");
+    expect(cause!.text).toContain("자사주");
+  });
+
+  it("시간창(3일) 밖 뉴스는 잇지 않는다", () => {
+    const news: SourceDoc = {
+      id: "S6",
+      kind: "news",
+      title: "OO, 대규모 수주 계약 체결",
+      source: "이데일리",
+      publishedAt: "2026-07-10T00:00:00.000Z",
+      tier: "news-mid",
+    };
+    const cause = computePriceCause({ today: "2026-07-18", changePct: 5, docs: [news] });
+    expect(cause!.kind).not.toBe("material");
+  });
+
   it("재료가 없고 지수가 같은 방향 ±1.5%+면 동반 사실로 설명한다", () => {
     const cause = computePriceCause({
       today: TODAY,

--- a/apps/web/lib/price-cause.ts
+++ b/apps/web/lib/price-cause.ts
@@ -16,8 +16,12 @@ import type { PriceCause, SourceDoc } from "@fomo/core";
 export const PRICE_CAUSE_MIN_MOVE_PCT = 3;
 /** 공시 시간창 — 공시일 ±2거래일 ≈ 달력 3일. */
 const OFFICIAL_WINDOW_DAYS = 3;
-/** 뉴스 시간창 — 당일 ±1일(전일 저녁 보도가 다음 날 반영되는 케이스). */
-const NEWS_WINDOW_DAYS = 1;
+/**
+ * 뉴스 시간창 — 3일력(공시와 동일). 실측(제닉스로보틱스): 7/15 자사주 신탁 보도가 7/17 +5.6%로
+ * 반영 — 재료 보도 후 2~3일 뒤 가격 반응은 흔하다(±1일은 주말·시차에도 깨짐). 원인 패턴 필터가
+ * 무관 기사 연결을 막는다.
+ */
+const NEWS_WINDOW_DAYS = 3;
 /** 지수 동반 판정 — 같은 방향 ±1.5% 이상. */
 const CO_MOVE_MIN_INDEX_PCT = 1.5;
 


### PR DESCRIPTION
프로덕션 실측에서 제닉스로보틱스 +5.6%의 원인(7/15 자사주 신탁 보도)이 ±1일 뉴스 창에 걸려 unknown — 공시 창(3일력)과 통일. 원인 패턴 필터가 무관 기사 연결 차단. 테스트 10케이스 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)