### PR TITLE
fix: parse concatenated committee review payloads

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -179,18 +179,18 @@ describe("expert committee orchestration", () => {
     const result = await runExpertReviewCommitteeStage("trading", {
       caller: async ({ input }) => {
         const candidates = input as Array<{ candidateId: string; stock: { symbol?: string } }>;
+        const reviews = candidates.slice(0, -1).map((candidate) => ({
+          candidateId: candidate.candidateId,
+          approved: true,
+          grade: "B",
+          paragraph: `${candidate.stock.symbol}의 구간과 거래량 근거를 대조해 현재 타이밍을 검수했습니다.`,
+          concerns: [],
+        }));
+        const middle = Math.ceil(reviews.length / 2);
         return {
           ok: true,
           model: "test-model",
-          content: JSON.stringify({
-            reviews: candidates.slice(0, -1).map((candidate) => ({
-              candidateId: candidate.candidateId,
-              approved: true,
-              grade: "B",
-              paragraph: `${candidate.stock.symbol}의 구간과 거래량 근거를 대조해 현재 타이밍을 검수했습니다.`,
-              concerns: [],
-            })),
-          }),
+          content: `${JSON.stringify({ reviews: reviews.slice(0, middle) })}${JSON.stringify({ reviews: reviews.slice(middle) })}`,
         };
       },
       buildPool: async () => fakePool(),
@@ -204,6 +204,7 @@ describe("expert committee orchestration", () => {
       },
     });
 
+    expect(result.error).toBeUndefined();
     expect(result.ok).toBe(true);
     const trading = (stored as { trading: Array<[string, { approved: boolean; grade: string; concerns: string[] }]> }).trading;
     expect(trading).toHaveLength(40);

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -185,12 +185,46 @@ export function validateAgentNumbers(text: string, input: unknown): string[] {
   return [...new Set(numericTokens(text).filter((token) => !allowed.has(token)))];
 }
 
-function parseJsonObject(text: string): unknown {
+function parseJsonObjects(text: string): unknown[] {
   const cleaned = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
-  const start = cleaned.indexOf("{");
-  const end = cleaned.lastIndexOf("}");
-  if (start < 0 || end <= start) throw new Error("agent output is not JSON");
-  return JSON.parse(cleaned.slice(start, end + 1));
+  const objects: unknown[] = [];
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < cleaned.length; index += 1) {
+    const character = cleaned[index]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "{") {
+      if (depth === 0) start = index;
+      depth += 1;
+      continue;
+    }
+    if (character !== "}" || depth === 0) continue;
+    depth -= 1;
+    if (depth !== 0 || start < 0) continue;
+    try {
+      objects.push(JSON.parse(cleaned.slice(start, index + 1)));
+    } catch {
+      // Keep scanning: a later complete object can still contain valid reviews.
+    }
+    start = -1;
+  }
+  if (objects.length === 0) throw new Error("agent output is not JSON");
+  return objects;
+}
+
+function parseJsonObject(text: string): unknown {
+  return parseJsonObjects(text).at(-1);
 }
 
 function isGrade(value: unknown): value is Grade {
@@ -198,9 +232,9 @@ function isGrade(value: unknown): value is Grade {
 }
 
 function parseAnalystBatch(text: string, expectedIds: readonly string[]): RawAnalystReview[] {
-  const parsed = parseJsonObject(text) as { reviews?: unknown[] };
-  if (!Array.isArray(parsed.reviews)) throw new Error("analyst reviews missing");
-  const rows = parsed.reviews.flatMap((value) => {
+  const parsed = parseJsonObjects(text) as Array<{ reviews?: unknown[]; candidateId?: unknown }>;
+  const values = parsed.flatMap((value) => Array.isArray(value.reviews) ? value.reviews : value.candidateId ? [value] : []);
+  const rows = values.flatMap((value) => {
     const row = value as Partial<RawAnalystReview>;
     if (
       typeof row.candidateId !== "string" ||


### PR DESCRIPTION
## Summary
- parse every complete top-level JSON object in analyst responses
- merge concatenated review arrays before candidate validation
- treat empty or omitted review rows as explicit C-grade rejections

## Production evidence
- qwen returned adjacent JSON objects and the previous parser failed at the second object

## Verification
- npm run typecheck
- npm run test -- expert-review-committee (7 tests, including concatenated JSON)