### PR TITLE
fix: respect committee provider rate limits

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -150,7 +150,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(9);
+    expect(result.report.callCount).toBe(17);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();
@@ -208,8 +208,8 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     const trading = (stored as { trading: Array<[string, { approved: boolean; grade: string; concerns: string[] }]> }).trading;
     expect(trading).toHaveLength(40);
-    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(4);
-    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(4);
+    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(8);
+    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(8);
   });
 
   it("분석가가 candidateId를 생략해도 배치 순서로 정상 응답을 복원한다", async () => {
@@ -296,15 +296,15 @@ describe("expert committee orchestration", () => {
     };
 
     const trading = await runExpertReviewCommitteeStage("trading", common);
-    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 4 });
+    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 8 });
     expect(publish).not.toHaveBeenCalled();
 
     const financial = await runExpertReviewCommitteeStage("financial", common);
-    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 8 });
+    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 16 });
     expect(publish).not.toHaveBeenCalled();
 
     const editor = await runExpertReviewCommitteeStage("editor", common);
-    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 9 });
+    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 17 });
     expect(publish).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -19,8 +19,8 @@ const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
 // Groq free/developer 조직의 TPM을 넘지 않도록 한 호출의 후보 수를 작게 유지한다.
-// 후보 50장 기준 분석가 5콜 + 5콜, 편집장 1콜로 일일 11콜이다.
-const BATCH_SIZE = 10;
+// 후보 50장 기준 분석가 10콜 + 10콜, 편집장 1콜로 일일 21콜이다.
+const BATCH_SIZE = 5;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "qwen/qwen3.6-27b";
@@ -110,7 +110,7 @@ interface CallState {
 }
 
 export interface CommitteeAgentCaller {
-  (args: { role: AnalystRole | "editor"; system: string; input: unknown; trace: string }): Promise<{ ok: boolean; content: string; model: string; status?: number }>;
+  (args: { role: AnalystRole | "editor"; system: string; input: unknown; trace: string }): Promise<{ ok: boolean; content: string; model: string; status?: number; retryAfterMs?: number }>;
 }
 
 export interface CommitteeRunResult {
@@ -326,7 +326,7 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
-    maxTokens: args.role === "editor" ? 2_500 : 1_400,
+    maxTokens: args.role === "editor" ? 2_500 : 1_000,
     timeoutMs: 45_000,
     trace: args.trace,
     metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },
@@ -349,6 +349,10 @@ async function callWithRetry(
     state.lastCallAt = Date.now();
     if (result.model) state.model = result.model;
     if (result.ok && result.content.trim()) return result.content;
+    if (result.status === 429 && result.retryAfterMs && result.retryAfterMs > 0) {
+      // Retry-After가 있으면 다음 시도까지의 대기 시간을 정확히 반영한다.
+      state.lastCallAt = Date.now() + result.retryAfterMs - state.minCallIntervalMs;
+    }
     lastError = `${args.role} agent call failed${result.status ? ` HTTP ${result.status}` : ""}`;
   }
   throw new Error(lastError);
@@ -430,7 +434,7 @@ function compactAnalystInput(role: AnalystRole, input: CommitteeCandidateInput):
         zone?.label,
         ...(zone?.evidence ?? []),
         ...(input.trading.wyckoff?.events.slice(-2).map((event) => event.label) ?? []),
-      ].filter(Boolean).slice(0, 6),
+      ].filter((fact): fact is string => typeof fact === "string").slice(0, 4).map((fact) => fact.slice(0, 120)),
     };
   }
   const metricFacts = input.financial.metrics.slice(0, 5).map((metric) => `${metric.label} ${metric.value}`);
@@ -449,7 +453,7 @@ function compactAnalystInput(role: AnalystRole, input: CommitteeCandidateInput):
       ...metricFacts,
       ...scoreFacts,
       ...financialFacts,
-    ].slice(0, 8),
+    ].slice(0, 6).map((fact) => fact.slice(0, 120)),
   };
 }
 

--- a/packages/shared/src/ai-client.ts
+++ b/packages/shared/src/ai-client.ts
@@ -41,6 +41,7 @@ export interface CallAiResult {
   ok: boolean;
   status: number;
   model: string;
+  retryAfterMs?: number;
 }
 
 interface LlmResponse {
@@ -161,6 +162,10 @@ export async function callAI(opts: CallAiOptions): Promise<CallAiResult> {
     });
     result.status = res.status;
     if (!res.ok) {
+      const retryAfterSeconds = Number.parseFloat(res.headers.get("retry-after") ?? "");
+      if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+        result.retryAfterMs = Math.round(retryAfterSeconds * 1_000);
+      }
       console.warn(`[ai-client] ${opts.trace ?? "call"} HTTP ${res.status}`);
       finishTrace({ ok: false, status: res.status });
       return result;


### PR DESCRIPTION
## Summary\n- split analyst batches to 5 candidates to reduce Groq TPM bursts\n- trim evidence payloads and analyst completion budget\n- propagate Groq Retry-After headers through the shared AI client\n- keep committee under 21 calls for a 50-candidate run\n\n## Verification\n- npm run test -- expert-review-committee ai-client\n- npm run typecheck\n\nProduction had HTTP 429 during the committee analyst stage; this prevents immediate retry storms and keeps the daily cron within provider limits.