### PR TITLE
fix: fail fast on long committee rate limits

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -150,7 +150,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(11);
+    expect(result.report.callCount).toBe(9);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();
@@ -208,8 +208,8 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     const trading = (stored as { trading: Array<[string, { approved: boolean; grade: string; concerns: string[] }]> }).trading;
     expect(trading).toHaveLength(40);
-    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(5);
-    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(5);
+    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(4);
+    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(4);
   });
 
   it("분석가가 candidateId를 생략해도 배치 순서로 정상 응답을 복원한다", async () => {
@@ -296,15 +296,15 @@ describe("expert committee orchestration", () => {
     };
 
     const trading = await runExpertReviewCommitteeStage("trading", common);
-    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 5 });
+    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 4 });
     expect(publish).not.toHaveBeenCalled();
 
     const financial = await runExpertReviewCommitteeStage("financial", common);
-    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 10 });
+    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 8 });
     expect(publish).not.toHaveBeenCalled();
 
     const editor = await runExpertReviewCommitteeStage("editor", common);
-    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 11 });
+    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 9 });
     expect(publish).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -19,8 +19,8 @@ const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
 // Groq free/developer 조직의 TPM을 넘지 않도록 한 호출의 후보 수를 작게 유지한다.
-// 후보 50장 기준 분석가 7콜 + 7콜, 편집장 1콜로 일일 15콜이다.
-const BATCH_SIZE = 8;
+// 후보 50장 기준 분석가 4콜 + 4콜, 편집장 1콜로 일일 9콜이다.
+const BATCH_SIZE = 13;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "qwen/qwen3.6-27b";
@@ -326,7 +326,7 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
-    maxTokens: args.role === "editor" ? 2_500 : 1_000,
+    maxTokens: args.role === "editor" ? 2_500 : 1_800,
     timeoutMs: 45_000,
     trace: args.trace,
     metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },
@@ -350,6 +350,9 @@ async function callWithRetry(
     if (result.model) state.model = result.model;
     if (result.ok && result.content.trim()) return result.content;
     if (result.status === 429 && result.retryAfterMs && result.retryAfterMs > 0) {
+      if (result.retryAfterMs > 15_000) {
+        throw new Error(`${args.role} agent rate limited; retry after ${Math.ceil(result.retryAfterMs / 1_000)}s`);
+      }
       // Retry-After가 있으면 다음 시도까지의 대기 시간을 정확히 반영한다.
       state.lastCallAt = Date.now() + result.retryAfterMs - state.minCallIntervalMs;
     }
@@ -434,7 +437,7 @@ function compactAnalystInput(role: AnalystRole, input: CommitteeCandidateInput):
         zone?.label,
         ...(zone?.evidence ?? []),
         ...(input.trading.wyckoff?.events.slice(-2).map((event) => event.label) ?? []),
-      ].filter((fact): fact is string => typeof fact === "string").slice(0, 4).map((fact) => fact.slice(0, 120)),
+      ].filter((fact): fact is string => typeof fact === "string").slice(0, 3).map((fact) => fact.slice(0, 80)),
     };
   }
   const metricFacts = input.financial.metrics.slice(0, 5).map((metric) => `${metric.label} ${metric.value}`);
@@ -453,7 +456,7 @@ function compactAnalystInput(role: AnalystRole, input: CommitteeCandidateInput):
       ...metricFacts,
       ...scoreFacts,
       ...financialFacts,
-    ].slice(0, 6).map((fact) => fact.slice(0, 120)),
+    ].slice(0, 4).map((fact) => fact.slice(0, 80)),
   };
 }
 


### PR DESCRIPTION
## Summary\n- restore 13-candidate compact batches for 4+4+1 calls\n- trim analyst facts to the minimum grounded evidence\n- stop retrying when Groq Retry-After exceeds 15 seconds instead of burning the Vercel 300-second budget\n- preserve previous committee snapshot on provider failure\n\n## Verification\n- npm run test -- expert-review-committee ai-client\n- npm run typecheck\n\nThis prevents long provider backoffs from turning the committee cron into a function timeout.