### PR TITLE
fix: split committee reviews under Groq token cap

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -149,7 +149,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(3);
+    expect(result.report.callCount).toBe(5);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -17,11 +17,11 @@ const COMMITTEE_VERSION = "committee-v1";
 const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
-const BATCH_SIZE = 50;
+const BATCH_SIZE = 20;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "llama-3.3-70b-versatile";
-const DEFAULT_CALL_INTERVAL_MS = 65_000;
+const DEFAULT_CALL_INTERVAL_MS = 35_000;
 
 type Grade = "A" | "B" | "C";
 type AnalystRole = "trading" | "financial";


### PR DESCRIPTION
## Production finding
A compact 50-candidate trading request still returned Groq `HTTP 429`; candidate production remained healthy at 50.

## Fix
- split each analyst pass into 20-candidate batches
- pace calls 35 seconds apart so at most two sub-limit batches share a rolling minute
- run 3 trading batches + 3 financial batches + 1 editor call = 7 calls/day
- keep the Vercel plan-compatible 300-second function ceiling

## Verification
- npm run typecheck:web
- npm run test -- expert-review-committee expert-review-store
- npm run build:web