### PR TITLE
fix: normalize committee analyst responses

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -211,6 +211,41 @@ describe("expert committee orchestration", () => {
     expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(4);
   });
 
+  it("분석가가 candidateId를 생략해도 배치 순서로 정상 응답을 복원한다", async () => {
+    let stored: unknown = null;
+    const result = await runExpertReviewCommitteeStage("trading", {
+      caller: async ({ input }) => {
+        const candidates = input as Array<{ candidateId: string; stock: { symbol?: string } }>;
+        return {
+          ok: true,
+          model: "test-model",
+          content: JSON.stringify({
+            reviews: candidates.map((candidate) => ({
+              approved: true,
+              grade: "B",
+              paragraph: `${candidate.stock.symbol}의 구간과 거래량 근거를 대조해 현재 타이밍을 검수했습니다.`,
+              concerns: [],
+            })),
+          }),
+        };
+      },
+      buildPool: async () => fakePool(),
+      readPrevious: async () => null,
+      writeFailure: async () => {},
+      writePicks: async () => {},
+      minCallIntervalMs: 0,
+      stageStorage: {
+        read: async () => stored,
+        write: async (_date, value) => { stored = value; },
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, candidateCount: 40 });
+    const trading = (stored as { trading: Array<[string, { responseMissing?: boolean }]> }).trading;
+    expect(trading).toHaveLength(40);
+    expect(trading.every(([, review]) => review.responseMissing === false)).toBe(true);
+  });
+
   it("3단 크론은 동일 후보를 이어받아 editor 성공 때만 활성본을 발행한다", async () => {
     const caller: CommitteeAgentCaller = async ({ role, input }) => {
       if (role === "editor") {

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -202,18 +202,47 @@ function parseAnalystBatch(text: string, expectedIds: readonly string[]): RawAna
   const parsed = parseJsonObject(text) as { reviews?: unknown[] };
   if (!Array.isArray(parsed.reviews)) throw new Error("analyst reviews missing");
   const rows = parsed.reviews.flatMap((value) => {
-    const row = value as Partial<RawAnalystReview>;
-    if (
-      typeof row.candidateId !== "string" ||
-      typeof row.approved !== "boolean" ||
-      !isGrade(row.grade) ||
-      typeof row.paragraph !== "string" ||
-      !Array.isArray(row.concerns) ||
-      !row.concerns.every((item) => typeof item === "string")
-    ) return [];
-    return [{ ...row, concerns: row.concerns, responseMissing: false } as RawAnalystReview];
+    const row = value as Partial<RawAnalystReview> & { candidateId?: unknown };
+    const approved = typeof row.approved === "boolean"
+      ? row.approved
+      : row.approved === "true"
+        ? true
+        : row.approved === "false"
+          ? false
+          : undefined;
+    const grade = typeof row.grade === "string" && isGrade(row.grade.toUpperCase())
+      ? row.grade.toUpperCase() as Grade
+      : undefined;
+    const concerns = Array.isArray(row.concerns)
+      ? row.concerns.filter((item): item is string => typeof item === "string")
+      : [];
+    if (approved === undefined || !grade || typeof row.paragraph !== "string") return [];
+    return [{
+      candidateId: typeof row.candidateId === "string" ? row.candidateId : undefined,
+      approved,
+      grade,
+      paragraph: row.paragraph,
+      concerns,
+    }];
   });
-  const byId = new Map(rows.map((row) => [row.candidateId, row]));
+  const expected = new Set(expectedIds);
+  const byId = new Map<string, RawAnalystReview>();
+  const unassigned: Array<Omit<RawAnalystReview, "candidateId" | "responseMissing">> = [];
+  for (const row of rows) {
+    if (row.candidateId && expected.has(row.candidateId) && !byId.has(row.candidateId)) {
+      byId.set(row.candidateId, { ...row, candidateId: row.candidateId, responseMissing: false });
+    } else {
+      // 일부 모델은 JSON 스키마는 지키지만 긴 candidateId를 생략하거나 변형한다.
+      // 배치 순서가 유지된 응답만 남은 후보에 순서대로 붙이고, 실제 누락 행은 아래에서 hard reject한다.
+      unassigned.push(row);
+    }
+  }
+  const remainingIds = expectedIds.filter((id) => !byId.has(id));
+  for (const row of unassigned) {
+    const candidateId = remainingIds.shift();
+    if (!candidateId) break;
+    byId.set(candidateId, { ...row, candidateId, responseMissing: false });
+  }
   return expectedIds.map((id) => byId.get(id) ?? {
     candidateId: id,
     approved: false,


### PR DESCRIPTION
## Summary\n- normalize analyst booleans and grades\n- recover structurally valid responses with missing or mutated candidate IDs by batch order\n- retain hard rejection for genuinely missing responses\n- add regression coverage for omitted candidate IDs\n\n## Verification\n- npm run test -- expert-review-committee\n- npm run typecheck\n\nFixes the production committee editor eligibility failure where trading and financial stages completed but all candidates were treated as missing.