### PR TITLE
fix: cap committee completion tokens

### DIFF
--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -253,6 +253,7 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
+    maxTokens: 2_500,
     timeoutMs: 45_000,
     trace: args.trace,
     metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },

--- a/packages/shared/__tests__/ai-client.test.ts
+++ b/packages/shared/__tests__/ai-client.test.ts
@@ -54,7 +54,7 @@ describe("ai-client provider routing", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     expect(isAiConfigured()).toBe(true);
-    const res = await callAI({ messages: [{ role: "user", content: "hello" }] });
+    const res = await callAI({ messages: [{ role: "user", content: "hello" }], maxTokens: 2500 });
 
     expect(res.ok).toBe(true);
     expect(res.content).toBe("ok");
@@ -65,8 +65,9 @@ describe("ai-client provider routing", () => {
         headers: expect.objectContaining({ Authorization: "Bearer groq-key" }),
       })
     );
-    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string) as { model: string };
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string) as { model: string; max_tokens: number };
     expect(body.model).toBe("llama-3.3-70b-versatile");
+    expect(body.max_tokens).toBe(2500);
   });
 
   it("uses Groq by default when only GROQ_API_KEY is configured", async () => {

--- a/packages/shared/src/ai-client.ts
+++ b/packages/shared/src/ai-client.ts
@@ -24,6 +24,8 @@ export interface CallAiOptions {
   /** 미지정 시 AI_MODEL env. 호출별 오버라이드로 모델 비교·라우팅. */
   model?: string;
   temperature?: number;
+  /** OpenAI 호환 max_tokens. 생략 시 공급자 기본값, 비용/TPM 게이트 경로는 반드시 명시한다. */
+  maxTokens?: number;
   /** 기본 25_000ms. */
   timeoutMs?: number;
   apiUrl?: string;
@@ -152,6 +154,7 @@ export async function callAI(opts: CallAiOptions): Promise<CallAiResult> {
       body: JSON.stringify({
         model,
         ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
         messages: opts.messages,
       }),
       signal: AbortSignal.timeout(opts.timeoutMs ?? 25_000),


### PR DESCRIPTION
## Production finding
Even a 20-candidate batch returned immediate Groq `HTTP 429`. The shared OpenAI-compatible client did not send `max_tokens`, leaving a large provider default completion reservation inside the TPM calculation.

## Fix
- add optional `maxTokens` support to the shared AI client
- send OpenAI-compatible `max_tokens` in the request body
- cap committee responses at 2,500 tokens per batch

## Verification
- npm run typecheck:shared
- npm run typecheck:web
- npm run test -- ai-client expert-review-committee expert-review-store