### PR TITLE
feat(depth): 로딩 단일화 + "어떤 회사예요" 섹션

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import {
   scoreToColor,
   cleanText,
@@ -1362,24 +1363,6 @@ function StockSynthesisBlock({
   );
 }
 
-function StockDepthLoadingBlock() {
-  return (
-    <section
-      className="mt-6 rounded-2xl border border-hairline bg-surface px-4 py-5"
-      aria-busy="true"
-      aria-live="polite"
-    >
-      <p className="font-pixel text-sm text-whiteout">페이지 불러오는 중</p>
-      <p className="mt-2 text-sm leading-6 text-muted">
-        가격·차트·원문 근거를 한 번에 맞춰 불러오고 있어요.
-      </p>
-      <div className="mt-5 flex justify-center">
-        <FlickerSpinner size={36} />
-      </div>
-    </section>
-  );
-}
-
 function OfficialFactsBlock({ facts }: { facts: CondensedInsight["officialFacts"] | undefined }) {
   if (!facts || facts.length === 0) return null;
   return (
@@ -2406,13 +2389,14 @@ export function StockInsightView({
         </div>
 
         <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
-          {/* 가격 먼저 — 일반 주식 상세 화면의 첫 독해 지점. */}
-          <StockPriceHeader basics={basics} front={front} />
-
+          {/* 전부 로드 전엔 아무것도 노출하지 않는다(2026-07-18 User Zero: "정보가 나왔다가 바뀌어 어색") —
+              가격 헤더 선노출·seed→fresh 교체 없이 메인홈과 동일한 로딩 하나만. */}
           {!detailsReady ? (
-            <StockDepthLoadingBlock />
+            <FullPageLoading estimateMs={LOADING_PRESETS.main.estimateMs} steps={LOADING_PRESETS.main.steps} />
           ) : (
           <>
+          {/* 가격 먼저 — 일반 주식 상세 화면의 첫 독해 지점. */}
+          <StockPriceHeader basics={basics} front={front} />
           <DiscoveryOverview front={front} insight={insight} context={context} />
           <DepthTabBar tab={depthTab} onChange={setDepthTab} />
           {depthTab === "ta" ? (
@@ -2428,6 +2412,20 @@ export function StockInsightView({
 
           {/* 무슨 일이 있었나(WO-22) — 원문 인사이트 전체(양면·출처·공식지표). 카드 대비 뎁스의 정보 우위. */}
           <StockWhyHappened insight={insight} />
+
+          {/* 어떤 회사예요 — 2026-07-18 User Zero "이 회사가 뭔데 왜 투자해볼 만한지 내용이 없다".
+              하단 한 줄 강등을 정식 섹션으로 승격. KR=네이버 기업개요, US=Nasdaq profile 한국어 요약. */}
+          {basics?.summary && (
+            <section className="mt-4 rounded-2xl border border-hairline bg-surface px-4 py-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-pixel text-sm text-whiteout">어떤 회사예요</p>
+                {basics.sector && (
+                  <span className="rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted">{cleanText(basics.sector)}</span>
+                )}
+              </div>
+              <p className="mt-2 text-sm leading-6 text-whiteout">{cleanText(basics.summary)}</p>
+            </section>
+          )}
 
           {/* 재무 한눈에(WO 1.5 F) — 근거 아래. KR=네이버·US=Yahoo, 없으면 생략. */}
           <FinanceGlanceBlock basics={basics} />
@@ -2445,14 +2443,6 @@ export function StockInsightView({
             <p className="mt-6 text-center text-[11px] leading-5 text-muted">
               포모 <span className="font-number font-bold" style={{ color: "#D8FF3A" }}>{front.fomo.fomoScore}</span>
               {` · ${fomoStateSummary(front.fomo)}`}
-            </p>
-          )}
-
-          {/* 회사가 뭐 하는 곳 — 맨 아래 한 줄로 강등(긴 blurb 폐기). */}
-          {basics?.summary && (
-            <p className="mt-8 border-t border-hairline pt-4 text-[12px] leading-5 text-muted">
-              <span className="text-muted/70">회사 </span>
-              {cleanText(basics.summary).split(/[.\n]/)[0]}
             </p>
           )}
 

--- a/apps/web/lib/stock-basics.ts
+++ b/apps/web/lib/stock-basics.ts
@@ -1,4 +1,5 @@
 import { assembleStockBasics, parseNaverStockBasic, resolveStock, type StockBasics } from "@fomo/core";
+import { getUsCompanyAbout } from "./us-company-about";
 
 /**
  * 종목 기본 정보(바닥) 수집 — STOCK_SCREEN_REDESIGN §2.
@@ -123,9 +124,11 @@ interface NasdaqLabelValue {
 
 /** Nasdaq summary+financials → StockBasics. 시총·52주·배당 + 연간 매출/영업이익. PER 미제공 시 생략(정직). */
 export async function fetchUsStockBasics(name: string, symbol: string): Promise<StockBasics | null> {
-  const [summaryRaw, financialsRaw] = await Promise.all([
+  const [summaryRaw, financialsRaw, about] = await Promise.all([
     getNasdaqJson(`https://api.nasdaq.com/api/quote/${encodeURIComponent(symbol)}/summary?assetclass=stocks`),
     getNasdaqJson(`https://api.nasdaq.com/api/company/${encodeURIComponent(symbol)}/financials?frequency=1`),
+    // 회사 소개(User Zero: "무슨 회사인지 없다") — company-profile 영문 → 한국어 요약, 심볼당 1회 영구 캐시.
+    getUsCompanyAbout(name, symbol).catch(() => undefined),
   ]);
 
   const summary = (summaryRaw as { data?: { summaryData?: Record<string, NasdaqLabelValue> } } | null)?.data?.summaryData;
@@ -174,6 +177,7 @@ export async function fetchUsStockBasics(name: string, symbol: string): Promise<
     ...(market ? { market } : {}),
     ...(marketCap ? { marketCap } : {}),
     ...(sector ? { sector } : {}),
+    ...(about ? { summary: about } : {}),
     metrics,
     ...(financials ? { financials } : {}),
   };

--- a/apps/web/lib/us-company-about.ts
+++ b/apps/web/lib/us-company-about.ts
@@ -1,0 +1,77 @@
+import { callAI, isAiConfigured } from "@fomo/shared";
+import { readFeedContent, writeFeedContent } from "./feed-content-store";
+
+/**
+ * US 회사 소개 한국어 요약 (2026-07-18 User Zero: "이 회사가 무슨 회사인지 내용이 하나도 없다").
+ *
+ * Nasdaq company-profile 의 CompanyDescription(영문)을 LLM 으로 한국어 2~3문장 요약해
+ * FeedContentCache 에 **영구 캐시**(회사 소개는 사실상 불변 — 심볼당 LLM 1콜이면 끝).
+ * 영문 원문 노출 금지 정책(#840 계열) 유지: 번역 실패·AI 미설정이면 undefined(섹션 생략이 정직).
+ */
+
+const KEY = (symbol: string) => `about:us:${symbol.toUpperCase()}`;
+const NASDAQ_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+const LLM_TIMEOUT_MS = 9_000;
+
+interface AboutRow {
+  about: string;
+  asOf: string;
+}
+
+async function fetchCompanyDescription(symbol: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(`https://api.nasdaq.com/api/company/${encodeURIComponent(symbol)}/company-profile`, {
+      headers: { "User-Agent": NASDAQ_UA, Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return undefined;
+    const json = (await res.json()) as { data?: { CompanyDescription?: { value?: string } } };
+    const desc = json.data?.CompanyDescription?.value?.trim();
+    return desc && desc.length >= 40 ? desc : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** 금지 문형 — 소개는 사실 서술만(투자 권유·과장 금지, AGENTS 블랙리스트). */
+const FORBIDDEN = /사세요|매수|매도|추천|목표가|반드시|폭등|급등할|놓치면/;
+
+async function translateAbout(name: string, description: string): Promise<string | undefined> {
+  if (!isAiConfigured()) return undefined;
+  const res = await callAI({
+    messages: [
+      {
+        role: "system",
+        content:
+          "아래 영문 회사 소개를 근거로 이 회사가 무엇을 하는 회사인지 한국어 2~3문장으로 설명하라. " +
+          "입력에 없는 사실·수치 추가 금지, 과장·투자 권유 금지, 존댓말(~해요체). 문장만 출력.",
+      },
+      { role: "user", content: JSON.stringify({ company: name, description: description.slice(0, 1200) }) },
+    ],
+    temperature: 0.2,
+    timeoutMs: LLM_TIMEOUT_MS,
+    trace: "us-company-about",
+  }).catch(() => ({ ok: false as const, content: "" }));
+  if (!res.ok || !res.content) return undefined;
+  const clean = res.content.replace(/\s+/g, " ").trim();
+  const hasKorean = /[가-힣]/.test(clean);
+  const latinRatio = (clean.match(/[A-Za-z]/g)?.length ?? 0) / Math.max(1, clean.length);
+  if (!hasKorean || latinRatio > 0.3 || clean.length < 30 || clean.length > 400 || FORBIDDEN.test(clean)) return undefined;
+  return clean;
+}
+
+/** 심볼의 한국어 회사 소개 — 영구 캐시 우선, 미스 시 fetch+번역+저장. 실패는 undefined(fail-open). */
+export async function getUsCompanyAbout(name: string, symbol: string): Promise<string | undefined> {
+  const cached = await readFeedContent<AboutRow>(KEY(symbol)).catch(() => null);
+  if (cached?.about) return cached.about;
+
+  const description = await fetchCompanyDescription(symbol);
+  if (!description) return undefined;
+  const about = await translateAbout(name, description);
+  if (!about) return undefined;
+  await writeFeedContent(KEY(symbol), { about, asOf: new Date().toISOString().slice(0, 10) } satisfies AboutRow).catch(
+    () => undefined
+  );
+  return about;
+}


### PR DESCRIPTION
## User Zero 2건

### 1. 뎁스 로딩 단일화
"차트 나오기 전에 정보가 나오고, 차트가 나오면 정보도 바뀌어 어색" — 전부 로드 전(`detailsReady`)엔 가격 헤더·seed 콘텐츠 포함 아무것도 노출하지 않고 **메인홈과 동일한 `FullPageLoading`** 하나만. 부분 렌더("페이지 불러오는 중" 블록) 삭제.

### 2. "어떤 회사예요" 섹션
"이 회사가 무슨 회사인지, 왜 투자해볼 만한지 내용이 없다"
- **US**: Nasdaq company-profile 영문 소개 → LLM 한국어 2~3문장 요약 → `FeedContentCache` **영구 캐시**(`about:us:<symbol>`, 심볼당 LLM 1콜이면 끝). 번역 실패·AI 미설정 시 섹션 생략(영문 노출 금지 정책). 금지 문형 가드(권유·과장·목표가).
- **KR**: 기존 네이버 기업개요(corporationSummary) 그대로 사용.
- **UI**: 맨 아래 한 줄로 강등돼 있던 회사 소개를 정식 섹션(제목 + 섹터 칩 + 본문)으로 승격 — 재무 한눈에 위. (기존 "긴 blurb 폐기" 결정은 User Zero 직접 요청으로 오버라이드)

## 검증
- 1156 테스트 · typecheck · next build(양쪽) 통과
- 머지 후 시게이트(STX) 등 US 종목 `stock-basics` summary 실측 첨부 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)