### PR TITLE
feat: add deterministic wyckoff zone analysis

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -15,6 +15,8 @@ import {
   type DailyOhlcv,
   type KeywordCard,
   type FomoTone,
+  type WyckoffAnalysis,
+  type WyckoffEvent,
 } from "@fomo/core";
 import {
   fetchThemeInsight,
@@ -385,6 +387,8 @@ function mergeFrontSeed(
     ...(fresh.axisHook ?? seed.axisHook ? { axisHook: fresh.axisHook ?? seed.axisHook } : {}),
     // 판단 층 단일 진실(WO 1.5 A) — 카드(seed)의 verdict 우선. 카드=뎁스 stance 모순 금지.
     ...(seed.verdict ?? fresh.verdict ? { verdict: seed.verdict ?? fresh.verdict } : {}),
+    // 전문 구간 분석은 260일 캔들을 받은 non-lite 응답을 우선한다.
+    ...(fresh.wyckoff ?? seed.wyckoff ? { wyckoff: fresh.wyckoff ?? seed.wyckoff } : {}),
     // 차트 시리즈(WO 1.6 D)는 non-lite 응답(fresh)에만 실린다.
     ...(fresh.chartSeries ?? seed.chartSeries ? { chartSeries: fresh.chartSeries ?? seed.chartSeries } : {}),
     ...(fresh.coinIssues?.length ? { coinIssues: fresh.coinIssues } : seed.coinIssues?.length ? { coinIssues: seed.coinIssues } : {}),
@@ -1504,15 +1508,19 @@ const TA_ROLE_GROUPS: Array<{ role: "event" | "balance" | "confirmation"; label:
 ];
 
 const CHART_COLOR = {
-  up: "#22C55E",
-  down: "#EF4444",
+  up: "#D8FF3A",
+  down: "#777873",
   wick: "rgba(250,250,250,0.52)",
   ma20: "#F59E0B",
   ma60: "#60A5FA",
   ma120: "#A78BFA",
   invalidation: "#F59E0B",
-  volumeUp: "rgba(34,197,94,0.32)",
-  volumeDown: "rgba(239,68,68,0.24)",
+  volumeUp: "rgba(216,255,58,0.34)",
+  volumeDown: "rgba(119,120,115,0.28)",
+  accumulation: "rgba(216,255,58,0.10)",
+  distribution: "rgba(148,163,184,0.12)",
+  markup: "rgba(216,255,58,0.07)",
+  markdown: "rgba(119,120,115,0.10)",
 } as const;
 
 /** 캔들+MA20/60/120+거래량+무효화 레벨선(WO 1.6 D-1) — 라인차트 금지, 라이브러리 없음. */
@@ -1520,11 +1528,14 @@ function AnalysisChart({
   series,
   invalidationLevel,
   candles,
+  analysis,
 }: {
   series: NonNullable<StockFrontResponse["chartSeries"]>;
   invalidationLevel?: number | undefined;
   candles?: DailyOhlcv[] | undefined;
+  analysis?: WyckoffAnalysis | undefined;
 }) {
+  const [selectedEvent, setSelectedEvent] = useState<WyckoffEvent | null>(null);
   const W = 320;
   const PLOT_W = 278;
   const PRICE_H = 166;
@@ -1545,6 +1556,7 @@ function AnalysisChart({
     });
   const n = renderedCandles.length;
   if (n < 2) return null;
+  const visibleStart = Math.max(0, (analysis?.sourceLength ?? n) - n);
 
   const lineValues = [
     ...renderedCandles.flatMap((c) => [c.high, c.low]),
@@ -1565,6 +1577,7 @@ function AnalysisChart({
   const max = rawMax + padding;
   const span = max - min || 1;
   const x = (i: number) => (i / (n - 1)) * PLOT_W;
+  const xAbsolute = (index: number) => x(index - visibleStart);
   const y = (v: number) => 4 + (1 - (v - min) / span) * (PRICE_H - 8);
 
   const linePath = (values: Array<number | null>): string => {
@@ -1597,6 +1610,13 @@ function AnalysisChart({
       Boolean(level) && (!includeLevel || Math.abs(level!.value / invalidationLevel! - 1) >= 0.018)
   );
   const priceTicks = [rawMax, (rawMax + rawMin) / 2, rawMin];
+  const visibleZones = (analysis?.zones ?? []).filter((zone) => zone.endIndex >= visibleStart && zone.startIndex <= visibleStart + n - 1);
+  const visibleEvents = (analysis?.events ?? []).filter((event) => event.index >= visibleStart && event.index <= visibleStart + n - 1);
+  const zoneName = (kind: (typeof visibleZones)[number]["kind"]) =>
+    kind === "accumulation" ? "매집" : kind === "distribution" ? "분산" : kind === "markup" ? "상승" : "하락";
+  const zoneColor = (kind: (typeof visibleZones)[number]["kind"]) => CHART_COLOR[kind];
+  const markerText = (kind: WyckoffEvent["kind"]) =>
+    kind === "spring" ? "S" : kind === "upthrust" ? "UT" : kind === "impulse" ? "I" : "P";
 
   return (
     <div>
@@ -1607,6 +1627,31 @@ function AnalysisChart({
         <span>C <b style={{ color: latest.close >= latest.open ? CHART_COLOR.up : CHART_COLOR.down }}>{formatAxisPrice(latest.close)}</b></span>
       </div>
       <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label="캔들·이동평균·거래량 차트">
+        {visibleZones.map((zone) => {
+          const start = Math.max(zone.startIndex, visibleStart);
+          const end = Math.min(zone.endIndex, visibleStart + n - 1);
+          const left = xAbsolute(start);
+          const right = xAbsolute(end);
+          const top = Math.max(2, y(Math.min(max, zone.high)));
+          const bottom = Math.min(PRICE_H - 1, y(Math.max(min, zone.low)));
+          return (
+            <g key={`${zone.kind}-${zone.startIndex}`}>
+              <rect
+                x={left}
+                y={top}
+                width={Math.max(2, right - left)}
+                height={Math.max(10, bottom - top)}
+                fill={zoneColor(zone.kind)}
+                stroke={zone.kind === "accumulation" ? "rgba(216,255,58,0.38)" : "rgba(250,250,250,0.22)"}
+                strokeWidth="0.7"
+                strokeDasharray="3 3"
+              />
+              <text x={left + 3} y={Math.min(PRICE_H - 4, top + 10)} fontSize="7.5" fontWeight="700" fill="rgba(250,250,250,0.72)">
+                {zoneName(zone.kind)} {zone.weeks}주차
+              </text>
+            </g>
+          );
+        })}
         {[0.2, 0.4, 0.6, 0.8].map((ratio) => (
           <line key={ratio} x1="0" x2={PLOT_W} y1={PRICE_H * ratio} y2={PRICE_H * ratio} stroke="rgba(255,255,255,0.09)" />
         ))}
@@ -1704,9 +1749,56 @@ function AnalysisChart({
             />
           </>
         )}
+        {visibleEvents.map((event) => {
+          const cx = xAbsolute(event.index);
+          const cy = Math.max(10, Math.min(PRICE_H - 10, y(event.price)));
+          const isBoundary = event.kind === "spring" || event.kind === "upthrust";
+          const fill = event.kind === "spring" || (event.kind === "impulse" && event.direction === "up") || event.kind === "pullback"
+            ? CHART_COLOR.up
+            : "#D5D6D1";
+          return (
+            <g
+              key={`${event.kind}-${event.index}`}
+              role="button"
+              tabIndex={0}
+              aria-label={`${event.label}: ${event.explanation}`}
+              onClick={() => setSelectedEvent(selectedEvent?.kind === event.kind && selectedEvent.index === event.index ? null : event)}
+              onKeyDown={(keyboardEvent) => {
+                if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") setSelectedEvent(event);
+              }}
+              className="cursor-pointer"
+            >
+              {isBoundary ? (
+                <polygon
+                  points={event.kind === "spring" ? `${cx},${cy - 7} ${cx - 5},${cy + 3} ${cx + 5},${cy + 3}` : `${cx},${cy + 7} ${cx - 5},${cy - 3} ${cx + 5},${cy - 3}`}
+                  fill={fill}
+                  stroke="#050706"
+                  strokeWidth="1"
+                />
+              ) : event.kind === "impulse" ? (
+                <polygon points={`${cx},${cy - 6} ${cx + 5},${cy} ${cx},${cy + 6} ${cx - 5},${cy}`} fill={fill} stroke="#050706" strokeWidth="1" />
+              ) : (
+                <circle cx={cx} cy={cy} r="5" fill={fill} stroke="#050706" strokeWidth="1" />
+              )}
+              <text x={cx} y={cy + 2.5} textAnchor="middle" fontSize={event.kind === "upthrust" ? "4.7" : "6"} fontWeight="900" fill="#050706">
+                {markerText(event.kind)}
+              </text>
+            </g>
+          );
+        })}
         <text x="0" y={H - 1} fontSize="8" fill="rgba(250,250,250,0.42)">{markerDateLabel(renderedCandles[0])}</text>
         <text x={PLOT_W} y={H - 1} textAnchor="end" fontSize="8" fill="rgba(250,250,250,0.42)">{markerDateLabel(latest)}</text>
       </svg>
+      {selectedEvent && (
+        <button
+          type="button"
+          onClick={() => setSelectedEvent(null)}
+          className="mt-2 w-full rounded-md border border-white/15 bg-black/50 px-3 py-2 text-left"
+        >
+          <span className="block text-[11px] font-bold text-whiteout">{selectedEvent.label}</span>
+          <span className="mt-1 block text-[10px] leading-4 text-muted">{selectedEvent.explanation}</span>
+        </button>
+      )}
       <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted">
         <span><span style={{ color: CHART_COLOR.up }}>■</span> 상승</span>
         <span><span style={{ color: CHART_COLOR.down }}>■</span> 하락</span>
@@ -1714,6 +1806,8 @@ function AnalysisChart({
         <span><span style={{ color: CHART_COLOR.ma60 }}>—</span> MA60</span>
         <span><span style={{ color: CHART_COLOR.ma120 }}>—</span> MA120</span>
         {includeLevel && <span><span style={{ color: CHART_COLOR.invalidation }}>┄</span> 관점 경계</span>}
+        {visibleZones.length > 0 && <span>▧ 구간</span>}
+        {visibleEvents.length > 0 && <span>◆ 이벤트</span>}
       </div>
     </div>
   );
@@ -1825,6 +1919,9 @@ function ChartAnalysisTab({
   const ta = front?.ta;
   const facts = ta?.facts ?? [];
   const verdict = front?.verdict;
+  const wyckoff = front?.wyckoff;
+  const currentZone = wyckoff?.currentZone;
+  const hasProfessionalAnalysis = Boolean(wyckoff?.summary || wyckoff?.events.length);
   const phaseText = verdict?.phase ? DEPTH_PHASE_TEXT[verdict.phase] : undefined;
   const series = front?.chartSeries;
   const invalidation = verdict?.invalidation;
@@ -1843,19 +1940,33 @@ function ChartAnalysisTab({
     <section className="mt-2">
       <div className="mb-3 flex items-start justify-between gap-4">
         <div>
-          <p className="font-pixel text-sm text-whiteout">가격 구조</p>
-          <p className="mt-1 text-[11px] leading-5 text-muted">캔들 배열·추세·핵심 가격대로 다음 확인 지점을 읽어요.</p>
+          <p className="font-pixel text-sm text-whiteout">구간·파동 분석</p>
+          <p className="mt-1 text-[11px] leading-5 text-muted">가격 구간과 거래량 사건을 같은 시간축에서 읽어요.</p>
         </div>
-        {phaseText && verdict?.phase && (
+        {(currentZone || (phaseText && verdict?.phase)) && (
           <button
             type="button"
-            onClick={() => setStructureTooltip({ title: "국면 해석", body: phaseText })}
+            onClick={() =>
+              setStructureTooltip({
+                title: currentZone ? "현재 구간 근거" : "국면 해석",
+                body: currentZone ? currentZone.evidence.join(" · ") : phaseText!,
+              })
+            }
             className="shrink-0 rounded-md border border-whiteout/20 px-2 py-1 text-[10px] font-bold text-whiteout"
           >
-            {verdict.phase === "accumulation" ? "축적" : verdict.phase === "markup" ? "상승" : verdict.phase === "distribution" ? "분산" : "하락"} 국면
+            {currentZone
+              ? currentZone.label
+              : `${verdict!.phase === "accumulation" ? "축적" : verdict!.phase === "markup" ? "상승" : verdict!.phase === "distribution" ? "분산" : "하락"} 국면`}
           </button>
         )}
       </div>
+
+      {wyckoff?.summary && (
+        <div className="mb-3 border-l-2 border-[#D8FF3A] bg-[#D8FF3A]/[0.06] px-3 py-3">
+          <p className="font-pixel text-[10px] text-[#D8FF3A]">지금 구간 요약</p>
+          <p className="mt-1.5 text-sm font-medium leading-6 text-whiteout">{wyckoff.summary}</p>
+        </div>
+      )}
 
       {metrics.length > 0 && (
         <div className="mb-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
@@ -1903,7 +2014,7 @@ function ChartAnalysisTab({
               ))}
             </div>
           </div>
-          <AnalysisChart series={visibleSeries} invalidationLevel={verdict?.invalidationLevel} candles={visibleCandles} />
+          <AnalysisChart series={visibleSeries} invalidationLevel={verdict?.invalidationLevel} candles={visibleCandles} analysis={wyckoff} />
           {invalidation && (
             <button
               type="button"
@@ -1919,7 +2030,29 @@ function ChartAnalysisTab({
         basisDays > 0 && <p className="mb-3 text-[11px] text-muted">최근 {basisDays}거래일 종가·거래량 기준</p>
       )}
 
-      {facts.length > 0 && (
+      {wyckoff && wyckoff.events.length > 0 && (
+        <div className="mt-4 border-y border-hairline py-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="font-pixel text-sm text-whiteout">구간 이벤트</p>
+            <span className="text-[10px] text-muted">실제 캔들·거래량 조건</span>
+          </div>
+          <div className="mt-2 space-y-2">
+            {wyckoff.events.slice(-4).reverse().map((event) => (
+              <button
+                key={`${event.kind}-${event.index}`}
+                type="button"
+                onClick={() => setStructureTooltip({ title: event.label, body: event.explanation })}
+                className="w-full border-l border-white/20 px-3 py-1.5 text-left transition-colors hover:border-[#D8FF3A]"
+              >
+                <span className="block text-xs font-bold text-whiteout">{event.label}</span>
+                <span className="mt-0.5 block text-[11px] leading-5 text-muted">{event.explanation}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {facts.length > 0 && !hasProfessionalAnalysis && (
         <div className="mt-4 rounded-xl border border-hairline bg-surface px-3 py-3">
           <div className="mb-3 flex items-center justify-between gap-3">
             <p className="font-pixel text-sm text-whiteout">차트에서 보이는 것</p>
@@ -1968,7 +2101,7 @@ function ChartAnalysisTab({
           )}
         </div>
       )}
-      {facts.length === 0 && !series && (
+      {facts.length === 0 && !series && !hasProfessionalAnalysis && (
         <div className="rounded-lg border border-hairline bg-surface px-3 py-5 text-center">
           <p className="text-sm leading-6 text-muted">차트에서 두드러진 신호는 아직 없어요.</p>
           <p className="mt-1 text-[11px] leading-5 text-muted">데이터가 더 쌓이면 지표가 여기에 붙어요.</p>

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -526,6 +526,8 @@ export interface StockFrontResponse {
   axisHook?: import("@fomo/core").MultiAxisHookSelection;
   /** 판단 층(WO Phase 1) — stance/근거/무효화. 캔들 부족 시 최소 verdict(관망). */
   verdict?: import("@fomo/core").CardVerdict;
+  /** 결정론 와이코프 구간·이벤트 분석. non-lite 응답에만. */
+  wyckoff?: import("@fomo/core").WyckoffAnalysis;
   /** 차트분석 탭 시리즈(WO 1.6 D) — 종가+MA20/60/120+거래량. non-lite 응답에만. */
   chartSeries?: {
     closes: number[];

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -74,7 +74,7 @@ async function getFront(stock: string, lite = false, naverCode?: string, symbol?
         ...(themeRelativeMap[canonical] ? { themeRelative: themeRelativeMap[canonical] } : {}),
       }, { lite, ...(naverCode ? { naverCode } : {}), ...(symbol ? { symbol } : {}) });
     },
-    ["fomo-stock-front", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? "", symbol ?? ""],
+    ["fomo-stock-front", "wyckoff-v1", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? "", symbol ?? ""],
     { revalidate: REVALIDATE_S, ...(marketTag ? { tags: [marketTag] } : {}) }
   );
   return load();

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -11,12 +11,14 @@ import {
   computeTechnicalAnalysis,
   selectTaFact,
   computeCardVerdict,
+  computeWyckoffAnalysis,
   type CardVerdict,
   type CardFrontSignals,
   type FomoScoreResult,
   type DailyOhlcv,
   type TaFact,
   type TechnicalAnalysisSnapshot,
+  type WyckoffAnalysis,
   type AxisSignal,
   type MultiAxisHookSelection,
 } from "@fomo/core";
@@ -205,6 +207,8 @@ export interface StockFrontData {
   axisHook?: MultiAxisHookSelection;
   /** 판단 층(WO Phase 1) — 결정론 verdict 엔진. 캔들 부족 시 최소 verdict(관망·신호 축적). */
   verdict?: CardVerdict;
+  /** 와이코프 구간·스프링/업스러스트·임펄스/눌림목 결정론 분석. non-lite에서만. */
+  wyckoff?: WyckoffAnalysis;
   /** 차트분석 탭 시리즈(WO 1.6 D) — 종가+MA20/60/120+거래량. non-lite 에서만. */
   chartSeries?: StockChartSeries;
   /** 코인 전용 최근 재료. 크론 캐시에서만 읽는다. */
@@ -427,6 +431,11 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     ...(typeof volRatio === "number" ? { volumeRatio: volRatio } : {}),
     currency: "KRW",
   }), coinIssues);
+  const wyckoff = computeWyckoffAnalysis({
+    candles: snapshot.candles,
+    ...(typeof verdict?.invalidationLevel === "number" ? { invalidationLevel: verdict.invalidationLevel } : {}),
+    currency: "KRW",
+  });
   const chartSeries = buildChartSeries(snapshot.candles);
   return {
     ...base,
@@ -434,6 +443,7 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     ...(taFact ? { taFact } : {}),
     ta,
     verdict,
+    wyckoff,
     ...(chartSeries ? { chartSeries } : {}),
     // 캔들차트(Phase A) — 국·미와 동일하게 non-lite 에서 실제 일봉 제공.
     ...(snapshot.candles.length > 0 ? { candles: snapshot.candles.slice(-260) } : {}),
@@ -497,6 +507,11 @@ export async function assembleStockFront(
         : {}),
       currency: "USD",
     });
+    const wyckoff = computeWyckoffAnalysis({
+      candles: daily.candles,
+      ...(typeof verdict?.invalidationLevel === "number" ? { invalidationLevel: verdict.invalidationLevel } : {}),
+      currency: "USD",
+    });
     const chartSeries = buildChartSeries(daily.candles);
     return {
       signals,
@@ -504,6 +519,7 @@ export async function assembleStockFront(
       ...(taFact ? { taFact } : {}),
       ta,
       verdict,
+      wyckoff,
       ...(daily.candles.length > 0 ? { candles: daily.candles.slice(-260) } : {}),
       ...(chartSeries ? { chartSeries } : {}),
       sparkline,
@@ -565,6 +581,13 @@ export async function assembleStockFront(
       : {}),
     currency: "KRW",
   });
+  const wyckoff = computeWyckoffAnalysis({
+    candles: daily.candles,
+    ...(typeof signals.foreignNetStreak === "number" ? { foreignNetStreak: signals.foreignNetStreak } : {}),
+    ...(typeof signals.institutionNetStreak === "number" ? { institutionNetStreak: signals.institutionNetStreak } : {}),
+    ...(typeof verdict?.invalidationLevel === "number" ? { invalidationLevel: verdict.invalidationLevel } : {}),
+    currency: "KRW",
+  });
   const chartSeries = lite ? undefined : buildChartSeries(daily.candles);
 
   return {
@@ -573,6 +596,7 @@ export async function assembleStockFront(
     ...(taFact ? { taFact } : {}),
     ...(ta ? { ta } : {}),
     verdict,
+    ...(!lite ? { wyckoff } : {}),
     ...(!lite && daily.candles.length > 0 ? { candles: daily.candles.slice(-260) } : {}),
     ...(chartSeries ? { chartSeries } : {}),
     sparkline: daily.closes.slice(lite ? -42 : -66),

--- a/packages/fomo-core/__tests__/wyckoff-analysis.test.ts
+++ b/packages/fomo-core/__tests__/wyckoff-analysis.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { computeWyckoffAnalysis, type DailyOhlcv } from "../src";
+
+function datedCandles(rows: Array<{ close: number; volume: number; low?: number; high?: number }>): DailyOhlcv[] {
+  return rows.map((row, index) => {
+    const date = new Date(Date.UTC(2025, 0, 2 + index)).toISOString().slice(0, 10);
+    const open = index > 0 ? rows[index - 1]!.close : row.close;
+    return {
+      date,
+      open,
+      high: Math.max(open, row.close, row.high ?? 0) * 1.001,
+      low: Math.min(open, row.close, row.low ?? Number.POSITIVE_INFINITY) * 0.999,
+      close: row.close,
+      volume: row.volume,
+    };
+  });
+}
+
+function accumulationRows(): Array<{ close: number; volume: number; low?: number; high?: number }> {
+  const rows: Array<{ close: number; volume: number; low?: number; high?: number }> = [];
+  for (let i = 0; i < 50; i += 1) rows.push({ close: 200 - i * 2, volume: 1_100_000 });
+  for (let i = 0; i < 60; i += 1) {
+    const close = 100.5 + Math.sin(i / 3.2) * 1.2 + i * 0.035;
+    rows.push({ close, volume: 900_000 - i * 6_000 });
+  }
+  const spring = 50 + 41;
+  rows[spring] = { close: 99.2, low: 96.2, high: 101.2, volume: 1_250_000 };
+  rows[spring + 1] = { close: 101.7, low: 99.7, high: 102.1, volume: 680_000 };
+  return rows;
+}
+
+function distributionRows(): Array<{ close: number; volume: number; low?: number; high?: number }> {
+  const rows: Array<{ close: number; volume: number; low?: number; high?: number }> = [];
+  for (let i = 0; i < 50; i += 1) rows.push({ close: 100 + i * 2, volume: 700_000 });
+  for (let i = 0; i < 60; i += 1) {
+    const close = 199.5 + Math.sin(i / 3.4) * 1.1 - i * 0.02;
+    rows.push({ close, volume: 620_000 + i * 8_000 });
+  }
+  const upthrust = 50 + 40;
+  rows[upthrust] = { close: 201.5, low: 198.8, high: 207.5, volume: 1_700_000 };
+  rows[upthrust + 1] = { close: 199.1, low: 197.9, high: 201.1, volume: 1_050_000 };
+  return rows;
+}
+
+function impulsePullbackRows(): Array<{ close: number; volume: number; low?: number; high?: number }> {
+  const rows: Array<{ close: number; volume: number; low?: number; high?: number }> = [];
+  for (let i = 0; i < 90; i += 1) rows.push({ close: 100 + Math.sin(i / 7) * 0.5, volume: 1_000_000 });
+  for (let i = 1; i <= 8; i += 1) rows.push({ close: 100 + i * 1.6, volume: 2_100_000 });
+  const pullbackCloses = [111.2, 110.3, 109.1, 108.1, 107.1, 106.4, 106.8, 107.2];
+  for (const close of pullbackCloses) rows.push({ close, low: close - 0.7, high: close + 0.8, volume: 720_000 });
+  return rows;
+}
+
+describe("computeWyckoffAnalysis", () => {
+  it("하락 뒤 수렴·거래 감소·저점 절상을 매집 구간으로 판정하고 스프링을 표시한다", () => {
+    const result = computeWyckoffAnalysis({
+      candles: datedCandles(accumulationRows()),
+      foreignNetStreak: 5,
+      invalidationLevel: 96.2,
+      currency: "KRW",
+    });
+    expect(result.currentZone?.kind).toBe("accumulation");
+    expect(result.currentZone?.weeks).toBeGreaterThanOrEqual(6);
+    expect(result.events.some((event) => event.kind === "spring")).toBe(true);
+    expect(result.summary).toMatch(/매집 추정 구간|매집 추정/);
+    expect(result.summary).toContain("외국인 5일 연속 순매수");
+    expect(result.summary).toContain("96원");
+  });
+
+  it("상승 뒤 고점 정체·거래 증가·상방 실패를 분산 구간과 업스러스트로 판정한다", () => {
+    const result = computeWyckoffAnalysis({ candles: datedCandles(distributionRows()), currency: "USD" });
+    expect(result.currentZone?.kind).toBe("distribution");
+    const event = result.events.find((candidate) => candidate.kind === "upthrust");
+    expect(event).toBeDefined();
+    expect(event?.explanation).toContain("$");
+    expect(result.summary).toContain("분산 추정 구간");
+  });
+
+  it("10봉 내 거래량 동반 강파동과 MA 지지·거래 감소 되돌림을 임펄스/눌림목으로 판정한다", () => {
+    const result = computeWyckoffAnalysis({ candles: datedCandles(impulsePullbackRows()), currency: "USD" });
+    const impulse = result.events.find((event) => event.kind === "impulse" && event.direction === "up");
+    const pullback = result.events.find((event) => event.kind === "pullback");
+    expect(impulse?.movePct).toBeGreaterThanOrEqual(8);
+    expect(impulse?.volumeRatio).toBeGreaterThanOrEqual(1.5);
+    expect(pullback?.retracementPct).toBeGreaterThanOrEqual(25);
+    expect(pullback?.retracementPct).toBeLessThanOrEqual(68);
+    expect(pullback?.explanation).toMatch(/MA20|MA60/);
+  });
+
+  it("조건이 모호한 횡보는 구간과 이벤트를 억지 생성하지 않는다", () => {
+    const rows = Array.from({ length: 90 }, (_, index) => ({ close: 100 + Math.sin(index / 5) * 0.3, volume: 1_000_000 }));
+    const result = computeWyckoffAnalysis({ candles: datedCandles(rows), invalidationLevel: 97 });
+    expect(result.currentZone).toBeUndefined();
+    expect(result.events).toHaveLength(0);
+    expect(result.summary).toBeUndefined();
+  });
+
+  it("같은 입력은 바이트 단위로 같은 결과를 낸다", () => {
+    const input = { candles: datedCandles(accumulationRows()), institutionNetStreak: 4, invalidationLevel: 97 } as const;
+    expect(JSON.stringify(computeWyckoffAnalysis(input))).toBe(JSON.stringify(computeWyckoffAnalysis(input)));
+  });
+
+  it("실수치가 다른 종목의 지금 구간 요약을 같은 문장으로 반복하지 않는다", () => {
+    const summaries = Array.from({ length: 6 }, (_, index) => {
+      const scale = 1 + index * 0.17;
+      const candles = datedCandles(
+        accumulationRows().map((row) => ({
+          ...row,
+          close: row.close * scale,
+          ...(row.low ? { low: row.low * scale } : {}),
+          ...(row.high ? { high: row.high * scale } : {}),
+        }))
+      );
+      return computeWyckoffAnalysis({ candles, foreignNetStreak: 3 + index, invalidationLevel: 96.2 * scale }).summary;
+    });
+    expect(summaries.every(Boolean)).toBe(true);
+    expect(new Set(summaries).size).toBe(summaries.length);
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -13,3 +13,4 @@ export * from "./discovery-supply";
 export * from "./fomo-score";
 export * from "./technical-analysis";
 export * from "./verdict";
+export * from "./wyckoff-analysis";

--- a/packages/fomo-core/src/keyword-cards/wyckoff-analysis.ts
+++ b/packages/fomo-core/src/keyword-cards/wyckoff-analysis.ts
@@ -1,0 +1,450 @@
+import type { DailyOhlcv } from "./technical-analysis";
+
+export type WyckoffZoneKind = "accumulation" | "distribution" | "markup" | "markdown";
+export type WyckoffEventKind = "spring" | "upthrust" | "impulse" | "pullback";
+
+export interface WyckoffZone {
+  kind: WyckoffZoneKind;
+  startIndex: number;
+  endIndex: number;
+  startDate?: string;
+  endDate?: string;
+  weeks: number;
+  low: number;
+  high: number;
+  rangePct: number;
+  volumeRatio?: number;
+  priceChangePct: number;
+  label: string;
+  evidence: string[];
+}
+
+export interface WyckoffEvent {
+  kind: WyckoffEventKind;
+  index: number;
+  startIndex?: number;
+  date?: string;
+  price: number;
+  direction?: "up" | "down";
+  movePct?: number;
+  volumeRatio?: number;
+  retracementPct?: number;
+  reference?: "MA20" | "MA60" | "range";
+  label: string;
+  explanation: string;
+}
+
+export interface WyckoffAnalysisInput {
+  candles: readonly DailyOhlcv[];
+  foreignNetStreak?: number;
+  institutionNetStreak?: number;
+  invalidationLevel?: number;
+  currency?: "KRW" | "USD";
+}
+
+export interface WyckoffAnalysis {
+  sourceLength: number;
+  currentZone?: WyckoffZone;
+  zones: WyckoffZone[];
+  events: WyckoffEvent[];
+  summary?: string;
+}
+
+const MIN_ZONE_DAYS = 30;
+const MAX_ZONE_DAYS = 100;
+const num = (value: number | undefined): value is number => typeof value === "number" && Number.isFinite(value);
+
+function avg(values: readonly number[]): number | undefined {
+  const clean = values.filter((value) => Number.isFinite(value));
+  if (clean.length === 0) return undefined;
+  return clean.reduce((sum, value) => sum + value, 0) / clean.length;
+}
+
+function quantile(values: readonly number[], q: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 0) return 0;
+  const position = (sorted.length - 1) * q;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower]!;
+  return sorted[lower]! + (sorted[upper]! - sorted[lower]!) * (position - lower);
+}
+
+function pct(change: number): string {
+  return `${change >= 0 ? "+" : ""}${change.toFixed(1)}%`;
+}
+
+function shortDate(date: string | undefined): string {
+  if (!date) return "최근";
+  const compact = date.match(/^\d{4}(\d{2})(\d{2})$/);
+  if (compact) return `${Number(compact[1])}/${Number(compact[2])}`;
+  const match = date.match(/(?:\d{4}-)?(\d{2})-(\d{2})/);
+  return match ? `${Number(match[1])}/${Number(match[2])}` : date;
+}
+
+function price(value: number, currency: "KRW" | "USD"): string {
+  if (currency === "USD") {
+    return `$${value.toLocaleString("en-US", { maximumFractionDigits: value < 100 ? 2 : 0 })}`;
+  }
+  return `${Math.round(value).toLocaleString("ko-KR")}원`;
+}
+
+function cleanCandles(candles: readonly DailyOhlcv[]): DailyOhlcv[] {
+  return candles.filter(
+    (candle) =>
+      num(candle.open) &&
+      num(candle.high) &&
+      num(candle.low) &&
+      num(candle.close) &&
+      num(candle.volume) &&
+      candle.open > 0 &&
+      candle.close > 0 &&
+      candle.high >= Math.max(candle.open, candle.close, candle.low) &&
+      candle.low <= Math.min(candle.open, candle.close, candle.high) &&
+      candle.volume >= 0
+  );
+}
+
+function smaAt(candles: readonly DailyOhlcv[], index: number, period: number): number | undefined {
+  if (index + 1 < period) return undefined;
+  return avg(candles.slice(index + 1 - period, index + 1).map((candle) => candle.close));
+}
+
+function rangeZone(candles: readonly DailyOhlcv[]): WyckoffZone | undefined {
+  if (candles.length < MIN_ZONE_DAYS + 25) return undefined;
+  const endIndex = candles.length - 1;
+  const full = candles.slice(-260);
+  const yearLow = Math.min(...full.map((candle) => candle.low));
+  const yearHigh = Math.max(...full.map((candle) => candle.high));
+  const locationSpan = Math.max(yearHigh - yearLow, yearHigh * 0.01);
+  const currentLocation = (candles[endIndex]!.close - yearLow) / locationSpan;
+
+  for (let days = Math.min(MAX_ZONE_DAYS, candles.length - 25); days >= MIN_ZONE_DAYS; days -= 1) {
+    const startIndex = candles.length - days;
+    const zoneCandles = candles.slice(startIndex);
+    const prior = candles.slice(Math.max(0, startIndex - 40), startIndex);
+    if (prior.length < 25) continue;
+
+    const closes = zoneCandles.map((candle) => candle.close);
+    const lowBand = quantile(closes, 0.1);
+    const highBand = quantile(closes, 0.9);
+    const mid = quantile(closes, 0.5);
+    const rangePct = mid > 0 ? ((highBand - lowBand) / mid) * 100 : 100;
+    if (rangePct > 16) continue;
+
+    const third = Math.max(8, Math.floor(zoneCandles.length / 3));
+    const first = zoneCandles.slice(0, third);
+    const middle = zoneCandles.slice(third, zoneCandles.length - third);
+    const last = zoneCandles.slice(-third);
+    if (middle.length < 5) continue;
+    const firstThirdMove = first[first.length - 1]!.close / first[0]!.close - 1;
+    // 직전 추세 꼬리를 구간 시작으로 잘못 포함하지 않는다. 첫 1/3도 이미 횡보 상태여야 한다.
+    if (Math.abs(firstThirdMove) > 0.06) continue;
+    const firstVolume = avg(first.map((candle) => candle.volume).filter((value) => value > 0));
+    const lastVolume = avg(last.map((candle) => candle.volume).filter((value) => value > 0));
+    const volumeRatio = num(firstVolume) && num(lastVolume) && firstVolume > 0 ? lastVolume / firstVolume : undefined;
+    const firstLow = quantile(first.map((candle) => candle.low), 0.2);
+    const middleLow = quantile(middle.map((candle) => candle.low), 0.2);
+    const lastLow = quantile(last.map((candle) => candle.low), 0.2);
+    const firstHigh = quantile(first.map((candle) => candle.high), 0.8);
+    const lastHigh = quantile(last.map((candle) => candle.high), 0.8);
+    const priorMove = prior[prior.length - 1]!.close / prior[0]!.close - 1;
+    const higherLows = middleLow >= firstLow * 0.985 && lastLow >= middleLow * 0.985 && lastLow >= firstLow * 1.003;
+    const upperFailures = lastHigh <= firstHigh * 1.02 && zoneCandles[endIndex - startIndex]!.close <= highBand * 0.99;
+    const weeks = Math.max(1, Math.ceil(days / 5));
+    const low = Math.min(...zoneCandles.map((candle) => candle.low));
+    const high = Math.max(...zoneCandles.map((candle) => candle.high));
+    const priceChangePct = (zoneCandles[zoneCandles.length - 1]!.close / zoneCandles[0]!.close - 1) * 100;
+
+    if (priorMove <= -0.1 && currentLocation <= 0.48 && higherLows && num(volumeRatio) && volumeRatio <= 0.9) {
+      return {
+        kind: "accumulation",
+        startIndex,
+        endIndex,
+        ...(zoneCandles[0]!.date ? { startDate: zoneCandles[0]!.date } : {}),
+        ...(zoneCandles[zoneCandles.length - 1]!.date ? { endDate: zoneCandles[zoneCandles.length - 1]!.date } : {}),
+        weeks,
+        low,
+        high,
+        rangePct,
+        volumeRatio,
+        priceChangePct,
+        label: `매집 추정 ${shortDate(zoneCandles[0]!.date)}~ · ${weeks}주차`,
+        evidence: [
+          `하락 뒤 가격 밴드 ${rangePct.toFixed(1)}% 수렴`,
+          `구간 후반 거래량 ${volumeRatio.toFixed(2)}배`,
+          `저점 ${pct((lastLow / firstLow - 1) * 100)} 절상`,
+        ],
+      };
+    }
+
+    if (priorMove >= 0.12 && currentLocation >= 0.55 && upperFailures && num(volumeRatio) && volumeRatio >= 1.12) {
+      return {
+        kind: "distribution",
+        startIndex,
+        endIndex,
+        ...(zoneCandles[0]!.date ? { startDate: zoneCandles[0]!.date } : {}),
+        ...(zoneCandles[zoneCandles.length - 1]!.date ? { endDate: zoneCandles[zoneCandles.length - 1]!.date } : {}),
+        weeks,
+        low,
+        high,
+        rangePct,
+        volumeRatio,
+        priceChangePct,
+        label: `분산 추정 ${shortDate(zoneCandles[0]!.date)}~ · ${weeks}주차`,
+        evidence: [
+          `상승 뒤 가격 밴드 ${rangePct.toFixed(1)}% 정체`,
+          `구간 후반 거래량 ${volumeRatio.toFixed(2)}배`,
+          `상단 재돌파 실패 · 고점 변화 ${pct((lastHigh / firstHigh - 1) * 100)}`,
+        ],
+      };
+    }
+  }
+  return undefined;
+}
+
+function trendZone(candles: readonly DailyOhlcv[]): WyckoffZone | undefined {
+  if (candles.length < 70) return undefined;
+  const lastIndex = candles.length - 1;
+  const signAt = (index: number): number => {
+    const ma20 = smaAt(candles, index, 20);
+    const ma60 = smaAt(candles, index, 60);
+    if (!num(ma20) || !num(ma60)) return 0;
+    if (candles[index]!.close > ma20 && ma20 > ma60 * 1.005) return 1;
+    if (candles[index]!.close < ma20 && ma20 < ma60 * 0.995) return -1;
+    return 0;
+  };
+  const sign = signAt(lastIndex);
+  if (sign === 0) return undefined;
+  let startIndex = lastIndex;
+  while (startIndex > 59 && signAt(startIndex - 1) === sign) startIndex -= 1;
+  const days = lastIndex - startIndex + 1;
+  const move = (candles[lastIndex]!.close / candles[startIndex]!.close - 1) * 100;
+  if (days < 10 || (sign > 0 ? move < 8 : move > -8)) return undefined;
+  const slice = candles.slice(startIndex);
+  const kind: WyckoffZoneKind = sign > 0 ? "markup" : "markdown";
+  const weeks = Math.max(1, Math.ceil(days / 5));
+  return {
+    kind,
+    startIndex,
+    endIndex: lastIndex,
+    ...(slice[0]!.date ? { startDate: slice[0]!.date } : {}),
+    ...(slice[slice.length - 1]!.date ? { endDate: slice[slice.length - 1]!.date } : {}),
+    weeks,
+    low: Math.min(...slice.map((candle) => candle.low)),
+    high: Math.max(...slice.map((candle) => candle.high)),
+    rangePct: ((Math.max(...slice.map((candle) => candle.high)) - Math.min(...slice.map((candle) => candle.low))) / slice[0]!.close) * 100,
+    priceChangePct: move,
+    label: `${kind === "markup" ? "상승" : "하락"} ${shortDate(slice[0]!.date)}~ · ${weeks}주차`,
+    evidence: [`20·60일선 ${sign > 0 ? "정배열" : "역배열"} ${days}거래일`, `구간 등락 ${pct(move)}`],
+  };
+}
+
+function boundaryEvents(
+  candles: readonly DailyOhlcv[],
+  zone: WyckoffZone | undefined,
+  currency: "KRW" | "USD"
+): WyckoffEvent[] {
+  if (!zone || (zone.kind !== "accumulation" && zone.kind !== "distribution")) return [];
+  const out: WyckoffEvent[] = [];
+  for (let index = zone.startIndex + 12; index <= zone.endIndex - 1; index += 1) {
+    const prior = candles.slice(Math.max(zone.startIndex, index - 20), index);
+    if (prior.length < 10) continue;
+    const current = candles[index]!;
+    const priorVolume = avg(prior.map((candle) => candle.volume).filter((value) => value > 0));
+    if (!num(priorVolume) || priorVolume <= 0) continue;
+    const volumeRatio = current.volume / priorVolume;
+    const recovery = candles.slice(index + 1, Math.min(zone.endIndex + 1, index + 4));
+    if (recovery.length === 0) continue;
+
+    if (zone.kind === "accumulation") {
+      const support = quantile(prior.map((candle) => candle.low), 0.15);
+      const recovered = recovery.find((candle) => candle.close >= support);
+      if (current.low <= support * 0.985 && recovered && volumeRatio >= 1.25) {
+        out.push({
+          kind: "spring",
+          index,
+          ...(current.date ? { date: current.date } : {}),
+          price: current.low,
+          volumeRatio,
+          label: `${shortDate(current.date)} 스프링 후보`,
+          explanation: `구간 하단 ${price(support, currency)}을 이탈한 뒤 ${recovery.indexOf(recovered) + 1}봉 안에 회복 · 거래량 ${volumeRatio.toFixed(1)}배`,
+        });
+      }
+    } else {
+      const resistance = quantile(prior.map((candle) => candle.high), 0.85);
+      const returned = recovery.find((candle) => candle.close <= resistance);
+      if (current.high >= resistance * 1.015 && returned && volumeRatio >= 1.25) {
+        out.push({
+          kind: "upthrust",
+          index,
+          ...(current.date ? { date: current.date } : {}),
+          price: current.high,
+          volumeRatio,
+          label: `${shortDate(current.date)} 업스러스트 후보`,
+          explanation: `구간 상단 ${price(resistance, currency)}을 돌파한 뒤 ${recovery.indexOf(returned) + 1}봉 안에 복귀 · 거래량 ${volumeRatio.toFixed(1)}배`,
+        });
+      }
+    }
+  }
+  return out.slice(-2);
+}
+
+function impulseEvents(candles: readonly DailyOhlcv[]): WyckoffEvent[] {
+  if (candles.length < 35) return [];
+  const candidates: WyckoffEvent[] = [];
+  const firstEnd = Math.max(30, candles.length - 140);
+  for (let end = firstEnd; end < candles.length; end += 1) {
+    let best: WyckoffEvent | undefined;
+    for (let days = 3; days <= 10; days += 1) {
+      const start = end - days;
+      if (start < 20) continue;
+      const startClose = candles[start]!.close;
+      const movePct = (candles[end]!.close / startClose - 1) * 100;
+      if (Math.abs(movePct) < 8) continue;
+      const impulseVolume = avg(candles.slice(start + 1, end + 1).map((candle) => candle.volume).filter((value) => value > 0));
+      const normalVolume = avg(candles.slice(Math.max(0, start - 20), start).map((candle) => candle.volume).filter((value) => value > 0));
+      if (!num(impulseVolume) || !num(normalVolume) || normalVolume <= 0) continue;
+      const volumeRatio = impulseVolume / normalVolume;
+      if (volumeRatio < 1.5) continue;
+      const direction = movePct > 0 ? "up" : "down";
+      const candidate: WyckoffEvent = {
+        kind: "impulse",
+        index: end,
+        startIndex: start,
+        ...(candles[end]!.date ? { date: candles[end]!.date } : {}),
+        price: candles[end]!.close,
+        direction,
+        movePct,
+        volumeRatio,
+        label: `${shortDate(candles[end]!.date)} ${direction === "up" ? "상방" : "하방"} 임펄스 ${pct(movePct)}`,
+        explanation: `${days}봉 동안 ${pct(movePct)} · 거래량은 직전 평균의 ${volumeRatio.toFixed(1)}배`,
+      };
+      if (!best || Math.abs(movePct) > Math.abs(best.movePct ?? 0)) best = candidate;
+    }
+    if (best) candidates.push(best);
+  }
+
+  return candidates
+    .sort((a, b) => Math.abs(b.movePct ?? 0) - Math.abs(a.movePct ?? 0))
+    .filter((candidate, index, all) => all.slice(0, index).every((kept) => Math.abs(kept.index - candidate.index) >= 8))
+    .slice(0, 3)
+    .sort((a, b) => a.index - b.index);
+}
+
+function pullbackEvents(
+  candles: readonly DailyOhlcv[],
+  impulses: readonly WyckoffEvent[],
+  currency: "KRW" | "USD"
+): WyckoffEvent[] {
+  const out: WyckoffEvent[] = [];
+  for (const impulse of impulses) {
+    if (impulse.direction !== "up" || !num(impulse.startIndex)) continue;
+    const end = Math.min(candles.length - 1, impulse.index + 20);
+    if (end < impulse.index + 3) continue;
+    const impulseStart = candles[impulse.startIndex]!.close;
+    const impulseVolume = avg(candles.slice(impulse.startIndex + 1, impulse.index + 1).map((candle) => candle.volume).filter((value) => value > 0));
+    if (!num(impulseVolume) || impulseVolume <= 0) continue;
+    let selected: WyckoffEvent | undefined;
+    for (let index = impulse.index + 3; index <= end; index += 1) {
+      const candle = candles[index]!;
+      const peak = Math.max(...candles.slice(impulse.index, index + 1).map((row) => row.high));
+      const wave = peak - impulseStart;
+      if (wave <= 0) continue;
+      const retracementPct = ((peak - candle.low) / wave) * 100;
+      if (retracementPct < 25 || retracementPct > 68) continue;
+      const ma20 = smaAt(candles, index, 20);
+      const ma60 = smaAt(candles, index, 60);
+      const references: Array<{ name: "MA20" | "MA60"; value: number }> = [];
+      if (num(ma20)) references.push({ name: "MA20", value: ma20 });
+      if (num(ma60)) references.push({ name: "MA60", value: ma60 });
+      const nearest = references.sort((a, b) => Math.abs(candle.low / a.value - 1) - Math.abs(candle.low / b.value - 1))[0];
+      if (!nearest || Math.abs(candle.low / nearest.value - 1) > 0.025 || candle.close < nearest.value * 0.985) continue;
+      const pullbackVolume = avg(candles.slice(impulse.index + 1, index + 1).map((row) => row.volume).filter((value) => value > 0));
+      if (!num(pullbackVolume) || pullbackVolume / impulseVolume > 0.85) continue;
+      selected = {
+        kind: "pullback",
+        index,
+        startIndex: impulse.index,
+        ...(candle.date ? { date: candle.date } : {}),
+        price: candle.low,
+        retracementPct,
+        volumeRatio: pullbackVolume / impulseVolume,
+        reference: nearest.name,
+        label: `${shortDate(candle.date)} 첫 눌림목 후보`,
+        explanation: `임펄스 고점 대비 ${retracementPct.toFixed(1)}% 되돌림 · ${nearest.name} ${price(nearest.value, currency)} 지지 테스트 · 거래량 ${(
+          pullbackVolume / impulseVolume
+        ).toFixed(2)}배`,
+      };
+    }
+    if (selected) out.push(selected);
+  }
+  return out.slice(-2);
+}
+
+function summaryOf(
+  zone: WyckoffZone | undefined,
+  events: readonly WyckoffEvent[],
+  input: WyckoffAnalysisInput
+): string | undefined {
+  const currency = input.currency ?? "KRW";
+  const clauses: string[] = [];
+  if (zone) {
+    const name = zone.kind === "accumulation" ? "매집 추정" : zone.kind === "distribution" ? "분산 추정" : zone.kind === "markup" ? "상승" : "하락";
+    clauses.push(`${shortDate(zone.startDate)}부터 ${zone.weeks}주째 ${name} 구간(폭 ${zone.rangePct.toFixed(1)}%, 구간 등락 ${pct(zone.priceChangePct)})`);
+  }
+  // "지금" 요약에는 최근 30거래일 사건만 사용한다. 오래된 이벤트는 차트 기록으로만 남긴다.
+  const latestEvent = events
+    .filter((event) => event.index >= Math.max(0, input.candles.length - 30))
+    .sort((a, b) => b.index - a.index)[0];
+  if (latestEvent) {
+    if (latestEvent.kind === "spring" || latestEvent.kind === "upthrust") {
+      clauses.push(`${latestEvent.label} · 거래량 ${latestEvent.volumeRatio?.toFixed(1)}배`);
+    } else if (latestEvent.kind === "impulse") {
+      clauses.push(`${latestEvent.label} · 거래량 ${latestEvent.volumeRatio?.toFixed(1)}배`);
+    } else {
+      clauses.push(`${latestEvent.label} · ${latestEvent.retracementPct?.toFixed(1)}% 되돌림 · ${latestEvent.reference} 지지 테스트`);
+    }
+  }
+  const flows = [
+    num(input.foreignNetStreak) && Math.abs(input.foreignNetStreak) >= 3
+      ? `외국인 ${Math.abs(input.foreignNetStreak)}일 연속 순${input.foreignNetStreak > 0 ? "매수" : "매도"}`
+      : undefined,
+    num(input.institutionNetStreak) && Math.abs(input.institutionNetStreak) >= 3
+      ? `기관 ${Math.abs(input.institutionNetStreak)}일 연속 순${input.institutionNetStreak > 0 ? "매수" : "매도"}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+  if (flows.length > 0) {
+    const meaning = zone?.kind === "accumulation" && [input.foreignNetStreak, input.institutionNetStreak].some((value) => num(value) && value > 0)
+      ? "저점권 손바뀜을 확인 중"
+      : zone?.kind === "distribution" && [input.foreignNetStreak, input.institutionNetStreak].some((value) => num(value) && value < 0)
+        ? "고점권 이탈 수급이 겹친 상태"
+        : "가격 구간과 수급 방향을 함께 확인 중";
+    clauses.push(`${flows.join("·")} 가세 — ${meaning}`);
+  }
+  if (clauses.length > 0 && num(input.invalidationLevel)) clauses.push(`관점 경계 ${price(input.invalidationLevel, currency)}`);
+  return clauses.length > 0 ? `${clauses.join(". ")}.` : undefined;
+}
+
+/**
+ * 캔들·거래량만으로 구간과 이벤트를 판정하는 결정론 엔진.
+ * 조건이 부족하면 빈 배열을 반환하며, LLM이나 임의 레벨을 사용하지 않는다.
+ */
+export function computeWyckoffAnalysis(input: WyckoffAnalysisInput): WyckoffAnalysis {
+  const candles = cleanCandles(input.candles);
+  if (candles.length < MIN_ZONE_DAYS) return { sourceLength: candles.length, zones: [], events: [] };
+  const currency = input.currency ?? "KRW";
+  const currentZone = rangeZone(candles) ?? trendZone(candles);
+  const boundary = boundaryEvents(candles, currentZone, currency);
+  const impulses = impulseEvents(candles);
+  const pullbacks = pullbackEvents(candles, impulses, currency);
+  const events = [...boundary, ...impulses, ...pullbacks].sort((a, b) => a.index - b.index);
+  const summary = summaryOf(currentZone, events, input);
+  return {
+    sourceLength: candles.length,
+    ...(currentZone ? { currentZone } : {}),
+    zones: currentZone ? [currentZone] : [],
+    events,
+    ...(summary ? { summary } : {}),
+  };
+}


### PR DESCRIPTION
## What changed

- Added a deterministic 260-day OHLCV Wyckoff zone engine for accumulation, distribution, markup, and markdown windows.
- Detects spring/upthrust boundary failures, volume-confirmed impulses, and MA20/60 pullbacks with measured retracement ratios.
- Returns stock-specific `지금 구간 요약` copy using actual zone, event, flow, and invalidation values.
- Renders zone boxes and interactive event markers on the existing SVG candlestick chart without adding a chart library.
- Preserves honest silence when the conditions do not qualify and versions the stock-front cache for immediate rollout.

## Why

The chart exposed candles and indicators but left the structural interpretation as a point-in-time phase badge and generic fact chips. This change makes the underlying measured range and wave events visible on the same time axis.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test -- wyckoff-analysis verdict technical-analysis stock-front` (33 tests)
- `npm run build:fomo-web`
- `npm run build:web`
- Live-data dry run against LCID, BE, MSTR, STX, CSCO, ADBE, 코오롱, 삼양홀딩스 candles
