### PR TITLE
fix(depth): 원인 뉴스 문구 보도 날짜 명시 — '같은 날' 오표기 제거

### DIFF
--- a/apps/web/lib/price-cause.ts
+++ b/apps/web/lib/price-cause.ts
@@ -91,8 +91,9 @@ export function computePriceCause(input: CauseDateWindowInput): PriceCause | und
     .filter((d) => CAUSE_NEWS_PATTERN.test(`${d.title} ${d.body ?? ""}`))
     .sort((a, b) => ((a.publishedAt ?? "") < (b.publishedAt ?? "") ? 1 : -1))[0];
   if (news) {
+    const newsDate = news.publishedAt ? `${mmdd(news.publishedAt)} ` : "";
     return {
-      text: `같은 날 보도된 재료: "${news.title.trim()}"`,
+      text: `${newsDate}보도된 재료: "${news.title.trim()}"`,
       kind: "material",
       ...(news.source ? { sourceLabel: news.source } : {}),
       ...(news.url ? { url: news.url } : {}),


### PR DESCRIPTION
뉴스 창 3일 확대(#852) 후 문구가 '같은 날 보도된 재료'로 고정돼 3일 전 보도를 오표기 — 보도일(mmdd) 명시로 사실 그대로. price-cause 테스트 10케이스 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)