### PR TITLE
fix: stage committee reviews across daily cron slots

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyAnalystFactGate,
   runExpertReviewCommittee,
+  runExpertReviewCommitteeStage,
   validateAgentNumbers,
   type CommitteeAgentCaller,
   type CommitteeCandidateInput,
@@ -149,7 +150,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(5);
+    expect(result.report.callCount).toBe(9);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();
@@ -171,5 +172,66 @@ describe("expert committee orchestration", () => {
     expect(result.previousRunRetained).toBe(true);
     expect(publish).not.toHaveBeenCalled();
     expect(writeFailure).toHaveBeenCalledOnce();
+  });
+
+  it("3단 크론은 동일 후보를 이어받아 editor 성공 때만 활성본을 발행한다", async () => {
+    const caller: CommitteeAgentCaller = async ({ role, input }) => {
+      if (role === "editor") {
+        const candidates = (input as { candidates: Array<{ candidateId: string }> }).candidates;
+        return {
+          ok: true,
+          model: "test-model",
+          content: JSON.stringify({
+            selectedIds: candidates.slice(0, 30).map((candidate) => candidate.candidateId),
+            rejected: candidates.slice(30).map((candidate) => ({ candidateId: candidate.candidateId, reasons: ["구성 중복"] })),
+            compositionSummary: "등급과 조용함을 함께 검수한 구성입니다.",
+          }),
+        };
+      }
+      const candidates = input as Array<{ candidateId: string; stock: { symbol?: string } }>;
+      return {
+        ok: true,
+        model: "test-model",
+        content: JSON.stringify({
+          reviews: candidates.map((candidate) => ({
+            candidateId: candidate.candidateId,
+            approved: true,
+            grade: "B",
+            paragraph: role === "trading"
+              ? `${candidate.stock.symbol}의 구간·거래량·무효화 근거를 서로 대조해 타이밍을 검수했습니다.`
+              : `${candidate.stock.symbol}의 공개 재무와 카드 재료를 대조해 기업 체력과 자료 한계를 함께 검수했습니다.`,
+            concerns: [],
+          })),
+        }),
+      };
+    };
+    let stored: unknown = null;
+    const stageStorage = {
+      read: async () => stored,
+      write: async (_date: string, value: unknown) => { stored = value; },
+    };
+    const publish = vi.fn(async () => {});
+    const common = {
+      caller,
+      buildPool: async () => fakePool(),
+      readPrevious: async () => null,
+      publish,
+      writeFailure: async () => {},
+      writePicks: async () => {},
+      minCallIntervalMs: 0,
+      stageStorage,
+    };
+
+    const trading = await runExpertReviewCommitteeStage("trading", common);
+    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 4 });
+    expect(publish).not.toHaveBeenCalled();
+
+    const financial = await runExpertReviewCommitteeStage("financial", common);
+    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 8 });
+    expect(publish).not.toHaveBeenCalled();
+
+    const editor = await runExpertReviewCommitteeStage("editor", common);
+    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 9 });
+    expect(publish).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/app/api/fomo/cron/daily-30/[stage]/route.ts
+++ b/apps/web/app/api/fomo/cron/daily-30/[stage]/route.ts
@@ -1,0 +1,14 @@
+import { GET as runDaily30Stage } from "../route";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ stage: string }> }
+) {
+  const { stage } = await params;
+  const url = new URL(request.url);
+  url.searchParams.set("stage", stage);
+  return runDaily30Stage(new Request(url, request));
+}

