### PR TITLE
fix(feed): 아카이브 캐시 오염 차단 — 빈 페이지 no-store

### DIFF
--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -365,8 +365,9 @@ export interface FeedArchiveResponse {
   /** 다음 페이지 커서 — null 이면 아카이브 끝. */
   nextBefore: string | null;
 }
-export const fetchFeedArchive = (before: string) =>
-  cachedGet(`feed-archive:${before}`, () => get<FeedArchiveResponse>(`/api/fomo/feed-hub?before=${before}`), 60 * MINUTE);
+// 로컬 캐시 없이 항상 신선 조회 — 서버 콜드 실패로 빈 페이지가 오면 캐시에 남지 않고 다음 스크롤에서 재시도.
+// 정상 페이지는 CDN(s-maxage 1h)이 이미 방패라 클라 캐시가 불필요하다.
+export const fetchFeedArchive = (before: string) => get<FeedArchiveResponse>(`/api/fomo/feed-hub?before=${before}`);
 
 /** 오늘(KST) YYYY-MM-DD — 아카이브 첫 커서용. */
 export const feedArchiveStartCursor = () => kstDateKey();

--- a/apps/web/app/api/fomo/feed-hub/route.ts
+++ b/apps/web/app/api/fomo/feed-hub/route.ts
@@ -19,16 +19,17 @@ export function OPTIONS() {
 export async function GET(request: Request) {
   try {
     // 아카이브 모드(무한 피드) — ?before=YYYY-MM-DD 커서로 지난 브리핑·버즈·회고를 페이지 단위 제공.
+    // ⚠️ 서버 캐시(unstable_cache) 금지 — 배포 직후 콜드 DB 읽기 실패가 "빈 페이지"로 6h 박히는
+    // 오염 실사고(2026-07-18, daily-30 KR 0장과 같은 계열). DB 점조회 3~4개라 캐시 없이도 싸다.
+    // 빈 페이지는 CDN 도 no-store — 실패와 진짜 없음을 구분할 수 없으니 캐시하지 않는 게 정직.
     const before = new URL(request.url).searchParams.get("before")?.trim();
     if (before && /^\d{4}-\d{2}-\d{2}$/.test(before)) {
-      const loadArchive = unstable_cache(
-        () => buildFeedArchiveResponse(before),
-        ["fomo-feed-archive", cacheVersion(), before],
-        { revalidate: 21_600 } // 지난 콘텐츠는 사실상 불변 — 6h
-      );
+      const archive = await buildFeedArchiveResponse(before);
       return withCors(
-        NextResponse.json(await loadArchive(), {
-          headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+        NextResponse.json(archive, {
+          headers: {
+            "Cache-Control": archive.items.length > 0 ? "public, s-maxage=3600, stale-while-revalidate=86400" : "no-store",
+          },
         })
       );
     }


### PR DESCRIPTION
배포 직후 콜드 DB 실패가 빈 아카이브 페이지로 6h 캐시되는 실사고 재발 방지(#848과 같은 계열). 서버 unstable_cache 제거(점조회 3~4개), 빈 페이지 CDN no-store, 클라 로컬 캐시 제거. 테스트 4케이스 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)