### PR TITLE
카드와 상세의 기업 점수 기준 시점 고정

### DIFF
--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -84,7 +84,7 @@ describe("company score", () => {
     expect(result.axes.find((axis) => axis.key === "quiet")?.score).toBe(69);
   });
 
-  it("preserves daily flow and quiet axes when fresh financial and chart axes arrive", () => {
+  it("keeps the daily card score stable when a fresh detail score arrives", () => {
     const seed = computeCompanyScore({
       signals: { foreignNetStreak: 5 },
       quiet: { quietScore: 64, signalScore: 78, hypePenalty: 14 },
@@ -97,21 +97,8 @@ describe("company score", () => {
     });
     const merged = mergeCompanyScoreResults(seed, fresh)!;
 
-    expect(merged.axes.map((axis) => axis.key)).toEqual([
-      "valuation",
-      "growth",
-      "profitability",
-      "flow",
-      "chart",
-      "quiet",
-    ]);
-    expect(merged.score).toBe(
-      Math.round(merged.axes.reduce((sum, axis) => sum + axis.score, 0) / merged.axes.length)
-    );
-    expect(merged.axes.find((axis) => axis.key === "flow")).toEqual(
-      seed.axes.find((axis) => axis.key === "flow")
-    );
-    expect(merged.availableAxisCount).toBe(6);
+    expect(merged).toEqual(seed);
+    expect(mergeCompanyScoreResults(undefined, fresh)).toEqual(fresh);
   });
 
   it("is deterministic and produces discriminating scores across five profiles", () => {

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -307,36 +307,12 @@ export function withCompanyQuietScore(
   };
 }
 
-/**
- * 일일 큐레이션(seed)의 수급·조용함 축과 상세 조회(fresh)의 재무·차트 축을 합친다.
- * 같은 축은 일일 큐레이션 값을 우선하고, 상세 조회는 없던 축만 보강한다.
- * 카드와 상세가 서로 다른 캐시 시점을 읽어 같은 축의 점수가 흔들리는 일을 막는다.
- */
+/** 카드에서 찍힌 기준 시점 점수를 상세에서도 고정한다. 검색 진입처럼 seed가 없을 때만 최신 점수를 쓴다. */
 export function mergeCompanyScoreResults(
   seed: CompanyScoreResult | undefined,
   fresh: CompanyScoreResult | undefined
 ): CompanyScoreResult | undefined {
-  if (!seed) return fresh;
-  if (!fresh) return seed;
-  const byKey = new Map<CompanyScoreAxisKey, CompanyScoreAxis>();
-  for (const axis of fresh.axes) byKey.set(axis.key, axis);
-  for (const axis of seed.axes) byKey.set(axis.key, axis);
-  const axes = ALL_AXES.flatMap((key) => {
-    const axis = byKey.get(key);
-    return axis ? [axis] : [];
-  });
-  const score = axes.length > 0 ? Math.round(axes.reduce((sum, axis) => sum + axis.score, 0) / axes.length) : null;
-  const label = scoreLabel(axes, {});
-  const asOf = fresh.asOf ?? seed.asOf;
-  return {
-    score,
-    label,
-    interpretation: interpretation(axes, label),
-    axes,
-    availableAxisCount: axes.length,
-    omittedAxes: ALL_AXES.filter((key) => !byKey.has(key)),
-    ...(asOf ? { asOf } : {}),
-  };
+  return seed ?? fresh;
 }
 
 function metricNumber(basics: StockBasics, term: string): number | undefined {


### PR DESCRIPTION
## 문제
프로덕션 육안 검증에서 GE Vernova 카드 74점이 상세 재무 조회 뒤 71점으로 바뀌는 현상을 확인했습니다. 서로 다른 캐시 시점의 축을 합치며 종합점수가 재계산된 것이 원인입니다.

## 수정
- 오늘 카드에서 찍힌 점수·축·asOf를 상세에서도 그대로 유지
- 검색처럼 카드 seed가 없는 진입만 최신 stock-front 전체 축 사용

## 검증
- company-score 테스트 통과
- 전체 typecheck 통과
- fomo-web production build 통과