--- a/apps/web/app/api/fomo/cron/daily-30/route.ts
+++ b/apps/web/app/api/fomo/cron/daily-30/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { withCors, kstDate } from "../../../../../lib/fomo";
-import { runExpertReviewCommittee } from "../../../../../lib/expert-review-committee";
+import { runExpertReviewCommitteeStage, type CommitteeStage } from "../../../../../lib/expert-review-committee";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -18,22 +18,26 @@ export async function GET(request: Request) {
   }
   const startedAt = Date.now();
   try {
-    const result = await runExpertReviewCommittee();
-    if (result.ok) revalidateTag("daily-30", { expire: 0 });
+    const requestedStage = new URL(request.url).searchParams.get("stage") ?? "trading";
+    if (!(["trading", "financial", "editor"] as string[]).includes(requestedStage)) {
+      return withCors(NextResponse.json({ ok: false, error: "stage must be trading|financial|editor" }, { status: 400 }));
+    }
+    const stage = requestedStage as CommitteeStage;
+    const result = await runExpertReviewCommitteeStage(stage);
+    if (result.ok && stage === "editor") revalidateTag("daily-30", { expire: 0 });
     return withCors(
       NextResponse.json(
         {
           ok: result.ok,
-          runId: result.report.runId,
-          status: result.report.status,
+          runId: result.runId,
+          stage,
+          status: result.ok ? (stage === "editor" ? "published" : "ready") : "failed",
           date: kstDate(),
-          model: result.report.model,
-          calls: result.report.callCount,
-          candidates: result.report.candidateCount,
-          selected: result.report.selectedCount,
-          assetCounts: result.report.assetCounts,
+          calls: result.callCount,
+          candidates: result.candidateCount,
+          selected: result.selectedCount,
           previousRunRetained: result.previousRunRetained,
-          ...(result.report.error ? { error: result.report.error } : {}),
+          ...(result.error ? { error: result.error } : {}),
           elapsedMs: Date.now() - startedAt,
         },
         { status: result.ok ? 200 : 503, headers: { "Cache-Control": "no-store" } }

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -12,16 +12,17 @@ import {
 } from "./expert-review-store";
 import { fetchStockBasics } from "./stock-basics";
 import { kstDate } from "./fomo";
+import { readFeedContent, writeFeedContent } from "./feed-content-store";
 
 const COMMITTEE_VERSION = "committee-v1";
 const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
-const BATCH_SIZE = 20;
+const BATCH_SIZE = 10;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "llama-3.3-70b-versatile";
-const DEFAULT_CALL_INTERVAL_MS = 35_000;
+const DEFAULT_CALL_INTERVAL_MS = 40_000;
 
 type Grade = "A" | "B" | "C";
 type AnalystRole = "trading" | "financial";
@@ -253,7 +254,7 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
-    maxTokens: 2_500,
+    maxTokens: args.role === "editor" ? 2_500 : 1_500,
     timeoutMs: 45_000,
     trace: args.trace,
     metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },
@@ -646,6 +647,10 @@ export interface CommitteeRunOptions {
   writeFailure?: (report: CommitteeRunReport) => Promise<void>;
   writePicks?: (response: Daily30Response) => Promise<void>;
   minCallIntervalMs?: number;
+  stageStorage?: {
+    read: (date: string) => Promise<unknown | null>;
+    write: (date: string, value: unknown) => Promise<void>;
+  };
 }
 
 export async function runExpertReviewCommittee(options: CommitteeRunOptions = {}): Promise<CommitteeRunResult> {
@@ -753,5 +758,208 @@ export async function runExpertReviewCommittee(options: CommitteeRunOptions = {}
     };
     await (options.writeFailure ?? writeFailedCommitteeRun)(report).catch(() => {});
     return { ok: false, report, previousRunRetained: Boolean(previous) };
+  }
+}
+
+export type CommitteeStage = "trading" | "financial" | "editor";
+
+interface StoredCommitteeStage {
+  runId: string;
+  version: string;
+  date: string;
+  startedAt: string;
+  model: string;
+  totalCallCount: number;
+  pool: Daily30Response;
+  candidates: CandidateRecord[];
+  trading?: Array<[string, CheckedAnalystReview]>;
+  financial?: Array<[string, CheckedAnalystReview]>;
+}
+
+export interface CommitteeStageResult {
+  ok: boolean;
+  stage: CommitteeStage;
+  runId: string;
+  candidateCount: number;
+  selectedCount: number;
+  callCount: number;
+  previousRunRetained: boolean;
+  error?: string;
+}
+
+const committeeStageId = (date: string) => `expert-committee:stage:${date}`;
+
+function callState(options: Pick<CommitteeRunOptions, "minCallIntervalMs">, model?: string): CallState {
+  const configuredInterval = Number(process.env.COMMITTEE_MIN_CALL_INTERVAL_MS ?? DEFAULT_CALL_INTERVAL_MS);
+  return {
+    callCount: 0,
+    model: model || process.env.COMMITTEE_AI_MODEL || DEFAULT_COMMITTEE_MODEL,
+    lastCallAt: 0,
+    minCallIntervalMs: options.minCallIntervalMs ?? (Number.isFinite(configuredInterval) ? Math.max(0, configuredInterval) : DEFAULT_CALL_INTERVAL_MS),
+  };
+}
+
+function reviewAudits(
+  candidates: readonly CandidateRecord[],
+  selectedIds: readonly string[],
+  editor: EditorOutput,
+  trading: Map<string, CheckedAnalystReview>,
+  financial: Map<string, CheckedAnalystReview>
+): CommitteeReviewAudit[] {
+  const selected = new Set(selectedIds);
+  return candidates.map((candidate) => {
+    const tradingReview = trading.get(candidate.id)!;
+    const financialReview = financial.get(candidate.id)!;
+    return {
+      candidateId: candidate.id,
+      canonical: candidate.card.canonical,
+      approved: selected.has(candidate.id),
+      timingGrade: tradingReview.grade,
+      valuationGrade: financialReview.grade,
+      tradingView: tradingReview.paragraph,
+      fundamentalView: financialReview.paragraph,
+      rejectionReasons: rejectionReasons(candidate, selected, editor, tradingReview, financialReview),
+      factGate: {
+        tradingFallback: tradingReview.factFallback,
+        financialFallback: financialReview.factFallback,
+        invalidNumbers: [...new Set([...tradingReview.invalidNumbers, ...financialReview.invalidNumbers])],
+      },
+    };
+  });
+}
+
+/**
+ * Vercel 300초 상한과 Groq 조직 TPM을 함께 지키는 일일 3단 실행.
+ * trading → financial → editor 순서로 같은 날짜 stage JSON을 이어받고 editor 성공 때만 활성 덱을 교체한다.
+ */
+export async function runExpertReviewCommitteeStage(
+  stage: CommitteeStage,
+  options: CommitteeRunOptions = {}
+): Promise<CommitteeStageResult> {
+  const date = kstDate();
+  const previous = await (options.readPrevious ?? readPublishedCommitteeSnapshot)().catch(() => null);
+  let stored = options.stageStorage
+    ? (await options.stageStorage.read(date).catch(() => null)) as StoredCommitteeStage | null
+    : await readFeedContent<StoredCommitteeStage>(committeeStageId(date)).catch(() => null);
+  const now = new Date();
+  const fallbackRunId = `${date}-${now.getTime().toString(36)}-${crypto.randomUUID().slice(0, 8)}`;
+  const state = callState(options, stored?.model);
+  const caller = options.caller ?? (isAiConfigured() ? defaultAgentCaller : undefined);
+
+  try {
+    if (!caller) throw new Error("committee AI is not configured");
+
+    if (stage === "trading") {
+      const pool = await (options.buildPool ?? (() => buildDaily30CandidatePoolResponse(CANDIDATE_TARGET)))();
+      const candidates = await candidateRecords(pool);
+      if (candidates.length < MIN_CANDIDATES) throw new Error(`committee candidate pool ${candidates.length}/${MIN_CANDIDATES}`);
+      const trading = enforceAnalystCopyQuality(await runAnalyst("trading", candidates, caller, state), candidates);
+      stored = {
+        runId: fallbackRunId,
+        version: COMMITTEE_VERSION,
+        date,
+        startedAt: now.toISOString(),
+        model: state.model,
+        totalCallCount: state.callCount,
+        pool,
+        candidates,
+        trading: [...trading],
+      };
+      if (options.stageStorage) await options.stageStorage.write(date, stored);
+      else await writeFeedContent(committeeStageId(date), stored);
+      return { ok: true, stage, runId: stored.runId, candidateCount: candidates.length, selectedCount: 0, callCount: stored.totalCallCount, previousRunRetained: Boolean(previous) };
+    }
+
+    if (!stored?.trading?.length) throw new Error("trading stage is not ready");
+    const trading = new Map(stored.trading);
+
+    if (stage === "financial") {
+      const financial = enforceAnalystCopyQuality(await runAnalyst("financial", stored.candidates, caller, state), stored.candidates);
+      stored = {
+        ...stored,
+        model: state.model,
+        totalCallCount: stored.totalCallCount + state.callCount,
+        financial: [...financial],
+      };
+      if (options.stageStorage) await options.stageStorage.write(date, stored);
+      else await writeFeedContent(committeeStageId(date), stored);
+      return { ok: true, stage, runId: stored.runId, candidateCount: stored.candidates.length, selectedCount: 0, callCount: stored.totalCallCount, previousRunRetained: Boolean(previous) };
+    }
+
+    if (!stored.financial?.length) throw new Error("financial stage is not ready");
+    const financial = new Map(stored.financial);
+    const editor = await runEditor(stored.candidates, trading, financial, caller, state);
+    const totalCallCount = stored.totalCallCount + state.callCount;
+    const completedAt = new Date().toISOString();
+    const committeeMeta = {
+      runId: stored.runId,
+      version: COMMITTEE_VERSION,
+      reviewedAt: completedAt,
+      candidateCount: stored.candidates.length,
+      selectedCount: editor.selectedIds.length,
+      callCount: totalCallCount,
+    };
+    const response = finalResponse(stored.pool, stored.candidates, editor.selectedIds, trading, financial, committeeMeta);
+    const reviews = reviewAudits(stored.candidates, editor.selectedIds, editor, trading, financial);
+    const report: CommitteeRunReport = {
+      runId: stored.runId,
+      version: COMMITTEE_VERSION,
+      date,
+      status: "published",
+      startedAt: stored.startedAt,
+      completedAt,
+      model: state.model,
+      callCount: totalCallCount,
+      candidateCount: stored.candidates.length,
+      selectedCount: editor.selectedIds.length,
+      selectedIds: editor.selectedIds,
+      reviews,
+      compositionSummary: editor.compositionSummary,
+      assetCounts: response.meta.assetCounts,
+    };
+    const { reviews: _reviews, ...reportSummary } = report;
+    void _reviews;
+    const snapshot: PublishedCommitteeSnapshot = {
+      runId: stored.runId,
+      version: COMMITTEE_VERSION,
+      reviewedAt: completedAt,
+      response,
+      report: reportSummary,
+    };
+    await (options.publish ?? publishCommitteeSnapshot)(snapshot, report);
+    await (options.writePicks ?? writeDaily30PicksSnapshot)(response).catch(() => {});
+    return { ok: true, stage, runId: stored.runId, candidateCount: stored.candidates.length, selectedCount: editor.selectedIds.length, callCount: totalCallCount, previousRunRetained: false };
+  } catch (error) {
+    const runId = stored?.runId ?? fallbackRunId;
+    const totalCallCount = (stored?.totalCallCount ?? 0) + state.callCount;
+    const report: CommitteeRunReport = {
+      runId,
+      version: COMMITTEE_VERSION,
+      date,
+      status: "failed",
+      startedAt: stored?.startedAt ?? now.toISOString(),
+      completedAt: new Date().toISOString(),
+      model: state.model,
+      callCount: totalCallCount,
+      candidateCount: stored?.candidates.length ?? 0,
+      selectedCount: 0,
+      selectedIds: [],
+      reviews: [],
+      compositionSummary: `${stage} 단계 실패로 직전 승인 덱을 유지했습니다.`,
+      assetCounts: previous?.response.meta.assetCounts ?? {},
+      error: error instanceof Error ? error.message : String(error),
+      previousRunRetained: Boolean(previous),
+    };
+    await (options.writeFailure ?? writeFailedCommitteeRun)(report).catch(() => {});
+    return {
+      ok: false,
+      stage,
+      runId,
+      candidateCount: report.candidateCount,
+      selectedCount: 0,
+      callCount: totalCallCount,
+      previousRunRetained: Boolean(previous),
+      ...(report.error ? { error: report.error } : {}),
+    };
   }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -5,8 +5,16 @@
   "outputDirectory": ".next-build",
   "crons": [
     {
-      "path": "/api/fomo/cron/daily-30",
+      "path": "/api/fomo/cron/daily-30/trading",
       "schedule": "0 21 * * *"
+    },
+    {
+      "path": "/api/fomo/cron/daily-30/financial",
+      "schedule": "10 21 * * *"
+    },
+    {
+      "path": "/api/fomo/cron/daily-30/editor",
+      "schedule": "20 21 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- split the daily expert committee into trading, financial, and editor cron stages
- persist intermediate stage state and publish only after the editor succeeds
- batch analysts in groups of 10 with Groq pacing and role-specific token limits
- retain the previous active deck on any failed stage

## Verification
- npm run typecheck
- npm run test (126 files, 1177 tests)
- npm run build:web
- npm run build:fomo-web