### PR TITLE
종합 기업 점수와 6축 레이더 적용

### DIFF
--- a/apps/fomo-web/__tests__/performanceScoreBands.test.ts
+++ b/apps/fomo-web/__tests__/performanceScoreBands.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { companyScoreBandStats, type CompanyScorePerformanceRow } from "../lib/companyScorePerformance";
+
+const DAY = 86_400_000;
+
+describe("company score performance bands", () => {
+  it("uses only honest 30-day observations and keeps losses in the denominator", () => {
+    const now = Date.UTC(2026, 6, 19);
+    const row = (score: number, returnPct: number, ageDays: number): CompanyScorePerformanceRow => ({
+      item: { stock: `${score}-${returnPct}`, firstSeenAt: now - ageDays * DAY, companyScore: score },
+      returnPct,
+    });
+    const stats = companyScoreBandStats(
+      [row(85, 12, 31), row(82, -4, 45), row(74, 3, 35), row(58, -2, 32), row(91, 20, 12)],
+      now
+    );
+    expect(stats).toEqual([
+      { label: "80점 이상", count: 2, winRate: 50 },
+      { label: "60–79점", count: 1, winRate: 100 },
+      { label: "60점 미만", count: 1, winRate: 0 },
+    ]);
+  });
+});

--- a/apps/fomo-web/components/CompanyScoreRadar.tsx
+++ b/apps/fomo-web/components/CompanyScoreRadar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { CompanyScoreAxisKey, CompanyScoreResult } from "@fomo/core";
+
+const NEON = "#D8FF3A";
+const ORDER: CompanyScoreAxisKey[] = ["valuation", "growth", "profitability", "flow", "chart", "quiet"];
+const LABEL: Record<CompanyScoreAxisKey, string> = {
+  valuation: "밸류",
+  growth: "성장",
+  profitability: "체력",
+  flow: "수급",
+  chart: "차트",
+  quiet: "조용함",
+};
+
+function point(index: number, score: number, radius = 82, center = 110): [number, number] {
+  const angle = -Math.PI / 2 + (index * Math.PI) / 3;
+  const scaled = radius * (score / 100);
+  return [center + Math.cos(angle) * scaled, center + Math.sin(angle) * scaled];
+}
+
+function polygon(score: number): string {
+  return ORDER.map((_, index) => point(index, score).join(",")).join(" ");
+}
+
+export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | null | undefined }) {
+  const [selected, setSelected] = useState<CompanyScoreAxisKey | null>(null);
+  const byKey = useMemo(() => new Map(result?.axes.map((axis) => [axis.key, axis]) ?? []), [result]);
+  const active = selected ? byKey.get(selected) : undefined;
+  const dataPolygon = ORDER.map((key, index) => point(index, byKey.get(key)?.score ?? 0).join(",")).join(" ");
+
+  if (!result || result.score === null) return null;
+
+  return (
+    <section className="mt-5 border-y border-hairline py-5" aria-labelledby="company-score-title">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="font-pixel text-[11px] text-muted">COMPANY SCORE</p>
+          <div className="mt-1.5 flex items-baseline gap-2">
+            <span id="company-score-title" className="font-number text-4xl font-bold leading-none" style={{ color: NEON }}>
+              {result.score}
+            </span>
+            <span className="text-sm font-semibold text-muted">/ 100</span>
+          </div>
+        </div>
+        <span className="max-w-[58%] text-right text-sm font-semibold leading-5 text-whiteout">{result.label}</span>
+      </div>
+
+      <div className="mt-4 flex justify-center">
+        <svg viewBox="0 0 220 220" className="h-[250px] w-[250px] max-w-full" role="img" aria-label="종합 기업 점수 6축 레이더">
+          {[25, 50, 75, 100].map((level) => (
+            <polygon key={level} points={polygon(level)} fill="none" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
+          ))}
+          {ORDER.map((key, index) => {
+            const [x, y] = point(index, 100);
+            return <line key={key} x1="110" y1="110" x2={x} y2={y} stroke="rgba(255,255,255,0.10)" strokeWidth="1" />;
+          })}
+          <polygon points={dataPolygon} fill="rgba(216,255,58,0.16)" stroke={NEON} strokeWidth="2" />
+          {ORDER.map((key, index) => {
+            const axis = byKey.get(key);
+            const [x, y] = point(index, axis?.score ?? 0);
+            const [labelX, labelY] = point(index, 118);
+            return (
+              <g key={key}>
+                {axis && <circle cx={x} cy={y} r="3.5" fill={NEON} />}
+                <text x={labelX} y={labelY} textAnchor="middle" dominantBaseline="middle" fill={axis ? "#FAFAFA" : "#666"} fontSize="10">
+                  {LABEL[key]}
+                </text>
+                <text x={labelX} y={labelY + 12} textAnchor="middle" dominantBaseline="middle" fill={axis ? NEON : "#666"} fontSize="9">
+                  {axis?.score ?? "—"}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <p className="text-sm leading-6 text-whiteout">{result.interpretation}</p>
+      <p className="mt-1 text-[10px] leading-4 text-muted">
+        실데이터가 없는 축은 종합점수에서 제외하고, 나머지 {result.availableAxisCount}개 축을 같은 비중으로 다시 계산했어요.
+      </p>
+
+      <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
+        {ORDER.map((key) => {
+          const axis = byKey.get(key);
+          const isActive = selected === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              disabled={!axis}
+              onClick={() => setSelected(isActive ? null : key)}
+              className="flex min-h-10 items-center justify-between border-b border-hairline py-2 text-left disabled:opacity-35"
+              aria-expanded={isActive}
+            >
+              <span className="text-xs text-muted">{LABEL[key]}</span>
+              <span className="font-number text-sm font-bold" style={{ color: axis ? NEON : "#666" }}>{axis?.score ?? "—"}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {active && (
+        <div className="mt-3 border-l-2 pl-3" style={{ borderColor: NEON }}>
+          <p className="text-xs font-semibold text-whiteout">{active.label} {active.score}점 근거</p>
+          {active.evidence.map((evidence) => (
+            <p key={evidence} className="mt-1 text-xs leading-5 text-muted">{evidence}</p>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -17,7 +17,7 @@ import { SectorCard } from "@/components/SectorCard";
 import { StockIssueCard, sectorCardData } from "@/components/FeedView";
 import { useFeedArchive } from "@/lib/useFeedArchive";
 import { CalendarCard } from "@/components/CalendarCard";
-import { discoveryStatus, verdictBalance } from "@/lib/discoveryPresentation";
+import { verdictBalance } from "@/lib/discoveryPresentation";
 
 /**
  * PC(≥1024px) 3컬럼 대시보드 — WO-PC-VERSION.
@@ -79,7 +79,7 @@ function CardListRow({
   active: boolean;
   onSelect: () => void;
 }) {
-  const status = card.type === "stock" ? discoveryStatus(front?.fomo) : undefined;
+  const companyScore = card.type === "stock" ? front?.companyScore : undefined;
   const balance = card.type === "stock" ? verdictBalance(front?.verdict) : undefined;
   const title =
     card.type === "stock" ? card.data.canonical : card.type === "sector" ? `${card.data.sector} 섹터` : card.data.headline;
@@ -105,12 +105,12 @@ function CardListRow({
     >
       <div className="flex items-center justify-between gap-2">
         <span className="min-w-0 truncate text-sm font-bold text-whiteout">{title}</span>
-        {status && (
+        {typeof companyScore?.score === "number" && (
           <span
             className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-bold"
-            style={{ borderColor: status.color, color: status.color }}
+            style={{ borderColor: NEON, color: NEON }}
           >
-            {status.label}
+            {companyScore.score}점
           </span>
         )}
       </div>
@@ -121,6 +121,7 @@ function CardListRow({
       {hook && (
         <p className="mt-1 truncate text-xs leading-5 text-muted">{hook}</p>
       )}
+      {companyScore?.label && <p className="mt-1 truncate text-[10px] leading-4 text-whiteout">{companyScore.label}</p>}
     </button>
   );
 }

--- a/apps/fomo-web/components/HomeView.tsx
+++ b/apps/fomo-web/components/HomeView.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { scoreToColor, type EmotionType } from "@fomo/core";
+import { type EmotionType } from "@fomo/core";
 import { KeywordCardFeed } from "@/components/KeywordCardFeed";
-import { CaretUpIcon, CaretDownIcon, SearchIcon, XMarkIcon } from "@/components/icons";
+import { SearchIcon } from "@/components/icons";
 import { KeywordHistory } from "@/components/KeywordHistory";
 import { FeedView } from "@/components/FeedView";
 import { SearchOverlay } from "@/components/SearchOverlay";
@@ -44,23 +44,9 @@ export function HomeView({
   onLoggedIn: () => void;
 }) {
   const [tab, setTab] = useState<Tab>("main");
-  const [indexHelpOpen, setIndexHelpOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const isDesktop = useIsDesktop();
-  const color = index ? scoreToColor(index.score) : undefined;
-
-  /**
-   * 전체 폴백 판정: 기본 온도만 있는 상태다.
-   * 이 경우에도 "수집 중"으로 고정하지 않고 온도 자체는 보여주되, 어제 대비처럼
-   * 실제 비교 데이터가 필요한 디테일만 숨긴다.
-   */
-  const isFullFallback = index
-    ? index.components.market === 15 &&
-      index.components.community === 15 &&
-      index.components.emotion === 15 &&
-      index.components.whale === 0 &&
-      !index.aiSummary
-    : false;
+  void index;
 
   // PC(≥1024px) — WO-PC-VERSION 3컬럼 대시보드. lg 미만 모바일 트리는 아래 그대로(틴더 덱 불가침).
   if (isDesktop) {
@@ -69,36 +55,18 @@ export function HomeView({
         <main className="fomo-phase-in mx-auto flex h-screen max-w-[1400px] flex-col gap-4 px-6 pb-5 pt-[calc(1.25rem+env(safe-area-inset-top))]">
           <div className="flex shrink-0 items-center justify-between">
             <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => setSearchOpen(true)}
-                className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
-                aria-label="종목 검색"
-              >
-                <SearchIcon size={13} />
-                <span>검색</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setIndexHelpOpen(true)}
-                className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
-                aria-label="오늘의 시장 온도 계산 방식 보기"
-              >
-                <span>온도</span>
-                {index ? (
-                  <span className="font-number text-sm font-bold leading-none" style={{ color }}>
-                    {index.score}
-                  </span>
-                ) : (
-                  <span>—</span>
-                )}
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
+              aria-label="종목 검색"
+            >
+              <SearchIcon size={13} />
+              <span>검색</span>
+            </button>
           </div>
           <DesktopDashboard />
         </main>
-        {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
         {searchOpen && <SearchOverlay onClose={() => setSearchOpen(false)} />}
       </>
     );
@@ -107,42 +75,17 @@ export function HomeView({
   return (
     <>
       <main className="fomo-phase-in mx-auto flex min-h-screen max-w-md flex-col px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-[calc(1rem+env(safe-area-inset-top))]">
-        {/* 상단 얇은 띠: 로고 + 시장 온도 축약 배지(WO 1.5 E — 큰 바는 몰입 방해라 접었다. 탭하면 설명 시트). */}
+        {/* 상단은 제품명과 검색만 남긴다. 시장 온도는 종합 기업 점수와 무관해 제거했다. */}
         <div className="flex items-center justify-between">
           <span className="font-pixel text-base text-whiteout">FOMO CLUB</span>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setSearchOpen(true)}
-              className="flex items-center rounded-full border border-hairline p-1.5 text-muted transition-colors hover:border-whiteout/20"
-              aria-label="종목 검색"
-            >
-              <SearchIcon size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={() => setIndexHelpOpen(true)}
-              className="flex items-center gap-1.5 rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted transition-colors hover:border-whiteout/20"
-              aria-label="오늘의 시장 온도 계산 방식 보기"
-            >
-              <span>온도</span>
-              {index ? (
-                <>
-                  <span className="font-number text-sm font-bold leading-none" style={{ color }}>
-                    {index.score}
-                  </span>
-                  {!isFullFallback && index.prevDayDelta !== 0 && (
-                    <span className="inline-flex items-center" style={{ color }}>
-                      {index.prevDayDelta > 0 ? <CaretUpIcon size={9} /> : <CaretDownIcon size={9} />}
-                      {Math.abs(index.prevDayDelta)}
-                    </span>
-                  )}
-                </>
-              ) : (
-                <span>—</span>
-              )}
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => setSearchOpen(true)}
+            className="flex items-center rounded-full border border-hairline p-1.5 text-muted transition-colors hover:border-whiteout/20"
+            aria-label="종목 검색"
+          >
+            <SearchIcon size={14} />
+          </button>
         </div>
 
         <div className={`mt-3 flex min-h-0 flex-1 flex-col ${tab === "feed" ? "overflow-y-auto scrollbar-none" : ""}`}>
@@ -165,76 +108,8 @@ export function HomeView({
         </div>
       </nav>
 
-      {indexHelpOpen && <FomoIndexInfoSheet index={index} onClose={() => setIndexHelpOpen(false)} />}
       {searchOpen && <SearchOverlay onClose={() => setSearchOpen(false)} />}
     </>
-  );
-}
-
-function FomoIndexInfoSheet({
-  index,
-  onClose,
-}: {
-  index: FomoIndexResponse | null;
-  onClose: () => void;
-}) {
-  const rows = [
-    { key: "market" as const, label: "시장 움직임", points: "30점", desc: "주요 지수와 거래 흐름이 뜨거운지 봅니다." },
-    { key: "community" as const, label: "뉴스·언급", points: "30점", desc: "공개 뉴스와 글에서 특정 종목·섹터 언급이 늘었는지 봅니다." },
-    { key: "emotion" as const, label: "사용자 반응", points: "30점", desc: "앱 안에서 남긴 관심·반응 데이터가 충분할 때 보조로 반영합니다." },
-    { key: "whale" as const, label: "외부 보조 신호", points: "10점", desc: "국내장 밖의 큰 흐름은 작게만 참고합니다." },
-  ];
-  const components = index?.components;
-
-  return (
-    <div className="fixed inset-0 z-[85]" role="dialog" aria-modal="true" aria-labelledby="fomo-index-info-title">
-      <button className="absolute inset-0 bg-black/72 backdrop-blur-md" onClick={onClose} aria-label="닫기" type="button" />
-      <div className="absolute inset-x-0 bottom-0 mx-auto max-w-md">
-        <section className="fomo-sheet-rise rounded-t-[28px] border border-hairline bg-[#1A1A1A] px-6 pb-[calc(24px+env(safe-area-inset-bottom))] pt-5">
-          <div className="mx-auto h-1 w-14 rounded-full bg-white/20" />
-          <div className="mt-6 flex items-start justify-between gap-4">
-            <div>
-              <p className="font-pixel text-[11px] text-muted">FOMO INDEX</p>
-              <h1 id="fomo-index-info-title" className="mt-2 text-2xl font-semibold text-whiteout">
-                시장 온도는 이렇게 계산해요
-              </h1>
-            </div>
-            <button
-              className="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-hairline text-muted transition-colors hover:text-whiteout"
-              onClick={onClose}
-              type="button"
-              aria-label="닫기"
-            >
-              <XMarkIcon size={20} />
-            </button>
-          </div>
-
-          <p className="mt-5 text-sm leading-6 text-muted">
-            오늘의 시장 온도는 발견 덱 위에 얹는 0~100점 분위기 지표예요. 카드의 개별 포모 점수와는 별도로,
-            시장 전체가 얼마나 뜨겁거나 차분한지 빠르게 보여줍니다.
-          </p>
-
-          <div className="mt-6 space-y-3">
-            {rows.map((row) => (
-              <div key={row.label} className="rounded-2xl border border-hairline bg-white/[0.035] px-4 py-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-sm font-semibold text-whiteout">{row.label}</span>
-                  <span className="font-number text-sm font-semibold" style={{ color: NEON }}>
-                    {components?.[row.key] ?? "—"} / {row.points}
-                  </span>
-                </div>
-                <p className="mt-1 text-xs leading-5 text-muted">{row.desc}</p>
-              </div>
-            ))}
-          </div>
-
-          <p className="mt-5 text-xs leading-5 text-muted">
-            데이터가 부족한 항목은 낮은 신뢰도로 반영돼요. 이 점수는 시장 분위기를 읽기 위한 정보이며,
-            투자 자문·매수·매도 신호가 아닙니다.
-          </p>
-        </section>
-      </div>
-    </div>
   );
 }
 

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
 import {
-  scoreToColor,
   cleanText,
   cleanQuote,
   communityWordings,
@@ -12,6 +11,7 @@ import {
   selectFomoHook,
   translateTaFact,
   confidenceGrade,
+  mergeCompanyScoreResults,
   type DailyOhlcv,
   type KeywordCard,
   type FomoTone,
@@ -32,6 +32,7 @@ import { isWatched, toggleWatch } from "@/lib/watchlist";
 import { describe52wGap, describeRsi } from "@/lib/depthCopy";
 import { discoveryStatus, verdictBalance } from "@/lib/discoveryPresentation";
 import { FlickerSpinner } from "@/components/FlickerSpinner";
+import { CompanyScoreRadar } from "@/components/CompanyScoreRadar";
 
 /**
  * 키워드 뎁스 페이지 — 카드/히스토리에서 공용. KEYWORD_CARD_FEED_DEV_SPEC v3 §3.
@@ -42,7 +43,6 @@ import { FlickerSpinner } from "@/components/FlickerSpinner";
  * 메인 카드·스와이프는 안 건드린다 — 뎁스 콘텐츠만.
  */
 export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose: () => void }) {
-  const color = scoreToColor(card.fomoScore);
   const [insight, setInsight] = useState<CondensedInsight | null>(null);
   const [loading, setLoading] = useState(true);
   // 숨은 연관주 탭 → 종목 전용 화면(stock-insight 재활용). null 이면 안 띄움.
@@ -98,12 +98,7 @@ export function KeywordDepthPage({ card, onClose }: { card: KeywordCard; onClose
     <div className="fixed inset-0 z-[60] bg-black pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <div className="mx-auto flex h-full max-w-md flex-col">
         <div className="flex items-center justify-between border-b border-hairline px-6 py-4">
-          <div className="flex items-center gap-2.5">
-            <span className="text-lg font-bold text-whiteout">{card.keyword}</span>
-            <span className="text-sm font-semibold" style={{ color }}>
-              포모 {card.fomoScore}
-            </span>
-          </div>
+          <span className="text-lg font-bold text-whiteout">{card.keyword}</span>
           <button onClick={onClose} className="font-pixel text-sm text-muted hover:text-whiteout">
             닫기
           </button>
@@ -369,11 +364,13 @@ function mergeFrontSeed(
 ): StockFrontResponse | null {
   if (!hasUsableFront(seed)) return fresh ?? null;
   if (!hasUsableFront(fresh)) return seed;
+  const companyScore = mergeCompanyScoreResults(seed.companyScore, fresh.companyScore);
   return {
     signals: { ...seed.signals, ...fresh.signals },
     // 상태 배지 단일 진실(카드=뎁스 모순 금지) — 카드(seed)의 포모 라벨 우선. 라이브 재계산(fresh)은
     // 시점·입력이 달라 "카드는 '가격 먼저'인데 뎁스는 '주목 집중'" 불일치를 만든다(2026-07-17 User Zero).
     fomo: seed.fomo ?? fresh.fomo,
+    ...(companyScore ? { companyScore } : {}),
     ...(fresh.taFact ?? seed.taFact ? { taFact: fresh.taFact ?? seed.taFact } : {}),
     ...(fresh.ta ?? seed.ta ? { ta: fresh.ta ?? seed.ta } : {}),
     ...(fresh.candles?.length ? { candles: fresh.candles } : seed.candles?.length ? { candles: seed.candles } : {}),
@@ -2530,6 +2527,7 @@ export function StockInsightView({
           <>
           {/* 가격 먼저 — 일반 주식 상세 화면의 첫 독해 지점. */}
           <StockPriceHeader basics={basics} front={front} />
+          <CompanyScoreRadar result={front?.companyScore} />
           <DiscoveryOverview front={front} insight={insight} context={context} />
           <DepthTabBar tab={depthTab} onChange={setDepthTab} />
           {depthTab === "ta" ? (
@@ -2568,14 +2566,6 @@ export function StockInsightView({
               {hasVerifiedFloor
                 ? "원문 기반 요약은 아직 얇아요."
                 : "이 종목으로 모인 원문은 아직 적어요. 확인된 자료가 들어오면 이 화면에 붙어요."}
-            </p>
-          )}
-
-          {/* 포모 점수 — 카드 메인에서 강등된 배지(WO 1.5 E). 주목도 참고용, 판단 아님. */}
-          {typeof front?.fomo?.fomoScore === "number" && (
-            <p className="mt-6 text-center text-[11px] leading-5 text-muted">
-              포모 <span className="font-number font-bold" style={{ color: "#D8FF3A" }}>{front.fomo.fomoScore}</span>
-              {` · ${fomoStateSummary(front.fomo)}`}
             </p>
           )}
 

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MOCK_KEYWORD_CARDS, scoreToColor, type KeywordCard } from "@fomo/core";
+import { MOCK_KEYWORD_CARDS, type KeywordCard } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { MyDiscoveryPreview } from "@/components/MyDiscoveryPreview";
 import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
@@ -106,7 +106,6 @@ export function KeywordHistory() {
       {history.length > 0 && <p className="mb-3 px-1 text-xs text-muted">내가 본 키워드</p>}
       <div className="flex flex-col gap-2.5">
         {history.map((h) => {
-          const color = scoreToColor(h.fomoScore);
           const full = MOCK_KEYWORD_CARDS.find((c) => c.id === h.id) ?? null;
           return (
             <button
@@ -119,12 +118,7 @@ export function KeywordHistory() {
                 <span className="text-base font-semibold text-whiteout">{h.keyword}</span>
                 <span aria-hidden>{h.emoji}</span>
               </div>
-              <div className="flex items-center gap-3">
-                <span className="text-sm font-semibold" style={{ color }}>
-                  {h.fomoScore}
-                </span>
-                <span className="text-[11px] text-muted">{relativeTime(h.ts)}</span>
-              </div>
+              <span className="text-[11px] text-muted">{relativeTime(h.ts)}</span>
             </button>
           );
         })}

--- a/apps/fomo-web/components/PerformanceProofPanel.tsx
+++ b/apps/fomo-web/components/PerformanceProofPanel.tsx
@@ -7,6 +7,7 @@ import {
   formatReturnPct,
   type DiscoverySeenItem,
 } from "@/lib/discoveryPerformance";
+import { companyScoreBandStats } from "@/lib/companyScorePerformance";
 
 const NEON = "#D8FF3A";
 
@@ -106,6 +107,7 @@ export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeen
     .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   const winRate = returns.length > 0 ? Math.round((returns.filter((value) => value > 0).length / returns.length) * 100) : null;
   const medianReturn = median(returns);
+  const scoreBands = companyScoreBandStats(rows);
 
   if (items.length === 0) return null;
 
@@ -134,6 +136,24 @@ export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeen
         </p>
       </div>
 
+      <div className="mt-3 border-y border-hairline py-3">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-semibold text-whiteout">점수대별 30일 후 승률</p>
+          <span className="text-[10px] text-muted">전체 기록 기준</span>
+        </div>
+        <div className="mt-2 grid grid-cols-3 gap-2">
+          {scoreBands.map((band) => (
+            <div key={band.label}>
+              <p className="text-[10px] text-muted">{band.label}</p>
+              <p className="mt-1 font-number text-base font-bold text-whiteout">
+                {band.winRate === null ? "축적 중" : `${band.winRate}%`}
+              </p>
+              <p className="text-[9px] text-muted">표본 {band.count}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
       <div className="mt-3 flex flex-col gap-2.5">
         {rows.slice(0, 10).map((row) => {
           const up = typeof row.returnPct === "number" && row.returnPct > 0;
@@ -155,6 +175,11 @@ export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeen
                       <span> · 발견가 {row.item.firstSeenPriceText ?? asPrice(row.item.firstSeenPrice, row.item.country)}</span>
                     )}
                   </p>
+                  {typeof row.item.companyScore === "number" && (
+                    <p className="mt-1 text-[11px] text-muted">
+                      발견 당시 {row.item.companyScore}점{row.item.companyScoreLabel ? ` · ${row.item.companyScoreLabel}` : ""}
+                    </p>
+                  )}
                 </div>
                 <span
                   className="shrink-0 rounded-full border border-hairline-soft px-2.5 py-1 text-sm font-bold tabular-nums"

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -6,6 +6,7 @@ import type {
   AxisSignal,
   CardFrontSignals,
   CardVerdict,
+  CompanyScoreResult,
   FomoScoreResult,
   FomoCardView,
   MultiAxisHookSelection,
@@ -27,8 +28,8 @@ import { whyShown } from "@/lib/whyShown";
 import { dedupeCardCopy } from "@/lib/cardCopyDedupe";
 import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
 import { isKrStockCode, stockLogoApiSrcForStock } from "@/lib/stockLogo";
-import { discoveryStatus, verdictBalance, type DiscoveryStatusView } from "@/lib/discoveryPresentation";
-import { FlameIcon, GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
+import { verdictBalance } from "@/lib/discoveryPresentation";
+import { GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
 
 /**
  * 공통 종목 무한 스와이프 덱.
@@ -48,6 +49,7 @@ const EMPTY_FOMO = computeFomoScore({});
 export type FrontEntry = {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
+  companyScore?: CompanyScoreResult;
   taFact?: TaFact;
   sparkline: number[];
   priceText?: string;
@@ -58,6 +60,7 @@ export type FrontEntry = {
   axisSignals?: AxisSignal[];
   axisHook?: MultiAxisHookSelection;
   verdict?: CardVerdict;
+  wyckoff?: NonNullable<StockFrontResponse["wyckoff"]>;
   candles?: NonNullable<StockFrontResponse["candles"]>;
   chartSeries?: NonNullable<StockFrontResponse["chartSeries"]>;
   coinIssues?: NonNullable<StockFrontResponse["coinIssues"]>;
@@ -129,23 +132,6 @@ function LogoBadge({
       aria-hidden
     >
       {ch}
-    </span>
-  );
-}
-
-/** 포모 강도 미터(DESIGN.md §8 모티프) — 10 도트 세그먼트, 점수만큼 오렌지 fill·나머지 dim. */
-function FomoMeter({ score, color }: { score: number; color: string }) {
-  const normalized = Math.max(0, Math.min(100, score));
-  const filled = normalized > 0 ? Math.max(1, Math.ceil(normalized / 10)) : 0;
-  return (
-    <span className="inline-flex items-center gap-[3px]" aria-hidden>
-      {Array.from({ length: 10 }, (_, i) => (
-        <span
-          key={i}
-          className="h-2 w-2 rounded-[1px]"
-          style={{ backgroundColor: i < filled ? color : "rgba(255,255,255,0.12)" }}
-        />
-      ))}
     </span>
   );
 }
@@ -273,29 +259,32 @@ function BundleCardFace({ bundle, progress }: { bundle: DeckThemeBundle; progres
   );
 }
 
-/** 발견 상태와 차트 균형을 분리해 보여준다. 매매 행동처럼 읽히는 라벨은 쓰지 않는다. */
-function DiscoverySignalBlock({
-  status,
-  score,
+/** 카드에서는 종합점수와 조합 라벨만 가볍게 노출하고, 축별 산식은 뎁스에서 푼다. */
+function CompanyScoreBlock({
+  companyScore,
   verdict,
   contextLine,
 }: {
-  status: DiscoveryStatusView;
-  score: number;
+  companyScore?: CompanyScoreResult | undefined;
   verdict?: CardVerdict | undefined;
   contextLine?: string | undefined;
 }) {
   const balance = verdictBalance(verdict);
   return (
-    <div className="mt-2.5 shrink-0 rounded-lg border border-hairline bg-white/[0.035] px-3 py-2">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-bold" style={{ color: status.color }}>{status.label}</span>
+    <div className="mt-2.5 shrink-0 border-y border-hairline py-2.5">
+      <div className="flex items-end justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-1.5">
+            <span className="font-number text-3xl font-bold leading-none" style={{ color: NEON }}>
+              {companyScore?.score ?? "—"}
+            </span>
+            <span className="text-xs font-semibold text-muted">점</span>
+          </div>
+          <p className="mt-1 truncate text-sm font-semibold text-whiteout">
+            {companyScore?.label ?? "근거 축 수집 중"}
+          </p>
+        </div>
         {balance && <span className="text-[10px] font-medium" style={{ color: balance.color }}>{balance.label}</span>}
-      </div>
-      <p className="mt-1 text-xs leading-5 text-muted" style={clampStyle(2)}>{status.summary}</p>
-      <div className="mt-2 flex items-center gap-2">
-        <span className="text-[10px] text-muted">관심 온도</span>
-        <FomoMeter score={score} color={status.color} />
       </div>
       {contextLine && (
         <p className="mt-1.5 text-xs leading-4 text-whiteout" style={clampStyle(1)}>
@@ -322,7 +311,7 @@ function StockCardFace({
   feedBull,
   feedBear,
   why,
-  fomo,
+  companyScore,
   discoveryContext,
   verdict,
   progress,
@@ -338,7 +327,7 @@ function StockCardFace({
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
   why?: string | undefined;
-  fomo: FomoScoreResult;
+  companyScore?: CompanyScoreResult | undefined;
   discoveryContext?: string | undefined;
   verdict?: CardVerdict | undefined;
   progress?: string | undefined;
@@ -390,10 +379,9 @@ function StockCardFace({
         {view.headline}
       </p>
 
-      {/* 발견 상태와 차트 균형은 서로 다른 축이다. */}
-      {verdict ? (
-        <DiscoverySignalBlock status={discoveryStatus(fomo)} score={fomo.fomoScore} verdict={verdict} contextLine={discoveryContext} />
-      ) : (
+      <CompanyScoreBlock companyScore={companyScore} verdict={verdict} contextLine={discoveryContext} />
+
+      {!verdict && (
         <>
           {why && (
             <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
@@ -560,6 +548,7 @@ export function StockSwipeDeck({
             [key]: {
               signals: d.signals,
               fomo: d.fomo,
+              ...(d.companyScore ? { companyScore: d.companyScore } : {}),
               ...(d.taFact ? { taFact: d.taFact } : {}),
               sparkline: d.sparkline,
               ...(d.priceText ? { priceText: d.priceText } : {}),
@@ -570,6 +559,7 @@ export function StockSwipeDeck({
               ...(d.axisSignals ? { axisSignals: d.axisSignals } : {}),
               ...(d.axisHook ? { axisHook: d.axisHook } : {}),
               ...(d.verdict ? { verdict: d.verdict } : {}),
+              ...(d.wyckoff ? { wyckoff: d.wyckoff } : {}),
               ...(d.coinIssues ? { coinIssues: d.coinIssues } : {}),
               ...(d.coinCause ? { coinCause: d.coinCause } : {}),
             },
@@ -678,7 +668,7 @@ export function StockSwipeDeck({
         feedBull={deduped.feedBull}
         feedBear={deduped.feedBear}
         why={deduped.why}
-        fomo={e.fomo}
+        companyScore={e.companyScore}
         discoveryContext={discoveryContext}
         verdict={e?.verdict}
         progress={progress}

--- a/apps/fomo-web/lib/companyScorePerformance.ts
+++ b/apps/fomo-web/lib/companyScorePerformance.ts
@@ -1,0 +1,36 @@
+import { daysSince, type DiscoverySeenItem } from "./discoveryPerformance";
+
+export interface CompanyScorePerformanceRow {
+  item: DiscoverySeenItem;
+  returnPct?: number;
+}
+
+export interface ScoreBandStat {
+  label: string;
+  count: number;
+  winRate: number | null;
+}
+
+export function companyScoreBandStats(
+  rows: readonly CompanyScorePerformanceRow[],
+  nowMs = Date.now()
+): ScoreBandStat[] {
+  const eligible = rows.filter(
+    (row) =>
+      daysSince(row.item.firstSeenAt, nowMs) >= 30 &&
+      typeof row.item.companyScore === "number" &&
+      typeof row.returnPct === "number"
+  );
+  return [
+    { label: "80점 이상", min: 80, max: 101 },
+    { label: "60–79점", min: 60, max: 80 },
+    { label: "60점 미만", min: 0, max: 60 },
+  ].map((band) => {
+    const matches = eligible.filter((row) => row.item.companyScore! >= band.min && row.item.companyScore! < band.max);
+    return {
+      label: band.label,
+      count: matches.length,
+      winRate: matches.length > 0 ? Math.round((matches.filter((row) => row.returnPct! > 0).length / matches.length) * 100) : null,
+    };
+  });
+}

--- a/apps/fomo-web/lib/discoveryPerformance.ts
+++ b/apps/fomo-web/lib/discoveryPerformance.ts
@@ -15,6 +15,8 @@ export interface DiscoverySeenItem {
   firstSeenPrice?: number;
   firstSeenPriceText?: string;
   firstSeenPriceCapturedAt?: number;
+  companyScore?: number;
+  companyScoreLabel?: string;
   symbol?: string;
   naverCode?: string;
   market?: StockMarket;
@@ -38,6 +40,7 @@ export interface DiscoverySeenInput {
 
 interface PriceFront {
   priceText?: string;
+  companyScore?: { score: number | null; label: string };
 }
 
 function parsePriceText(text: string | undefined): number | undefined {
@@ -68,6 +71,8 @@ function read(): DiscoverySeenItem[] {
           ...(typeof candidate.firstSeenPriceCapturedAt === "number"
             ? { firstSeenPriceCapturedAt: candidate.firstSeenPriceCapturedAt }
             : {}),
+          ...(typeof candidate.companyScore === "number" ? { companyScore: candidate.companyScore } : {}),
+          ...(typeof candidate.companyScoreLabel === "string" ? { companyScoreLabel: candidate.companyScoreLabel } : {}),
           ...(typeof candidate.symbol === "string" ? { symbol: candidate.symbol } : {}),
           ...(typeof candidate.naverCode === "string" ? { naverCode: candidate.naverCode } : {}),
           ...(typeof candidate.market === "string" ? { market: candidate.market as StockMarket } : {}),
@@ -121,6 +126,11 @@ export function recordDiscoverySeen(
     typeof price === "number" &&
     typeof base.firstSeenPrice !== "number" &&
     nowMs - base.firstSeenAt <= PRICE_CAPTURE_GRACE_MS;
+  const score = opts.front?.companyScore?.score;
+  const canCaptureScore =
+    typeof score === "number" &&
+    typeof base.companyScore !== "number" &&
+    nowMs - base.firstSeenAt <= PRICE_CAPTURE_GRACE_MS;
 
   const next: DiscoverySeenItem = {
     ...base,
@@ -135,6 +145,12 @@ export function recordDiscoverySeen(
           firstSeenPrice: price,
           firstSeenPriceCapturedAt: nowMs,
           ...(opts.front?.priceText ? { firstSeenPriceText: opts.front.priceText } : {}),
+        }
+      : {}),
+    ...(canCaptureScore
+      ? {
+          companyScore: score,
+          ...(opts.front?.companyScore?.label ? { companyScoreLabel: opts.front.companyScore.label } : {}),
         }
       : {}),
   };

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -507,11 +507,13 @@ export const fetchStockBasics = (stock: string, opts: { naverCode?: string; symb
 /** 카드 앞면 FOMO 신호(rev2 후속) — baseline·라이브 수급 streak·시총순위·3개월 스파크라인. 도달 종목 lazy. */
 export type { CardFrontSignals } from "@fomo/core";
 export type { FomoScoreResult } from "@fomo/core";
+export type { CompanyScoreResult } from "@fomo/core";
 export type { TaFact } from "@fomo/core";
 export type { AxisSignal, MultiAxisHookSelection } from "@fomo/core";
 export interface StockFrontResponse {
   signals: import("@fomo/core").CardFrontSignals;
   fomo: import("@fomo/core").FomoScoreResult;
+  companyScore?: import("@fomo/core").CompanyScoreResult;
   taFact?: import("@fomo/core").TaFact;
   ta?: import("@fomo/core").TechnicalAnalysisSnapshot;
   /** 캔들차트용 실제 일봉 OHLCV. non-lite 응답에 최대 260거래일. */
@@ -569,7 +571,7 @@ export const fetchStockFront = (stock: string, opts: { lite?: boolean; naverCode
   }${opts.symbol ? `&symbol=${encodeURIComponent(opts.symbol)}` : ""}`;
 
   return cachedGet(
-    `stock-front:v2:${opts.lite ? "lite" : "full"}:${stock}:${opts.naverCode ?? ""}:${opts.symbol ?? ""}`,
+    `stock-front:v3-company-score:${opts.lite ? "lite" : "full"}:${stock}:${opts.naverCode ?? ""}:${opts.symbol ?? ""}`,
     async () => {
       try {
         return await fetchJsonWithTimeout<StockFrontResponse>(

--- a/apps/web/app/api/fomo/stock-front/route.ts
+++ b/apps/web/app/api/fomo/stock-front/route.ts
@@ -74,7 +74,7 @@ async function getFront(stock: string, lite = false, naverCode?: string, symbol?
         ...(themeRelativeMap[canonical] ? { themeRelative: themeRelativeMap[canonical] } : {}),
       }, { lite, ...(naverCode ? { naverCode } : {}), ...(symbol ? { symbol } : {}) });
     },
-    ["fomo-stock-front", "wyckoff-v1", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? "", symbol ?? ""],
+    ["fomo-stock-front", "company-score-v1", lite ? "lite" : "full", cacheVersion(), today, stock, naverCode ?? "", symbol ?? ""],
     { revalidate: REVALIDATE_S, ...(marketTag ? { tags: [marketTag] } : {}) }
   );
   return load();

--- a/apps/web/lib/coin-discovery.ts
+++ b/apps/web/lib/coin-discovery.ts
@@ -1,4 +1,4 @@
-import { computeCardVerdict, computeFomoScore, isFrontHookSafe } from "@fomo/core";
+import { computeCardVerdict, computeCompanyScore, computeFomoScore, computeWyckoffAnalysis, isFrontHookSafe } from "@fomo/core";
 import type { CardFrontSignals } from "@fomo/core";
 import { kstDate } from "./fomo";
 import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
@@ -131,6 +131,12 @@ export function coinFrontSeed(
     volumeRatio: signal.volumeRatio,
     currency: "KRW",
   });
+  const verdict = composeCoinVerdict(baseVerdict, coinIssues);
+  const wyckoff = computeWyckoffAnalysis({
+    candles: snapshot.candles,
+    ...(typeof verdict.invalidationLevel === "number" ? { invalidationLevel: verdict.invalidationLevel } : {}),
+    currency: "KRW",
+  });
   const coinCause = buildCoinCause(snapshot, coinIssues);
   const primaryIssue = coinIssues.find((issue) => issue.scope === "coin");
   return {
@@ -143,7 +149,15 @@ export function coinFrontSeed(
     priceText: krw(snapshot.price),
     changeText: `${snapshot.changePct > 0 ? "+" : ""}${snapshot.changePct.toFixed(2)}%`,
     changeDir,
-    verdict: composeCoinVerdict(baseVerdict, coinIssues),
+    verdict,
+    wyckoff,
+    companyScore: computeCompanyScore({
+      signals,
+      verdict,
+      wyckoff,
+      currentPrice: snapshot.price,
+      asOf: snapshot.fetchedAt,
+    }),
     candles,
     ...(chartSeries ? { chartSeries } : {}),
     ...(coinIssues.length ? { coinIssues: [...coinIssues].slice(0, 3) } : {}),

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -1,5 +1,5 @@
 import { unstable_cache } from "next/cache";
-import { isDiscoveryCopySafe } from "@fomo/core";
+import { isDiscoveryCopySafe, withCompanyQuietScore } from "@fomo/core";
 import type { CardFrontSignals, StockCountry } from "@fomo/core";
 import { cacheVersion, kstDate as kstDateOf } from "./fomo";
 import { parsePriceText } from "./quote-prices";
@@ -400,6 +400,21 @@ function responseFromSelected(
     if (stockById.has(candidate.id)) continue;
     stockById.set(candidate.id, candidate.stock);
     stocks.push(candidate.stock);
+    const current = fronts[candidate.stock.canonical];
+    if (current) {
+      fronts[candidate.stock.canonical] = {
+        ...current,
+        companyScore: withCompanyQuietScore(
+          current.companyScore,
+          {
+            quietScore: candidate.quietScore,
+            signalScore: candidate.signalScore,
+            hypePenalty: candidate.hypePenalty,
+          },
+          asOf
+        ),
+      };
+    }
   }
   // cards = 덱(종목 30장) + 피드(콘텐츠·내러티브). 클라가 표면별로 필터: 메인=stock, 피드=content/narrative.
   const all = [...deck, ...feed];

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -19,7 +19,10 @@ import {
   stockMentionRole,
   synthesizeDiscoveryInsight,
   computeCardVerdict,
+  computeCompanyScore,
+  computeWyckoffAnalysis,
   type CardVerdict,
+  type CompanyScoreResult,
   type DailyOhlcv,
   type AxisSignal,
   type CardFrontSignals,
@@ -31,6 +34,7 @@ import {
   type FomoScoreResult,
   type InvestorFlow,
   type MultiAxisHookSelection,
+  type WyckoffAnalysis,
   type SectorStock,
   type StockCountry,
   type RawArticle,
@@ -131,6 +135,7 @@ const INDUSTRY_HINTS: Array<{ label: string; pattern: RegExp }> = [
 export interface DiscoveryFrontSeed {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
+  companyScore?: CompanyScoreResult;
   sparkline: number[];
   priceText?: string;
   changeText?: string;
@@ -139,6 +144,7 @@ export interface DiscoveryFrontSeed {
   axisHook?: MultiAxisHookSelection;
   /** 판단 층(WO Phase 1) — 캔들이 있는 종목만(가짜 판단 금지). */
   verdict?: CardVerdict;
+  wyckoff?: WyckoffAnalysis;
   /** 프리웜이 이미 확보한 실제 일봉. 코인은 상세 첫 렌더의 차트 바닥으로 재사용한다. */
   candles?: DailyOhlcv[];
   chartSeries?: {
@@ -1641,6 +1647,9 @@ function frontSeed(
       : typeof materialMentionScore === "number"
         ? { mentionCount: 1, mentionScore: materialMentionScore }
         : undefined;
+  const flowEvents = candidate.events.filter((event) => event.kind === "flow_entry" && typeof event.flowDays === "number");
+  const foreignNetStreak = flowEvents.find((event) => event.flowActor === "foreign")?.flowDays;
+  const institutionNetStreak = flowEvents.find((event) => event.flowActor === "institution")?.flowDays;
   const signals: CardFrontSignals = {
     ...(typeof row.changePct === "number" ? { changePct: row.changePct } : {}),
     ...(typeof volumeEvent?.volumeRatio === "number" ? { volumeRatio: volumeEvent.volumeRatio } : {}),
@@ -1648,6 +1657,8 @@ function frontSeed(
     ...(currentNewsEventLabel ? { newsEventLabel: currentNewsEventLabel } : {}),
     ...(currentNewsEvent?.source ? { newsEventSource: currentNewsEvent.source } : {}),
     ...(row.marketCapRank && row.marketCapRankSource !== "curated" ? { marketCapRank: { scope: "market", market: row.market, rank: row.marketCapRank } } : {}),
+    ...(typeof foreignNetStreak === "number" ? { foreignNetStreak } : {}),
+    ...(typeof institutionNetStreak === "number" ? { institutionNetStreak } : {}),
     ...(theme ? {
       themeLabel: theme.sector,
       themeRelativeRank: theme.rank,
@@ -2220,7 +2231,24 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     if (!row) continue;
     const attention = attentionMap[candidate.ticker];
     const front = frontSeed(row, candidate, attention, themeSignals.get(candidate.ticker), sparklineByTicker.get(candidate.ticker) ?? []);
-    front.verdict = verdictForCandidate(candidate, dailyByTicker.get(candidate.ticker)?.candles ?? []);
+    const candidateCandles = dailyByTicker.get(candidate.ticker)?.candles ?? [];
+    front.verdict = verdictForCandidate(candidate, candidateCandles);
+    const wyckoff = computeWyckoffAnalysis({
+      candles: candidateCandles,
+      ...(typeof front.signals.foreignNetStreak === "number" ? { foreignNetStreak: front.signals.foreignNetStreak } : {}),
+      ...(typeof front.signals.institutionNetStreak === "number" ? { institutionNetStreak: front.signals.institutionNetStreak } : {}),
+      ...(typeof front.verdict.invalidationLevel === "number" ? { invalidationLevel: front.verdict.invalidationLevel } : {}),
+      currency: candidate.country === "US" ? "USD" : "KRW",
+    });
+    front.wyckoff = wyckoff;
+    front.companyScore = computeCompanyScore({
+      signals: front.signals,
+      verdict: front.verdict,
+      wyckoff,
+      insiderPurchaseConfirmed: candidate.events.some((event) => event.insiderPurchase === true),
+      ...(typeof candidateCandles.at(-1)?.close === "number" ? { currentPrice: candidateCandles.at(-1)!.close } : {}),
+      asOf,
+    });
     const stock = await stockPayload(row, candidate, front);
     // 2026-07-12: US 큐레이션 대형주는 뉴스 재료가 없어도(Vercel egress에서 US 뉴스 차단) verdict 맥락으로
     // 진입 — "시총 높은 아는 기업"(User Zero). 국장 발굴 정체성은 불변(KR 은 이 분기 안 탐).

--- a/apps/web/lib/stock-basics.ts
+++ b/apps/web/lib/stock-basics.ts
@@ -123,12 +123,12 @@ interface NasdaqLabelValue {
 }
 
 /** Nasdaq summary+financials → StockBasics. 시총·52주·배당 + 연간 매출/영업이익. PER 미제공 시 생략(정직). */
-export async function fetchUsStockBasics(name: string, symbol: string): Promise<StockBasics | null> {
+export async function fetchUsStockBasics(name: string, symbol: string, includeAbout = true): Promise<StockBasics | null> {
   const [summaryRaw, financialsRaw, about] = await Promise.all([
     getNasdaqJson(`https://api.nasdaq.com/api/quote/${encodeURIComponent(symbol)}/summary?assetclass=stocks`),
     getNasdaqJson(`https://api.nasdaq.com/api/company/${encodeURIComponent(symbol)}/financials?frequency=1`),
     // 회사 소개(User Zero: "무슨 회사인지 없다") — company-profile 영문 → 한국어 요약, 심볼당 1회 영구 캐시.
-    getUsCompanyAbout(name, symbol).catch(() => undefined),
+    includeAbout ? getUsCompanyAbout(name, symbol).catch(() => undefined) : Promise.resolve(undefined),
   ]);
 
   const summary = (summaryRaw as { data?: { summaryData?: Record<string, NasdaqLabelValue> } } | null)?.data?.summaryData;
@@ -153,13 +153,18 @@ export async function fetchUsStockBasics(name: string, symbol: string): Promise<
   } | null)?.data?.incomeStatementTable;
   if (income?.headers && income.rows?.length) {
     // headers: value2=최신 → value4=과거. 최근 3개 연도를 오래된→최신으로.
-    const keys = (["value4", "value3", "value2"] as const).filter((k) => income.headers?.[k]);
+    const keys = (["value5", "value4", "value3", "value2"] as const).filter((k) => income.headers?.[k]);
     const periods = keys.map((k) => ({ title: income.headers![k]!, estimate: false }));
     const pickRow = (label: RegExp) => income.rows!.find((row) => label.test(row.value1 ?? ""));
     const buildRow = (label: string, source: Record<string, string> | undefined) => {
       if (!source) return null;
       const values = keys.map((k) => formatUsdThousands(source[k]) ?? "—");
-      return values.some((v) => v !== "—") ? { label, values } : null;
+      const rawValues = keys.map((k) => {
+        const value = String(source[k] ?? "").replace(/[^\d.-]/g, "");
+        const parsed = value && value !== "--" ? Number(value) : NaN;
+        return Number.isFinite(parsed) ? parsed : null;
+      });
+      return values.some((v) => v !== "—") ? { label, values, rawValues } : null;
     };
     const rows = [
       buildRow("벌어들인 돈(매출)", pickRow(/^Total Revenue$/i)),

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -12,6 +12,8 @@ import {
   selectTaFact,
   computeCardVerdict,
   computeWyckoffAnalysis,
+  computeCompanyScore,
+  companyFinancialsFromBasics,
   type CardVerdict,
   type CardFrontSignals,
   type FomoScoreResult,
@@ -19,10 +21,11 @@ import {
   type TaFact,
   type TechnicalAnalysisSnapshot,
   type WyckoffAnalysis,
+  type CompanyScoreResult,
   type AxisSignal,
   type MultiAxisHookSelection,
 } from "@fomo/core";
-import { fetchStockBasics, fetchStockBasicsLite } from "./stock-basics";
+import { fetchStockBasics, fetchStockBasicsLite, fetchUsStockBasics } from "./stock-basics";
 import { fetchNasdaqDailyCandles, fetchUsDailyCandles } from "./us-market-source";
 import type { DiscoveryMarketRow } from "./market-source-types";
 import { readUsMarketQuoteRows } from "./us-market-cache";
@@ -183,6 +186,8 @@ export interface StockFrontData {
   signals: CardFrontSignals;
   /** 포모 점수(척추) — C·L·라벨. 카드 점수/라벨/헤드라인의 단일 출처. */
   fomo: FomoScoreResult;
+  /** 실데이터가 있는 축만 동일 가중치로 재정규화한 종합 기업 점수. */
+  companyScore?: CompanyScoreResult;
   /** TA 셀렉터가 고른 사실 1개 — 점수/진열이 아니라 카드·상세 보조 문맥. */
   taFact?: TaFact;
   /** 차트분석(TA) 전체 스냅샷 — 뎁스 '차트분석' 탭용. 관측 서술 facts 배열(non-lite에서만). */
@@ -437,6 +442,13 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     currency: "KRW",
   });
   const chartSeries = buildChartSeries(snapshot.candles);
+  const companyScore = computeCompanyScore({
+    signals,
+    verdict,
+    wyckoff,
+    currentPrice: snapshot.price,
+    asOf: snapshot.fetchedAt,
+  });
   return {
     ...base,
     fomo,
@@ -444,6 +456,7 @@ async function assembleCoinStockFront(market: string, lite: boolean): Promise<St
     ta,
     verdict,
     wyckoff,
+    companyScore,
     ...(chartSeries ? { chartSeries } : {}),
     // 캔들차트(Phase A) — 국·미와 동일하게 non-lite 에서 실제 일봉 제공.
     ...(snapshot.candles.length > 0 ? { candles: snapshot.candles.slice(-260) } : {}),
@@ -474,6 +487,7 @@ export async function assembleStockFront(
     const cachedFront = await assembleUsCachedStockFront(stock, coverage, { ...options, symbol: usSymbol }).catch(() => null);
     if (options.lite === true) return cachedFront ?? { signals: {}, fomo: computeFomoScore({}), sparkline: [] };
 
+    const basicsPromise = fetchUsStockBasics(stock, usSymbol, false).catch(() => null);
     let daily = await fetchUsDailyCandles(usSymbol, 260).catch(() => ({ candles: [], closes: [], volumes: [] }));
     if (daily.candles.length === 0) {
       daily = await fetchNasdaqDailyCandles(usSymbol, 365).catch(() => ({ candles: [], closes: [], volumes: [] }));
@@ -512,6 +526,17 @@ export async function assembleStockFront(
       ...(typeof verdict?.invalidationLevel === "number" ? { invalidationLevel: verdict.invalidationLevel } : {}),
       currency: "USD",
     });
+    const basics = await basicsPromise;
+    const financials = companyFinancialsFromBasics(basics);
+    const latestPrice = daily.closes.at(-1);
+    const companyScore = computeCompanyScore({
+      ...(financials ? { financials } : {}),
+      signals,
+      verdict,
+      wyckoff,
+      ...(typeof latestPrice === "number" ? { currentPrice: latestPrice } : {}),
+      ...(signals.asOf ? { asOf: signals.asOf } : {}),
+    });
     const chartSeries = buildChartSeries(daily.candles);
     return {
       signals,
@@ -520,6 +545,7 @@ export async function assembleStockFront(
       ta,
       verdict,
       wyckoff,
+      companyScore,
       ...(daily.candles.length > 0 ? { candles: daily.candles.slice(-260) } : {}),
       ...(chartSeries ? { chartSeries } : {}),
       sparkline,
@@ -588,6 +614,16 @@ export async function assembleStockFront(
     ...(typeof verdict?.invalidationLevel === "number" ? { invalidationLevel: verdict.invalidationLevel } : {}),
     currency: "KRW",
   });
+  const financials = companyFinancialsFromBasics(basics);
+  const latestPrice = daily.closes.at(-1);
+  const companyScore = computeCompanyScore({
+    ...(financials ? { financials } : {}),
+    signals,
+    verdict,
+    wyckoff,
+    ...(typeof latestPrice === "number" ? { currentPrice: latestPrice } : {}),
+    ...(signals.asOf ? { asOf: signals.asOf } : {}),
+  });
   const chartSeries = lite ? undefined : buildChartSeries(daily.candles);
 
   return {
@@ -596,6 +632,7 @@ export async function assembleStockFront(
     ...(taFact ? { taFact } : {}),
     ...(ta ? { ta } : {}),
     verdict,
+    companyScore,
     ...(!lite ? { wyckoff } : {}),
     ...(!lite && daily.candles.length > 0 ? { candles: daily.candles.slice(-260) } : {}),
     ...(chartSeries ? { chartSeries } : {}),

--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  companyFinancialsFromBasics,
+  computeCompanyScore,
+  mergeCompanyScoreResults,
+  withCompanyQuietScore,
+  type CompanyScoreInput,
+  type StockBasics,
+} from "../src";
+
+const accumulation: CompanyScoreInput = {
+  financials: {
+    currentPer: 6.4,
+    currentPbr: 0.8,
+    perHistory: [14, 11, 9, 8, 7],
+    pbrHistory: [1.4, 1.2, 1.1, 1.0, 0.9],
+    valuationHistoryLabel: "최근 5개년",
+    revenue: [100, 120, 156],
+    operatingIncome: [5, 11, 24],
+    periods: ["2023", "2024", "2025"],
+  },
+  signals: { foreignNetStreak: 5, institutionNetStreak: 3 },
+  verdict: {
+    stance: "enter",
+    stanceText: "근거 확인",
+    phase: "accumulation",
+    evidence: [],
+    invalidation: "90 아래",
+    invalidationLevel: 90,
+    confidence: "high",
+  },
+  wyckoff: {
+    sourceLength: 260,
+    zones: [],
+    currentZone: {
+      kind: "accumulation",
+      startIndex: 200,
+      endIndex: 259,
+      weeks: 7,
+      low: 88,
+      high: 104,
+      rangePct: 18,
+      priceChangePct: 4,
+      label: "매집 추정 구간",
+      evidence: [],
+    },
+    events: [
+      { kind: "pullback", index: 258, price: 100, label: "첫 눌림목", explanation: "MA20 지지", retracementPct: 38 },
+    ],
+  },
+  currentPrice: 100,
+  quiet: { quietScore: 62, signalScore: 74, hypePenalty: 12 },
+  asOf: "2026-07-19",
+};
+
+describe("company score", () => {
+  it("uses six evidence-backed axes and derives the combined label", () => {
+    const result = computeCompanyScore(accumulation);
+    expect(result.availableAxisCount).toBe(6);
+    expect(result.omittedAxes).toEqual([]);
+    expect(result.label).toBe("역사 밴드 하단 + 매집 7주차");
+    expect(result.axes.find((axis) => axis.key === "valuation")?.evidence[0]).toContain("PER 6.40배");
+    expect(result.axes.find((axis) => axis.key === "quiet")?.evidence[0]).toBe("신호 74.0 - 화제성 12.0 = 62.0");
+  });
+
+  it("excludes missing financial axes and re-normalizes the remaining axes", () => {
+    const result = computeCompanyScore({
+      signals: { foreignNetStreak: 4 },
+      verdict: accumulation.verdict,
+      wyckoff: accumulation.wyckoff,
+      currentPrice: 100,
+      quiet: { quietScore: 48 },
+    });
+    expect(result.availableAxisCount).toBe(3);
+    expect(result.omittedAxes).toEqual(expect.arrayContaining(["valuation", "growth", "profitability"]));
+    const expected = Math.round(result.axes.reduce((sum, axis) => sum + axis.score, 0) / result.axes.length);
+    expect(result.score).toBe(expected);
+  });
+
+  it("keeps a selected quiet score without dropping insider evidence", () => {
+    const base = computeCompanyScore({ insiderPurchaseConfirmed: true, verdict: accumulation.verdict });
+    const result = withCompanyQuietScore(base, { quietScore: 55, signalScore: 70, hypePenalty: 15 });
+    expect(result.axes.find((axis) => axis.key === "flow")?.evidence).toContain("내부자 공개시장 매수 공시 확인");
+    expect(result.axes.find((axis) => axis.key === "quiet")?.score).toBe(69);
+  });
+
+  it("preserves daily flow and quiet axes when fresh financial and chart axes arrive", () => {
+    const seed = computeCompanyScore({
+      signals: { foreignNetStreak: 5 },
+      quiet: { quietScore: 64, signalScore: 78, hypePenalty: 14 },
+    });
+    const fresh = computeCompanyScore({
+      financials: accumulation.financials,
+      verdict: accumulation.verdict,
+      wyckoff: accumulation.wyckoff,
+      currentPrice: accumulation.currentPrice,
+    });
+    const merged = mergeCompanyScoreResults(seed, fresh)!;
+
+    expect(merged.axes.map((axis) => axis.key)).toEqual([
+      "valuation",
+      "growth",
+      "profitability",
+      "flow",
+      "chart",
+      "quiet",
+    ]);
+    expect(merged.score).toBe(
+      Math.round(merged.axes.reduce((sum, axis) => sum + axis.score, 0) / merged.axes.length)
+    );
+    expect(merged.axes.find((axis) => axis.key === "flow")).toEqual(
+      seed.axes.find((axis) => axis.key === "flow")
+    );
+    expect(merged.availableAxisCount).toBe(6);
+  });
+
+  it("is deterministic and produces discriminating scores across five profiles", () => {
+    const profiles: CompanyScoreInput[] = [
+      accumulation,
+      { ...accumulation, financials: { ...accumulation.financials!, currentPer: 18, currentPbr: 1.5 }, quiet: { quietScore: 20 } },
+      {
+        financials: { revenue: [100, 90, 72], operatingIncome: [12, 5, -4], periods: ["2023", "2024", "2025"] },
+        verdict: { stance: "avoid", stanceText: "분산", phase: "distribution", evidence: [], confidence: "medium" },
+        quiet: { quietScore: 12 },
+      },
+      {
+        financials: { revenue: [100, 130, 180], operatingIncome: [8, 18, 40], periods: ["2023", "2024", "2025"] },
+        verdict: { stance: "watch", stanceText: "상승", phase: "markup", evidence: [], confidence: "medium" },
+        quiet: { quietScore: 35 },
+      },
+      { insiderPurchaseConfirmed: true, quiet: { quietScore: 72, signalScore: 80, hypePenalty: 8 } },
+    ];
+    const scores = profiles.map((profile) => computeCompanyScore(profile).score!);
+    expect(computeCompanyScore(accumulation)).toEqual(computeCompanyScore(accumulation));
+    expect(new Set(scores).size).toBeGreaterThanOrEqual(4);
+    expect(Math.max(...scores) - Math.min(...scores)).toBeGreaterThanOrEqual(20);
+  });
+
+  it("reads real raw financial series and does not infer valuation without history", () => {
+    const basics: StockBasics = {
+      name: "테스트",
+      metrics: [{ label: "지금 주가는 이익의", value: "8.4배", term: "PER" }],
+      financials: {
+        periods: [
+          { title: "2023", estimate: false },
+          { title: "2024", estimate: false },
+          { title: "2025", estimate: false },
+        ],
+        rows: [
+          { label: "벌어들인 돈(매출)", values: ["100억", "120억", "150억"], rawValues: [100, 120, 150] },
+          { label: "남긴 돈(영업이익)", values: ["5억", "12억", "24억"], rawValues: [5, 12, 24] },
+        ],
+      },
+    };
+    const input = companyFinancialsFromBasics(basics)!;
+    const result = computeCompanyScore({ financials: input });
+    expect(result.axes.map((axis) => axis.key)).toEqual(["growth", "profitability"]);
+    expect(result.omittedAxes).toContain("valuation");
+  });
+});

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -1,0 +1,372 @@
+import type { StockBasics } from "../stock-basics";
+import type { CardFrontSignals } from "./card-front-hook";
+import type { CardVerdict } from "./verdict";
+import type { WyckoffAnalysis } from "./wyckoff-analysis";
+
+export type CompanyScoreAxisKey = "valuation" | "growth" | "profitability" | "flow" | "chart" | "quiet";
+
+export interface CompanyScoreAxis {
+  key: CompanyScoreAxisKey;
+  label: string;
+  score: number;
+  evidence: string[];
+}
+
+export interface CompanyFinancialScoreInput {
+  currentPer?: number;
+  currentPbr?: number;
+  currentPsr?: number;
+  perHistory?: number[];
+  pbrHistory?: number[];
+  psrHistory?: number[];
+  valuationHistoryLabel?: string;
+  revenue?: number[];
+  operatingIncome?: number[];
+  periods?: string[];
+}
+
+export interface CompanyQuietScoreInput {
+  quietScore: number;
+  signalScore?: number;
+  hypePenalty?: number;
+}
+
+export interface CompanyScoreInput {
+  financials?: CompanyFinancialScoreInput;
+  signals?: Pick<CardFrontSignals, "foreignNetStreak" | "institutionNetStreak">;
+  insiderPurchaseConfirmed?: boolean;
+  whaleStrength?: number;
+  verdict?: CardVerdict;
+  wyckoff?: WyckoffAnalysis;
+  currentPrice?: number;
+  quiet?: CompanyQuietScoreInput;
+  asOf?: string;
+}
+
+export interface CompanyScoreResult {
+  score: number | null;
+  label: string;
+  interpretation: string;
+  axes: CompanyScoreAxis[];
+  availableAxisCount: number;
+  omittedAxes: CompanyScoreAxisKey[];
+  asOf?: string;
+}
+
+const AXIS_LABEL: Record<CompanyScoreAxisKey, string> = {
+  valuation: "밸류에이션",
+  growth: "성장",
+  profitability: "수익성·체력",
+  flow: "수급",
+  chart: "차트 타이밍",
+  quiet: "조용함",
+};
+
+const ALL_AXES = Object.keys(AXIS_LABEL) as CompanyScoreAxisKey[];
+const clamp = (value: number, min = 0, max = 100) => Math.max(min, Math.min(max, value));
+const finite = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+const pct = (value: number) => `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+
+function lastTwo(values: readonly number[] | undefined): [number, number] | undefined {
+  const clean = (values ?? []).filter(Number.isFinite);
+  return clean.length >= 2 ? [clean[clean.length - 2]!, clean[clean.length - 1]!] : undefined;
+}
+
+function yoy(pair: [number, number] | undefined): number | undefined {
+  if (!pair || pair[0] === 0) return undefined;
+  return ((pair[1] - pair[0]) / Math.abs(pair[0])) * 100;
+}
+
+function historicalPosition(current: number | undefined, history: readonly number[] | undefined): number | undefined {
+  if (!finite(current)) return undefined;
+  const clean = (history ?? []).filter((value) => Number.isFinite(value) && value > 0);
+  if (clean.length < 3) return undefined;
+  const low = Math.min(...clean);
+  const high = Math.max(...clean);
+  if (high === low) return current <= low ? 0 : 100;
+  return clamp(((current - low) / (high - low)) * 100);
+}
+
+function valuationAxis(financials: CompanyFinancialScoreInput | undefined): CompanyScoreAxis | undefined {
+  if (!financials) return undefined;
+  const operating = lastTwo(financials.operatingIncome)?.[1];
+  const useSales = finite(operating) && operating <= 0;
+  const candidates = useSales
+    ? [{ term: "PSR", value: financials.currentPsr, history: financials.psrHistory }]
+    : [
+        { term: "PER", value: financials.currentPer, history: financials.perHistory },
+        { term: "PBR", value: financials.currentPbr, history: financials.pbrHistory },
+      ];
+  const available = candidates.flatMap((candidate) => {
+    const position = historicalPosition(candidate.value, candidate.history);
+    return finite(candidate.value) && finite(position) ? [{ ...candidate, position }] : [];
+  });
+  if (available.length === 0) return undefined;
+  const score = Math.round(available.reduce((sum, item) => sum + (100 - item.position), 0) / available.length);
+  const band = financials.valuationHistoryLabel ?? `최근 ${available[0]!.history?.length ?? 0}개년`;
+  return {
+    key: "valuation",
+    label: AXIS_LABEL.valuation,
+    score: clamp(score),
+    evidence: available.map((item) => {
+      const position = Math.round(item.position);
+      const bandPosition = position <= 50 ? `하단 ${position}%` : `상단 ${100 - position}%`;
+      return `${item.term} ${item.value!.toFixed(2)}배 · ${band} 밴드 ${bandPosition}`;
+    }),
+  };
+}
+
+function growthAxis(financials: CompanyFinancialScoreInput | undefined): CompanyScoreAxis | undefined {
+  if (!financials) return undefined;
+  const revenueYoy = yoy(lastTwo(financials.revenue));
+  const operatingYoy = yoy(lastTwo(financials.operatingIncome));
+  const components: number[] = [];
+  if (finite(revenueYoy)) components.push(clamp(((revenueYoy + 20) / 50) * 100));
+  if (finite(operatingYoy)) components.push(clamp(((operatingYoy + 50) / 150) * 100));
+  if (components.length === 0) return undefined;
+  const evidence: string[] = [];
+  const latest = financials.periods?.at(-1);
+  if (finite(revenueYoy)) evidence.push(`매출 YoY ${pct(revenueYoy)}${latest ? ` · ${latest}` : ""}`);
+  if (finite(operatingYoy)) evidence.push(`영업이익 YoY ${pct(operatingYoy)}${latest ? ` · ${latest}` : ""}`);
+  const revenue = financials.revenue ?? [];
+  if (revenue.length >= 3 && revenue.at(-2)! !== 0 && revenue.at(-3)! !== 0) {
+    const previous = ((revenue.at(-2)! - revenue.at(-3)!) / Math.abs(revenue.at(-3)!)) * 100;
+    if (finite(revenueYoy)) evidence.push(`매출 성장 ${revenueYoy >= previous ? "가속" : "감속"} · 직전 ${pct(previous)}`);
+  }
+  return {
+    key: "growth",
+    label: AXIS_LABEL.growth,
+    score: Math.round(components.reduce((sum, value) => sum + value, 0) / components.length),
+    evidence,
+  };
+}
+
+function profitabilityAxis(financials: CompanyFinancialScoreInput | undefined): CompanyScoreAxis | undefined {
+  if (!financials) return undefined;
+  const revenue = lastTwo(financials.revenue);
+  const operating = lastTwo(financials.operatingIncome);
+  if (!revenue || !operating || revenue[1] === 0) return undefined;
+  const currentMargin = (operating[1] / Math.abs(revenue[1])) * 100;
+  const previousMargin = revenue[0] === 0 ? undefined : (operating[0] / Math.abs(revenue[0])) * 100;
+  let score = clamp(50 + currentMargin * 1.6);
+  if (finite(previousMargin)) score = clamp(score + clamp(currentMargin - previousMargin, -10, 10));
+  return {
+    key: "profitability",
+    label: AXIS_LABEL.profitability,
+    score: Math.round(score),
+    evidence: [
+      `영업이익률 ${currentMargin.toFixed(1)}% · ${operating[1] >= 0 ? "흑자" : "적자"}`,
+      ...(finite(previousMargin) ? [`직전 ${previousMargin.toFixed(1)}% → 현재 ${currentMargin.toFixed(1)}%`] : []),
+    ],
+  };
+}
+
+function flowAxis(input: CompanyScoreInput): CompanyScoreAxis | undefined {
+  const foreign = input.signals?.foreignNetStreak;
+  const institution = input.signals?.institutionNetStreak;
+  const whale = input.whaleStrength;
+  if (!finite(foreign) && !finite(institution) && input.insiderPurchaseConfirmed !== true && !finite(whale)) return undefined;
+  let score = 50;
+  const evidence: string[] = [];
+  if (finite(foreign) && foreign !== 0) {
+    score += clamp(foreign, -8, 8) * 4;
+    evidence.push(`외국인 ${Math.abs(foreign)}일 연속 순${foreign > 0 ? "매수" : "매도"}`);
+  }
+  if (finite(institution) && institution !== 0) {
+    score += clamp(institution, -8, 8) * 4;
+    evidence.push(`기관 ${Math.abs(institution)}일 연속 순${institution > 0 ? "매수" : "매도"}`);
+  }
+  if (input.insiderPurchaseConfirmed) {
+    score += 24;
+    evidence.push("내부자 공개시장 매수 공시 확인");
+  }
+  if (finite(whale)) {
+    score += clamp(whale, -1, 1) * 25;
+    evidence.push(`고래 신호 강도 ${whale.toFixed(2)}`);
+  }
+  return { key: "flow", label: AXIS_LABEL.flow, score: Math.round(clamp(score)), evidence };
+}
+
+function chartAxis(input: CompanyScoreInput): CompanyScoreAxis | undefined {
+  const phase = input.wyckoff?.currentZone?.kind ?? input.verdict?.phase;
+  const events = input.wyckoff?.events ?? [];
+  if (!phase && events.length === 0 && !finite(input.verdict?.invalidationLevel)) return undefined;
+  const phaseScore = { accumulation: 74, markup: 64, distribution: 26, markdown: 30 } as const;
+  let score = phase ? phaseScore[phase] : 50;
+  const evidence: string[] = [];
+  const zone = input.wyckoff?.currentZone;
+  if (zone) evidence.push(zone.label.includes("주차") ? zone.label : `${zone.label} · ${zone.weeks}주차`);
+  else if (phase) evidence.push(`${phase === "accumulation" ? "매집" : phase === "markup" ? "상승" : phase === "distribution" ? "분산" : "하락"} 국면`);
+  const latestEvent = [...events].reverse().find((event) => ["spring", "pullback", "impulse", "upthrust"].includes(event.kind));
+  if (latestEvent) {
+    score += latestEvent.kind === "spring" ? 12 : latestEvent.kind === "pullback" ? 9 : latestEvent.kind === "impulse" ? 5 : -14;
+    evidence.push(latestEvent.label);
+  }
+  if (finite(input.currentPrice) && finite(input.verdict?.invalidationLevel) && input.currentPrice > 0) {
+    const distance = ((input.currentPrice - input.verdict.invalidationLevel) / input.currentPrice) * 100;
+    if (distance >= 0 && distance <= 12) score += 6;
+    else if (distance < 0) score -= 16;
+    evidence.push(`무효선 거리 ${pct(distance)}`);
+  }
+  return { key: "chart", label: AXIS_LABEL.chart, score: Math.round(clamp(score)), evidence };
+}
+
+function quietAxis(quiet: CompanyQuietScoreInput | undefined): CompanyScoreAxis | undefined {
+  if (!quiet || !finite(quiet.quietScore)) return undefined;
+  const score = Math.round(clamp((quiet.quietScore / 80) * 100));
+  const equation = finite(quiet.signalScore) && finite(quiet.hypePenalty)
+    ? `신호 ${quiet.signalScore.toFixed(1)} - 화제성 ${quiet.hypePenalty.toFixed(1)} = ${quiet.quietScore.toFixed(1)}`
+    : `quietScore ${quiet.quietScore.toFixed(1)}`;
+  return { key: "quiet", label: AXIS_LABEL.quiet, score, evidence: [equation] };
+}
+
+function axisOf(axes: readonly CompanyScoreAxis[], key: CompanyScoreAxisKey): CompanyScoreAxis | undefined {
+  return axes.find((axis) => axis.key === key);
+}
+
+function chartWeeks(axes: readonly CompanyScoreAxis[], input: CompanyScoreInput): number | undefined {
+  const inputWeeks = input.wyckoff?.currentZone?.weeks;
+  if (finite(inputWeeks)) return inputWeeks;
+  const chartEvidence = axisOf(axes, "chart")?.evidence.join(" ") ?? "";
+  const parsed = Number(chartEvidence.match(/(\d+)주차/u)?.[1]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function scoreLabel(axes: readonly CompanyScoreAxis[], input: CompanyScoreInput): string {
+  const value = axisOf(axes, "valuation");
+  const growth = axisOf(axes, "growth");
+  const flow = axisOf(axes, "flow");
+  const chart = axisOf(axes, "chart");
+  const quiet = axisOf(axes, "quiet");
+  const weeks = chartWeeks(axes, input);
+  if ((value?.score ?? 0) >= 70 && (chart?.score ?? 0) >= 65) {
+    return `역사 밴드 하단 + ${weeks ? `매집 ${weeks}주차` : "차트 타이밍 우위"}`;
+  }
+  if ((growth?.score ?? 0) >= 70 && finite(value?.score) && value!.score <= 40) return "성장은 강하지만 밸류 부담";
+  if ((chart?.score ?? 0) <= 35) {
+    const distribution = input.verdict?.phase === "distribution" || chart?.evidence.some((item) => item.includes("분산"));
+    return `${distribution ? "분산" : "하락"} 신호 우세`;
+  }
+  if ((flow?.score ?? 0) >= 70 && (quiet?.score ?? 0) >= 65) return "조용한 수급 유입 + 낮은 화제성";
+  if ((chart?.score ?? 0) >= 65) return weeks ? `매집 추정 ${weeks}주차` : "차트 타이밍 우위";
+  if ((growth?.score ?? 0) >= 70) return "성장 가속이 가장 강한 축";
+  const top = [...axes].sort((a, b) => b.score - a.score).slice(0, 2);
+  return top.length > 0 ? `${top.map((axis) => axis.label).join(" + ")} 우위` : "근거 축 수집 중";
+}
+
+function interpretation(axes: readonly CompanyScoreAxis[], label: string): string {
+  if (axes.length === 0) return "계산에 필요한 실데이터가 아직 부족해 종합 점수를 보류했어요.";
+  const sorted = [...axes].sort((a, b) => b.score - a.score);
+  const top = sorted[0]!;
+  const bottom = sorted.at(-1)!;
+  const leadEvidence = top.evidence[0] ?? "확인된 근거";
+  if (top.key === bottom.key) return `${label}. ${leadEvidence}를 근거로 계산했어요.`;
+  return `${label}. 가장 강한 축은 ${top.label} ${top.score}점(${leadEvidence})이고, ${bottom.label} ${bottom.score}점이 상대적으로 약해요.`;
+}
+
+export function computeCompanyScore(input: CompanyScoreInput): CompanyScoreResult {
+  const axes = [
+    valuationAxis(input.financials),
+    growthAxis(input.financials),
+    profitabilityAxis(input.financials),
+    flowAxis(input),
+    chartAxis(input),
+    quietAxis(input.quiet),
+  ].filter((axis): axis is CompanyScoreAxis => axis !== undefined);
+  const score = axes.length > 0 ? Math.round(axes.reduce((sum, axis) => sum + axis.score, 0) / axes.length) : null;
+  const label = scoreLabel(axes, input);
+  return {
+    score,
+    label,
+    interpretation: interpretation(axes, label),
+    axes,
+    availableAxisCount: axes.length,
+    omittedAxes: ALL_AXES.filter((key) => !axes.some((axis) => axis.key === key)),
+    ...(input.asOf ? { asOf: input.asOf } : {}),
+  };
+}
+
+export function withCompanyQuietScore(
+  base: CompanyScoreResult | undefined,
+  quiet: CompanyQuietScoreInput,
+  asOf?: string
+): CompanyScoreResult {
+  const quietScoreAxis = quietAxis(quiet);
+  const axes = [...(base?.axes ?? []).filter((axis) => axis.key !== "quiet"), ...(quietScoreAxis ? [quietScoreAxis] : [])];
+  const score = axes.length > 0 ? Math.round(axes.reduce((sum, axis) => sum + axis.score, 0) / axes.length) : null;
+  const label = scoreLabel(axes, {});
+  const resultAsOf = asOf ?? base?.asOf;
+  return {
+    score,
+    label,
+    interpretation: interpretation(axes, label),
+    axes,
+    availableAxisCount: axes.length,
+    omittedAxes: ALL_AXES.filter((key) => !axes.some((axis) => axis.key === key)),
+    ...(resultAsOf ? { asOf: resultAsOf } : {}),
+  };
+}
+
+/**
+ * 일일 큐레이션(seed)의 수급·조용함 축과 상세 조회(fresh)의 재무·차트 축을 합친다.
+ * 같은 축은 일일 큐레이션 값을 우선하고, 상세 조회는 없던 축만 보강한다.
+ * 카드와 상세가 서로 다른 캐시 시점을 읽어 같은 축의 점수가 흔들리는 일을 막는다.
+ */
+export function mergeCompanyScoreResults(
+  seed: CompanyScoreResult | undefined,
+  fresh: CompanyScoreResult | undefined
+): CompanyScoreResult | undefined {
+  if (!seed) return fresh;
+  if (!fresh) return seed;
+  const byKey = new Map<CompanyScoreAxisKey, CompanyScoreAxis>();
+  for (const axis of fresh.axes) byKey.set(axis.key, axis);
+  for (const axis of seed.axes) byKey.set(axis.key, axis);
+  const axes = ALL_AXES.flatMap((key) => {
+    const axis = byKey.get(key);
+    return axis ? [axis] : [];
+  });
+  const score = axes.length > 0 ? Math.round(axes.reduce((sum, axis) => sum + axis.score, 0) / axes.length) : null;
+  const label = scoreLabel(axes, {});
+  const asOf = fresh.asOf ?? seed.asOf;
+  return {
+    score,
+    label,
+    interpretation: interpretation(axes, label),
+    axes,
+    availableAxisCount: axes.length,
+    omittedAxes: ALL_AXES.filter((key) => !byKey.has(key)),
+    ...(asOf ? { asOf } : {}),
+  };
+}
+
+function metricNumber(basics: StockBasics, term: string): number | undefined {
+  const metric = basics.metrics.find((item) => item.term === term);
+  const value = metric?.value.replace(/,/g, "").match(/-?\d+(?:\.\d+)?/)?.[0];
+  const parsed = value ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function companyFinancialsFromBasics(basics: StockBasics | null | undefined): CompanyFinancialScoreInput | undefined {
+  if (!basics) return undefined;
+  const financials = basics.financials;
+  const actualIndexes = financials?.periods.flatMap((period, index) => (period.estimate ? [] : [index])) ?? [];
+  const actualValues = (raw: Array<number | null> | undefined) =>
+    actualIndexes.map((index) => raw?.[index]).filter((value): value is number => finite(value));
+  const revenue = actualValues(financials?.rows.find((row) => row.label.includes("매출"))?.rawValues);
+  const operatingIncome = actualValues(financials?.rows.find((row) => row.label.includes("영업이익"))?.rawValues);
+  const periods = actualIndexes.map((index) => financials!.periods[index]!.title);
+  const currentPer = metricNumber(basics, "PER");
+  const currentPbr = metricNumber(basics, "PBR");
+  const input: CompanyFinancialScoreInput = {
+    ...(finite(currentPer) ? { currentPer } : {}),
+    ...(finite(currentPbr) ? { currentPbr } : {}),
+    ...(basics.valuationHistory?.per ? { perHistory: basics.valuationHistory.per } : {}),
+    ...(basics.valuationHistory?.pbr ? { pbrHistory: basics.valuationHistory.pbr } : {}),
+    ...(basics.valuationHistory?.psr ? { psrHistory: basics.valuationHistory.psr } : {}),
+    ...(basics.valuationHistory?.label ? { valuationHistoryLabel: basics.valuationHistory.label } : {}),
+    ...(revenue.length ? { revenue } : {}),
+    ...(operatingIncome.length ? { operatingIncome } : {}),
+    ...(periods?.length ? { periods } : {}),
+  };
+  return Object.keys(input).length > 0 ? input : undefined;
+}

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -14,3 +14,4 @@ export * from "./fomo-score";
 export * from "./technical-analysis";
 export * from "./verdict";
 export * from "./wyckoff-analysis";
+export * from "./company-score";

--- a/packages/fomo-core/src/stock-basics.ts
+++ b/packages/fomo-core/src/stock-basics.ts
@@ -25,6 +25,8 @@ export interface StockFinancialRow {
   label: string;
   /** 기간별 값(친구 단위로 포맷). periods 순서와 매칭. */
   values: string[];
+  /** 동일 기간의 원시 숫자. YoY·마진 같은 결정론 계산에만 쓰며 결측은 null. */
+  rawValues?: Array<number | null>;
 }
 
 export interface StockFinancials {
@@ -32,6 +34,14 @@ export interface StockFinancials {
   rows: StockFinancialRow[];
   /** 이익 안정성 한 줄(A) — *사실까지만*. 예 "남기는 돈이 해마다 출렁여". */
   note?: string;
+}
+
+export interface StockValuationHistory {
+  periods: string[];
+  per?: number[];
+  pbr?: number[];
+  psr?: number[];
+  label: string;
 }
 
 /** PER → "이게 무슨 뜻" 한 줄(사실: 시장 기대 수준 묘사. 싸다/비싸다 단정 금지). */
@@ -74,6 +84,8 @@ export interface StockBasics {
   metrics: StockMetric[];
   /** 연간 재무(매출·영업이익·순이익 등). 없으면 undefined. */
   financials?: StockFinancials;
+  /** 실제 연간 배수 이력. 확보된 기간만 명시하며 5년 미만을 5년으로 부풀리지 않는다. */
+  valuationHistory?: StockValuationHistory;
 }
 
 const num = (s: string): number | null => {
@@ -202,12 +214,13 @@ export function parseNaverFinanceAnnual(json: unknown): {
     const r = rowList.find((x) => typeof x.title === "string" && (x.title as string).includes(want.match));
     if (!r) continue;
     const cols = (r.columns ?? {}) as Record<string, { value?: string }>;
+    const rawValues = periods.map((p) => num(cols[p.key]?.value ?? ""));
     const values = periods.map((p) => {
       const raw = cols[p.key]?.value;
       return raw ? formatEok(raw) ?? raw : "—";
     });
     // 전부 결측이면 행 자체를 넣지 않는다(가짜로 안 채움).
-    if (values.some((v) => v !== "—")) rows.push({ label: want.label, values });
+    if (values.some((v) => v !== "—")) rows.push({ label: want.label, values, rawValues });
   }
   if (rows.length > 0) {
     const financials: StockFinancials = {
@@ -237,6 +250,19 @@ export function assembleStockBasics(
   const b = parseNaverStockBasic(basic);
   const ti = parseNaverTotalInfos(integration);
   const fa = parseNaverFinanceAnnual(financeAnnual);
+  const finance = (financeAnnual ?? {}) as { financeInfo?: { trTitleList?: Array<{ title?: string; key?: string; isConsensus?: string }>; rowList?: Array<{ title?: string; columns?: Record<string, { value?: string }> }> } };
+  const periodRows = finance.financeInfo?.trTitleList ?? [];
+  const actualPeriods = periodRows.filter((period) => period.isConsensus !== "Y" && period.key);
+  const valuationRow = (title: string) => finance.financeInfo?.rowList?.find((row) => row.title === title);
+  const valuationValues = (title: string) => {
+    const row = valuationRow(title);
+    const values = actualPeriods.map((period) => num(row?.columns?.[period.key!]?.value ?? "")).filter((value): value is number => value !== null && value > 0);
+    return values.length >= 3 ? values : undefined;
+  };
+  const perHistory = valuationValues("PER");
+  const pbrHistory = valuationValues("PBR");
+  const psrHistory = valuationValues("PSR");
+  const historyYears = Math.max(perHistory?.length ?? 0, pbrHistory?.length ?? 0, psrHistory?.length ?? 0);
   return {
     name: b.name || name,
     ...(b.market ? { market: b.market } : {}),
@@ -247,5 +273,16 @@ export function assembleStockBasics(
     ...(fa.summary ? { summary: fa.summary } : {}),
     metrics: ti.metrics,
     ...(fa.financials ? { financials: fa.financials } : {}),
+    ...(historyYears >= 3
+      ? {
+          valuationHistory: {
+            periods: actualPeriods.map((period) => (period.title ?? "").replace(/\.$/, "")),
+            ...(perHistory ? { per: perHistory } : {}),
+            ...(pbrHistory ? { pbr: pbrHistory } : {}),
+            ...(psrHistory ? { psr: psrHistory } : {}),
+            label: `최근 ${historyYears}개년`,
+          },
+        }
+      : {}),
   };
 }


### PR DESCRIPTION
## 변경
- 관심온도/FOMO 점수를 실데이터 기반 종합 기업 점수로 교체
- 밸류·성장·수익성·수급·차트·조용함 6축을 결정론적으로 계산하고 누락 축은 재정규화
- 카드 점수/조합 라벨, 상세 SVG 레이더/축별 근거, 30일 점수대별 사후 승률 연결
- 시장 온도 UI 제거 및 카드/상세 점수 캐시 시점 일관성 보장

## 검증
- npm run test -- company-score performanceScoreBands stock-front daily-30 discovery-supply (54 tests)
- npm run typecheck
- npm run build:web
- npm run build:fomo-web
- 로컬 브라우저: SNT홀딩스 카드 85점 = 상세 85점, 콘솔 오류 0건
- 실데이터 5종목 분포: 32~77점