### PR TITLE
fix(pwa): standalone 3버그 — safe-area·스와이프 touch-action·피드 뎁스 포털

### DIFF
--- a/apps/fomo-web/components/FeedDepthPage.tsx
+++ b/apps/fomo-web/components/FeedDepthPage.tsx
@@ -241,7 +241,7 @@ export function FeedDepthPage({ item, onClose, inline = false }: { item: FeedHub
 
   return (
     <div className="fixed inset-0 z-[70] overflow-y-auto bg-canvas">
-      <div className="mx-auto max-w-xl px-6 pb-16 pt-6">
+      <div className="mx-auto max-w-xl px-6 pb-[calc(4rem+env(safe-area-inset-bottom))] pt-[calc(1.5rem+env(safe-area-inset-top))]">
         <button type="button" onClick={onClose} className="mb-5 font-pixel text-xs text-muted underline">
           ← 피드로
         </button>

--- a/apps/fomo-web/components/FeedView.tsx
+++ b/apps/fomo-web/components/FeedView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { CalendarCard } from "@/components/CalendarCard";
 import { ContentCard } from "@/components/ContentCard";
 import { NarrativeCard } from "@/components/NarrativeCard";
@@ -153,10 +154,22 @@ export function FeedView() {
         <p className="py-4 text-center text-[11px] text-muted">최근 한 달 콘텐츠를 전부 봤어요.</p>
       )}
 
-      {narrative && <NarrativeDepthPage card={narrative} onClose={() => setNarrative(null)} />}
-      {selected && <FeedDepthPage item={selected} onClose={() => setSelected(null)} />}
+      {/* 뎁스 오버레이는 body 로 portal — 피드 탭의 overflow-y-auto 스크롤 컨테이너 안에서
+          fixed 가 갇혀(iOS standalone) "뎁스가 안 뜨던" 문제 해소. 컨테이너 밖 뷰포트 기준 렌더. */}
+      <OverlayPortal>
+        {narrative && <NarrativeDepthPage card={narrative} onClose={() => setNarrative(null)} />}
+        {selected && <FeedDepthPage item={selected} onClose={() => setSelected(null)} />}
+      </OverlayPortal>
     </div>
   );
+}
+
+/** 스크롤 컨테이너 탈출용 body 포털 — 마운트 후에만(SSR 안전). */
+function OverlayPortal({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted || typeof document === "undefined") return null;
+  return createPortal(children, document.body);
 }
 
 /** 메인 덱 필터(WO-GNB) — daily-30 카드에서 종목 카드만. 콘텐츠·섹터·내러티브는 피드(feed-hub) 소관. */

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -66,7 +66,7 @@ export function HomeView({
   if (isDesktop) {
     return (
       <>
-        <main className="fomo-phase-in mx-auto flex h-screen max-w-[1400px] flex-col gap-4 px-6 py-5">
+        <main className="fomo-phase-in mx-auto flex h-screen max-w-[1400px] flex-col gap-4 px-6 pb-5 pt-[calc(1.25rem+env(safe-area-inset-top))]">
           <div className="flex shrink-0 items-center justify-between">
             <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
             <div className="flex items-center gap-2">
@@ -106,7 +106,7 @@ export function HomeView({
 
   return (
     <>
-      <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-20 pt-4">
+      <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-[calc(1rem+env(safe-area-inset-top))]">
         {/* 상단 얇은 띠: 로고 + 시장 온도 축약 배지(WO 1.5 E — 큰 바는 몰입 방해라 접었다. 탭하면 설명 시트). */}
         <div className="flex items-center justify-between">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
@@ -157,7 +157,7 @@ export function HomeView({
       </main>
 
       {/* 하단 GNB: 메인 / 피드 / 히스토리 (WO-GNB — 두 표면 분리) */}
-      <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-[#1E1E1E] bg-black">
+      <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-[#1E1E1E] bg-black pb-[env(safe-area-inset-bottom)]">
         <div className="mx-auto flex max-w-md">
           <TabButton active={tab === "main"} onClick={() => setTab("main")} label="메인" />
           <TabButton active={tab === "feed"} onClick={() => setTab("feed")} label="피드" />

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -92,7 +92,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
   };
 
   return (
-    <div className="fixed inset-0 z-[60] bg-black">
+    <div className="fixed inset-0 z-[60] bg-black pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <div className="mx-auto flex h-full max-w-md flex-col">
         <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
           <div className="flex items-center gap-2.5">
@@ -2380,7 +2380,7 @@ export function StockInsightView({
     !hasInsight && !insight?.officialFacts?.length && auditWordings(insight).length === 0;
 
   return (
-    <div className={inline ? "flex h-full min-h-0 flex-col" : "fixed inset-0 z-[70] bg-black"}>
+    <div className={inline ? "flex h-full min-h-0 flex-col" : "fixed inset-0 z-[70] bg-black pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"}>
       <div className={inline ? "flex h-full min-h-0 flex-col" : "mx-auto flex h-full max-w-md flex-col"}>
         <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
           <div className="flex items-center gap-2.5">

--- a/apps/fomo-web/components/NarrativeDepthPage.tsx
+++ b/apps/fomo-web/components/NarrativeDepthPage.tsx
@@ -127,7 +127,7 @@ export function NarrativeDepthPage({
   }
 
   return (
-    <div className={inline ? "flex h-full min-h-0 flex-col" : "fixed inset-0 z-[70] bg-black"}>
+    <div className={inline ? "flex h-full min-h-0 flex-col" : "fixed inset-0 z-[70] bg-black pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"}>
       <div className={inline ? "flex h-full min-h-0 flex-col" : "mx-auto flex h-full max-w-md flex-col"}>
         <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
           <button onClick={onClose} className="font-pixel text-sm text-muted hover:text-whiteout" aria-label="뒤로">

--- a/apps/fomo-web/components/SearchOverlay.tsx
+++ b/apps/fomo-web/components/SearchOverlay.tsx
@@ -175,7 +175,7 @@ export function SearchOverlay({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="fixed inset-0 z-[80] flex flex-col bg-canvas">
-      <div className="mx-auto flex w-full max-w-md flex-1 flex-col px-6 pt-5">
+      <div className="mx-auto flex w-full max-w-md flex-1 flex-col px-6 pb-[env(safe-area-inset-bottom)] pt-[calc(1.25rem+env(safe-area-inset-top))]">
         {/* 검색 입력 */}
         <div className="flex items-center gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-2 rounded-2xl border border-hairline bg-white/[0.04] px-4 py-3">

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -947,7 +947,9 @@ export function StockSwipeDeck({
             else if (top.type === "narrative") openNarrativeDepth(top.data);
           }}
           className="absolute inset-0 z-10 cursor-pointer overflow-hidden rounded-2xl border border-hairline-soft bg-surface-raised px-6 py-7"
-          style={{ transform: topTransform, transition: topTransition }}
+          // touch-action: none — iOS(특히 standalone PWA)가 가로 드래그를 스크롤·뒤로가기 제스처로
+          // 가로채 pointermove 가 안 오던 스와이프 불능 해소. 카드 위 제스처는 덱이 전담한다.
+          style={{ transform: topTransform, transition: topTransition, touchAction: "none" }}
         >
           {/* 드래그 스탬프(틴더식 아이콘) — 거리에 비례해 또렷·확대. 우=관심(하트)·좌=패스(X)·위=슈퍼관심(별). */}
           <span


### PR DESCRIPTION
설치형 PWA(standalone) 실측 3건. `viewportFit: cover`(설치형 요건)로 content가 노치까지 확장됐는데 대응 부재 + iOS 터치/스크롤 특유 버그.

### 1. 상단 노치 침범 (헤더·검색 버튼 잘림)
`env(safe-area-inset-*)` 패딩 추가: 모바일/데스크톱 `main` 상단, 하단 GNB 하단, 전 풀스크린 뎁스 오버레이(Feed·Narrative·Keyword·StockInsight)·SearchOverlay.

### 2. 카드 스와이프 불능
스와이프 카드에 `touch-action` 없음 → iOS(특히 standalone)가 가로 드래그를 스크롤·뒤로가기 제스처로 가로채 `pointermove` 미수신. 카드에 `touch-action: none`.

### 3. 피드 카드 탭 → 뎁스 안 뜸
피드 탭 `overflow-y-auto` 스크롤 컨테이너 안의 `fixed` 오버레이가 iOS에서 컨테이너 기준으로 갇힘(뷰포트 탈출 실패) → 화면 밖 렌더. `FeedDepthPage`·`NarrativeDepthPage`를 `createPortal(document.body)`로 스크롤 컨테이너 밖으로.

## 검증
- typecheck·next build 통과
- 비-standalone 브라우저에서 피드 뎁스·스와이프 회귀 없음, env 인셋 0이라 레이아웃 불변
- 머지 후 실기기(iOS 설치형) 확인 권장 — 브라우저 pane은 노치 인셋 시뮬 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)