### PR TITLE
fix: enforce structured committee responses

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -150,7 +150,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(5);
+    expect(result.report.callCount).toBe(9);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();
@@ -208,8 +208,8 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     const trading = (stored as { trading: Array<[string, { approved: boolean; grade: string; concerns: string[] }]> }).trading;
     expect(trading).toHaveLength(40);
-    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(2);
-    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(2);
+    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(4);
+    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(4);
   });
 
   it("분석가가 candidateId를 생략해도 배치 순서로 정상 응답을 복원한다", async () => {
@@ -296,15 +296,15 @@ describe("expert committee orchestration", () => {
     };
 
     const trading = await runExpertReviewCommitteeStage("trading", common);
-    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 2 });
+    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 4 });
     expect(publish).not.toHaveBeenCalled();
 
     const financial = await runExpertReviewCommitteeStage("financial", common);
-    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 4 });
+    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 8 });
     expect(publish).not.toHaveBeenCalled();
 
     const editor = await runExpertReviewCommitteeStage("editor", common);
-    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 5 });
+    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 9 });
     expect(publish).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -19,8 +19,8 @@ const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
 // Groq free/developer 조직의 TPM을 넘지 않도록 입력을 압축하고 호출 수를 줄인다.
-// 후보 50장 기준 분석가 3콜 + 3콜, 편집장 1콜로 일일 7콜이다.
-const BATCH_SIZE = 20;
+// 후보 50장 기준 분석가 5콜 + 5콜, 편집장 1콜로 일일 11콜이다.
+const BATCH_SIZE = 10;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "llama-3.1-8b-instant";
@@ -326,7 +326,8 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
-    maxTokens: args.role === "editor" ? 1_000 : 1_300,
+    maxTokens: args.role === "editor" ? 900 : 1_500,
+    jsonMode: true,
     timeoutMs: 45_000,
     trace: args.trace,
     metadata: { committeeVersion: COMMITTEE_VERSION, role: args.role },

--- a/packages/shared/src/ai-client.ts
+++ b/packages/shared/src/ai-client.ts
@@ -26,6 +26,8 @@ export interface CallAiOptions {
   temperature?: number;
   /** OpenAI 호환 max_tokens. 생략 시 공급자 기본값, 비용/TPM 게이트 경로는 반드시 명시한다. */
   maxTokens?: number;
+  /** OpenAI 호환 JSON object 응답 모드. 구조화된 검수 결과처럼 파싱 계약이 필요한 호출에 사용한다. */
+  jsonMode?: boolean;
   /** 기본 25_000ms. */
   timeoutMs?: number;
   apiUrl?: string;
@@ -156,6 +158,7 @@ export async function callAI(opts: CallAiOptions): Promise<CallAiResult> {
         model,
         ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
         ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.jsonMode ? { response_format: { type: "json_object" } } : {}),
         messages: opts.messages,
       }),
       signal: AbortSignal.timeout(opts.timeoutMs ?? 25_000),


### PR DESCRIPTION
## Summary\n- request JSON object responses from the provider for committee calls\n- use 10-candidate analyst batches so outputs remain complete\n- keep the compact llama model and call budget\n\n## Verification\n- npm run typecheck\n- npm run test -- expert-review-committee ai-client\n\nThis keeps the fact gate fail-closed while avoiding truncated or prose-only analyst payloads.