### PR TITLE
fix: balance committee batch latency

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -150,7 +150,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(17);
+    expect(result.report.callCount).toBe(11);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();
@@ -208,8 +208,8 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     const trading = (stored as { trading: Array<[string, { approved: boolean; grade: string; concerns: string[] }]> }).trading;
     expect(trading).toHaveLength(40);
-    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(8);
-    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(8);
+    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(5);
+    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(5);
   });
 
   it("분석가가 candidateId를 생략해도 배치 순서로 정상 응답을 복원한다", async () => {
@@ -296,15 +296,15 @@ describe("expert committee orchestration", () => {
     };
 
     const trading = await runExpertReviewCommitteeStage("trading", common);
-    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 8 });
+    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 5 });
     expect(publish).not.toHaveBeenCalled();
 
     const financial = await runExpertReviewCommitteeStage("financial", common);
-    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 16 });
+    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 10 });
     expect(publish).not.toHaveBeenCalled();
 
     const editor = await runExpertReviewCommitteeStage("editor", common);
-    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 17 });
+    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 11 });
     expect(publish).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -19,12 +19,12 @@ const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
 // Groq free/developer 조직의 TPM을 넘지 않도록 한 호출의 후보 수를 작게 유지한다.
-// 후보 50장 기준 분석가 10콜 + 10콜, 편집장 1콜로 일일 21콜이다.
-const BATCH_SIZE = 5;
+// 후보 50장 기준 분석가 7콜 + 7콜, 편집장 1콜로 일일 15콜이다.
+const BATCH_SIZE = 8;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "qwen/qwen3.6-27b";
-const DEFAULT_CALL_INTERVAL_MS = 20_000;
+const DEFAULT_CALL_INTERVAL_MS = 5_000;
 
 type Grade = "A" | "B" | "C";
 type AnalystRole = "trading" | "financial";


### PR DESCRIPTION
## Summary\n- use 8-candidate analyst batches with a 5-second pacing interval\n- keep compact evidence payloads and Retry-After handling\n- finish a 50-candidate run in 15 calls total within the Vercel 300-second stage limit\n\n## Verification\n- npm run test -- expert-review-committee ai-client\n- npm run typecheck\n\nThe previous 5-candidate pacing avoided token bursts but exceeded the 300-second production function limit.