### PR TITLE
feat: add daily expert review committee

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -371,6 +371,9 @@ function mergeFrontSeed(
     // 시점·입력이 달라 "카드는 '가격 먼저'인데 뎁스는 '주목 집중'" 불일치를 만든다(2026-07-17 User Zero).
     fomo: seed.fomo ?? fresh.fomo,
     ...(companyScore ? { companyScore } : {}),
+    ...(seed.committeeReview ?? fresh.committeeReview
+      ? { committeeReview: seed.committeeReview ?? fresh.committeeReview }
+      : {}),
     ...(fresh.taFact ?? seed.taFact ? { taFact: fresh.taFact ?? seed.taFact } : {}),
     ...(fresh.ta ?? seed.ta ? { ta: fresh.ta ?? seed.ta } : {}),
     ...(fresh.candles?.length ? { candles: fresh.candles } : seed.candles?.length ? { candles: seed.candles } : {}),
@@ -1441,6 +1444,35 @@ function DepthTabBar({ tab, onChange }: { tab: "why" | "ta"; onChange: (t: "why"
         );
       })}
     </div>
+  );
+}
+
+function ExpertCommitteeReview({ review }: { review: StockFrontResponse["committeeReview"] | undefined }) {
+  if (!review) return null;
+  const gradeTone = (grade: "A" | "B" | "C") => grade === "A" ? "#D8FF3A" : grade === "B" ? "#f4f5f7" : "#8a8f98";
+  return (
+    <section className="mt-4 border-y border-hairline bg-surface/70 px-4 py-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-pixel text-sm text-whiteout">전문 분석</p>
+        <span className="text-[10px] text-muted">사실 대조 완료 · {review.reviewedAt.slice(0, 10)}</span>
+      </div>
+      <div className="mt-4 grid gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <p className="text-xs font-bold text-muted">차트·타이밍</p>
+            <span className="font-pixel text-xs" style={{ color: gradeTone(review.timingGrade) }}>{review.timingGrade}</span>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-whiteout">{cleanText(review.tradingView)}</p>
+        </div>
+        <div className="border-t border-hairline pt-4">
+          <div className="flex items-center gap-2">
+            <p className="text-xs font-bold text-muted">기업·재무</p>
+            <span className="font-pixel text-xs" style={{ color: gradeTone(review.valuationGrade) }}>{review.valuationGrade}</span>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-whiteout">{cleanText(review.fundamentalView)}</p>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -2528,6 +2560,7 @@ export function StockInsightView({
           {/* 가격 먼저 — 일반 주식 상세 화면의 첫 독해 지점. */}
           <StockPriceHeader basics={basics} front={front} />
           <CompanyScoreRadar result={front?.companyScore} />
+          <ExpertCommitteeReview review={front?.committeeReview} />
           <DiscoveryOverview front={front} insight={insight} context={context} />
           <DepthTabBar tab={depthTab} onChange={setDepthTab} />
           {depthTab === "ta" ? (

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -50,6 +50,7 @@ export type FrontEntry = {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
   companyScore?: CompanyScoreResult;
+  committeeReview?: NonNullable<StockFrontResponse["committeeReview"]>;
   taFact?: TaFact;
   sparkline: number[];
   priceText?: string;

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -514,6 +514,15 @@ export interface StockFrontResponse {
   signals: import("@fomo/core").CardFrontSignals;
   fomo: import("@fomo/core").FomoScoreResult;
   companyScore?: import("@fomo/core").CompanyScoreResult;
+  committeeReview?: {
+    runId: string;
+    reviewedAt: string;
+    tradingView: string;
+    fundamentalView: string;
+    timingGrade: "A" | "B" | "C";
+    valuationGrade: "A" | "B" | "C";
+    factChecked: true;
+  };
   taFact?: import("@fomo/core").TaFact;
   ta?: import("@fomo/core").TechnicalAnalysisSnapshot;
   /** 캔들차트용 실제 일봉 OHLCV. non-lite 응답에 최대 260거래일. */
@@ -755,6 +764,14 @@ export interface Daily30Response extends DiscoveryResponse {
       hypePenalty: number;
     }>;
     assetCounts: Record<Daily30AssetClass, number>;
+    committee?: {
+      runId: string;
+      version: string;
+      reviewedAt: string;
+      candidateCount: number;
+      selectedCount: number;
+      callCount: number;
+    };
   };
 }
 

--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyAnalystFactGate,
+  runExpertReviewCommittee,
+  validateAgentNumbers,
+  type CommitteeAgentCaller,
+  type CommitteeCandidateInput,
+} from "../../lib/expert-review-committee";
+import type { Daily30Response } from "../../lib/daily-30";
+
+const input: CommitteeCandidateInput = {
+  candidateId: "stock:KR:000000:테스트",
+  assetClass: "kr-stock",
+  stock: { canonical: "테스트", naverCode: "000000", country: "KR", market: "KOSPI", sector: "테스트" },
+  material: { headline: "공시 확인", sourceLabel: "DART" },
+  selection: { signalScore: 82, hypePenalty: 7, quietScore: 75 },
+  trading: {
+    signals: { changePct: 1.5, volumeRatio: 2.1 },
+    verdict: {
+      stance: "watch",
+      stanceText: "82,000원 무효선을 확인하는 구간입니다.",
+      evidence: ["거래량 2.1배"],
+      invalidation: "82,000원 이탈 시 무효",
+      invalidationLevel: 82000,
+      confidence: "medium",
+    },
+    candleSummary: {
+      sourceLength: 260,
+      historyLabel: "52주",
+      return20dPct: 1.5,
+      averageVolume20d: 120000,
+      rangeLow: 78000,
+      rangeHigh: 91000,
+      maLatest: { ma20: 83500, ma60: 81000, ma120: 79000 },
+    },
+  },
+  financial: { metrics: [], scoreAxes: [] },
+};
+
+describe("expert committee fact gate", () => {
+  it("입력 JSON에 있는 숫자와 반올림 표기는 허용한다", () => {
+    expect(validateAgentNumbers("거래량 2.1배, 등락률 +1.5%, 무효선 82,000원", input)).toEqual([]);
+  });
+
+  it("입력에 없는 숫자는 문단을 결정론 폴백으로 교체한다", () => {
+    const checked = applyAnalystFactGate("trading", {
+      candidateId: input.candidateId,
+      approved: true,
+      grade: "A",
+      paragraph: "목표가 999,000원까지 열려 있습니다.",
+      concerns: [],
+    }, input);
+    expect(checked.factFallback).toBe(true);
+    expect(checked.invalidNumbers).toContain("999000");
+    expect(checked.paragraph).toBe(input.trading.verdict?.stanceText);
+    expect(checked.paragraph).not.toContain("999");
+  });
+
+  it("공개 daily-30 라우트에는 후보 생성기나 LLM 실행기를 import하지 않는다", () => {
+    const route = readFileSync(new URL("../../app/api/fomo/daily-30/route.ts", import.meta.url), "utf8");
+    expect(route).not.toContain("buildDaily30Response");
+    expect(route).not.toContain("expert-review-committee");
+    expect(route).toContain("getCachedDaily30Response");
+  });
+});
+
+function fakePool(count = 40): Daily30Response {
+  const cards = Array.from({ length: count }, (_, index) => ({
+    kind: "stock" as const,
+    canonical: `테스트코인${index}`,
+    symbol: `KRW-C${String(index).padStart(2, "0")}`,
+    market: "COIN" as const,
+    country: "KR" as const,
+    marquee: false,
+    sector: "코인",
+    headline: "검증 가능한 신호",
+  }));
+  return {
+    asOf: "2026-07-19T00:00:00.000Z",
+    country: "all",
+    stocks: cards.map(({ kind: _kind, ...stock }) => stock),
+    cards,
+    fronts: Object.fromEntries(cards.map((card, index) => [card.canonical, {
+      signals: { changePct: index / 10, asOf: "2026-07-19" },
+      fomo: {} as never,
+      sparkline: [100, 101],
+      priceText: "101원",
+      changeText: "+1%",
+    }])),
+    confidence: "H",
+    source: "test",
+    meta: {
+      targetCount: count,
+      cards: cards.map((card, index) => ({
+        id: `stock:KR:${card.symbol}:${card.canonical}`,
+        assetClass: "coin" as const,
+        quietScore: 80 - index / 10,
+        signalScore: 90 - index / 10,
+        hypePenalty: 10,
+      })),
+      assetCounts: { "kr-stock": 0, "us-stock": 0, coin: count, macro: 0 },
+    },
+  };
+}
+
+describe("expert committee orchestration", () => {
+  it("후보 40장을 두 분석가와 편집장이 검수해 승인 30장만 발행한다", async () => {
+    const caller: CommitteeAgentCaller = async ({ role, input }) => {
+      if (role === "editor") {
+        const candidates = (input as { candidates: Array<{ candidateId: string }> }).candidates;
+        return {
+          ok: true,
+          model: "test-model",
+          content: JSON.stringify({
+            selectedIds: candidates.slice(0, 30).map((candidate) => candidate.candidateId),
+            rejected: candidates.slice(30).map((candidate) => ({ candidateId: candidate.candidateId, reasons: ["구성 중복"] })),
+            compositionSummary: "등급과 조용함을 함께 검수한 구성입니다.",
+          }),
+        };
+      }
+      const candidates = input as CommitteeCandidateInput[];
+      return {
+        ok: true,
+        model: "test-model",
+        content: JSON.stringify({
+          reviews: candidates.map((candidate) => ({
+            candidateId: candidate.candidateId,
+            approved: true,
+            grade: "B",
+            paragraph: role === "trading"
+              ? `${candidate.stock.symbol}의 구간·거래량·무효화 근거를 서로 대조해 타이밍을 검수했습니다.`
+              : `${candidate.stock.symbol}의 공개 재무와 카드 재료를 대조해 기업 체력과 자료 한계를 함께 검수했습니다.`,
+            concerns: [],
+          })),
+        }),
+      };
+    };
+    const publish = vi.fn(async () => {});
+    const result = await runExpertReviewCommittee({
+      caller,
+      buildPool: async () => fakePool(),
+      readPrevious: async () => null,
+      publish,
+      writeFailure: async () => {},
+      writePicks: async () => {},
+    });
+    expect(result.ok).toBe(true);
+    expect(result.report.candidateCount).toBe(40);
+    expect(result.report.selectedCount).toBe(30);
+    expect(result.report.callCount).toBe(17);
+    expect(result.response?.stocks).toHaveLength(30);
+    expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it("에이전트 실패 시 새 활성본을 발행하지 않고 직전 승인본을 유지한다", async () => {
+    const publish = vi.fn(async () => {});
+    const writeFailure = vi.fn(async () => {});
+    const result = await runExpertReviewCommittee({
+      caller: async () => ({ ok: false, content: "", model: "test-model" }),
+      buildPool: async () => fakePool(),
+      readPrevious: async () => ({ runId: "previous", version: "committee-v1", reviewedAt: "2026-07-18", response: fakePool(30), report: {} as never }),
+      publish,
+      writeFailure,
+      writePicks: async () => {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.previousRunRetained).toBe(true);
+    expect(publish).not.toHaveBeenCalled();
+    expect(writeFailure).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/__tests__/lib/expert-review-store.test.ts
+++ b/apps/web/__tests__/lib/expert-review-store.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { writeFeedContent } = vi.hoisted(() => ({ writeFeedContent: vi.fn() }));
+
+vi.mock("../../lib/feed-content-store", () => ({
+  readFeedContent: vi.fn(),
+  readFeedContentByPrefix: vi.fn(),
+  writeFeedContent,
+}));
+
+import { publishCommitteeSnapshot, writeFailedCommitteeRun, type CommitteeRunReport } from "../../lib/expert-review-store";
+
+const report: CommitteeRunReport = {
+  runId: "run-1",
+  version: "committee-v1",
+  date: "2026-07-19",
+  status: "failed",
+  startedAt: "2026-07-19T00:00:00.000Z",
+  completedAt: "2026-07-19T00:01:00.000Z",
+  model: "test-model",
+  callCount: 1,
+  candidateCount: 50,
+  selectedCount: 0,
+  selectedIds: [],
+  reviews: [],
+  compositionSummary: "직전 승인본 유지",
+  assetCounts: {},
+  previousRunRetained: true,
+};
+
+describe("expert committee publication ordering", () => {
+  beforeEach(() => writeFeedContent.mockReset());
+
+  it("실패 실행은 이력만 쓰고 활성 승인본을 교체하지 않는다", async () => {
+    await writeFailedCommitteeRun(report);
+    expect(writeFeedContent).toHaveBeenCalledTimes(1);
+    expect(writeFeedContent.mock.calls[0]?.[0]).toContain("expert-committee:run:");
+    expect(writeFeedContent.mock.calls.some((call) => call[0] === "expert-committee:active")).toBe(false);
+  });
+
+  it("성공 실행은 이력을 먼저 저장한 뒤 활성 승인본을 교체한다", async () => {
+    const published = { ...report, status: "published" as const, selectedCount: 30 };
+    const snapshot = {
+      runId: "run-1",
+      version: "committee-v1",
+      reviewedAt: report.completedAt,
+      response: {} as never,
+      report: published,
+    };
+    await publishCommitteeSnapshot(snapshot, published);
+    expect(writeFeedContent.mock.calls.map((call) => call[0])).toEqual([
+      "expert-committee:run:2026-07-19:run-1",
+      "expert-committee:active",
+    ]);
+  });
+});

--- a/apps/web/app/admin/committee/page.tsx
+++ b/apps/web/app/admin/committee/page.tsx
@@ -1,0 +1,88 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { readCommitteeRunReports, readPublishedCommitteeSnapshot } from "../../../lib/expert-review-store";
+
+const gradeColor = (grade: string) => grade === "A" ? "#d8ff3a" : grade === "B" ? "#f4f5f7" : "#8a8f98";
+
+export default async function CommitteeAuditPage() {
+  const password = process.env.DASHBOARD_PASSWORD;
+  const session = (await cookies()).get("dashboard_session")?.value;
+  if (!password || session !== password) redirect("/login");
+
+  const [active, runs] = await Promise.all([
+    readPublishedCommitteeSnapshot(),
+    readCommitteeRunReports(14),
+  ]);
+  const latest = runs[0];
+
+  return (
+    <main style={{ minHeight: "100vh", padding: "28px clamp(18px, 4vw, 56px)", background: "#050506", color: "#f4f5f7" }}>
+      <header style={{ display: "flex", alignItems: "end", justifyContent: "space-between", gap: 24, borderBottom: "1px solid #25262a", paddingBottom: 18 }}>
+        <div>
+          <p className="eyebrow">FOMO CLUB / DAILY REVIEW</p>
+          <h1 style={{ marginTop: 8, fontSize: 28 }}>전문가 위원회 감사</h1>
+        </div>
+        <div style={{ textAlign: "right", color: "#a6acb6", fontFamily: "var(--font-mono)", fontSize: 12 }}>
+          <div>{active ? `ACTIVE ${active.runId}` : "NO ACTIVE RUN"}</div>
+          <div style={{ marginTop: 5 }}>{active?.reviewedAt ?? "-"}</div>
+        </div>
+      </header>
+
+      {latest && (
+        <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", borderBottom: "1px solid #25262a" }}>
+          {[
+            ["상태", latest.status],
+            ["후보", latest.candidateCount],
+            ["승인", latest.selectedCount],
+            ["AI 호출", latest.callCount],
+            ["모델", latest.model],
+          ].map(([label, value]) => (
+            <div key={String(label)} style={{ padding: "18px 16px", borderRight: "1px solid #25262a" }}>
+              <div className="eyebrow">{label}</div>
+              <div style={{ marginTop: 8, fontFamily: "var(--font-mono)", fontSize: 18 }}>{String(value)}</div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      <section style={{ padding: "24px 0", borderBottom: "1px solid #25262a" }}>
+        <p className="eyebrow">RUN HISTORY</p>
+        <div style={{ marginTop: 12, display: "grid", gap: 1, background: "#25262a" }}>
+          {runs.map((run) => (
+            <div key={run.runId} style={{ display: "grid", gridTemplateColumns: "140px minmax(180px, 1fr) 90px 90px 90px", gap: 12, padding: "12px 14px", background: "#0c0d10", fontSize: 13 }}>
+              <span>{run.date}</span><span style={{ fontFamily: "var(--font-mono)", color: "#a6acb6" }}>{run.runId}</span>
+              <span style={{ color: run.status === "published" ? "#d8ff3a" : "#e16a5a" }}>{run.status}</span>
+              <span>{run.selectedCount}/{run.candidateCount}</span><span>{run.callCount} calls</span>
+            </div>
+          ))}
+          {runs.length === 0 && <div style={{ padding: 18, background: "#0c0d10", color: "#8a8f98" }}>실행 이력이 없습니다.</div>}
+        </div>
+      </section>
+
+      {latest && (
+        <section style={{ padding: "24px 0" }}>
+          <p className="eyebrow">LATEST DECISIONS</p>
+          <p style={{ marginTop: 10, color: "#a6acb6", lineHeight: 1.7 }}>{latest.compositionSummary}</p>
+          <div style={{ marginTop: 18, borderTop: "1px solid #25262a" }}>
+            {latest.reviews.map((review) => (
+              <article key={review.candidateId} style={{ display: "grid", gridTemplateColumns: "minmax(140px, 0.6fr) minmax(260px, 1.7fr) minmax(260px, 1.7fr)", gap: 24, padding: "18px 0", borderBottom: "1px solid #25262a" }}>
+                <div>
+                  <strong>{review.canonical}</strong>
+                  <div style={{ marginTop: 8, color: review.approved ? "#d8ff3a" : "#8a8f98", fontSize: 12 }}>{review.approved ? "APPROVED" : "REJECTED"}</div>
+                  <div style={{ marginTop: 8, display: "flex", gap: 8, fontFamily: "var(--font-mono)" }}>
+                    <span style={{ color: gradeColor(review.timingGrade) }}>T {review.timingGrade}</span>
+                    <span style={{ color: gradeColor(review.valuationGrade) }}>F {review.valuationGrade}</span>
+                  </div>
+                </div>
+                <div><p className="eyebrow">TRADING VIEW</p><p style={{ marginTop: 8, lineHeight: 1.65, color: "#d5d7dc" }}>{review.tradingView}</p></div>
+                <div><p className="eyebrow">FUNDAMENTAL VIEW</p><p style={{ marginTop: 8, lineHeight: 1.65, color: "#d5d7dc" }}>{review.fundamentalView}</p>
+                  {!review.approved && <p style={{ marginTop: 10, color: "#e16a5a", fontSize: 12 }}>{review.rejectionReasons.join(" · ")}</p>}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminPage() {
+  redirect("/admin/committee");
+}

--- a/apps/web/app/api/fomo/committee-report/route.ts
+++ b/apps/web/app/api/fomo/committee-report/route.ts
@@ -1,0 +1,28 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../lib/fomo";
+import { readCommitteeRunReports, readPublishedCommitteeSnapshot } from "../../../../lib/expert-review-store";
+
+export const dynamic = "force-dynamic";
+
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET?.trim();
+  if (cronSecret && request.headers.get("authorization") === `Bearer ${cronSecret}`) return true;
+  const password = process.env.DASHBOARD_PASSWORD;
+  return Boolean(password) && (await cookies()).get("dashboard_session")?.value === password;
+}
+
+export async function GET(request: Request) {
+  if (!(await isAuthorized(request))) {
+    return withCors(NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }));
+  }
+  const requested = Number(new URL(request.url).searchParams.get("limit") ?? "7");
+  const limit = Number.isFinite(requested) ? Math.max(1, Math.min(30, Math.round(requested))) : 7;
+  const [active, runs] = await Promise.all([
+    readPublishedCommitteeSnapshot(),
+    readCommitteeRunReports(limit),
+  ]);
+  return withCors(NextResponse.json({ ok: true, active: active?.report ?? null, runs }, {
+    headers: { "Cache-Control": "no-store" },
+  }));
+}

--- a/apps/web/app/api/fomo/cron/daily-30/route.ts
+++ b/apps/web/app/api/fomo/cron/daily-30/route.ts
@@ -1,29 +1,42 @@
 import { NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { withCors, kstDate } from "../../../../../lib/fomo";
-import type { Daily30Response } from "../../../../../lib/daily-30";
+import { runExpertReviewCommittee } from "../../../../../lib/expert-review-committee";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 60;
+export const maxDuration = 300;
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return true;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
 
 export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return withCors(NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }));
+  }
   const startedAt = Date.now();
   try {
-    const warmUrl = new URL("/api/fomo/daily-30", request.url);
-    const upstream = await fetch(warmUrl, { cache: "no-store" });
-    if (!upstream.ok) throw new Error(`daily-30 warmup ${upstream.status}`);
-    const response = (await upstream.json()) as Daily30Response;
+    const result = await runExpertReviewCommittee();
+    if (result.ok) revalidateTag("daily-30", { expire: 0 });
     return withCors(
       NextResponse.json(
         {
-          ok: true,
-          asOf: response.asOf,
+          ok: result.ok,
+          runId: result.report.runId,
+          status: result.report.status,
           date: kstDate(),
-          cards: response.cards?.length ?? 0,
-          stocks: response.stocks.length,
-          assetCounts: response.meta.assetCounts,
+          model: result.report.model,
+          calls: result.report.callCount,
+          candidates: result.report.candidateCount,
+          selected: result.report.selectedCount,
+          assetCounts: result.report.assetCounts,
+          previousRunRetained: result.previousRunRetained,
+          ...(result.report.error ? { error: result.report.error } : {}),
           elapsedMs: Date.now() - startedAt,
         },
-        { headers: { "Cache-Control": "no-store" } }
+        { status: result.ok ? 200 : 503, headers: { "Cache-Control": "no-store" } }
       )
     );
   } catch (err) {

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -14,6 +14,7 @@ import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContent
 import { buildCoinDiscoveryResponse } from "./coin-discovery";
 import { readTodayFeedContent, type TodayFeedContent } from "./feed-briefing";
 import { readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+import { readPublishedCommitteeSnapshot } from "./expert-review-store";
 
 export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
 
@@ -35,12 +36,21 @@ export interface Daily30Response extends DiscoveryResponse {
     repeatRatio?: number;
     /** 2026-07-12 US 파이프라인 진단(임시) + 원인 설명률(WO 뎁스 재건 E) causeCoverage. */
     debug?: Record<string, number | { movers: number; explained: number; ratio: number }>;
+    /** 일일 전문가 위원회 승인 정보. 없으면 아직 위원회 발행 전인 레거시 응답이다. */
+    committee?: {
+      runId: string;
+      version: string;
+      reviewedAt: string;
+      candidateCount: number;
+      selectedCount: number;
+      callCount: number;
+    };
   };
 }
 
 type CandidateKind = "stock" | "content" | "narrative";
 
-interface Daily30Candidate {
+export interface Daily30Candidate {
   kind: CandidateKind;
   id: string;
   card: DiscoveryDeckCardPayload;
@@ -387,7 +397,8 @@ function responseFromSelected(
   deck: readonly Daily30Candidate[],
   feed: readonly Daily30Candidate[],
   discoveries: readonly DiscoveryResponse[],
-  asOf: string
+  asOf: string,
+  targetCount = DAILY_CARD_TARGET
 ): Daily30Response {
   const fronts: Record<string, DiscoveryFrontSeed> = {};
   const stocks: DiscoveryStockPayload[] = [];
@@ -429,7 +440,7 @@ function responseFromSelected(
     confidence: deck.length >= DAILY_CARD_TARGET ? "H" : deck.length >= 20 ? "M" : "L",
     source: "KR/US discovery·수급·내부자·거래량·고래·매크로 통합 quietScore",
     meta: {
-      targetCount: DAILY_CARD_TARGET,
+      targetCount,
       cards: all.map((candidate) => ({
         id: candidate.id,
         assetClass: candidate.assetClass,
@@ -449,6 +460,29 @@ interface Daily30PicksSnapshot {
   picks: Array<{ canonical: string; headline?: string; price?: number; symbol?: string; naverCode?: string; market?: string; country?: string }>;
 }
 
+export async function writeDaily30PicksSnapshot(response: Daily30Response): Promise<void> {
+  const date = kstDateOf();
+  const stocksByCanonical = new Map(response.stocks.map((stock) => [stock.canonical, stock]));
+  const picks: Daily30PicksSnapshot = {
+    date,
+    picks: Object.entries(response.fronts).flatMap(([canonical, front]) => {
+      const stock = stocksByCanonical.get(canonical);
+      if (!stock) return [];
+      const price = parsePriceText(front.priceText);
+      return [{
+        canonical,
+        ...(stock.headline ? { headline: stock.headline } : {}),
+        ...(typeof price === "number" ? { price } : {}),
+        ...(stock.symbol ? { symbol: stock.symbol } : {}),
+        ...(stock.naverCode ? { naverCode: stock.naverCode } : {}),
+        ...(stock.market ? { market: stock.market } : {}),
+        ...(stock.country ? { country: stock.country } : {}),
+      }];
+    }),
+  };
+  await writeFeedContent(`daily30-picks:${date}`, picks);
+}
+
 /** 어제(가장 최근, 오늘 제외) 30장 스냅샷 — 신선도 로테이션 기준. 없으면 빈 맵(첫날). */
 async function readYesterdayPicks(today: string): Promise<FreshnessSnapshot> {
   const rows = await readFeedContentByPrefix<Daily30PicksSnapshot>("daily30-picks:", 3).catch(
@@ -462,11 +496,18 @@ async function readYesterdayPicks(today: string): Promise<FreshnessSnapshot> {
   return { headlines };
 }
 
-export async function buildDaily30Response(): Promise<Daily30Response> {
+interface Daily30BuildOptions {
+  targetCount?: number;
+  persistPicks?: boolean;
+}
+
+async function buildDaily30ResponseWithOptions(options: Daily30BuildOptions = {}): Promise<Daily30Response> {
+  const targetCount = Math.max(1, Math.min(50, options.targetCount ?? DAILY_CARD_TARGET));
+  const persistPicks = options.persistPicks ?? true;
   const today = kstDateOf();
   const [kr, us, coin, rawContent, feedContent, freshness] = await Promise.all([
-    buildDiscoveryResponse({ country: "KR", targetedMaterial: true, targetedMaterialLimit: 36 }),
-    buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 16 }),
+    buildDiscoveryResponse({ country: "KR", targetedMaterial: true, targetedMaterialLimit: 36, allowAiSynthesis: false }),
+    buildDiscoveryResponse({ country: "US", targetedMaterial: true, targetedMaterialLimit: 16, allowAiSynthesis: false }),
     // 코인(WO 미장·코인 확충) — 시총 상위 30 커버리지. 신호 없으면 stocks 0(쿼터 강제 없음 — 정직).
     buildCoinDiscoveryResponse().catch(
       (): DiscoveryResponse => ({ asOf: "", stocks: [], fronts: {}, confidence: "L", source: "coin unavailable" })
@@ -503,7 +544,7 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
     .filter((c) => c.kind === "content" || c.kind === "narrative")
     .sort((a, b) => b.quietScore - a.quietScore || a.id.localeCompare(b.id))
     .slice(0, FEED_CARD_LIMIT);
-  const deck = selectDaily30Candidates(stockCandidates, DAILY_CARD_TARGET);
+  const deck = selectDaily30Candidates(stockCandidates, targetCount);
 
   // 신선도 스냅샷 저장 — 내일 빌드의 로테이션 기준. 실패해도 응답은 정상(fail-open).
   const picks: Daily30PicksSnapshot = {
@@ -524,12 +565,18 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
         };
       }),
   };
-  await writeFeedContent(`daily30-picks:${today}`, picks).catch(() => {});
+  if (persistPicks) await writeFeedContent(`daily30-picks:${today}`, picks).catch(() => {});
   // 중복률(어제 대비) — 수용 지표(≤50%) 모니터링용.
   const repeatCount = picks.picks.filter((p) => freshness.headlines.has(p.canonical)).length;
   const repeatRatio = picks.picks.length > 0 ? Math.round((repeatCount / picks.picks.length) * 100) / 100 : 0;
 
-  const response = responseFromSelected(deck, feedCandidates, [kr, us, coin], kr.asOf > us.asOf ? kr.asOf : us.asOf);
+  const response = responseFromSelected(
+    deck,
+    feedCandidates,
+    [kr, us, coin],
+    kr.asOf > us.asOf ? kr.asOf : us.asOf,
+    targetCount
+  );
   // 2026-07-12 진단: US 파이프라인 각 단계 카운트 — 미장 1장 원인이 discovery/후보/셀렉션 어디인지.
   // 원인 설명률(WO 뎁스 재건 E — 해자의 측정): ±3% 무버 중 원인(원문 연결·재료 서술)이 붙은 비율.
   // 북극성 지표 ≥0.9 — 급등락 카드를 눌렀을 때 열에 아홉은 답이 있어야 BM을 붙일 자격이 생긴다.
@@ -568,15 +615,31 @@ export async function buildDaily30Response(): Promise<Daily30Response> {
   return { ...response, meta: { ...response.meta, repeatRatio, debug } };
 }
 
+export async function buildDaily30Response(): Promise<Daily30Response> {
+  return buildDaily30ResponseWithOptions();
+}
+
+/**
+ * 위원회 크론 입력. 공개 요청에서 호출하지 않는다.
+ * 기존 결정론 품질 게이트·quietScore·자산군 보정을 그대로 쓰되 편집장이 고를 여유 후보만 50장까지 만든다.
+ */
+export async function buildDaily30CandidatePoolResponse(targetCount = 50): Promise<Daily30Response> {
+  return buildDaily30ResponseWithOptions({ targetCount, persistPicks: false });
+}
+
 /**
  * 공유 캐시 getter — daily-30 라우트와 feed-hub 가 같은 캐시 엔트리를 쓴다(중복 빌드 방지).
  * feed-content 크론이 tags 로 즉시 무효화한다.
  */
 export async function getCachedDaily30Response(): Promise<Daily30Response> {
   const load = unstable_cache(
-    () => buildDaily30Response(),
-    ["fomo-daily-30", cacheVersion(), kstDateOf()],
-    { revalidate: 60 * 60 * 12, tags: ["daily-30"] }
+    async () => {
+      const snapshot = await readPublishedCommitteeSnapshot();
+      if (!snapshot?.response) throw new Error("expert committee has not published a deck yet");
+      return snapshot.response;
+    },
+    ["fomo-daily-30-approved", cacheVersion(), kstDateOf()],
+    { revalidate: 60 * 5, tags: ["daily-30"] }
   );
   return load();
 }

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -136,6 +136,16 @@ export interface DiscoveryFrontSeed {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
   companyScore?: CompanyScoreResult;
+  /** 일일 위원회가 사실 게이트를 통과시킨 전문 분석. 요청 경로에서는 생성하지 않고 승인 스냅샷만 읽는다. */
+  committeeReview?: {
+    runId: string;
+    reviewedAt: string;
+    tradingView: string;
+    fundamentalView: string;
+    timingGrade: "A" | "B" | "C";
+    valuationGrade: "A" | "B" | "C";
+    factChecked: true;
+  };
   sparkline: number[];
   priceText?: string;
   changeText?: string;
@@ -221,6 +231,8 @@ export interface BuildDiscoveryResponseOptions {
   targetedMaterial?: boolean;
   targetedMaterialLimit?: number;
   country?: DiscoveryCountryScope;
+  /** 위원회 후보 생산처럼 결정론 출력이 필요한 경로에서 false. 공개 기본 동작은 유지한다. */
+  allowAiSynthesis?: boolean;
 }
 
 interface RawNaverStock {
@@ -1301,12 +1313,13 @@ function headlineCandidate(
 async function stockPayload(
   row: DiscoveryMarketRow,
   candidate: DiscoveryCandidate,
-  front?: DiscoveryFrontSeed
+  front?: DiscoveryFrontSeed,
+  allowAiSynthesis = true
 ): Promise<DiscoveryStockPayload> {
   const def = resolveStock(candidate.ticker);
   const sector = cleanSectorLabel(candidate.sector) ?? (def ? sectorOf(def.canonical) : undefined);
   const resolvedCandidate = headlineCandidate(row, candidate, sector);
-  const whyDriven = await synthesizeWhyDrivenInsight(resolvedCandidate);
+  const whyDriven = await synthesizeWhyDrivenInsight(resolvedCandidate, { allowAi: allowAiSynthesis });
   const synthesis = whyDriven.insight;
   const frontReason = frontMaterialReason(front);
   const synthesizedWhy = synthesis.headline;
@@ -1607,10 +1620,13 @@ function attachReachedVolumeEvents(
   });
 }
 
-async function hydrateReachedWhySynthesis(candidates: readonly DiscoveryCandidate[]): Promise<DiscoveryCandidate[]> {
+async function hydrateReachedWhySynthesis(
+  candidates: readonly DiscoveryCandidate[],
+  allowAiSynthesis = true
+): Promise<DiscoveryCandidate[]> {
   const results = await mapLimit(candidates, 3, async (candidate) => ({
     ticker: candidate.ticker,
-    result: await synthesizeWhyDrivenInsight(candidate),
+    result: await synthesizeWhyDrivenInsight(candidate, { allowAi: allowAiSynthesis }),
   }));
   return candidates.map((candidate) => {
     const found = results.find((row) => row.status === "fulfilled" && row.value.ticker === candidate.ticker);
@@ -2000,6 +2016,7 @@ function interleaveThemeBundles(
 
 export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOptions = {}): Promise<DiscoveryResponse> {
   const scope = options.country ?? "KR";
+  const allowAiSynthesis = options.allowAiSynthesis ?? true;
   const targetedMaterialEnabled = options.targetedMaterial ?? TARGETED_MATERIAL_DEFAULT_ENABLED;
   const deckCardCount = discoveryDeckCardCount(scope);
   const targetedMaterialLimit = targetedMaterialEnabled
@@ -2219,7 +2236,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
   );
   ranked = attachReachedVolumeEvents(ranked, rowsByTicker, dailyByTicker, asOf);
   if (scope !== "US") {
-    ranked = await hydrateReachedWhySynthesis(ranked);
+    ranked = await hydrateReachedWhySynthesis(ranked, allowAiSynthesis);
   }
   logDiscoverySignalCoverage("after-rank", ranked);
   const sparklineByTicker = new Map(
@@ -2249,7 +2266,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       ...(typeof candidateCandles.at(-1)?.close === "number" ? { currentPrice: candidateCandles.at(-1)!.close } : {}),
       asOf,
     });
-    const stock = await stockPayload(row, candidate, front);
+    const stock = await stockPayload(row, candidate, front, allowAiSynthesis);
     // 2026-07-12: US 큐레이션 대형주는 뉴스 재료가 없어도(Vercel egress에서 US 뉴스 차단) verdict 맥락으로
     // 진입 — "시총 높은 아는 기업"(User Zero). 국장 발굴 정체성은 불변(KR 은 이 분기 안 탐).
     const usSeed =

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -1,0 +1,704 @@
+import { callAI, isAiConfigured, resolveModel } from "@fomo/shared";
+import { companyFinancialsFromBasics, computeCompanyScore, type StockBasics } from "@fomo/core";
+import { buildDaily30CandidatePoolResponse, writeDaily30PicksSnapshot, type Daily30Response } from "./daily-30";
+import type { DiscoveryDeckCardPayload, DiscoveryFrontSeed, DiscoveryStockPayload } from "./discovery-supply";
+import {
+  publishCommitteeSnapshot,
+  readPublishedCommitteeSnapshot,
+  writeFailedCommitteeRun,
+  type CommitteeReviewAudit,
+  type CommitteeRunReport,
+  type PublishedCommitteeSnapshot,
+} from "./expert-review-store";
+import { fetchStockBasics } from "./stock-basics";
+import { kstDate } from "./fomo";
+
+const COMMITTEE_VERSION = "committee-v1";
+const CANDIDATE_TARGET = 50;
+const MIN_CANDIDATES = 40;
+const FINAL_TARGET = 30;
+const BATCH_SIZE = 5;
+const BATCH_CONCURRENCY = 2;
+const MAX_CALLS = 110;
+
+type Grade = "A" | "B" | "C";
+type AnalystRole = "trading" | "financial";
+
+interface CandidateRecord {
+  id: string;
+  assetClass: string;
+  signalScore: number;
+  hypePenalty: number;
+  quietScore: number;
+  cardIndex: number;
+  card: { kind: "stock" } & DiscoveryStockPayload;
+  front: DiscoveryFrontSeed;
+  basics?: StockBasics;
+  input: CommitteeCandidateInput;
+}
+
+export interface CommitteeCandidateInput {
+  candidateId: string;
+  assetClass: string;
+  stock: {
+    canonical: string;
+    symbol?: string;
+    naverCode?: string;
+    country: string;
+    market?: string;
+    sector: string;
+  };
+  material: {
+    headline?: string;
+    whyShown?: string;
+    reason?: string;
+    sourceLabel?: string;
+    sourceUrl?: string;
+  };
+  selection: {
+    signalScore: number;
+    hypePenalty: number;
+    quietScore: number;
+  };
+  trading: {
+    signals: DiscoveryFrontSeed["signals"];
+    verdict?: DiscoveryFrontSeed["verdict"];
+    wyckoff?: DiscoveryFrontSeed["wyckoff"];
+    companyChartAxis?: DiscoveryFrontSeed["companyScore"];
+    candleSummary: ReturnType<typeof summarizeCandles>;
+  };
+  financial: {
+    companySummary?: string;
+    marketCap?: string;
+    metrics: StockBasics["metrics"];
+    financials?: StockBasics["financials"];
+    valuationHistory?: StockBasics["valuationHistory"];
+    scoreAxes: NonNullable<DiscoveryFrontSeed["companyScore"]>["axes"];
+  };
+}
+
+interface RawAnalystReview {
+  candidateId: string;
+  approved: boolean;
+  grade: Grade;
+  paragraph: string;
+  concerns: string[];
+}
+
+interface CheckedAnalystReview extends RawAnalystReview {
+  factFallback: boolean;
+  invalidNumbers: string[];
+}
+
+interface EditorOutput {
+  selectedIds: string[];
+  rejected: Array<{ candidateId: string; reasons: string[] }>;
+  compositionSummary: string;
+}
+
+interface CallState {
+  callCount: number;
+  model: string;
+}
+
+export interface CommitteeAgentCaller {
+  (args: { role: AnalystRole | "editor"; system: string; input: unknown; trace: string }): Promise<{ ok: boolean; content: string; model: string }>;
+}
+
+export interface CommitteeRunResult {
+  ok: boolean;
+  report: CommitteeRunReport;
+  response?: Daily30Response;
+  previousRunRetained: boolean;
+}
+
+function isStockCard(card: DiscoveryDeckCardPayload): card is { kind: "stock" } & DiscoveryStockPayload {
+  return !((card as { kind?: string }).kind) || (card as { kind?: string }).kind === "stock";
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function summarizeCandles(front: DiscoveryFrontSeed) {
+  const candles = (front.candles ?? []).filter((candle) => finite(candle.close) && candle.close > 0);
+  const latest = candles.at(-1);
+  const prior20 = candles.at(-21);
+  const window = candles.slice(-20);
+  const averageVolume = window.length > 0
+    ? window.reduce((sum, candle) => sum + (finite(candle.volume) ? candle.volume : 0), 0) / window.length
+    : undefined;
+  const closes = candles.map((candle) => candle.close);
+  return {
+    sourceLength: candles.length,
+    historyLabel: candles.length >= 240 ? "52주" : `${Math.max(1, Math.round(candles.length / 21))}개월`,
+    ...(latest ? { latest } : {}),
+    ...(latest && prior20 ? { return20dPct: Number((((latest.close - prior20.close) / prior20.close) * 100).toFixed(2)) } : {}),
+    ...(finite(averageVolume) ? { averageVolume20d: Math.round(averageVolume) } : {}),
+    ...(closes.length ? { rangeLow: Math.min(...closes), rangeHigh: Math.max(...closes) } : {}),
+    maLatest: {
+      ma20: front.chartSeries?.ma20.at(-1),
+      ma60: front.chartSeries?.ma60.at(-1),
+      ma120: front.chartSeries?.ma120.at(-1),
+    },
+  };
+}
+
+function numericTokens(text: string): string[] {
+  const matches = text.match(/[+-]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?/g) ?? [];
+  return matches.flatMap((token) => {
+    const value = Number(token.replace(/,/g, ""));
+    return Number.isFinite(value) ? [String(value)] : [];
+  });
+}
+
+function collectAllowedNumbers(value: unknown, allowed: Set<string>): void {
+  if (finite(value)) {
+    allowed.add(String(value));
+    allowed.add(String(Math.round(value)));
+    allowed.add(value.toFixed(1));
+    allowed.add(value.toFixed(2));
+    return;
+  }
+  if (typeof value === "string") {
+    for (const token of numericTokens(value)) allowed.add(token);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectAllowedNumbers(item, allowed);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value as Record<string, unknown>)) collectAllowedNumbers(item, allowed);
+  }
+}
+
+/** 에이전트 문장에 입력 JSON에 없던 숫자가 섞이면 해당 숫자를 모두 반환한다. */
+export function validateAgentNumbers(text: string, input: unknown): string[] {
+  const allowed = new Set<string>();
+  collectAllowedNumbers(input, allowed);
+  return [...new Set(numericTokens(text).filter((token) => !allowed.has(token)))];
+}
+
+function parseJsonObject(text: string): unknown {
+  const cleaned = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start < 0 || end <= start) throw new Error("agent output is not JSON");
+  return JSON.parse(cleaned.slice(start, end + 1));
+}
+
+function isGrade(value: unknown): value is Grade {
+  return value === "A" || value === "B" || value === "C";
+}
+
+function parseAnalystBatch(text: string, expectedIds: readonly string[]): RawAnalystReview[] {
+  const parsed = parseJsonObject(text) as { reviews?: unknown[] };
+  if (!Array.isArray(parsed.reviews)) throw new Error("analyst reviews missing");
+  const rows = parsed.reviews.flatMap((value) => {
+    const row = value as Partial<RawAnalystReview>;
+    if (
+      typeof row.candidateId !== "string" ||
+      typeof row.approved !== "boolean" ||
+      !isGrade(row.grade) ||
+      typeof row.paragraph !== "string" ||
+      !Array.isArray(row.concerns) ||
+      !row.concerns.every((item) => typeof item === "string")
+    ) return [];
+    return [{ ...row, concerns: row.concerns } as RawAnalystReview];
+  });
+  const byId = new Map(rows.map((row) => [row.candidateId, row]));
+  if (expectedIds.some((id) => !byId.has(id))) throw new Error("analyst omitted candidate");
+  return expectedIds.map((id) => byId.get(id)!);
+}
+
+function tradingFallback(input: CommitteeCandidateInput): string {
+  if (input.trading.wyckoff?.summary) return input.trading.wyckoff.summary;
+  if (input.trading.verdict?.stanceText) return input.trading.verdict.stanceText;
+  return "결정론 차트 엔진에서 확정할 수 있는 구간 근거가 부족해 타이밍 판단을 보류합니다.";
+}
+
+function financialFallback(input: CommitteeCandidateInput): string {
+  const axes = input.financial.scoreAxes.filter((axis) => axis.key === "valuation" || axis.key === "growth" || axis.key === "profitability");
+  const evidence = axes.flatMap((axis) => axis.evidence).filter(Boolean);
+  if (evidence.length > 0) return evidence.join(" · ");
+  return "검증 가능한 재무 시계열이 충분하지 않아 기업가치 판단을 보류합니다.";
+}
+
+export function applyAnalystFactGate(
+  role: AnalystRole,
+  review: RawAnalystReview,
+  input: CommitteeCandidateInput
+): CheckedAnalystReview {
+  const invalidNumbers = validateAgentNumbers([review.paragraph, ...review.concerns].join(" "), input);
+  if (invalidNumbers.length === 0) return { ...review, factFallback: false, invalidNumbers: [] };
+  return {
+    ...review,
+    paragraph: role === "trading" ? tradingFallback(input) : financialFallback(input),
+    concerns: ["입력에 없는 수치가 감지되어 에이전트 문단을 결정론 산출로 교체했습니다."],
+    factFallback: true,
+    invalidNumbers,
+  };
+}
+
+async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
+  const result = await callAI({
+    ...(process.env.COMMITTEE_AI_MODEL ? { model: process.env.COMMITTEE_AI_MODEL } : {}),
+    messages: [
+      { role: "system", content: args.system },
+      { role: "user", content: JSON.stringify(args.input) },
+    ],
+    temperature: 0.1,
+    timeoutMs: 45_000,
+    trace: args.trace,
+    metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },
+  });
+  return result;
+}
+
+async function callWithRetry(
+  caller: CommitteeAgentCaller,
+  args: Parameters<CommitteeAgentCaller>[0],
+  state: CallState
+): Promise<string> {
+  let lastError = "agent call failed";
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (state.callCount >= MAX_CALLS) throw new Error(`committee call cap exceeded: ${MAX_CALLS}`);
+    state.callCount += 1;
+    const result = await caller(args);
+    if (result.model) state.model = result.model;
+    if (result.ok && result.content.trim()) return result.content;
+    lastError = `${args.role} agent call failed`;
+    if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, 750));
+  }
+  throw new Error(lastError);
+}
+
+const TRADING_SYSTEM = `당신은 FOMO Club의 트레이딩 분석 검수자다.
+입력 JSON의 signals, verdict, wyckoff, candleSummary만 근거로 구간 판정의 타당성을 검수한다.
+입력에 없는 숫자를 새로 만들거나 계산하지 않는다. approved=false는 엔진 판정과 입력 데이터가 명백히 충돌할 때만 사용한다.
+각 후보에 timing grade A/B/C와 한국어 한 문단을 쓴다. 예측 확정이 아니라 구간, 타이밍, 무효화 근거를 설명한다.
+반드시 {"reviews":[{"candidateId":"...","approved":true,"grade":"A","paragraph":"...","concerns":[]}]} JSON만 반환한다.`;
+
+const FINANCIAL_SYSTEM = `당신은 FOMO Club의 재무 분석 검수자다.
+입력 JSON의 financial, material, companyScore 근거만 사용해 수익성, 성장, 밸류와 핵심 리스크를 검수한다.
+입력에 없는 숫자를 새로 만들거나 계산하지 않는다. 재무가 얇으면 C 등급과 보류 문장을 쓰되 그 이유만으로 반려하지 않는다.
+approved=false는 표시된 사실이 서로 명백히 충돌하거나 품질상 발행할 수 없을 때만 사용한다.
+각 후보에 valuation grade A/B/C와 한국어 한 문단을 쓴다.
+반드시 {"reviews":[{"candidateId":"...","approved":true,"grade":"A","paragraph":"...","concerns":[]}]} JSON만 반환한다.`;
+
+const EDITOR_SYSTEM = `당신은 FOMO Club 편집장이다.
+두 분석가가 승인한 후보 중 정확히 targetCount개를 고른다. companyScore, quietScore, 두 등급, 자산군 다양성, 문구 중복을 함께 본다.
+입력에 없는 후보를 고르지 말고 입력에 없는 숫자를 쓰지 않는다. selectedIds는 중복 없이 정확히 targetCount개다.
+반드시 {"selectedIds":["..."],"rejected":[{"candidateId":"...","reasons":["..."]}],"compositionSummary":"..."} JSON만 반환한다.`;
+
+async function mapConcurrent<T, R>(items: readonly T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  async function run() {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index]!);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => run()));
+  return results;
+}
+
+async function runAnalyst(
+  role: AnalystRole,
+  candidates: readonly CandidateRecord[],
+  caller: CommitteeAgentCaller,
+  state: CallState
+): Promise<Map<string, CheckedAnalystReview>> {
+  const batches = Array.from({ length: Math.ceil(candidates.length / BATCH_SIZE) }, (_, index) =>
+    candidates.slice(index * BATCH_SIZE, (index + 1) * BATCH_SIZE)
+  );
+  const system = role === "trading" ? TRADING_SYSTEM : FINANCIAL_SYSTEM;
+  const results = await mapConcurrent(batches, BATCH_CONCURRENCY, async (batch) => {
+    const input = batch.map((candidate) => candidate.input);
+    const text = await callWithRetry(caller, {
+      role,
+      system,
+      input,
+      trace: `expert-committee-${role}`,
+    }, state);
+    return parseAnalystBatch(text, batch.map((candidate) => candidate.id)).map((review, index) =>
+      applyAnalystFactGate(role, review, batch[index]!.input)
+    );
+  });
+  return new Map(results.flat().map((review) => [review.candidateId, review]));
+}
+
+function enforceAnalystCopyQuality(
+  reviews: Map<string, CheckedAnalystReview>,
+  candidates: readonly CandidateRecord[]
+): Map<string, CheckedAnalystReview> {
+  const keys = new Map<string, string[]>();
+  for (const candidate of candidates) {
+    const review = reviews.get(candidate.id);
+    if (!review) continue;
+    const key = review.paragraph
+      .replaceAll(candidate.card.canonical, "")
+      .replace(/\s+/g, "")
+      .trim();
+    keys.set(key, [...(keys.get(key) ?? []), candidate.id]);
+  }
+  const repeatedIds = new Set([...keys.values()].filter((ids) => ids.length >= 3).flat());
+  return new Map([...reviews].map(([id, review]) => {
+    const tooShort = review.paragraph.replace(/\s+/g, "").length < 30;
+    if (!tooShort && !repeatedIds.has(id)) return [id, review];
+    return [id, {
+      ...review,
+      approved: false,
+      grade: "C",
+      concerns: [...review.concerns, tooShort ? "전문 분석 문단이 지나치게 짧음" : "후보 간 분석 문구 반복"],
+    }];
+  }));
+}
+
+function parseEditor(text: string): EditorOutput {
+  const parsed = parseJsonObject(text) as Partial<EditorOutput>;
+  if (
+    !Array.isArray(parsed.selectedIds) ||
+    !parsed.selectedIds.every((id) => typeof id === "string") ||
+    !Array.isArray(parsed.rejected) ||
+    typeof parsed.compositionSummary !== "string"
+  ) throw new Error("editor output invalid");
+  const rejected = parsed.rejected.flatMap((item) => {
+    if (
+      !item ||
+      typeof item.candidateId !== "string" ||
+      !Array.isArray(item.reasons) ||
+      !item.reasons.every((reason) => typeof reason === "string")
+    ) return [];
+    return [{ candidateId: item.candidateId, reasons: item.reasons }];
+  });
+  return { selectedIds: parsed.selectedIds, rejected, compositionSummary: parsed.compositionSummary };
+}
+
+async function runEditor(
+  candidates: readonly CandidateRecord[],
+  trading: Map<string, CheckedAnalystReview>,
+  financial: Map<string, CheckedAnalystReview>,
+  caller: CommitteeAgentCaller,
+  state: CallState
+): Promise<EditorOutput> {
+  const eligible = candidates.filter((candidate) => trading.get(candidate.id)?.approved && financial.get(candidate.id)?.approved);
+  if (eligible.length < FINAL_TARGET) throw new Error(`committee eligible candidates ${eligible.length}/${FINAL_TARGET}`);
+  const assetCounts = eligible.reduce<Record<string, number>>((counts, candidate) => {
+    counts[candidate.assetClass] = (counts[candidate.assetClass] ?? 0) + 1;
+    return counts;
+  }, {});
+  const input = {
+    targetCount: FINAL_TARGET,
+    candidateCount: eligible.length,
+    assetCounts,
+    candidates: eligible.map((candidate) => ({
+      candidateId: candidate.id,
+      canonical: candidate.card.canonical,
+      assetClass: candidate.assetClass,
+      sector: candidate.card.sector,
+      headline: candidate.card.headline,
+      companyScore: candidate.front.companyScore?.score,
+      quietScore: candidate.quietScore,
+      timingGrade: trading.get(candidate.id)!.grade,
+      valuationGrade: financial.get(candidate.id)!.grade,
+      tradingView: trading.get(candidate.id)!.paragraph,
+      fundamentalView: financial.get(candidate.id)!.paragraph,
+      analystConcerns: [...trading.get(candidate.id)!.concerns, ...financial.get(candidate.id)!.concerns],
+    })),
+  };
+  const text = await callWithRetry(caller, { role: "editor", system: EDITOR_SYSTEM, input, trace: "expert-committee-editor" }, state);
+  const output = parseEditor(text);
+  const known = new Set(eligible.map((candidate) => candidate.id));
+  const selected = [...new Set(output.selectedIds)];
+  if (selected.length !== FINAL_TARGET || selected.some((id) => !known.has(id))) {
+    throw new Error(`editor selection invalid: ${selected.length}/${FINAL_TARGET}`);
+  }
+  const summaryInvalid = validateAgentNumbers(output.compositionSummary, input);
+  const rejected = output.rejected.map((row) => {
+    const invalid = validateAgentNumbers(row.reasons.join(" "), input);
+    return invalid.length > 0 ? { candidateId: row.candidateId, reasons: ["편집 품질 기준 미달"] } : row;
+  });
+  return {
+    selectedIds: selected,
+    rejected,
+    compositionSummary: summaryInvalid.length > 0
+      ? "자산군·등급·조용함을 함께 보고 중복을 줄인 구성입니다."
+      : output.compositionSummary,
+  };
+}
+
+async function candidateRecords(response: Daily30Response): Promise<CandidateRecord[]> {
+  const cards: DiscoveryDeckCardPayload[] = response.cards ?? response.stocks.map((stock) => ({ kind: "stock", ...stock }));
+  const raw = cards.flatMap((card, cardIndex) => {
+    if (!isStockCard(card)) return [];
+    const meta = response.meta.cards[cardIndex];
+    const front = response.fronts[card.canonical];
+    if (!meta || !front) return [];
+    return [{ id: meta.id, assetClass: meta.assetClass, signalScore: meta.signalScore, hypePenalty: meta.hypePenalty, quietScore: meta.quietScore, cardIndex, card, front }];
+  }).slice(0, CANDIDATE_TARGET);
+
+  return mapConcurrent(raw, 6, async (candidate): Promise<CandidateRecord> => {
+    const basics = candidate.card.market === "COIN"
+      ? undefined
+      : await fetchStockBasics(candidate.card.canonical, candidate.card.naverCode, candidate.card.symbol).catch(() => undefined);
+    const financials = companyFinancialsFromBasics(basics);
+    const latestPrice = candidate.front.candles?.at(-1)?.close;
+    const companyScore = computeCompanyScore({
+      ...(financials ? { financials } : {}),
+      signals: candidate.front.signals,
+      ...(candidate.front.verdict ? { verdict: candidate.front.verdict } : {}),
+      ...(candidate.front.wyckoff ? { wyckoff: candidate.front.wyckoff } : {}),
+      insiderPurchaseConfirmed: /내부자|임원|대주주|Form\s?4/i.test([
+        candidate.card.headline,
+        candidate.card.whyShown,
+        candidate.card.reason,
+      ].filter(Boolean).join(" ")),
+      ...(finite(latestPrice) ? { currentPrice: latestPrice } : {}),
+      quiet: {
+        quietScore: candidate.quietScore,
+        signalScore: candidate.signalScore,
+        hypePenalty: candidate.hypePenalty,
+      },
+      asOf: candidate.front.signals.asOf ?? response.asOf,
+    });
+    const front: DiscoveryFrontSeed = { ...candidate.front, companyScore };
+    const scoreAxes = companyScore.axes;
+    return {
+      ...candidate,
+      front,
+      ...(basics ? { basics } : {}),
+      input: {
+        candidateId: candidate.id,
+        assetClass: candidate.assetClass,
+        stock: {
+          canonical: candidate.card.canonical,
+          ...(candidate.card.symbol ? { symbol: candidate.card.symbol } : {}),
+          ...(candidate.card.naverCode ? { naverCode: candidate.card.naverCode } : {}),
+          country: candidate.card.country,
+          ...(candidate.card.market ? { market: candidate.card.market } : {}),
+          sector: candidate.card.sector,
+        },
+        material: {
+          ...(candidate.card.headline ? { headline: candidate.card.headline } : {}),
+          ...(candidate.card.whyShown ? { whyShown: candidate.card.whyShown } : {}),
+          ...(candidate.card.reason ? { reason: candidate.card.reason } : {}),
+          ...(candidate.card.sourceLabel ? { sourceLabel: candidate.card.sourceLabel } : {}),
+          ...(candidate.card.sourceUrl ? { sourceUrl: candidate.card.sourceUrl } : {}),
+        },
+        selection: {
+          signalScore: candidate.signalScore,
+          hypePenalty: candidate.hypePenalty,
+          quietScore: candidate.quietScore,
+        },
+        trading: {
+          signals: front.signals,
+          ...(front.verdict ? { verdict: front.verdict } : {}),
+          ...(front.wyckoff ? { wyckoff: front.wyckoff } : {}),
+          companyChartAxis: companyScore,
+          candleSummary: summarizeCandles(front),
+        },
+        financial: {
+          ...(basics?.summary ? { companySummary: basics.summary } : {}),
+          ...(basics?.marketCap ? { marketCap: basics.marketCap } : {}),
+          metrics: basics?.metrics ?? [],
+          ...(basics?.financials ? { financials: basics.financials } : {}),
+          ...(basics?.valuationHistory ? { valuationHistory: basics.valuationHistory } : {}),
+          scoreAxes: scoreAxes.filter((axis) => axis.key === "valuation" || axis.key === "growth" || axis.key === "profitability"),
+        },
+      },
+    };
+  });
+}
+
+function finalResponse(
+  pool: Daily30Response,
+  candidates: readonly CandidateRecord[],
+  selectedIds: readonly string[],
+  trading: Map<string, CheckedAnalystReview>,
+  financial: Map<string, CheckedAnalystReview>,
+  runMeta: NonNullable<Daily30Response["meta"]["committee"]>
+): Daily30Response {
+  const byId = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+  const selected = selectedIds.map((id) => byId.get(id)!).filter(Boolean);
+  const poolCards: DiscoveryDeckCardPayload[] = pool.cards ?? pool.stocks.map((stock) => ({ kind: "stock", ...stock }));
+  const feedPairs = poolCards.flatMap((card, index) => (isStockCard(card) ? [] : [{ card, meta: pool.meta.cards[index] }])).filter((pair) => pair.meta);
+  const fronts: Daily30Response["fronts"] = {};
+  const stocks: DiscoveryStockPayload[] = [];
+  const cards: DiscoveryDeckCardPayload[] = [];
+  const metaCards: Daily30Response["meta"]["cards"] = [];
+  for (const candidate of selected) {
+    const tradingReview = trading.get(candidate.id)!;
+    const financialReview = financial.get(candidate.id)!;
+    const { kind: _kind, ...stock } = candidate.card;
+    void _kind;
+    stocks.push(stock);
+    cards.push(candidate.card);
+    metaCards.push({ id: candidate.id, assetClass: candidate.assetClass as Daily30Response["meta"]["cards"][number]["assetClass"], quietScore: candidate.quietScore, signalScore: candidate.signalScore, hypePenalty: candidate.hypePenalty });
+    fronts[candidate.card.canonical] = {
+      ...candidate.front,
+      committeeReview: {
+        runId: runMeta.runId,
+        reviewedAt: runMeta.reviewedAt,
+        tradingView: tradingReview.paragraph,
+        fundamentalView: financialReview.paragraph,
+        timingGrade: tradingReview.grade,
+        valuationGrade: financialReview.grade,
+        factChecked: true,
+      },
+    };
+  }
+  for (const pair of feedPairs) {
+    cards.push(pair.card);
+    metaCards.push(pair.meta!);
+  }
+  const assetCounts = metaCards.reduce<Daily30Response["meta"]["assetCounts"]>((counts, meta) => {
+    counts[meta.assetClass] += 1;
+    return counts;
+  }, { "kr-stock": 0, "us-stock": 0, coin: 0, macro: 0 });
+  return {
+    ...pool,
+    stocks,
+    cards,
+    fronts,
+    confidence: "H",
+    source: `${pool.source} · 전문가 위원회 승인`,
+    meta: {
+      ...pool.meta,
+      targetCount: FINAL_TARGET,
+      cards: metaCards,
+      assetCounts,
+      committee: runMeta,
+    },
+  };
+}
+
+function rejectionReasons(
+  candidate: CandidateRecord,
+  selected: ReadonlySet<string>,
+  editor: EditorOutput,
+  trading: CheckedAnalystReview,
+  financial: CheckedAnalystReview
+): string[] {
+  if (selected.has(candidate.id)) return [];
+  const reasons = [
+    ...(!trading.approved ? trading.concerns : []),
+    ...(!financial.approved ? financial.concerns : []),
+    ...(editor.rejected.find((row) => row.candidateId === candidate.id)?.reasons ?? []),
+  ].filter(Boolean);
+  return reasons.length > 0 ? reasons : ["최종 구성의 중복·다양성 기준에서 제외"];
+}
+
+export interface CommitteeRunOptions {
+  caller?: CommitteeAgentCaller;
+  buildPool?: () => Promise<Daily30Response>;
+  readPrevious?: () => Promise<PublishedCommitteeSnapshot | null>;
+  publish?: (snapshot: PublishedCommitteeSnapshot, report: CommitteeRunReport) => Promise<void>;
+  writeFailure?: (report: CommitteeRunReport) => Promise<void>;
+  writePicks?: (response: Daily30Response) => Promise<void>;
+}
+
+export async function runExpertReviewCommittee(options: CommitteeRunOptions = {}): Promise<CommitteeRunResult> {
+  const startedAt = new Date();
+  const date = kstDate();
+  const runId = `${date}-${startedAt.getTime().toString(36)}-${crypto.randomUUID().slice(0, 8)}`;
+  const previous = await (options.readPrevious ?? readPublishedCommitteeSnapshot)().catch(() => null);
+  const state: CallState = { callCount: 0, model: resolveModel(process.env.COMMITTEE_AI_MODEL) };
+  let candidateCount = 0;
+  try {
+    if (!(options.caller ?? (isAiConfigured() ? defaultAgentCaller : undefined))) {
+      throw new Error("committee AI is not configured");
+    }
+    const caller = options.caller ?? defaultAgentCaller;
+    const pool = await (options.buildPool ?? (() => buildDaily30CandidatePoolResponse(CANDIDATE_TARGET)))();
+    const candidates = await candidateRecords(pool);
+    candidateCount = candidates.length;
+    if (candidateCount < MIN_CANDIDATES) throw new Error(`committee candidate pool ${candidateCount}/${MIN_CANDIDATES}`);
+    const trading = enforceAnalystCopyQuality(await runAnalyst("trading", candidates, caller, state), candidates);
+    const financial = enforceAnalystCopyQuality(await runAnalyst("financial", candidates, caller, state), candidates);
+    const editor = await runEditor(candidates, trading, financial, caller, state);
+    const completedAt = new Date().toISOString();
+    const committeeMeta = {
+      runId,
+      version: COMMITTEE_VERSION,
+      reviewedAt: completedAt,
+      candidateCount,
+      selectedCount: editor.selectedIds.length,
+      callCount: state.callCount,
+    };
+    const response = finalResponse(pool, candidates, editor.selectedIds, trading, financial, committeeMeta);
+    const selected = new Set(editor.selectedIds);
+    const reviews: CommitteeReviewAudit[] = candidates.map((candidate) => {
+      const tradingReview = trading.get(candidate.id)!;
+      const financialReview = financial.get(candidate.id)!;
+      return {
+        candidateId: candidate.id,
+        canonical: candidate.card.canonical,
+        approved: selected.has(candidate.id),
+        timingGrade: tradingReview.grade,
+        valuationGrade: financialReview.grade,
+        tradingView: tradingReview.paragraph,
+        fundamentalView: financialReview.paragraph,
+        rejectionReasons: rejectionReasons(candidate, selected, editor, tradingReview, financialReview),
+        factGate: {
+          tradingFallback: tradingReview.factFallback,
+          financialFallback: financialReview.factFallback,
+          invalidNumbers: [...new Set([...tradingReview.invalidNumbers, ...financialReview.invalidNumbers])],
+        },
+      };
+    });
+    const report: CommitteeRunReport = {
+      runId,
+      version: COMMITTEE_VERSION,
+      date,
+      status: "published",
+      startedAt: startedAt.toISOString(),
+      completedAt,
+      model: state.model,
+      callCount: state.callCount,
+      candidateCount,
+      selectedCount: editor.selectedIds.length,
+      selectedIds: editor.selectedIds,
+      reviews,
+      compositionSummary: editor.compositionSummary,
+      assetCounts: response.meta.assetCounts,
+    };
+    const { reviews: _reviews, ...reportSummary } = report;
+    void _reviews;
+    const snapshot: PublishedCommitteeSnapshot = {
+      runId,
+      version: COMMITTEE_VERSION,
+      reviewedAt: completedAt,
+      response,
+      report: reportSummary,
+    };
+    await (options.publish ?? publishCommitteeSnapshot)(snapshot, report);
+    await (options.writePicks ?? writeDaily30PicksSnapshot)(response).catch(() => {});
+    return { ok: true, report, response, previousRunRetained: false };
+  } catch (error) {
+    const completedAt = new Date().toISOString();
+    const report: CommitteeRunReport = {
+      runId,
+      version: COMMITTEE_VERSION,
+      date,
+      status: "failed",
+      startedAt: startedAt.toISOString(),
+      completedAt,
+      model: state.model,
+      callCount: state.callCount,
+      candidateCount,
+      selectedCount: 0,
+      selectedIds: [],
+      reviews: [],
+      compositionSummary: "위원회 실행 실패로 직전 승인 덱을 유지했습니다.",
+      assetCounts: previous?.response.meta.assetCounts ?? {},
+      error: error instanceof Error ? error.message : String(error),
+      previousRunRetained: Boolean(previous),
+    };
+    await (options.writeFailure ?? writeFailedCommitteeRun)(report).catch(() => {});
+    return { ok: false, report, previousRunRetained: Boolean(previous) };
+  }
+}

--- a/apps/web/lib/expert-review-store.ts
+++ b/apps/web/lib/expert-review-store.ts
@@ -1,0 +1,72 @@
+import type { Daily30Response } from "./daily-30";
+import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
+
+const ACTIVE_ID = "expert-committee:active";
+const RUN_PREFIX = "expert-committee:run:";
+
+export type CommitteeRunStatus = "published" | "failed";
+
+export interface CommitteeReviewAudit {
+  candidateId: string;
+  canonical: string;
+  approved: boolean;
+  timingGrade: "A" | "B" | "C";
+  valuationGrade: "A" | "B" | "C";
+  tradingView: string;
+  fundamentalView: string;
+  rejectionReasons: string[];
+  factGate: {
+    tradingFallback: boolean;
+    financialFallback: boolean;
+    invalidNumbers: string[];
+  };
+}
+
+export interface CommitteeRunReport {
+  runId: string;
+  version: string;
+  date: string;
+  status: CommitteeRunStatus;
+  startedAt: string;
+  completedAt: string;
+  model: string;
+  callCount: number;
+  candidateCount: number;
+  selectedCount: number;
+  selectedIds: string[];
+  reviews: CommitteeReviewAudit[];
+  compositionSummary: string;
+  assetCounts: Record<string, number>;
+  error?: string;
+  previousRunRetained?: boolean;
+}
+
+export interface PublishedCommitteeSnapshot {
+  runId: string;
+  version: string;
+  reviewedAt: string;
+  response: Daily30Response;
+  report: Omit<CommitteeRunReport, "reviews">;
+}
+
+export async function readPublishedCommitteeSnapshot(): Promise<PublishedCommitteeSnapshot | null> {
+  return readFeedContent<PublishedCommitteeSnapshot>(ACTIVE_ID);
+}
+
+export async function publishCommitteeSnapshot(
+  snapshot: PublishedCommitteeSnapshot,
+  report: CommitteeRunReport
+): Promise<void> {
+  // 이력부터 남기고 활성 포인터를 마지막에 교체한다. 중간 실패 시 전일 활성본이 그대로 유지된다.
+  await writeFeedContent(`${RUN_PREFIX}${report.date}:${report.runId}`, report);
+  await writeFeedContent(ACTIVE_ID, snapshot);
+}
+
+export async function writeFailedCommitteeRun(report: CommitteeRunReport): Promise<void> {
+  await writeFeedContent(`${RUN_PREFIX}${report.date}:${report.runId}`, report);
+}
+
+export async function readCommitteeRunReports(limit = 14): Promise<CommitteeRunReport[]> {
+  const rows = await readFeedContentByPrefix<CommitteeRunReport>(RUN_PREFIX, limit);
+  return rows.map((entry) => entry.row);
+}

--- a/apps/web/lib/insight-synthesis.ts
+++ b/apps/web/lib/insight-synthesis.ts
@@ -611,12 +611,16 @@ async function aiSynthesize(candidate: DiscoveryCandidate, fallback: DiscoveryIn
   return validateWhyInsightOutput(parseAiJson(res.content), candidate, fallback);
 }
 
-export async function synthesizeWhyDrivenInsight(candidate: DiscoveryCandidate): Promise<WhySynthesisResult> {
-  const key = cacheKey(candidate);
+export async function synthesizeWhyDrivenInsight(
+  candidate: DiscoveryCandidate,
+  options: { allowAi?: boolean } = {}
+): Promise<WhySynthesisResult> {
+  const allowAi = options.allowAi ?? true;
+  const key = `${cacheKey(candidate)}:ai=${allowAi ? "1" : "0"}`;
   const hit = cache.get(key);
   if (hit) return hit;
   const fallback = synthesizeDiscoveryInsight(candidate);
-  const ai = await aiSynthesize(candidate, fallback);
+  const ai = allowAi ? await aiSynthesize(candidate, fallback) : undefined;
   const rule = ai ? undefined : buildSoWhatFallback(candidate, fallback);
   const result: WhySynthesisResult = ai
     ? { insight: ai, method: "ai" }


### PR DESCRIPTION
## Summary
- build a deterministic 40-50 stock candidate pool and run batched trading, financial, and editor reviews only in the daily cron
- reject agent numbers absent from source JSON, reject thin/repeated analysis, and keep the previous approved deck on any failed run
- publish versioned committee audit reports, expose a protected admin audit view, and render fact-checked trading/fundamental views in stock depth
- make public daily-30 reads consume only the last approved snapshot

## Cost and reliability
- 5 candidates per analyst batch: 17 calls for 40 candidates, 21 calls for 50 candidates before retries
- hard cap: 110 calls per run
- no committee LLM calls in public request routes

## Verification
- npm run lint
- npm run typecheck
- npm run test (126 files, 1,176 tests)
- npm run build:web
- npm run build:fomo-web