### PR TITLE
fix: route committee reviews to sustainable Groq limits

### DIFF
--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -18,11 +18,11 @@ const COMMITTEE_VERSION = "committee-v1";
 const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
-const BATCH_SIZE = 10;
+const BATCH_SIZE = 13;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
-const DEFAULT_COMMITTEE_MODEL = "llama-3.3-70b-versatile";
-const DEFAULT_CALL_INTERVAL_MS = 40_000;
+const DEFAULT_COMMITTEE_MODEL = "qwen/qwen3.6-27b";
+const DEFAULT_CALL_INTERVAL_MS = 62_000;
 
 type Grade = "A" | "B" | "C";
 type AnalystRole = "trading" | "financial";
@@ -254,7 +254,7 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
-    maxTokens: args.role === "editor" ? 2_500 : 1_500,
+    maxTokens: args.role === "editor" ? 2_500 : 1_800,
     timeoutMs: 45_000,
     trace: args.trace,
     metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },


### PR DESCRIPTION
## Summary
- move the daily committee from the exhausted 70B free-plan bucket to qwen/qwen3.6-27b
- process 50 candidates in four 13-item batches per analyst stage
- enforce a 62-second interval so rolling TPM windows do not overlap
- keep editor capacity separate while remaining below the 110-call daily cap

## Production evidence
- 70B trading stage failed with HTTP 429 after 2 attempts
- candidate generation remained healthy

## Verification
- npm run typecheck
- npm run test -- ai-client expert-review-committee expert-review-store