### PR TITLE
fix(db): index relation foreign keys

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,6 +207,8 @@ model Bot {
   alerts                 Alert[]
   dailySummaries         DailySummary[]
   systemLogs             SystemLog[]
+
+  @@index([userId])
 }
 
 model Strategy {
@@ -307,6 +309,8 @@ model StrategyRun {
   strategy          Strategy          @relation(fields: [strategyId], references: [id])
   session           StrategySession?  @relation(fields: [sessionId], references: [id])
 
+  @@index([botId])
+  @@index([strategyId])
   @@index([sessionId, executedAt])
 }
 
@@ -340,6 +344,7 @@ model Position {
   trades          Trade[]
 
   @@index([botId, symbol, status])
+  @@index([strategyId])
   @@index([sessionId, status])
 }
 
@@ -372,6 +377,8 @@ model Trade {
   session         StrategySession? @relation(fields: [sessionId], references: [id])
 
   @@index([botId, executedAt])
+  @@index([strategyId])
+  @@index([positionId])
   @@index([sessionId, executedAt])
 }
 
@@ -390,6 +397,10 @@ model Alert {
   bot        Bot              @relation(fields: [botId], references: [id])
   strategy   Strategy?        @relation(fields: [strategyId], references: [id])
   session    StrategySession? @relation(fields: [sessionId], references: [id])
+
+  @@index([botId])
+  @@index([strategyId])
+  @@index([sessionId])
 }
 
 model MarketCandle {
@@ -420,6 +431,7 @@ model SystemLog {
   createdAt DateTime       @default(now())
   bot       Bot?           @relation(fields: [botId], references: [id])
 
+  @@index([botId])
   @@index([createdAt])
 }
 
@@ -491,6 +503,7 @@ model NewsletterDigest {
   updatedAt    DateTime               @updatedAt
   profile      ResearchProfile?       @relation(fields: [profileId], references: [id])
 
+  @@index([profileId])
   @@index([generatedAt])
   @@index([status, scheduledFor])
 }
@@ -596,6 +609,7 @@ model TarotDrawHistoryCard {
   card        TarotCard        @relation(fields: [cardId], references: [id])
 
   @@index([drawId])
+  @@index([cardId])
 }
 
 // 관심 종목/섹터 즐겨찾기
@@ -639,6 +653,8 @@ model TarotReport {
   user      User              @relation(fields: [userId], references: [id])
   draw      TarotDrawHistory  @relation(fields: [drawId], references: [id])
 
+  @@index([userId])
+  @@index([drawId])
   @@index([status, createdAt])
 }
 
@@ -668,6 +684,7 @@ model TarotCardCollection {
 
   @@unique([userId, cardId])
   @@index([userId])
+  @@index([cardId])
 }
 
 // 모바일 앱 이벤트 트래킹

--- a/scripts/__tests__/scout-rotation.test.ts
+++ b/scripts/__tests__/scout-rotation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
 
 // import 시 main() 자동실행 방지(네트워크/파일 쓰기).
 beforeAll(() => {
@@ -45,6 +46,52 @@ describe("반복 방지 — 카테고리·영역 로테이션 + dedup", async ()
   it("Hardening: override 영역 강제 선택", () => {
     expect(hardening.pickArea(new Date(), "security")).toBe("security");
     expect(hardening.pickArea(new Date(), "bogus")).not.toBe("bogus");
+  });
+
+  it("Hardening DB: unique와 복합 인덱스의 선두 FK는 누락으로 잡지 않는다", () => {
+    const schema = `
+      model Bot {
+        id     String @id
+        userId String?
+        user   User?  @relation(fields: [userId], references: [id])
+      }
+
+      model Strategy {
+        id    String @id
+        botId String
+        key   String
+        bot   Bot    @relation(fields: [botId], references: [id])
+
+        @@unique([botId, key])
+      }
+
+      model ResearchProfile {
+        id     String @id
+        userId String @unique
+        user   User   @relation(fields: [userId], references: [id])
+      }
+
+      model Alert {
+        id         String @id
+        botId      String
+        strategyId String?
+        bot        Bot       @relation(fields: [botId], references: [id])
+        strategy   Strategy? @relation(fields: [strategyId], references: [id])
+
+        @@index([botId, strategyId])
+      }
+    `;
+
+    expect(hardening.findUnindexedRelationFields(schema)).toEqual([
+      "Bot.userId",
+      "Alert.strategyId",
+    ]);
+  });
+
+  it("Hardening DB: 운영 Prisma 스키마의 모든 관계 FK가 인덱스로 보호된다", () => {
+    const schema = readFileSync(new URL("../../prisma/schema.prisma", import.meta.url), "utf8");
+
+    expect(hardening.findUnindexedRelationFields(schema)).toEqual([]);
   });
 
   it("isoWeek 는 연속 주에 증가한다", () => {

--- a/scripts/hardening-scout.ts
+++ b/scripts/hardening-scout.ts
@@ -185,18 +185,55 @@ async function scanApi(): Promise<AreaReport> {
   };
 }
 
+function prismaIndexFields(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((field) => field.trim().replace(/\(.+\)$/, ""))
+    .filter(Boolean);
+}
+
+export function findUnindexedRelationFields(schema: string): string[] {
+  const missing: string[] = [];
+  const modelPattern = /^\s*model\s+(\w+)\s*\{([\s\S]*?)^\s*\}/gm;
+
+  for (const model of schema.matchAll(modelPattern)) {
+    const modelName = model[1]!;
+    const body = model[2]!;
+    const indexedPrefixes: string[][] = [];
+
+    for (const line of body.split("\n")) {
+      const field = line.match(/^\s*(\w+)\s+[^\n]+\s@(id|unique)\b/);
+      if (field) indexedPrefixes.push([field[1]!]);
+    }
+
+    for (const index of body.matchAll(/@@(?:id|unique|index)\s*\(\s*\[([^\]]+)\]/g)) {
+      indexedPrefixes.push(prismaIndexFields(index[1]!));
+    }
+
+    for (const relation of body.matchAll(/@relation\s*\(([^)]*)\)/g)) {
+      const relationFields = relation[1]!.match(/fields\s*:\s*\[([^\]]+)\]/);
+      if (!relationFields) continue;
+
+      const fields = prismaIndexFields(relationFields[1]!);
+      const covered = indexedPrefixes.some((indexFields) =>
+        fields.every((field, index) => indexFields[index] === field)
+      );
+      if (!covered) missing.push(`${modelName}.${fields.join("+")}`);
+    }
+  }
+
+  return missing;
+}
+
 async function scanDb(): Promise<AreaReport> {
   const findings: Finding[] = [];
   const schema = await readIfExists("prisma/schema.prisma");
   if (schema) {
     const models = [...schema.matchAll(/^model\s+(\w+)/gm)].map((m) => m[1]!);
     const indexCount = (schema.match(/@@index/g) ?? []).length;
-    const relationNoIndex = models.filter((m) => {
-      const block = schema.slice(schema.indexOf(`model ${m}`), schema.indexOf("}", schema.indexOf(`model ${m}`)));
-      return /@relation/.test(block) && !/@@index/.test(block);
-    });
-    if (relationNoIndex.length > 0) {
-      findings.push({ title: `@relation 있으나 @@index 없는 모델 ${relationNoIndex.length}개`, detail: `${relationNoIndex.join(", ")} — FK 조회 느려질 수 있음(인덱스 검토). 모델 ${models.length}개, 인덱스 ${indexCount}개.` });
+    const unindexedRelations = findUnindexedRelationFields(schema);
+    if (unindexedRelations.length > 0) {
+      findings.push({ title: `관계 FK 인덱스 누락 ${unindexedRelations.length}개`, detail: `${unindexedRelations.join(", ")} — FK 조회 느려질 수 있음(인덱스 검토). 모델 ${models.length}개, 인덱스 ${indexCount}개.` });
     }
   }
   return {


### PR DESCRIPTION
## What changed
- add indexes for every Prisma relation foreign key that was not already covered by an `@id`, `@unique`, `@@id`, `@@unique`, or leading `@@index` column
- make Hardening Scout evaluate relation fields instead of treating any model-level index as sufficient
- add regression coverage for unique/composite-index detection and the production schema

## Why
Issue #817 reported four relation models without indexes. Review found two were false positives (`Strategy.botId` is covered by a composite unique index and `ResearchProfile.userId` is unique), while the old scanner also missed relation fields in models that happened to have an unrelated index.

## Validation
- `HARDENING_AREA=db npm run hardening:scout` (0 findings)
- `npm test` (120 files, 1,152 tests)
- `npm run lint`
- `npm run typecheck`
- `DATABASE_URL=... npx prisma validate`
- `npm run spec:analyze`

## Deployment note
Prisma schema change included. After merge, the manual DB Push workflow should be run without `--accept-data-loss`; the change is additive indexes only.

Closes #817