### PR TITLE
fix: preserve committee model on provider fallback

### DIFF
--- a/packages/shared/__tests__/ai-client.test.ts
+++ b/packages/shared/__tests__/ai-client.test.ts
@@ -88,4 +88,26 @@ describe("ai-client provider routing", () => {
     expect(res.model).toBe("llama-3.3-70b-versatile");
     expect(fetchMock).toHaveBeenCalledWith("https://api.groq.com/openai/v1/chat/completions", expect.any(Object));
   });
+
+  it("preserves an explicit non-Gemini model when bypassing the global Gemini endpoint", async () => {
+    snapshotEnv();
+    process.env.AI_API_URL = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+    process.env.AI_API_KEY = "gemini-key";
+    process.env.GROQ_API_KEY = "groq-key";
+    process.env.GROQ_MODEL = "qwen/qwen3.6-27b";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await callAI({
+      model: "llama-3.1-8b-instant",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.model).toBe("llama-3.1-8b-instant");
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string) as { model: string };
+    expect(body.model).toBe("llama-3.1-8b-instant");
+  });
 });

--- a/packages/shared/src/ai-client.ts
+++ b/packages/shared/src/ai-client.ts
@@ -95,7 +95,10 @@ function resolveRuntimeConfig(opts: Pick<CallAiOptions, "apiUrl" | "apiKey" | "m
       return {
         url: GROQ_API_URL,
         key: fallbackKey,
-        model: groqModel(),
+        // 호출부가 명시한 비-Gemini 모델은 보존한다. 전역 Gemini 설정을
+        // 우회하는 위원회처럼 호출별 비용·품질 게이트가 있는 경로가
+        // GROQ_MODEL 환경값에 의해 다시 무거운 모델로 올라가지 않게 한다.
+        model: isGeminiModel(model) ? groqModel() : model,
       };
     }
     return { url: "", key: "", model, blockedProvider: "gemini" };


### PR DESCRIPTION
## Summary\n- preserve an explicitly selected non-Gemini model when the shared client reroutes a blocked Gemini endpoint to Groq\n- prevent GROQ_MODEL from silently restoring the heavy committee model\n- add a regression test for the Gemini-to-Groq fallback path\n\n## Verification\n- npm run typecheck\n- npm run test -- expert-review-committee ai-client