### PR TITLE
feat(feed): 무한 피드 — 렌더 8개 제한 제거 + 지난 콘텐츠 아카이브

### DIFF
--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -15,6 +15,7 @@ import type { FrontEntry } from "@/components/StockSwipeDeck";
 import { FeedDepthPage } from "@/components/FeedDepthPage";
 import { SectorCard } from "@/components/SectorCard";
 import { StockIssueCard, sectorCardData } from "@/components/FeedView";
+import { useFeedArchive } from "@/lib/useFeedArchive";
 import { CalendarCard } from "@/components/CalendarCard";
 import { discoveryStatus, verdictBalance } from "@/lib/discoveryPresentation";
 
@@ -133,6 +134,9 @@ export function DesktopDashboard() {
   const [feedItem, setFeedItem] = useState<FeedHubItem | null>(null);
   const [feedItems, setFeedItems] = useState<FeedHubItem[]>([]);
   const [seenItems] = useState(() => getDiscoverySeen());
+  // 무한 피드(2026-07-18) — 오늘치 아래로 지난 브리핑·버즈·회고를 계속 이어 붙인다.
+  const feedTodayIds = useMemo(() => new Set(feedItems.map(feedItemId)), [feedItems]);
+  const { archive: feedArchive, sentinelRef: feedSentinelRef, done: feedArchiveDone } = useFeedArchive(feedItems.length > 0, feedTodayIds);
 
   useEffect(() => {
     let alive = true;
@@ -268,8 +272,9 @@ export function DesktopDashboard() {
       </section>
 
       {/* ③ 우 — feed-hub(피드 탭과 동일 소스·이원화 금지) + 성과 되짚기. 클릭 → 중앙 뎁스. */}
+      {/* 2026-07-18 User Zero "피드 10장도 안 돼": slice(0,8) 제한 제거 — 오늘치 전부 + 지난 콘텐츠 무한 이어 붙이기. */}
       <section className="scrollbar-none min-h-0 space-y-3 overflow-y-auto">
-        {(feedItems.length > 0 ? feedItems : []).slice(0, 8).map((item, index) => {
+        {[...feedItems, ...(feedItems.length > 0 ? feedArchive : [])].map((item, index) => {
           const id = feedItemId(item);
           const active = feedItem === item;
           return (
@@ -295,6 +300,7 @@ export function DesktopDashboard() {
             </button>
           );
         })}
+        {feedItems.length > 0 && !feedArchiveDone && <div ref={feedSentinelRef} className="h-8" aria-hidden />}
         {feedItems.length === 0 &&
           contentCards.slice(0, 4).map((card) => (
             <div key={card.data.id} className="rounded-2xl border border-hairline bg-surface px-5 py-5">

--- a/apps/fomo-web/components/FeedView.tsx
+++ b/apps/fomo-web/components/FeedView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CalendarCard } from "@/components/CalendarCard";
 import { ContentCard } from "@/components/ContentCard";
 import { NarrativeCard } from "@/components/NarrativeCard";
@@ -9,6 +9,7 @@ import { SectorCard } from "@/components/SectorCard";
 import { FeedDepthPage } from "@/components/FeedDepthPage";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import { fetchFeedHub, type FeedHubItem } from "@/lib/fomoApi";
+import { feedItemKey, useFeedArchive } from "@/lib/useFeedArchive";
 import type { DeckCard, DeckNarrative, DeckSectorCardData } from "@/lib/discoveryDeck";
 
 /**
@@ -65,6 +66,8 @@ export function FeedView() {
   const [failed, setFailed] = useState(false);
   const [selected, setSelected] = useState<FeedHubItem | null>(null);
   const [narrative, setNarrative] = useState<DeckNarrative | null>(null);
+  const todayIds = useMemo(() => new Set((items ?? []).map(feedItemKey)), [items]);
+  const { archive, sentinelRef, done: archiveDone } = useFeedArchive(!!items && items.length > 0, todayIds);
 
   useEffect(() => {
     let alive = true;
@@ -99,44 +102,56 @@ export function FeedView() {
   const cardShell =
     "block w-full rounded-2xl border border-hairline bg-surface px-5 py-5 text-left transition-colors hover:border-whiteout/20";
 
+  const renderItem = (item: FeedHubItem) => {
+    if (item.type === "narrative") {
+      return (
+        <button key={item.narrative.id} type="button" onClick={() => setNarrative(item.narrative)} className={cardShell}>
+          <NarrativeCard card={item.narrative} />
+        </button>
+      );
+    }
+    if (item.type === "sector") {
+      return (
+        <button key={item.sector.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
+          <SectorCard card={sectorCardData(item)} />
+        </button>
+      );
+    }
+    if (item.type === "stock-issue") {
+      return (
+        <button key={item.stockIssue.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
+          <StockIssueCard item={item} />
+        </button>
+      );
+    }
+    if (item.type === "calendar") {
+      // 캘린더는 인라인 완결(전체 정보가 카드 안) — 뎁스 불요, 막다른 탭 아님.
+      return (
+        <div key={item.calendar.id} className="w-full rounded-2xl border border-hairline bg-surface px-5 py-5">
+          <CalendarCard calendar={item.calendar} />
+        </div>
+      );
+    }
+    return (
+      <button key={item.content.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
+        <ContentCard card={item.content} />
+      </button>
+    );
+  };
+
   return (
     <div className="space-y-3 pb-4">
-      {items.map((item) => {
-        if (item.type === "narrative") {
-          return (
-            <button key={item.narrative.id} type="button" onClick={() => setNarrative(item.narrative)} className={cardShell}>
-              <NarrativeCard card={item.narrative} />
-            </button>
-          );
-        }
-        if (item.type === "sector") {
-          return (
-            <button key={item.sector.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
-              <SectorCard card={sectorCardData(item)} />
-            </button>
-          );
-        }
-        if (item.type === "stock-issue") {
-          return (
-            <button key={item.stockIssue.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
-              <StockIssueCard item={item} />
-            </button>
-          );
-        }
-        if (item.type === "calendar") {
-          // 캘린더는 인라인 완결(전체 정보가 카드 안) — 뎁스 불요, 막다른 탭 아님.
-          return (
-            <div key={item.calendar.id} className="w-full rounded-2xl border border-hairline bg-surface px-5 py-5">
-              <CalendarCard calendar={item.calendar} />
-            </div>
-          );
-        }
-        return (
-          <button key={item.content.id} type="button" onClick={() => setSelected(item)} className={cardShell}>
-            <ContentCard card={item.content} />
-          </button>
-        );
-      })}
+      {items.map(renderItem)}
+
+      {/* 무한 피드(2026-07-18) — 오늘치가 끝나면 지난 브리핑·버즈·회고를 계속 이어 붙인다. */}
+      {archive.length > 0 && (
+        <p className="pt-3 text-center font-pixel text-[11px] text-muted">지난 콘텐츠</p>
+      )}
+      {archive.map(renderItem)}
+      {!archiveDone && <div ref={sentinelRef} className="h-8" aria-hidden />}
+      {archiveDone && archive.length > 0 && (
+        <p className="py-4 text-center text-[11px] text-muted">최근 한 달 콘텐츠를 전부 봤어요.</p>
+      )}
 
       {narrative && <NarrativeDepthPage card={narrative} onClose={() => setNarrative(null)} />}
       {selected && <FeedDepthPage item={selected} onClose={() => setSelected(null)} />}

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -359,6 +359,18 @@ export interface FeedHubResponse {
 export const fetchFeedHub = () =>
   cachedGet(`feed-hub:${kstDateKey()}`, () => get<FeedHubResponse>("/api/fomo/feed-hub"), 15 * MINUTE);
 
+/** 피드 아카이브(무한 스크롤) — before(exclusive) 이전의 지난 브리핑·버즈·회고 페이지. */
+export interface FeedArchiveResponse {
+  items: FeedHubItem[];
+  /** 다음 페이지 커서 — null 이면 아카이브 끝. */
+  nextBefore: string | null;
+}
+export const fetchFeedArchive = (before: string) =>
+  cachedGet(`feed-archive:${before}`, () => get<FeedArchiveResponse>(`/api/fomo/feed-hub?before=${before}`), 60 * MINUTE);
+
+/** 오늘(KST) YYYY-MM-DD — 아카이브 첫 커서용. */
+export const feedArchiveStartCursor = () => kstDateKey();
+
 /** 무로그인 대기함(WO 검색 요청→다음날 카드) — 익명 deviceId(=sessionId)의 요청 상태. */
 export interface MyRequestResolved {
   canonical: string;

--- a/apps/fomo-web/lib/useFeedArchive.ts
+++ b/apps/fomo-web/lib/useFeedArchive.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { feedArchiveStartCursor, fetchFeedArchive, type FeedHubItem } from "./fomoApi";
+
+/**
+ * 피드 아카이브 무한 스크롤 훅 (2026-07-18 User Zero: "무한스크롤처럼 피드를 계속").
+ * 오늘 피드 아래에 sentinel 을 두면, 보일 때마다 지난 날짜의 브리핑·버즈·회고 페이지를 이어 받는다.
+ * 주말·휴장일은 빈 페이지라 최대 4페이지까지 연쇄 로드해 공백을 건너뛴다.
+ */
+
+export function feedItemKey(item: FeedHubItem): string {
+  if (item.type === "narrative") return item.narrative.id;
+  if (item.type === "sector") return item.sector.id;
+  if (item.type === "stock-issue") return item.stockIssue.id;
+  if (item.type === "calendar") return item.calendar.id;
+  return item.content.id;
+}
+
+const EMPTY_PAGE_HOPS = 4;
+
+export function useFeedArchive(enabled: boolean, existingIds?: ReadonlySet<string>) {
+  const [archive, setArchive] = useState<FeedHubItem[]>([]);
+  const [done, setDone] = useState(false);
+  const cursorRef = useRef<string | null>(feedArchiveStartCursor());
+  const loadingRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (loadingRef.current) return;
+    loadingRef.current = true;
+    try {
+      let gained = 0;
+      for (let hop = 0; hop < EMPTY_PAGE_HOPS && gained === 0; hop += 1) {
+        const cursor = cursorRef.current;
+        if (!cursor) {
+          setDone(true);
+          return;
+        }
+        const page = await fetchFeedArchive(cursor);
+        cursorRef.current = page.nextBefore;
+        const fresh = page.items.filter((item) => !existingIds?.has(feedItemKey(item)));
+        if (fresh.length > 0) {
+          gained = fresh.length;
+          setArchive((prev) => {
+            const seen = new Set(prev.map(feedItemKey));
+            return [...prev, ...fresh.filter((item) => !seen.has(feedItemKey(item)))];
+          });
+        }
+        if (!page.nextBefore) setDone(true);
+      }
+    } catch {
+      // 아카이브 실패는 조용히 — 오늘 피드는 이미 떠 있다(다음 스크롤에서 재시도).
+    } finally {
+      loadingRef.current = false;
+    }
+  }, [existingIds]);
+
+  useEffect(() => {
+    if (!enabled || done) return;
+    const el = sentinelRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) void loadMore();
+      },
+      { rootMargin: "600px 0px" } // 바닥 도달 전에 미리 당겨 끊김 없는 스크롤
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enabled, done, loadMore]);
+
+  return { archive, sentinelRef, done };
+}

--- a/apps/web/__tests__/lib/feed-archive.test.ts
+++ b/apps/web/__tests__/lib/feed-archive.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+// 아카이브는 발행된 실콘텐츠(FeedContentCache 행)만 읽는다 — 저장소를 날짜별로 흉내 낸다.
+const store = new Map<string, unknown>();
+vi.mock("../../lib/feed-content-store", () => ({
+  readFeedContent: vi.fn(async (id: string) => store.get(id) ?? null),
+  writeFeedContent: vi.fn(async () => {}),
+  readFeedContentByPrefix: vi.fn(async () => []),
+  deleteFeedContent: vi.fn(async () => {}),
+}));
+
+import { buildFeedArchiveResponse } from "../../lib/feed-hub";
+import { kstDate } from "../../lib/fomo";
+
+function briefingRow(id: string, headline: string) {
+  return {
+    card: {
+      kind: "content",
+      id,
+      contentType: "briefing",
+      scope: "domestic",
+      headline,
+      facts: [],
+      source: "테스트",
+      asOf: id.slice(-10),
+    },
+  };
+}
+
+// 2026-07-18 User Zero: "무한스크롤처럼 피드를 계속" — 지난 브리핑·버즈가 페이지 단위로 이어진다.
+describe("feed archive (무한 피드)", () => {
+  it("before 이전 3일치의 발행 콘텐츠를 날짜 내림차순으로 반환하고 커서를 넘긴다", async () => {
+    store.clear();
+    const d1 = kstDate(-1);
+    const d2 = kstDate(-2);
+    store.set(`briefing:kr:${d1}`, briefingRow(`content:briefing:kr:${d1}`, "어제의 국장 브리핑"));
+    store.set(`buzz:${d2}`, briefingRow(`content:buzz:${d2}`, "그제의 버즈"));
+
+    const page = await buildFeedArchiveResponse(kstDate());
+    const ids = page.items.map((i) => (i as { content: { id: string } }).content.id);
+    expect(ids).toEqual([`content:briefing:kr:${d1}`, `content:buzz:${d2}`]);
+    expect(page.nextBefore).toBe(kstDate(-3));
+  });
+
+  it("행이 없는 날(주말 등)은 빈 페이지 + 커서 전진 — 클라이언트가 계속 넘길 수 있다", async () => {
+    store.clear();
+    const page = await buildFeedArchiveResponse(kstDate(-10));
+    expect(page.items).toEqual([]);
+    expect(page.nextBefore).toBe(kstDate(-13));
+  });
+
+  it("최대 조회 기간(30일)을 넘으면 nextBefore=null 로 끝을 알린다", async () => {
+    store.clear();
+    const page = await buildFeedArchiveResponse(kstDate(-29));
+    expect(page.nextBefore).toBeNull();
+  });
+
+  it("이번 주 회고는 오늘 피드 소관이라 아카이브에서 제외한다(중복 금지)", async () => {
+    store.clear();
+    const today = kstDate();
+    const iso = (d: string) => {
+      const dt = new Date(`${d}T00:00:00Z`);
+      const day = dt.getUTCDay() || 7;
+      dt.setUTCDate(dt.getUTCDate() + 4 - day);
+      const ys = new Date(Date.UTC(dt.getUTCFullYear(), 0, 1));
+      return `${dt.getUTCFullYear()}-W${String(Math.ceil(((dt.getTime() - ys.getTime()) / 86_400_000 + 1) / 7)).padStart(2, "0")}`;
+    };
+    store.set(`recap:${iso(today)}`, briefingRow(`content:recap:${iso(today)}`, "이번 주 회고"));
+    const page = await buildFeedArchiveResponse(today);
+    expect(page.items.map((i) => (i as { content: { id: string } }).content.id)).not.toContain(`content:recap:${iso(today)}`);
+  });
+});

--- a/apps/web/app/api/fomo/feed-hub/route.ts
+++ b/apps/web/app/api/fomo/feed-hub/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { withCors, kstDate, cacheVersion } from "../../../../lib/fomo";
-import { buildFeedHubResponse, type FeedHubResponse } from "../../../../lib/feed-hub";
+import { buildFeedArchiveResponse, buildFeedHubResponse, type FeedHubResponse } from "../../../../lib/feed-hub";
 
 /**
  * 피드 집계 API (WO 피드 파이프라인 통합) — FeedView·PC 우측 컬럼의 단일 소스.
@@ -16,8 +16,23 @@ export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    // 아카이브 모드(무한 피드) — ?before=YYYY-MM-DD 커서로 지난 브리핑·버즈·회고를 페이지 단위 제공.
+    const before = new URL(request.url).searchParams.get("before")?.trim();
+    if (before && /^\d{4}-\d{2}-\d{2}$/.test(before)) {
+      const loadArchive = unstable_cache(
+        () => buildFeedArchiveResponse(before),
+        ["fomo-feed-archive", cacheVersion(), before],
+        { revalidate: 21_600 } // 지난 콘텐츠는 사실상 불변 — 6h
+      );
+      return withCors(
+        NextResponse.json(await loadArchive(), {
+          headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+        })
+      );
+    }
+
     const load = unstable_cache(
       () => buildFeedHubResponse(),
       ["fomo-feed-hub", cacheVersion(), kstDate()],

--- a/apps/web/lib/feed-hub.ts
+++ b/apps/web/lib/feed-hub.ts
@@ -13,6 +13,7 @@ import { buildCoinIssueCards, buildEventCard, buildHotIssueCards, buildTermCard 
 import { hydrateKoreanTitles } from "./content-i18n";
 import { buildDailyReceiptCard } from "./feed-receipt";
 import { readWeeklyCalendar, type WeeklyCalendar } from "./earnings-calendar";
+import { readFeedContent } from "./feed-content-store";
 import type { DiscoveryMarketRow } from "./market-source-types";
 
 /**
@@ -451,4 +452,79 @@ export async function buildFeedHubResponse(): Promise<FeedHubResponse> {
     scopeCounts,
     source: "브리핑·버즈·회고·내러티브·섹터·지수·거시·고래·종목이슈·거시이슈 통합(feed-hub)",
   };
+}
+
+// ── 아카이브(무한 피드) — 지난 날짜의 브리핑·버즈·회고를 이어 붙인다 ─────────
+//
+// 2026-07-18 User Zero: "피드가 너무 없어 — 무한스크롤처럼 계속 보여줘". 오늘치(위)가 끝나면
+// 클라이언트가 before 커서로 지난 콘텐츠를 페이지 단위로 이어 받는다. 전부 이미 발행된
+// 실콘텐츠(FeedContentCache 영구 행)만 — 과거를 재생성하거나 지어내지 않는다(정직).
+
+/** 브리핑 계열 저장 행(feed-briefing.ts 규약) — 카드만 읽는다. */
+interface ArchivedBriefingRow {
+  card?: DeckContentCard;
+}
+
+export interface FeedArchiveResponse {
+  /** 이 페이지의 지난 콘텐츠(날짜 내림차순). */
+  items: FeedHubItem[];
+  /** 다음 페이지 커서(exclusive) — null 이면 아카이브 끝. */
+  nextBefore: string | null;
+}
+
+const ARCHIVE_PAGE_DAYS = 3;
+const ARCHIVE_MAX_LOOKBACK_DAYS = 30;
+
+function isoWeekOfDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+function shiftDate(iso: string, days: number): string {
+  return new Date(Date.parse(`${iso}T00:00:00Z`) + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * 아카이브 페이지 — before(exclusive)부터 과거 3일치의 발행 콘텐츠(브리핑 US/KR·버즈·주간 회고).
+ * 주말·휴장일은 행이 없어 빈 페이지일 수 있다 — nextBefore 로 계속 넘겨 최대 30일까지 훑는다.
+ */
+export async function buildFeedArchiveResponse(before: string): Promise<FeedArchiveResponse> {
+  const today = kstDate();
+  const oldestAllowed = shiftDate(today, -ARCHIVE_MAX_LOOKBACK_DAYS);
+  const start = before <= today ? before : today;
+  const dates = Array.from({ length: ARCHIVE_PAGE_DAYS }, (_, i) => shiftDate(start, -(i + 1))).filter((d) => d >= oldestAllowed);
+  if (dates.length === 0) return { items: [], nextBefore: null };
+
+  const items: FeedHubItem[] = [];
+  const seen = new Set<string>();
+  const push = (card: DeckContentCard | undefined, type: FeedItemType) => {
+    if (!card || seen.has(card.id)) return;
+    seen.add(card.id);
+    items.push({ type: type as "briefing", scope: contentScope(card), content: card });
+  };
+
+  const seenWeeks = new Set<string>([isoWeekOfDate(today)]); // 이번 주 회고는 오늘 피드가 담당 — 중복 금지
+  for (const date of dates) {
+    const [us, kr, buzz] = await Promise.all([
+      readFeedContent<ArchivedBriefingRow>(`briefing:us:${date}`).catch(() => null),
+      readFeedContent<ArchivedBriefingRow>(`briefing:kr:${date}`).catch(() => null),
+      readFeedContent<ArchivedBriefingRow>(`buzz:${date}`).catch(() => null),
+    ]);
+    push(us?.card, "briefing");
+    push(kr?.card, "briefing");
+    push(buzz?.card, "buzz");
+    const week = isoWeekOfDate(date);
+    if (!seenWeeks.has(week)) {
+      seenWeeks.add(week);
+      const recap = await readFeedContent<ArchivedBriefingRow>(`recap:${week}`).catch(() => null);
+      push(recap?.card, "recap");
+    }
+  }
+
+  const oldest = dates[dates.length - 1]!;
+  return { items, nextBefore: oldest > oldestAllowed ? oldest : null };
 }


### PR DESCRIPTION
## User Zero: "카드는 30장인데 피드는 10장도 안 돼 — 무한스크롤처럼"

실측: 서버(feed-hub)는 28개를 주는데 **PC 우측 컬럼이 `slice(0, 8)`로 8개만 렌더** — 체감 부족의 주범.

### 변경
1. **렌더 제한 제거**: PC 우측 컬럼 오늘치 전부(28+)
2. **아카이브 API** `?before=YYYY-MM-DD`: 지난 날짜의 발행 콘텐츠(브리핑 US/KR·버즈·주간 회고)를 3일 단위 페이지. 이미 발행된 실콘텐츠(FeedContentCache 영구 행)만 — 정직 원칙. 최대 30일 lookback, 이번 주 회고 제외(오늘 피드와 중복 금지)
3. **useFeedArchive 훅**: sentinel IntersectionObserver(600px 프리페치), 주말 빈 페이지 4연쇄 스킵, 오늘 피드와 id dedupe(버즈 어제 폴백 중복 방지)
4. **양 표면 연결**: 모바일 피드 탭 + PC 우측 컬럼 — 스크롤 끝에서 자동 로드, "지난 콘텐츠" 구분선

### 효과
오늘 28개 + 지난 30일 브리핑·버즈·회고(하루 ~3개 × 거래일) ≈ **총 80~90개 연속 스크롤**. 크론이 매일 쌓는 만큼 아카이브는 자동으로 깊어진다.

## 검증
- feed-archive 4케이스 신규, 전체 1156 통과 · typecheck 0 · next build(backend·fomo-web) 통과
- 머지 후 프로덕션 API(?before=)·브라우저 무한 스크롤 실측 첨부 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)