### PR TITLE
feat(coin): 재료 뉴스 파이프라인을 카드·뎁스에 연결

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -386,6 +386,8 @@ function mergeFrontSeed(
     ...(seed.verdict ?? fresh.verdict ? { verdict: seed.verdict ?? fresh.verdict } : {}),
     // 차트 시리즈(WO 1.6 D)는 non-lite 응답(fresh)에만 실린다.
     ...(fresh.chartSeries ?? seed.chartSeries ? { chartSeries: fresh.chartSeries ?? seed.chartSeries } : {}),
+    ...(fresh.coinIssues?.length ? { coinIssues: fresh.coinIssues } : seed.coinIssues?.length ? { coinIssues: seed.coinIssues } : {}),
+    ...(fresh.coinCause ?? seed.coinCause ? { coinCause: fresh.coinCause ?? seed.coinCause } : {}),
   };
 }
 
@@ -793,6 +795,7 @@ function movementTrigger(
   insight: CondensedInsight | null,
   context: StockContext | undefined
 ): string | undefined {
+  if (front?.coinCause?.text) return cleanText(front.coinCause.text);
   if (insight && insight.confidence !== "insufficient" && insight.whyHot.trim()) return cleanText(insight.whyHot);
   // 원인 연결 엔진(WO 뎁스 재건 A) — 급변동일 때 시간창 매칭된 재료가 일반 재료·대표주 카피보다 우선.
   if (insight?.cause?.kind === "material") return cleanText(insight.cause.text);
@@ -1014,6 +1017,11 @@ function WhyMovementTab({
             ↳ {insight.cause.sourceLabel ?? "출처"} · 원문 보기 →
           </a>
         )}
+        {front?.coinCause?.url && (
+          <a href={front.coinCause.url} target="_blank" rel="noreferrer" className="mt-2 block text-[11px] text-muted hover:text-whiteout">
+            ↳ {front.coinCause.sourceLabel} · 원문 보기 →
+          </a>
+        )}
         {sources.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 border-t border-hairline pt-3">
             {sources.map((source) => (
@@ -1064,6 +1072,44 @@ function WhyMovementTab({
       <p className="mt-3 text-[11px] leading-5 text-muted">
         확인된 재료와 선택한 기간의 가격 흐름을 나란히 보여줘요. 둘 사이의 인과를 추정해 붙이지 않아요.
       </p>
+    </section>
+  );
+}
+
+function CoinIssuesBlock({ issues }: { issues: NonNullable<StockFrontResponse["coinIssues"]> }) {
+  if (issues.length === 0) return null;
+  return (
+    <section className="mt-6 border-y border-hairline py-1">
+      <div className="flex items-center justify-between gap-3 py-3">
+        <div>
+          <p className="font-pixel text-sm text-whiteout">지금 이슈</p>
+          <p className="mt-1 text-[11px] text-muted">이 코인과 연결된 최근 보도와 시장 공통 변수</p>
+        </div>
+        <span className="font-number text-[11px] text-muted">{issues.length}건</span>
+      </div>
+      <div className="divide-y divide-hairline">
+        {issues.slice(0, 3).map((issue) => (
+          <a
+            key={issue.id}
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="group block py-4"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded border border-whiteout/20 px-1.5 py-0.5 text-[10px] font-bold text-whiteout">
+                {issue.typeLabel}
+              </span>
+              {issue.scope === "market" && <span className="text-[10px] text-muted">시장 공통</span>}
+              <span className="ml-auto text-[10px] text-muted">
+                {issue.source} · {issue.publishedAt.slice(0, 10)}
+              </span>
+            </div>
+            <p className="mt-2 text-sm font-bold leading-5 text-whiteout group-hover:underline">{cleanText(issue.title)}</p>
+            <p className="mt-1.5 text-[12px] leading-5 text-muted">{cleanText(issue.meaning)}</p>
+          </a>
+        ))}
+      </div>
     </section>
   );
 }
@@ -2375,6 +2421,10 @@ export function StockInsightView({
           <>
           {/* 재료와 같은 기간의 가격·거래 반응 — 기술적 구조는 차트분석 탭으로 분리. */}
           <WhyMovementTab front={front} insight={insight} context={context} />
+
+          {(context?.market === "COIN" || context?.symbol?.toUpperCase().startsWith("KRW-") === true) && (
+            <CoinIssuesBlock issues={front?.coinIssues ?? []} />
+          )}
 
           {/* 무슨 일이 있었나(WO-22) — 원문 인사이트 전체(양면·출처·공식지표). 카드 대비 뎁스의 정보 우위. */}
           <StockWhyHappened insight={insight} />

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -60,6 +60,8 @@ export type FrontEntry = {
   verdict?: CardVerdict;
   candles?: NonNullable<StockFrontResponse["candles"]>;
   chartSeries?: NonNullable<StockFrontResponse["chartSeries"]>;
+  coinIssues?: NonNullable<StockFrontResponse["coinIssues"]>;
+  coinCause?: NonNullable<StockFrontResponse["coinCause"]>;
 };
 
 type UndoEntry = {
@@ -568,6 +570,8 @@ export function StockSwipeDeck({
               ...(d.axisSignals ? { axisSignals: d.axisSignals } : {}),
               ...(d.axisHook ? { axisHook: d.axisHook } : {}),
               ...(d.verdict ? { verdict: d.verdict } : {}),
+              ...(d.coinIssues ? { coinIssues: d.coinIssues } : {}),
+              ...(d.coinCause ? { coinCause: d.coinCause } : {}),
             },
           }))
         )

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -521,6 +521,27 @@ export interface StockFrontResponse {
     ma60: Array<number | null>;
     ma120: Array<number | null>;
   };
+  coinIssues?: Array<{
+    id: string;
+    symbols: string[];
+    scope: "coin" | "market";
+    type: "regulation" | "network" | "institution" | "onchain" | "macro";
+    typeLabel: string;
+    direction: "positive" | "negative" | "neutral";
+    title: string;
+    meaning: string;
+    source: string;
+    url: string;
+    publishedAt: string;
+  }>;
+  coinCause?: {
+    text: string;
+    relation: "same-window" | "recent-context";
+    sourceLabel: string;
+    url: string;
+    asOf: string;
+    issueId: string;
+  };
 }
 
 export interface FeedSignalPoint {

--- a/apps/web/__tests__/lib/coin-discovery.test.ts
+++ b/apps/web/__tests__/lib/coin-discovery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { coinFrontSeed, computeCoinSignal, hasDiscoverySignal, coinHeadline, type CoinSignal } from "../../lib/coin-discovery";
+import { coinCoverageHeadline, coinFrontSeed, computeCoinSignal, hasDiscoverySignal, coinHeadline, type CoinSignal } from "../../lib/coin-discovery";
 import type { CoinMarketSnapshot } from "../../lib/coin-market-source";
+import type { CoinMaterialItem } from "../../lib/coin-materials";
 
 function snapshot(overrides: Partial<CoinMarketSnapshot> = {}): CoinMarketSnapshot {
   const days = 40;
@@ -74,6 +75,14 @@ describe("coin discovery signals", () => {
     expect(coinHeadline(s, signal)).toBe("하루 +7.2% · 24시간 거래대금 평소 2.1배");
   });
 
+  it("무신호 커버리지 헤드라인에도 시총·거래대금 순위를 단독 재료로 쓰지 않음", () => {
+    const signal: CoinSignal = { volumeRatio: 0.9, vacuumInflow: false, bigMove: false, quiet: true };
+    const headline = coinCoverageHeadline(snapshot({ marketCapRank: 1 }), signal);
+    expect(headline).not.toContain("시총 1위");
+    expect(headline).not.toContain("거래대금 1위");
+    expect(headline).toContain("거래 참여 평소 0.9배");
+  });
+
   it("프리웜에서 확보한 실제 캔들과 차트 시리즈를 카드 seed에 유지", () => {
     const s = snapshot({ accTradePrice24h: 1.5e10 });
     const signal = computeCoinSignal(s)!;
@@ -84,5 +93,29 @@ describe("coin discovery signals", () => {
     expect(front.chartSeries?.closes).toHaveLength(40);
     expect(front.chartSeries?.volumes).toHaveLength(40);
     expect(front.chartSeries?.ma20.at(-1)).toBe(1500);
+  });
+
+  it("코인 재료를 카드 seed의 계기·이슈·verdict에 같은 계약으로 전달", () => {
+    const s = snapshot({ accTradePrice24h: 1.5e10, changePct: 4.1 });
+    const signal = computeCoinSignal(s)!;
+    const issue: CoinMaterialItem = {
+      id: "btc-etf",
+      symbols: ["TEST"],
+      scope: "coin",
+      type: "regulation",
+      typeLabel: "규제·법안",
+      direction: "positive",
+      title: "테스트코인 현물 ETF 순유입 확인",
+      meaning: "기관 접근성에 영향을 주는 이슈입니다.",
+      source: "토큰포스트",
+      url: "https://example.com/btc-etf",
+      publishedAt: "2026-07-02T12:00:00Z",
+    };
+    const front = coinFrontSeed(s, signal, [issue]);
+
+    expect(front.signals.newsEventLabel).toBe(issue.title);
+    expect(front.coinCause?.relation).toBe("same-window");
+    expect(front.coinIssues).toEqual([issue]);
+    expect(front.verdict?.stanceText).toContain(issue.title);
   });
 });

--- a/apps/web/__tests__/lib/coin-materials.test.ts
+++ b/apps/web/__tests__/lib/coin-materials.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { CardVerdict, RawArticle } from "@fomo/core";
+import {
+  buildCoinCause,
+  buildCoinMaterialCache,
+  classifyCoinDirection,
+  classifyCoinIssue,
+  composeCoinVerdict,
+  issuesForSymbol,
+  matchCoinSymbols,
+} from "../../lib/coin-materials";
+
+const NOW = new Date("2026-07-18T00:00:00.000Z");
+
+function article(overrides: Partial<RawArticle> = {}): RawArticle {
+  return {
+    id: "issue-1",
+    title: "비트코인 현물 ETF 5일 연속 순유입",
+    summary: "기관 자금 흐름이 집계됐다.",
+    url: "https://example.com/issue-1",
+    source: "토큰포스트",
+    publishedAt: "2026-07-17T12:00:00.000Z",
+    lang: "ko",
+    ...overrides,
+  };
+}
+
+describe("coin material matching", () => {
+  it("상위 코인 alias를 경계 기준으로 매칭하고 짧은 영문 부분문자는 제외", () => {
+    expect(matchCoinSymbols("비트코인과 ETH, 솔라나 수급")).toEqual(["BTC", "ETH", "SOL"]);
+    expect(matchCoinSymbols("solution protocol update")).not.toContain("SOL");
+    expect(matchCoinSymbols("비트코인캐시 BCH 네트워크 업그레이드")).toEqual(["BCH"]);
+    expect(matchCoinSymbols("이더리움클래식 하드포크")).toEqual(["ETC"]);
+  });
+
+  it("코인 전용 문법으로 이슈 유형과 명시 방향만 분류", () => {
+    expect(classifyCoinIssue("CLARITY 법안 하원 통과")).toBe("regulation");
+    expect(classifyCoinIssue("이더리움 펙트라 업그레이드 완료")).toBe("network");
+    expect(classifyCoinIssue("비트코인 6만3000달러대 회복")).toBeNull();
+    expect(classifyCoinDirection("비트코인 ETF 순유출")).toBe("negative");
+    expect(classifyCoinDirection("CLARITY 법안 통과 기대")).toBe("neutral");
+  });
+
+  it("코인별 이슈와 시장 공통 규제 이슈를 캐시하되 일반 가격 기사는 제외", () => {
+    const cache = buildCoinMaterialCache([
+      article(),
+      article({
+        id: "issue-2",
+        title: "가상자산 CLARITY 법안 상원 논의",
+        url: "https://example.com/issue-2",
+        publishedAt: "2026-07-17T10:00:00.000Z",
+      }),
+      article({
+        id: "noise",
+        title: "비트코인 하루 2% 상승",
+        summary: "가격 변동을 전했다.",
+        url: "https://example.com/noise",
+      }),
+      article({
+        id: "digest",
+        title: "[자정 뉴스브리핑] 오늘 주요 소식 外",
+        summary: "비트코인 ETF와 SEC 소식을 종합했다.",
+        url: "https://example.com/digest",
+      }),
+      article({
+        id: "summary-alias",
+        title: "로빈후드 체인 거래량 증가",
+        summary: "이더리움과 금리도 함께 언급됐다.",
+        url: "https://example.com/summary-alias",
+      }),
+    ], NOW);
+
+    const btc = issuesForSymbol(cache, "BTC");
+    expect(btc).toHaveLength(2);
+    expect(btc[0]?.scope).toBe("coin");
+    expect(btc[1]?.scope).toBe("market");
+    expect(btc.some((issue) => issue.id === "noise")).toBe(false);
+    expect(btc.some((issue) => issue.id === "digest")).toBe(false);
+    expect(cache.bySymbol.ETH?.some((issue) => issue.id === "summary-alias") ?? false).toBe(false);
+  });
+
+  it("가격과 기사 시각은 48시간 동시성으로만 연결하고 인과를 단정하지 않음", () => {
+    const issue = buildCoinMaterialCache([article()], NOW).bySymbol.BTC!;
+    const cause = buildCoinCause({ changePct: 4.2, fetchedAt: "2026-07-18T00:00:00.000Z" }, issue);
+    expect(cause?.relation).toBe("same-window");
+    expect(cause?.text).toContain("같은 48시간에 보도");
+    expect(cause?.text).not.toMatch(/때문|영향으로|덕분/);
+  });
+
+  it("verdict는 실제 이슈와 기존 차트 판단을 함께 남겨 코인별 문구가 달라짐", () => {
+    const base: CardVerdict = {
+      stance: "watch",
+      stanceText: "20일선 회복 확인이 더 필요해요.",
+      evidence: ["종가가 20일선 아래"],
+      confidence: "medium",
+    };
+    const issues = buildCoinMaterialCache([article()], NOW).bySymbol.BTC!;
+    const verdict = composeCoinVerdict(base, issues);
+    expect(verdict.stance).toBe("watch");
+    expect(verdict.stanceText).toContain("현물 ETF 5일 연속 순유입");
+    expect(verdict.stanceText).toContain(base.stanceText);
+  });
+});

--- a/apps/web/__tests__/lib/feed-extras.test.ts
+++ b/apps/web/__tests__/lib/feed-extras.test.ts
@@ -3,6 +3,33 @@ import type { RawArticle } from "@fomo/core";
 
 vi.mock("../../lib/fomo-news-sources", () => ({ fetchAllNews: vi.fn(async () => mockedNews) }));
 vi.mock("../../lib/coin-market-source", () => ({ readCoinMarketSnapshots: vi.fn(async () => mockedSnapshots) }));
+vi.mock("../../lib/coin-materials", () => ({
+  readLatestCoinMaterials: vi.fn(async () => {
+    const cryptoSources = new Set(["토큰포스트", "블록미디어", "코인데스크코리아"]);
+    const qualified = mockedNews.filter(
+      (item) => cryptoSources.has(item.source) && /(법안|규제|승인|CLARITY|클래리티|ETF|반감기|업그레이드|금리|CPI|PPI)/i.test(item.title)
+    );
+    if (qualified.length === 0) return null;
+    return {
+      asOf: NOW.slice(0, 10),
+      collectedAt: NOW,
+      bySymbol: {},
+      global: qualified.map((item) => ({
+        id: item.id,
+        symbols: [],
+        scope: "market",
+        type: /반감기|업그레이드/i.test(item.title) ? "network" : "regulation",
+        typeLabel: /반감기|업그레이드/i.test(item.title) ? "네트워크" : "규제·법안",
+        direction: "neutral",
+        title: item.title,
+        meaning: "코인 시장 공통 이슈",
+        source: item.source,
+        url: item.url,
+        publishedAt: item.publishedAt,
+      })),
+    };
+  }),
+}));
 
 import {
   buildCoinIssueCards,

--- a/apps/web/app/api/fomo/cron/coin-market-prewarm/route.ts
+++ b/apps/web/app/api/fomo/cron/coin-market-prewarm/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { withCors } from "../../../../../lib/fomo";
 import { fetchUpbitCoinSnapshots, writeCoinMarketSnapshots } from "../../../../../lib/coin-market-source";
+import { collectAndStoreCoinMaterials } from "../../../../../lib/coin-materials";
 
 /**
  * 코인 시세·캔들 프리웜 크론 (WO Phase C) — us-market-prewarm 패턴.
@@ -24,7 +25,13 @@ export async function GET(request: Request) {
   }
   const startedAt = Date.now();
   try {
-    const snapshots = await fetchUpbitCoinSnapshots();
+    const [snapshots, materialsResult] = await Promise.all([
+      fetchUpbitCoinSnapshots(),
+      collectAndStoreCoinMaterials().then(
+        (stats) => ({ ok: true as const, ...stats }),
+        (error: unknown) => ({ ok: false as const, error: (error as Error)?.message ?? "coin material prewarm failed" })
+      ),
+    ]);
     const stats = await writeCoinMarketSnapshots(snapshots);
     revalidateTag("daily-30", { expire: 0 });
     revalidateTag("feed-hub", { expire: 0 });
@@ -36,6 +43,7 @@ export async function GET(request: Request) {
           universe: snapshots.length,
           written: stats.rows,
           withCandles: stats.rowsWithCandles,
+          materials: materialsResult,
           elapsedMs: Date.now() - startedAt,
         },
         { headers: { "Cache-Control": "no-store" } }

--- a/apps/web/lib/coin-discovery.ts
+++ b/apps/web/lib/coin-discovery.ts
@@ -2,6 +2,14 @@ import { computeCardVerdict, computeFomoScore, isFrontHookSafe } from "@fomo/cor
 import type { CardFrontSignals } from "@fomo/core";
 import { kstDate } from "./fomo";
 import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
+import {
+  buildCoinCause,
+  composeCoinVerdict,
+  issuesForSymbol,
+  materialHeadline,
+  readLatestCoinMaterials,
+  type CoinMaterialItem,
+} from "./coin-materials";
 import type { DiscoveryFrontSeed, DiscoveryResponse, DiscoveryStockPayload } from "./discovery-supply";
 import { buildChartSeries } from "./stock-front";
 
@@ -70,12 +78,6 @@ function krw(price: number): string {
   return `${price.toLocaleString("ko-KR", { maximumFractionDigits: 4 })}원`;
 }
 
-function eok(valueKrw: number): string {
-  const eokValue = valueKrw / 1e8;
-  if (eokValue >= 10_000) return `${(eokValue / 10_000).toFixed(1)}조`;
-  return `${Math.round(eokValue).toLocaleString("ko-KR")}억`;
-}
-
 function ratioText(ratio: number): string {
   return ratio >= 10 ? `${Math.round(ratio)}배` : `${ratio.toFixed(1)}배`;
 }
@@ -98,11 +100,13 @@ export function coinHeadline(snapshot: CoinMarketSnapshot, signal: CoinSignal): 
   return parts.join(" · ");
 }
 
-/** 커버리지(무신호) 헤드라인 — 시총 순위·거래대금 사실만. 신호 문구를 흉내내지 않는다. */
+/** 커버리지(무신호) 헤드라인 — 순위는 보조 메타로만 두고 가격·수급 상태를 말한다. */
 export function coinCoverageHeadline(snapshot: CoinMarketSnapshot, signal: CoinSignal): string {
   const parts: string[] = [];
-  if (typeof snapshot.marketCapRank === "number") parts.push(`시총 ${snapshot.marketCapRank}위`);
-  parts.push(`24시간 거래대금 평소 ${ratioText(signal.volumeRatio)}`);
+  if (Math.abs(snapshot.changePct) >= 1) {
+    parts.push(`하루 ${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(1)}%`);
+  }
+  parts.push(`거래 참여 평소 ${ratioText(signal.volumeRatio)}`);
   if (typeof snapshot.athChangePct === "number" && snapshot.athChangePct <= -30) {
     parts.push(`전고점 대비 ${Math.round(Math.abs(snapshot.athChangePct))}% 아래`);
   }
@@ -110,7 +114,11 @@ export function coinCoverageHeadline(snapshot: CoinMarketSnapshot, signal: CoinS
   return parts.join(" · ");
 }
 
-export function coinFrontSeed(snapshot: CoinMarketSnapshot, signal: CoinSignal): DiscoveryFrontSeed {
+export function coinFrontSeed(
+  snapshot: CoinMarketSnapshot,
+  signal: CoinSignal,
+  coinIssues: readonly CoinMaterialItem[] = []
+): DiscoveryFrontSeed {
   const changePct = Number(snapshot.changePct.toFixed(2));
   const volumeRatio = Number(signal.volumeRatio.toFixed(2));
   const signals: CardFrontSignals = { changePct, volumeRatio };
@@ -118,27 +126,38 @@ export function coinFrontSeed(snapshot: CoinMarketSnapshot, signal: CoinSignal):
   const changeDir: "up" | "down" | "flat" = snapshot.changePct > 0 ? "up" : snapshot.changePct < 0 ? "down" : "flat";
   const candles = snapshot.candles.slice(-120);
   const chartSeries = buildChartSeries(candles);
+  const baseVerdict = computeCardVerdict({
+    candles: snapshot.candles,
+    volumeRatio: signal.volumeRatio,
+    currency: "KRW",
+  });
+  const coinCause = buildCoinCause(snapshot, coinIssues);
+  const primaryIssue = coinIssues.find((issue) => issue.scope === "coin");
   return {
-    signals,
+    signals: {
+      ...signals,
+      ...(primaryIssue ? { newsEventLabel: primaryIssue.title, newsEventSource: primaryIssue.source } : {}),
+    },
     fomo: computeFomoScore({ changePct, volumeRatio, asOf: kstDate() }),
     sparkline: closes.slice(-30),
     priceText: krw(snapshot.price),
     changeText: `${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(2)}%`,
     changeDir,
-    verdict: computeCardVerdict({
-      candles: snapshot.candles,
-      volumeRatio: signal.volumeRatio,
-      currency: "KRW",
-    }),
+    verdict: composeCoinVerdict(baseVerdict, coinIssues),
     candles,
     ...(chartSeries ? { chartSeries } : {}),
+    ...(coinIssues.length ? { coinIssues: [...coinIssues].slice(0, 3) } : {}),
+    ...(coinCause ? { coinCause } : {}),
   };
 }
 
-function coinStockPayload(snapshot: CoinMarketSnapshot, signal: CoinSignal, headline: string): DiscoveryStockPayload {
-  // 뎁스 보조(재무 블록 미해당) — 거래소·거래대금·시총 순위(CoinGecko) 사실 표기.
-  const capText = typeof snapshot.marketCapRank === "number" ? ` · 시총 ${snapshot.marketCapRank}위` : "";
-  const reason = `Upbit 원화마켓 · 24시간 거래대금 ${eok(snapshot.accTradePrice24h)}${capText}`;
+function coinStockPayload(
+  snapshot: CoinMarketSnapshot,
+  signal: CoinSignal,
+  headline: string,
+  primaryIssue?: CoinMaterialItem
+): DiscoveryStockPayload {
+  const reason = primaryIssue?.title ?? headline;
   return {
     canonical: snapshot.koreanName,
     market: "COIN",
@@ -150,15 +169,17 @@ function coinStockPayload(snapshot: CoinMarketSnapshot, signal: CoinSignal, head
     headline,
     whyShown: headline,
     reason,
-    insightTag: signal.vacuumInflow
+    insightTag: primaryIssue
+      ? `₿ ${primaryIssue.typeLabel}`
+      : signal.vacuumInflow
       ? "₿ 진공 후 유입"
       : signal.bigMove
         ? "₿ 급등락"
         : signal.volumeRatio >= VOLUME_ANOMALY_RATIO
           ? "₿ 거래대금 이상"
-          : "₿ 시총 상위",
-    sourceLabel: "Upbit 일봉 · CoinGecko",
-    sourceUrl: `https://upbit.com/exchange?code=CRIX.UPBIT.${snapshot.market}`,
+          : "₿ 시장 관찰",
+    sourceLabel: primaryIssue ? `${primaryIssue.source} · ${primaryIssue.typeLabel}` : "Upbit 일봉 · CoinGecko",
+    sourceUrl: primaryIssue?.url ?? `https://upbit.com/exchange?code=CRIX.UPBIT.${snapshot.market}`,
   };
 }
 
@@ -167,7 +188,10 @@ function coinStockPayload(snapshot: CoinMarketSnapshot, signal: CoinSignal, head
  * 캐시 비었거나 신호 없으면 stocks 0(정직) — 파이프라인은 정상.
  */
 export async function buildCoinDiscoveryResponse(): Promise<DiscoveryResponse> {
-  const snapshots = await readCoinMarketSnapshots().catch((): CoinMarketSnapshot[] => []);
+  const [snapshots, materialCache] = await Promise.all([
+    readCoinMarketSnapshots().catch((): CoinMarketSnapshot[] => []),
+    readLatestCoinMaterials().catch(() => null),
+  ]);
   const stocks: DiscoveryStockPayload[] = [];
   const fronts: Record<string, DiscoveryFrontSeed> = {};
 
@@ -180,11 +204,13 @@ export async function buildCoinDiscoveryResponse(): Promise<DiscoveryResponse> {
     .slice(0, COIN_CARD_LIMIT);
 
   for (const { snapshot, signal } of scored) {
-    const headline = coinHeadline(snapshot, signal);
+    const issues = issuesForSymbol(materialCache, snapshot.symbol);
+    const primaryIssue = issues.find((issue) => issue.scope === "coin");
+    const headline = primaryIssue ? materialHeadline(primaryIssue, snapshot) : coinHeadline(snapshot, signal);
     if (!isFrontHookSafe(headline)) continue; // 카피 가드 — 발굴 문구도 예외 없음
-    const payload = coinStockPayload(snapshot, signal, headline);
+    const payload = coinStockPayload(snapshot, signal, headline, primaryIssue);
     stocks.push(payload);
-    fronts[payload.canonical] = coinFrontSeed(snapshot, signal);
+    fronts[payload.canonical] = coinFrontSeed(snapshot, signal, issues);
   }
 
   // 2026-07-11 User Zero: 코인은 발굴이 아니라 커버리지(#820) — 시총 10위권 유니버스에서
@@ -198,11 +224,13 @@ export async function buildCoinDiscoveryResponse(): Promise<DiscoveryResponse> {
       .sort((a, b) => (a.snapshot.marketCapRank ?? 999) - (b.snapshot.marketCapRank ?? 999))
       .slice(0, COIN_CARD_LIMIT - stocks.length);
     for (const { snapshot, signal } of fillers) {
-      const headline = coinCoverageHeadline(snapshot, signal);
+      const issues = issuesForSymbol(materialCache, snapshot.symbol);
+      const primaryIssue = issues.find((issue) => issue.scope === "coin");
+      const headline = primaryIssue ? materialHeadline(primaryIssue, snapshot) : coinCoverageHeadline(snapshot, signal);
       if (!isFrontHookSafe(headline)) continue;
-      const payload = coinStockPayload(snapshot, signal, headline);
+      const payload = coinStockPayload(snapshot, signal, headline, primaryIssue);
       stocks.push(payload);
-      fronts[payload.canonical] = coinFrontSeed(snapshot, signal);
+      fronts[payload.canonical] = coinFrontSeed(snapshot, signal, issues);
     }
   }
 
@@ -211,6 +239,6 @@ export async function buildCoinDiscoveryResponse(): Promise<DiscoveryResponse> {
     stocks,
     fronts,
     confidence: stocks.length > 0 ? "H" : "L",
-    source: "Upbit 일봉·거래대금 캐시 · CoinGecko",
+    source: "코인 뉴스 재료 캐시 · Upbit 일봉·거래대금 · CoinGecko",
   };
 }

--- a/apps/web/lib/coin-materials.ts
+++ b/apps/web/lib/coin-materials.ts
@@ -1,0 +1,271 @@
+import type { CardVerdict, RawArticle } from "@fomo/core";
+import { kstDate } from "./fomo";
+import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { fetchCryptoNews } from "./fomo-news-sources";
+import type { CoinMarketSnapshot } from "./coin-market-source";
+
+export type CoinIssueType = "regulation" | "network" | "institution" | "onchain" | "macro";
+export type CoinIssueDirection = "positive" | "negative" | "neutral";
+
+export interface CoinMaterialItem {
+  id: string;
+  symbols: string[];
+  scope: "coin" | "market";
+  type: CoinIssueType;
+  typeLabel: string;
+  direction: CoinIssueDirection;
+  title: string;
+  meaning: string;
+  source: string;
+  url: string;
+  publishedAt: string;
+}
+
+export interface CoinMaterialCache {
+  asOf: string;
+  collectedAt: string;
+  bySymbol: Record<string, CoinMaterialItem[]>;
+  global: CoinMaterialItem[];
+}
+
+export interface CoinCause {
+  text: string;
+  relation: "same-window" | "recent-context";
+  sourceLabel: string;
+  url: string;
+  asOf: string;
+  issueId: string;
+}
+
+type CoinAlias = { symbol: string; aliases: string[] };
+
+/** 시총 상위권 카드 유니버스와 무관하게 기사 매칭 사전은 30개를 유지한다. */
+export const COIN_ALIASES: readonly CoinAlias[] = [
+  { symbol: "BTC", aliases: ["비트코인", "bitcoin", "btc"] },
+  { symbol: "ETH", aliases: ["이더리움", "이더", "ethereum", "ether", "eth"] },
+  { symbol: "USDT", aliases: ["테더", "tether", "usdt"] },
+  { symbol: "XRP", aliases: ["리플", "ripple", "xrp"] },
+  { symbol: "BNB", aliases: ["바이낸스코인", "bnb"] },
+  { symbol: "SOL", aliases: ["솔라나", "solana", "sol"] },
+  { symbol: "USDC", aliases: ["유에스디코인", "usd coin", "usdc"] },
+  { symbol: "DOGE", aliases: ["도지코인", "dogecoin", "doge"] },
+  { symbol: "ADA", aliases: ["에이다", "카르다노", "cardano", "ada"] },
+  { symbol: "TRX", aliases: ["트론", "tron", "trx"] },
+  { symbol: "AVAX", aliases: ["아발란체", "avalanche", "avax"] },
+  { symbol: "LINK", aliases: ["체인링크", "chainlink", "link"] },
+  { symbol: "DOT", aliases: ["폴카닷", "polkadot", "dot"] },
+  { symbol: "SUI", aliases: ["수이", "sui"] },
+  { symbol: "XLM", aliases: ["스텔라루멘", "스텔라", "stellar", "xlm"] },
+  { symbol: "HBAR", aliases: ["헤데라", "hedera", "hbar"] },
+  { symbol: "BCH", aliases: ["비트코인캐시", "bitcoin cash", "bch"] },
+  { symbol: "LTC", aliases: ["라이트코인", "litecoin", "ltc"] },
+  { symbol: "TON", aliases: ["톤코인", "toncoin", "ton"] },
+  { symbol: "SHIB", aliases: ["시바이누", "shiba inu", "shib"] },
+  { symbol: "UNI", aliases: ["유니스왑", "uniswap", "uni"] },
+  { symbol: "APT", aliases: ["앱토스", "aptos", "apt"] },
+  { symbol: "ETC", aliases: ["이더리움클래식", "ethereum classic", "etc"] },
+  { symbol: "NEAR", aliases: ["니어프로토콜", "니어", "near protocol", "near"] },
+  { symbol: "ICP", aliases: ["인터넷컴퓨터", "internet computer", "icp"] },
+  { symbol: "FIL", aliases: ["파일코인", "filecoin", "fil"] },
+  { symbol: "ATOM", aliases: ["코스모스", "cosmos", "atom"] },
+  { symbol: "ARB", aliases: ["아비트럼", "arbitrum", "arb"] },
+  { symbol: "OP", aliases: ["옵티미즘", "optimism", "op"] },
+  { symbol: "AAVE", aliases: ["에이브", "aave"] },
+] as const;
+
+const TYPE_LABEL: Record<CoinIssueType, string> = {
+  regulation: "규제·법안",
+  network: "네트워크",
+  institution: "기관·트레저리",
+  onchain: "온체인·수급",
+  macro: "거시 연동",
+};
+
+const CRYPTO_CONTEXT = /가상자산|암호화폐|코인|블록체인|비트코인|이더리움|BTC|ETH|스테이블코인|디지털자산/i;
+const OMNIBUS_BRIEFING = /뉴스브리핑|시세브리핑|주요 뉴스|오늘의 코인|마켓 브리핑|팟캐스트/i;
+const ISSUE_PATTERNS: Array<{ type: CoinIssueType; pattern: RegExp }> = [
+  { type: "regulation", pattern: /CLARITY|클래리티|법안|규제|SEC|의회|상원|하원|ETF|과세|세제|승인|소송/i },
+  { type: "network", pattern: /업그레이드|하드포크|소프트포크|반감기|메인넷|테스트넷|펙트라|Pectra|Fusaka|프로토콜/i },
+  { type: "institution", pattern: /트레저리|재무전략|기관|기업.{0,12}(매수|보유|투자)|커스터디|수탁|상장|비트마인|BitMine|MicroStrategy|스트래티지/i },
+  { type: "onchain", pattern: /고래|온체인|거래소.{0,12}(순유입|순유출|입금|출금)|순유입|순유출|언락|락업|스테이킹|CVD|채굴자|청산|레버리지|미결제약정/i },
+  { type: "macro", pattern: /연준|FOMC|금리|달러(?:화|\s?지수|\s?인덱스|\s?강세|\s?약세)|DXY|CPI|PPI|물가|고용|유동성|위험자산|국채|통화정책/i },
+];
+
+function escaped(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function aliasMatches(text: string, alias: string): boolean {
+  if (/^[a-z0-9 ]+$/i.test(alias)) {
+    return new RegExp(`(^|[^a-z0-9])${escaped(alias)}([^a-z0-9]|$)`, "i").test(text);
+  }
+  return text.toLocaleLowerCase("ko-KR").includes(alias.toLocaleLowerCase("ko-KR"));
+}
+
+export function matchCoinSymbols(text: string): string[] {
+  const matches = COIN_ALIASES.filter((coin) => coin.aliases.some((alias) => aliasMatches(text, alias))).map((coin) => coin.symbol);
+  // 파생 자산의 긴 이름이 원 자산 alias를 포함하는 경우(비트코인캐시, 이더리움클래식) 오배선 방지.
+  if (matches.includes("BCH") && matches.includes("BTC")) {
+    const rest = text.replace(/비트코인\s?캐시|bitcoin\s+cash|\bBCH\b/gi, " ");
+    if (!["비트코인", "bitcoin", "btc"].some((alias) => aliasMatches(rest, alias))) matches.splice(matches.indexOf("BTC"), 1);
+  }
+  if (matches.includes("ETC") && matches.includes("ETH")) {
+    const rest = text.replace(/이더리움\s?클래식|ethereum\s+classic|\bETC\b/gi, " ");
+    if (!["이더리움", "이더", "ethereum", "ether", "eth"].some((alias) => aliasMatches(rest, alias))) matches.splice(matches.indexOf("ETH"), 1);
+  }
+  return matches;
+}
+
+export function classifyCoinIssue(text: string): CoinIssueType | null {
+  return ISSUE_PATTERNS.find((entry) => entry.pattern.test(text))?.type ?? null;
+}
+
+export function classifyCoinDirection(text: string): CoinIssueDirection {
+  if (/기대|전망|가능성|검토|논의|추진/i.test(text)) return "neutral";
+  if (/ETF.{0,24}(순유출|유출)|해킹|취약점|공격|제재|기소|소송|언락|락업 해제|대규모 매도|강제청산|청산 급증|중단/i.test(text)) return "negative";
+  if (/ETF.{0,24}(순유입|유입)|승인|가결|법안 통과|매수|도입|채택|업그레이드 완료|메인넷 출시|트레저리 편입/i.test(text)) return "positive";
+  return "neutral";
+}
+
+function meaningFor(type: CoinIssueType, direction: CoinIssueDirection, scope: "coin" | "market"): string {
+  const scopeText = scope === "market" ? "코인 시장 공통 변수" : "해당 코인의 최근 재료";
+  const directionText = direction === "positive" ? "우호적 사실" : direction === "negative" ? "부담 요인" : "방향 확인이 필요한 사실";
+  const grammar: Record<CoinIssueType, string> = {
+    regulation: "규제 적용 범위와 기관 접근성에 영향을 주는 이슈",
+    network: "네트워크 기능·공급 일정에 직접 연결되는 이슈",
+    institution: "기관 보유·수탁·기업 수요를 확인하는 이슈",
+    onchain: "거래소 이동과 보유 주체의 수급 변화를 보여주는 이슈",
+    macro: "금리·달러와 위험자산 환경을 함께 보는 이슈",
+  };
+  return `${grammar[type]} · ${scopeText}, 현재 분류는 ${directionText}입니다.`;
+}
+
+function issueDateValid(article: RawArticle, now: Date): boolean {
+  const published = Date.parse(article.publishedAt);
+  const age = now.getTime() - published;
+  return Number.isFinite(published) && age >= -60 * 60 * 1000 && age <= 7 * 24 * 60 * 60 * 1000;
+}
+
+function titleKey(title: string): string {
+  return title.toLocaleLowerCase("ko-KR").replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+function compareIssues(a: CoinMaterialItem, b: CoinMaterialItem): number {
+  const priority: Record<CoinIssueType, number> = { regulation: 5, network: 4, institution: 4, onchain: 3, macro: 2 };
+  return Date.parse(b.publishedAt) - Date.parse(a.publishedAt) || priority[b.type] - priority[a.type];
+}
+
+export function buildCoinMaterialCache(articles: readonly RawArticle[], now = new Date()): CoinMaterialCache {
+  const bySymbol: Record<string, CoinMaterialItem[]> = {};
+  const global: CoinMaterialItem[] = [];
+  const seen = new Set<string>();
+  for (const article of articles) {
+    if (!issueDateValid(article, now)) continue;
+    if (OMNIBUS_BRIEFING.test(article.title)) continue;
+    const symbols = matchCoinSymbols(article.title);
+    // 카드에 그대로 노출할 제목 자체가 재료 문법을 가져야 한다. 본문에만 재료가 있는 가격 속보는 제외한다.
+    const type = classifyCoinIssue(article.title);
+    if (!type) continue;
+    const scope = symbols.length > 0 ? "coin" : "market";
+    if (
+      scope === "market" &&
+      (!CRYPTO_CONTEXT.test(article.title) || (type !== "regulation" && type !== "macro" && type !== "onchain"))
+    ) continue;
+    const key = titleKey(article.title);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const direction = classifyCoinDirection(`${article.title} ${article.summary ?? ""}`);
+    const item: CoinMaterialItem = {
+      id: article.id || article.url,
+      symbols,
+      scope,
+      type,
+      typeLabel: TYPE_LABEL[type],
+      direction,
+      title: article.title.trim(),
+      meaning: meaningFor(type, direction, scope),
+      source: article.source,
+      url: article.url,
+      publishedAt: article.publishedAt,
+    };
+    if (scope === "market") global.push(item);
+    for (const symbol of symbols) (bySymbol[symbol] ??= []).push(item);
+  }
+  for (const symbol of Object.keys(bySymbol)) bySymbol[symbol] = bySymbol[symbol]!.sort(compareIssues).slice(0, 6);
+  global.sort(compareIssues).splice(6);
+  const asOf = new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  return { asOf, collectedAt: now.toISOString(), bySymbol, global };
+}
+
+const CACHE_PREFIX = "coin-materials:";
+
+export async function collectAndStoreCoinMaterials(): Promise<{ articles: number; matched: number; global: number }> {
+  const articles = await fetchCryptoNews();
+  const cache = buildCoinMaterialCache(articles);
+  await writeFeedContent(`${CACHE_PREFIX}${cache.asOf}`, cache);
+  return {
+    articles: articles.length,
+    matched: Object.values(cache.bySymbol).reduce((sum, items) => sum + items.length, 0),
+    global: cache.global.length,
+  };
+}
+
+export async function readLatestCoinMaterials(): Promise<CoinMaterialCache | null> {
+  const today = await readFeedContent<CoinMaterialCache>(`${CACHE_PREFIX}${kstDate()}`);
+  if (today) return today;
+  return (await readFeedContentByPrefix<CoinMaterialCache>(CACHE_PREFIX, 1))[0]?.row ?? null;
+}
+
+export function issuesForSymbol(cache: CoinMaterialCache | null, symbol: string, limit = 3): CoinMaterialItem[] {
+  if (!cache) return [];
+  const combined = [...(cache.bySymbol[symbol.toUpperCase()] ?? []), ...cache.global];
+  const seen = new Set<string>();
+  return combined.filter((item) => {
+    const key = titleKey(item.title);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).sort((a, b) => (a.scope === b.scope ? compareIssues(a, b) : a.scope === "coin" ? -1 : 1)).slice(0, limit);
+}
+
+function hoursApart(left: string, right: string): number {
+  return Math.abs(Date.parse(left) - Date.parse(right)) / 3_600_000;
+}
+
+export function buildCoinCause(snapshot: Pick<CoinMarketSnapshot, "changePct" | "fetchedAt">, issues: readonly CoinMaterialItem[]): CoinCause | undefined {
+  const issue = issues.find((item) => item.scope === "coin") ?? issues[0];
+  if (!issue) return undefined;
+  const sameWindow = issue.scope === "coin" && Math.abs(snapshot.changePct) >= 3 && hoursApart(snapshot.fetchedAt, issue.publishedAt) <= 48;
+  const move = `${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(1)}%`;
+  return {
+    text: sameWindow
+      ? `오늘 ${move} 변동과 같은 48시간에 보도된 이슈: ${issue.title}`
+      : `${issue.scope === "market" ? "시장 공통" : "해당 코인"} 최근 이슈: ${issue.title}`,
+    relation: sameWindow ? "same-window" : "recent-context",
+    sourceLabel: `${issue.source} · ${issue.typeLabel}`,
+    url: issue.url,
+    asOf: issue.publishedAt,
+    issueId: issue.id,
+  };
+}
+
+export function materialHeadline(issue: CoinMaterialItem, snapshot: Pick<CoinMarketSnapshot, "changePct" | "fetchedAt">): string {
+  const title = issue.title.length > 76 ? `${issue.title.slice(0, 73)}…` : issue.title;
+  if (issue.scope === "coin" && Math.abs(snapshot.changePct) >= 3 && hoursApart(snapshot.fetchedAt, issue.publishedAt) <= 48) {
+    return `${title} · 오늘 ${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(1)}%`;
+  }
+  return title;
+}
+
+export function composeCoinVerdict(base: CardVerdict, issues: readonly CoinMaterialItem[]): CardVerdict {
+  const issue = issues.find((item) => item.scope === "coin") ?? issues[0];
+  if (!issue) return base;
+  const direction = issue.direction === "positive" ? "우호 재료" : issue.direction === "negative" ? "부담 재료" : "방향 미확정 재료";
+  const title = issue.title.length > 48 ? `${issue.title.slice(0, 45)}…` : issue.title;
+  const stanceText = `${issue.typeLabel} '${title}' 확인 · ${direction}. 차트 판단은 ${base.stanceText}`;
+  return {
+    ...base,
+    stanceText,
+    evidence: [`${issue.typeLabel} · ${issue.source} · ${direction}`, ...base.evidence].slice(0, 3),
+  };
+}

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -60,6 +60,7 @@ import { reprocessNewsHook, ruleReprocessNewsHook, type NewsHookInput } from "./
 import { synthesizeWhyDrivenInsight } from "./insight-synthesis";
 import { isAbstractTemplate } from "./copy-guards";
 import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContentCard } from "./deck-content";
+import type { CoinCause, CoinMaterialItem } from "./coin-materials";
 
 const UA = { "User-Agent": "Mozilla/5.0", Accept: "application/json,text/plain,*/*" };
 const MARKETS: DiscoveryMarket[] = ["KOSPI", "KOSDAQ"];
@@ -147,6 +148,10 @@ export interface DiscoveryFrontSeed {
     ma60: Array<number | null>;
     ma120: Array<number | null>;
   };
+  /** 코인 전용: 크론에서 수집·분류한 최근 이슈. 요청 경로 외부 fetch 없음. */
+  coinIssues?: CoinMaterialItem[];
+  /** 가격 변동과 이슈 발행 시각의 결정론적 시간창 연결. */
+  coinCause?: CoinCause;
 }
 
 export interface DiscoveryStockPayload extends Omit<SectorStock, "sector"> {

--- a/apps/web/lib/feed-extras.ts
+++ b/apps/web/lib/feed-extras.ts
@@ -2,7 +2,7 @@
  * 콘텐츠 피드 베리에이션 빌더 (2026-07-11 User Zero: "매번 지수 얘기뿐 — 다양하게").
  *
  * 신규 4타입 — 전부 결정론(LLM 없음, 요청 경로 안전):
- * - coin-issue : 코인 핫이슈 — 시총 10위권 스냅샷 캐시에서 최대 무버·거래대금 이상.
+ * - coin-issue : 크론 코인 재료 캐시 우선 + 시세 스냅샷의 유의미한 무버 보조.
  * - hot-issue  : 미장·국장 뉴스 핫이슈 — 이미 수집된 기사에서 다수 소스가 겹치는 사건.
  * - term       : 오늘의 경제용어 — 정적 용어사전 날짜 로테이션(사실 서술만).
  * - event      : 시장 일정 — 규칙 계산 만기일(3째 금요일/둘째 목요일) + Fed 공개 FOMC 일정.
@@ -15,6 +15,7 @@ import type { DeckContentCard, DeckContentFact } from "./deck-content";
 import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
 import { computeCoinSignal } from "./coin-discovery";
 import { fetchAllNews } from "./fomo-news-sources";
+import { readLatestCoinMaterials } from "./coin-materials";
 import { koreanTitle } from "./content-i18n";
 
 function kstNow(): Date {
@@ -36,12 +37,6 @@ function krwText(price: number): string {
   return `${price.toLocaleString("ko-KR", { maximumFractionDigits: 2 })}원`;
 }
 
-// 코인 전문 매체(토큰포스트·블록미디어)만 — 일반 경제지의 우연한 코인 언급 잡음 배제.
-// isFresh(아래 hot-issue 절 정의, HOT_ISSUE_WINDOW_HOURS=30h)를 그대로 재사용한다.
-const CRYPTO_NEWS_SOURCES = new Set(["토큰포스트", "블록미디어"]);
-// 규제·법안·ETF·거시 지표 등 "왜 중요한가"가 있는 사건만 — 순수 가격 변동 기사(예: "OO 코인 5% 상승")는 걸러낸다.
-const COIN_MACRO_PATTERN = /(법안|규제|승인|입법|반감기|스테이블코인|클래리티|CLARITY|의회|채택|정책|과세|세제|ETF|연준|금리|물가|CPI|PPI)/;
-
 function priceTableFacts(withSignal: readonly { snapshot: CoinMarketSnapshot }[]): DeckContentFact[] {
   return [...withSignal]
     .sort((a, b) => (a.snapshot.marketCapRank ?? 999) - (b.snapshot.marketCapRank ?? 999))
@@ -62,16 +57,27 @@ const COIN_MOVER_MIN_VOLUME_RATIO = 1.5;
  * 별도 카드로 함께 노출한다(최대 2장). 매크로 없는 조용한 날은 기존처럼 무버 폴백만.
  */
 export async function buildCoinIssueCards(): Promise<DeckContentCard[]> {
-  const snapshots = await readCoinMarketSnapshots().catch((): CoinMarketSnapshot[] => []);
+  const [snapshots, materialCache] = await Promise.all([
+    readCoinMarketSnapshots().catch((): CoinMarketSnapshot[] => []),
+    readLatestCoinMaterials().catch(() => null),
+  ]);
   const withSignal = snapshots
     .map((snapshot) => ({ snapshot, signal: computeCoinSignal(snapshot) }))
     .filter((x): x is { snapshot: CoinMarketSnapshot; signal: NonNullable<ReturnType<typeof computeCoinSignal>> } => x.signal !== null);
 
-  const now = new Date();
-  const articles = await fetchAllNews().catch((): RawArticle[] => []);
-  const macroArticle = dedupeByTitle(
-    articles.filter((a) => CRYPTO_NEWS_SOURCES.has(a.source) && isFresh(a, now) && COIN_MACRO_PATTERN.test(a.title))
-  ).sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))[0];
+  const allIssues = materialCache
+    ? [...materialCache.global, ...Object.values(materialCache.bySymbol).flat()]
+    : [];
+  const seenIssues = new Set<string>();
+  const macroArticle = allIssues
+    .filter((issue) => issue.type === "regulation" || issue.type === "network" || issue.type === "macro")
+    .filter((issue) => {
+      const key = normalizedTitleKey(issue.title);
+      if (!key || seenIssues.has(key)) return false;
+      seenIssues.add(key);
+      return true;
+    })
+    .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))[0];
 
   const cards: DeckContentCard[] = [];
   if (macroArticle) {
@@ -99,7 +105,6 @@ export async function buildCoinIssueCards(): Promise<DeckContentCard[]> {
     if (!macroArticle || significant) {
       const headlineParts = [`${mover.snapshot.koreanName} 하루 ${signedPct(mover.snapshot.changePct)}`];
       if (mover.signal.volumeRatio >= 1.3) headlineParts.push(`거래대금 평소 ${mover.signal.volumeRatio.toFixed(1)}배`);
-      if (typeof mover.snapshot.marketCapRank === "number") headlineParts.push(`시총 ${mover.snapshot.marketCapRank}위`);
       cards.push({
         kind: "content",
         id: macroArticle ? `content:coin-issue:mover:${kstDate()}` : `content:coin-issue:${kstDate()}`,

--- a/apps/web/lib/fomo-news-sources.ts
+++ b/apps/web/lib/fomo-news-sources.ts
@@ -103,6 +103,7 @@ const KR_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] 
 const CRYPTO_FEEDS: { id: string; url: string; source: string; tier: SourceTier }[] = [
   { id: "tokenpost", url: "https://www.tokenpost.kr/rss", source: "토큰포스트", tier: "news-mid" },
   { id: "blockmedia", url: "https://www.blockmedia.co.kr/feed", source: "블록미디어", tier: "news-mid" },
+  { id: "coindesk-korea", url: "https://www.coindeskkorea.com/feed", source: "코인데스크코리아", tier: "news-mid" },
 ];
 
 // ───────────────────────── 네이버 금융 뉴스 (JSON) ─────────────────────────
@@ -274,6 +275,16 @@ export const NEWS_SOURCES: readonly NewsSource[] = [
   ...KR_FEEDS.map(makeKoreanRssSource),
   ...CRYPTO_FEEDS.map(makeKoreanRssSource),
 ];
+
+const CRYPTO_NEWS_SOURCES: readonly NewsSource[] = CRYPTO_FEEDS.map(makeKoreanRssSource);
+
+/** 코인 카드 재료 크론 전용 수집. 요청 경로에서는 호출하지 않고 프리웜 결과만 읽는다. */
+export async function fetchCryptoNews(): Promise<RawArticle[]> {
+  const settled = await Promise.allSettled(CRYPTO_NEWS_SOURCES.map((source) => source.fetch()));
+  const out: RawArticle[] = [];
+  for (const result of settled) if (result.status === "fulfilled") out.push(...result.value);
+  return out;
+}
 
 /** 모든 enabled 소스를 병렬 수집해 정규화 기사 배열로 합산. */
 export async function fetchAllNews(): Promise<RawArticle[]> {

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -25,6 +25,14 @@ import { fetchNasdaqDailyCandles, fetchUsDailyCandles } from "./us-market-source
 import type { DiscoveryMarketRow } from "./market-source-types";
 import { readUsMarketQuoteRows } from "./us-market-cache";
 import { readCoinMarketSnapshots } from "./coin-market-source";
+import {
+  buildCoinCause,
+  composeCoinVerdict,
+  issuesForSymbol,
+  readLatestCoinMaterials,
+  type CoinCause,
+  type CoinMaterialItem,
+} from "./coin-materials";
 import { usSymbolForStock } from "./us-symbols";
 import { readSupplyDemandHistory } from "./supply-demand-store";
 import type { StockAttentionSignal, ThemeRelativeSignal } from "./stock-signal-coverage";
@@ -199,6 +207,10 @@ export interface StockFrontData {
   verdict?: CardVerdict;
   /** 차트분석 탭 시리즈(WO 1.6 D) — 종가+MA20/60/120+거래량. non-lite 에서만. */
   chartSeries?: StockChartSeries;
+  /** 코인 전용 최근 재료. 크론 캐시에서만 읽는다. */
+  coinIssues?: CoinMaterialItem[];
+  /** 코인 가격 변동과 기사 발행 시각의 결정론적 연결. */
+  coinCause?: CoinCause;
 }
 
 export interface StockFrontOptions {
@@ -362,9 +374,16 @@ async function assembleUsCachedStockFront(
  * 주식과 같은 표준: TA·verdict·chartSeries 전부 같은 엔진에 캔들만 공급. 재무는 코인 미해당.
  */
 async function assembleCoinStockFront(market: string, lite: boolean): Promise<StockFrontData> {
-  const snapshots = await readCoinMarketSnapshots().catch(() => []);
+  const [snapshots, materialCache] = await Promise.all([
+    readCoinMarketSnapshots().catch(() => []),
+    readLatestCoinMaterials().catch(() => null),
+  ]);
   const snapshot = snapshots.find((s) => s.market.toUpperCase() === market);
   if (!snapshot) return { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
+
+  const coinIssues = issuesForSymbol(materialCache, snapshot.symbol);
+  const coinCause = buildCoinCause(snapshot, coinIssues);
+  const primaryIssue = coinIssues.find((issue) => issue.scope === "coin");
 
   const fullValues = snapshot.tradeValues.slice(0, -1);
   const avg20 = fullValues.length >= 5 ? fullValues.slice(-20).reduce((a, b) => a + b, 0) / Math.min(20, fullValues.length) : 0;
@@ -372,6 +391,7 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
   const signals: CardFrontSignals = {
     changePct: Number(snapshot.changePct.toFixed(2)),
     ...(typeof volRatio === "number" ? { volumeRatio: Number(volRatio.toFixed(2)) } : {}),
+    ...(primaryIssue ? { newsEventLabel: primaryIssue.title, newsEventSource: primaryIssue.source } : {}),
   };
   const closes = snapshot.candles.map((c) => c.close);
   const sparkline = closes.slice(-66);
@@ -387,6 +407,8 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     priceText,
     changeText,
     changeDir,
+    ...(coinIssues.length ? { coinIssues } : {}),
+    ...(coinCause ? { coinCause } : {}),
   };
   if (lite) {
     return { ...base, fomo: computeFomoScore({ ...signals }) };
@@ -400,11 +422,11 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     ...(ta.inputs.bollingerSqueeze ? { bollingerSqueeze: true } : {}),
   });
   const taFact = selectTaFact(fomo, ta);
-  const verdict = computeCardVerdict({
+  const verdict = composeCoinVerdict(computeCardVerdict({
     candles: snapshot.candles,
     ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
     currency: "KRW",
-  });
+  }), coinIssues);
   const chartSeries = buildChartSeries(snapshot.candles);
   return {
     ...base,


### PR DESCRIPTION
## 변경\n- 토큰포스트·블록미디어·코인데스크코리아 RSS를 코인 프리웜 크론에서 수집하고 상위 30 alias/전용 이슈 문법으로 캐시\n- 코인 카드 헤드라인을 실제 재료 우선으로 전환하고 순위 단독 카피 제거\n- 코인 뎁스의 확인된 계기를 48시간 동시성 근거로 교체하고 지금 이슈 2~3건/원문 노출\n- 재료+기존 TA verdict를 결합해 stanceText 탈템플릿\n\n## 검증\n- 관련 Vitest 29개 통과\n- backend/fomo-web typecheck 통과\n- backend/fomo-web production build 통과\n- 실 RSS 110건 수집, BTC 3건/ETH 2건 매칭 확인