### PR TITLE
fix: keep daily 30 available when committee fails

### DIFF
--- a/.github/workflows/daily-30-health.yml
+++ b/.github/workflows/daily-30-health.yml
@@ -1,0 +1,54 @@
+name: Daily 30 Availability
+
+on:
+  schedule:
+    # Vercel editor cron(21:20 UTC, max 5m) 종료 뒤 공개 응답을 검증한다.
+    - cron: "30 21 * * *"
+  workflow_dispatch:
+    inputs:
+      rerun_committee:
+        description: "Run trading, financial and editor stages before verification"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-30-availability
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun committee stages
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.rerun_committee }}
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          for STAGE in trading financial editor; do
+            URL="https://fomo-club-backend.vercel.app/api/fomo/cron/daily-30/${STAGE}"
+            if [ -n "${CRON_SECRET:-}" ]; then
+              curl -fsS --max-time 320 "$URL" -H "Authorization: Bearer ${CRON_SECRET}"
+            else
+              curl -fsS --max-time 320 "$URL"
+            fi
+          done
+
+      - name: Verify published daily-30
+        run: |
+          set -euo pipefail
+          curl -fsS --max-time 320 "https://fomo-club-backend.vercel.app/api/fomo/daily-30" > /tmp/daily30.json
+          node -e '
+            const fs = require("fs");
+            const json = JSON.parse(fs.readFileSync("/tmp/daily30.json", "utf8"));
+            const cards = Math.max(json.cards?.length || 0, json.stocks?.length || 0);
+            console.log(JSON.stringify({ cards, stale: json.meta?.stale || null, source: json.source }));
+            if (cards < 20) {
+              console.error(`daily-30 availability check failed: ${cards}/20 cards`);
+              process.exit(1);
+            }
+          '

--- a/.github/workflows/feed-content.yml
+++ b/.github/workflows/feed-content.yml
@@ -78,5 +78,10 @@ jobs:
             const json = JSON.parse(fs.readFileSync("/tmp/daily30.json", "utf8"));
             const contents = (json.cards || []).filter((c) => c.kind === "content");
             const kinds = contents.map((c) => c.contentType);
-            console.log(JSON.stringify({ cards: json.cards?.length || 0, contents: contents.length, kinds }));
+            const cards = Math.max(json.cards?.length || 0, json.stocks?.length || 0);
+            console.log(JSON.stringify({ cards, contents: contents.length, kinds, stale: json.meta?.stale || null }));
+            if (cards < 20) {
+              console.error(`daily-30 self-check failed: ${cards}/20 cards`);
+              process.exit(1);
+            }
           '

--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -232,6 +232,13 @@ export function DesktopDashboard() {
       <section className="flex min-h-0 flex-col rounded-2xl border border-hairline bg-surface">
         <div className="border-b border-hairline px-4 py-3">
           <p className="font-pixel text-sm text-whiteout">오늘의 30장</p>
+          {daily.meta?.stale && (
+            <p className="mt-1 text-[10px] leading-4 text-muted" role="status">
+              {daily.meta.stale === "committee-yesterday"
+                ? "어제 기준 카드예요 · 갱신 중"
+                : "검수 갱신 중인 카드예요"}
+            </p>
+          )}
           <div className="mt-2.5 flex flex-wrap gap-1.5" role="tablist" aria-label="시장 필터">
             {FILTER_TABS.map((tab) => {
               const active = filter === tab.key;

--- a/apps/fomo-web/components/UnifiedDailyDeck.tsx
+++ b/apps/fomo-web/components/UnifiedDailyDeck.tsx
@@ -93,7 +93,12 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
   const [state, setState] = useState<
     | { kind: "loading" }
     | { kind: "error" }
-    | { kind: "ready"; cards: DeckCard[]; fronts: Record<string, FrontEntry> }
+    | {
+        kind: "ready";
+        cards: DeckCard[];
+        fronts: Record<string, FrontEntry>;
+        stale?: "committee-yesterday" | "engine-direct";
+      }
   >({ kind: "loading" });
   // 무로그인 대기함 배너 — ready N개 / not_found 안내(각 1회).
   const [requestBanner, setRequestBanner] = useState<{ ready: number; notFound: string[] } | null>(null);
@@ -130,7 +135,12 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
             setRequestBanner({ ready: readyRows.length, notFound: notFoundRows.map((row) => row.query) });
             ackRequests([...readyRows, ...notFoundRows].map((row) => row.query));
           }
-          setState({ kind: "ready", cards: [...requestCards, ...next.cards], fronts: next.fronts });
+          setState({
+            kind: "ready",
+            cards: [...requestCards, ...next.cards],
+            fronts: next.fronts,
+            ...(discovery.meta?.stale ? { stale: discovery.meta.stale } : {}),
+          });
           return;
         } catch (err) {
           lastError = err;
@@ -165,6 +175,13 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      {state.stale && (
+        <p className="mb-2 shrink-0 px-1 text-[11px] leading-4 text-muted" role="status">
+          {state.stale === "committee-yesterday"
+            ? "어제 기준 카드예요 · 갱신 중"
+            : "검수 갱신 중인 카드예요"}
+        </p>
+      )}
       {requestBanner && (
         <div className="mb-2 shrink-0 rounded-xl border border-hairline px-3.5 py-2" style={{ backgroundColor: "rgba(216,255,58,0.10)" }}>
           <p className="text-xs leading-5 text-whiteout">

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -32,7 +32,8 @@ const CACHE_TTL = {
   themeInsight: 6 * HOUR,
   stockInsight: 6 * HOUR,
   performancePrices: 10 * MINUTE,
-  daily30: HOUR,
+  // 비상 스냅샷/엔진 응답이 오늘 위원회 발행 뒤 빠르게 정상본으로 교체되도록 짧게 유지한다.
+  daily30: 5 * MINUTE,
 } as const;
 export const KEYWORDS_UPDATED_EVENT = "fomo:keywords-updated";
 export const DISCOVERY_UPDATED_EVENT = "fomo:discovery-updated";
@@ -772,6 +773,7 @@ export interface Daily30Response extends DiscoveryResponse {
       selectedCount: number;
       callCount: number;
     };
+    stale?: "committee-yesterday" | "engine-direct";
   };
 }
 

--- a/apps/web/__tests__/lib/daily-30-fallback.test.ts
+++ b/apps/web/__tests__/lib/daily-30-fallback.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (factory: () => unknown) => factory,
+}));
+
+import {
+  resolveDaily30Response,
+  type Daily30Response,
+} from "../../lib/daily-30";
+import type { PublishedCommitteeSnapshot } from "../../lib/expert-review-store";
+
+function response(count = 30): Daily30Response {
+  const stocks = Array.from({ length: count }, (_, index) => ({
+    canonical: `종목${index}`,
+    country: "KR" as const,
+    market: "KOSPI",
+    sector: "기타 업종",
+  }));
+  return {
+    asOf: "2026-07-20T00:00:00.000Z",
+    country: "all",
+    stocks,
+    cards: stocks,
+    fronts: {},
+    confidence: "M",
+    source: "test",
+    meta: {
+      targetCount: 30,
+      cards: [],
+      assetCounts: { "kr-stock": count, "us-stock": 0, coin: 0, macro: 0 },
+    },
+  } as unknown as Daily30Response;
+}
+
+function snapshot(date: string, count = 30): PublishedCommitteeSnapshot {
+  return {
+    runId: `run-${date}`,
+    version: "committee-v1",
+    reviewedAt: `${date}T01:00:00.000Z`,
+    response: response(count),
+    report: {
+      runId: `run-${date}`,
+      version: "committee-v1",
+      date,
+      status: "published",
+      startedAt: `${date}T00:00:00.000Z`,
+      completedAt: `${date}T01:00:00.000Z`,
+      model: "test",
+      callCount: 3,
+      candidateCount: 50,
+      selectedCount: count,
+      selectedIds: [],
+      compositionSummary: "test",
+      assetCounts: {},
+    },
+  };
+}
+
+describe("daily-30 availability fallback", () => {
+  it("오늘 위원회 발행분을 정상 경로로 반환한다", async () => {
+    const current = snapshot("2026-07-20");
+    const result = await resolveDaily30Response({
+      today: "2026-07-20",
+      readToday: vi.fn().mockResolvedValue(current),
+      readRecent: vi.fn(),
+      buildDirect: vi.fn(),
+    });
+    expect(result).toBe(current.response);
+    expect(result.meta.stale).toBeUndefined();
+  });
+
+  it("오늘 발행 실패 시 최근 3일 승인본을 stale 표시와 함께 반환한다", async () => {
+    const recent = snapshot("2026-07-19");
+    const buildDirect = vi.fn();
+    const result = await resolveDaily30Response({
+      today: "2026-07-20",
+      readToday: vi.fn().mockResolvedValue(null),
+      readRecent: vi.fn().mockResolvedValue(recent),
+      buildDirect,
+    });
+    expect(result.meta.stale).toBe("committee-yesterday");
+    expect(buildDirect).not.toHaveBeenCalled();
+  });
+
+  it("승인 스냅샷도 없으면 엔진 직생성 결과를 반환한다", async () => {
+    const direct = response();
+    const result = await resolveDaily30Response({
+      today: "2026-07-20",
+      readToday: vi.fn().mockResolvedValue(null),
+      readRecent: vi.fn().mockResolvedValue(null),
+      buildDirect: vi.fn().mockResolvedValue(direct),
+    });
+    expect(result.meta.stale).toBe("engine-direct");
+    expect(result.stocks).toHaveLength(30);
+  });
+
+  it("세 경로가 모두 20장 미만일 때만 실패한다", async () => {
+    await expect(
+      resolveDaily30Response({
+        today: "2026-07-20",
+        readToday: vi.fn().mockResolvedValue(snapshot("2026-07-20", 3)),
+        readRecent: vi.fn().mockResolvedValue(snapshot("2026-07-19", 10)),
+        buildDirect: vi.fn().mockResolvedValue(response(19)),
+      })
+    ).rejects.toThrow("engine produced 19/20");
+  });
+});

--- a/apps/web/__tests__/lib/expert-review-store.test.ts
+++ b/apps/web/__tests__/lib/expert-review-store.test.ts
@@ -1,14 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { writeFeedContent } = vi.hoisted(() => ({ writeFeedContent: vi.fn() }));
-
-vi.mock("../../lib/feed-content-store", () => ({
+const { readFeedContent, readFeedContentByPrefix, writeFeedContent } = vi.hoisted(() => ({
   readFeedContent: vi.fn(),
   readFeedContentByPrefix: vi.fn(),
+  writeFeedContent: vi.fn(),
+}));
+
+vi.mock("../../lib/feed-content-store", () => ({
+  readFeedContent,
+  readFeedContentByPrefix,
   writeFeedContent,
 }));
 
-import { publishCommitteeSnapshot, writeFailedCommitteeRun, type CommitteeRunReport } from "../../lib/expert-review-store";
+import {
+  publishCommitteeSnapshot,
+  readRecentPublishedCommitteeSnapshot,
+  writeFailedCommitteeRun,
+  type CommitteeRunReport,
+  type PublishedCommitteeSnapshot,
+} from "../../lib/expert-review-store";
 
 const report: CommitteeRunReport = {
   runId: "run-1",
@@ -29,7 +39,11 @@ const report: CommitteeRunReport = {
 };
 
 describe("expert committee publication ordering", () => {
-  beforeEach(() => writeFeedContent.mockReset());
+  beforeEach(() => {
+    readFeedContent.mockReset();
+    readFeedContentByPrefix.mockReset();
+    writeFeedContent.mockReset();
+  });
 
   it("실패 실행은 이력만 쓰고 활성 승인본을 교체하지 않는다", async () => {
     await writeFailedCommitteeRun(report);
@@ -50,7 +64,36 @@ describe("expert committee publication ordering", () => {
     await publishCommitteeSnapshot(snapshot, published);
     expect(writeFeedContent.mock.calls.map((call) => call[0])).toEqual([
       "expert-committee:run:2026-07-19:run-1",
+      "expert-committee:snapshot:2026-07-19:run-1",
       "expert-committee:active",
     ]);
+  });
+
+  it("오늘 캐시 키와 무관하게 최근 3일 안의 최신 발행본을 찾는다", async () => {
+    const response = {
+      stocks: Array.from({ length: 30 }, (_, index) => ({ canonical: `종목${index}` })),
+      cards: Array.from({ length: 30 }, (_, index) => ({ canonical: `종목${index}` })),
+    } as never;
+    const recent = {
+      runId: "run-recent",
+      version: "committee-v1",
+      reviewedAt: "2026-07-19T01:00:00.000Z",
+      response,
+      report: { ...report, runId: "run-recent", date: "2026-07-19" },
+    } satisfies PublishedCommitteeSnapshot;
+    const expired = {
+      ...recent,
+      runId: "run-expired",
+      reviewedAt: "2026-07-15T01:00:00.000Z",
+      report: { ...recent.report, runId: "run-expired", date: "2026-07-15" },
+    };
+    readFeedContent.mockResolvedValue(null);
+    readFeedContentByPrefix.mockResolvedValue([
+      { id: "expert-committee:snapshot:2026-07-15:run-expired", row: expired },
+      { id: "expert-committee:snapshot:2026-07-19:run-recent", row: recent },
+    ]);
+
+    await expect(readRecentPublishedCommitteeSnapshot("2026-07-20", 3)).resolves.toEqual(recent);
+    expect(readFeedContentByPrefix).toHaveBeenCalledWith("expert-committee:snapshot:", 10);
   });
 });

--- a/apps/web/app/api/fomo/cron/daily-30/route.ts
+++ b/apps/web/app/api/fomo/cron/daily-30/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { withCors, kstDate } from "../../../../../lib/fomo";
 import { runExpertReviewCommitteeStage, type CommitteeStage } from "../../../../../lib/expert-review-committee";
+import { daily30CardCount, resolveDaily30Response } from "../../../../../lib/daily-30";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -24,7 +25,15 @@ export async function GET(request: Request) {
     }
     const stage = requestedStage as CommitteeStage;
     const result = await runExpertReviewCommitteeStage(stage);
-    if (result.ok && stage === "editor") revalidateTag("daily-30", { expire: 0 });
+    let verifiedCards: number | undefined;
+    if (result.ok && stage === "editor") {
+      revalidateTag("daily-30", { expire: 0 });
+      const published = await resolveDaily30Response();
+      verifiedCards = daily30CardCount(published);
+      if (verifiedCards < 20) {
+        throw new Error(`daily-30 post-publish verification failed: ${verifiedCards}/20 cards`);
+      }
+    }
     return withCors(
       NextResponse.json(
         {
@@ -36,6 +45,7 @@ export async function GET(request: Request) {
           calls: result.callCount,
           candidates: result.candidateCount,
           selected: result.selectedCount,
+          ...(verifiedCards !== undefined ? { verifiedCards } : {}),
           previousRunRetained: result.previousRunRetained,
           ...(result.error ? { error: result.error } : {}),
           elapsedMs: Date.now() - startedAt,

--- a/apps/web/app/api/fomo/daily-30/route.ts
+++ b/apps/web/app/api/fomo/daily-30/route.ts
@@ -3,7 +3,8 @@ import { withCors, kstDate } from "../../../../lib/fomo";
 import { getCachedDaily30Response, type Daily30Response } from "../../../../lib/daily-30";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 60;
+// 위원회·스냅샷 동시 부재 때 결정론 엔진 직생성까지 허용하는 최후 비상 경로.
+export const maxDuration = 300;
 
 export function OPTIONS() {
   return withCors(new NextResponse(null, { status: 204 }));
@@ -11,9 +12,13 @@ export function OPTIONS() {
 
 export async function GET() {
   try {
+    const response = await getCachedDaily30Response();
+    const cacheControl = response.meta.stale
+      ? "public, s-maxage=60, stale-while-revalidate=300"
+      : "public, s-maxage=3600, stale-while-revalidate=86400";
     return withCors(
-      NextResponse.json(await getCachedDaily30Response(), {
-        headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+      NextResponse.json(response, {
+        headers: { "Cache-Control": cacheControl },
       })
     );
   } catch (err) {

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -14,7 +14,11 @@ import { expandDeckContentCardsForScope, fetchDeckContentCards, type DeckContent
 import { buildCoinDiscoveryResponse } from "./coin-discovery";
 import { readTodayFeedContent, type TodayFeedContent } from "./feed-briefing";
 import { readFeedContentByPrefix, writeFeedContent } from "./feed-content-store";
-import { readPublishedCommitteeSnapshot } from "./expert-review-store";
+import {
+  readPublishedCommitteeSnapshot,
+  readRecentPublishedCommitteeSnapshot,
+  type PublishedCommitteeSnapshot,
+} from "./expert-review-store";
 
 export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
 
@@ -45,6 +49,8 @@ export interface Daily30Response extends DiscoveryResponse {
       selectedCount: number;
       callCount: number;
     };
+    /** 위원회 미발행 시 사용한 비상 공급 경로. 정상 발행본에는 없다. */
+    stale?: "committee-yesterday" | "engine-direct";
   };
 }
 
@@ -496,12 +502,12 @@ async function readYesterdayPicks(today: string): Promise<FreshnessSnapshot> {
   return { headlines };
 }
 
-interface Daily30BuildOptions {
+export interface Daily30BuildOptions {
   targetCount?: number;
   persistPicks?: boolean;
 }
 
-async function buildDaily30ResponseWithOptions(options: Daily30BuildOptions = {}): Promise<Daily30Response> {
+export async function buildDaily30ResponseWithOptions(options: Daily30BuildOptions = {}): Promise<Daily30Response> {
   const targetCount = Math.max(1, Math.min(50, options.targetCount ?? DAILY_CARD_TARGET));
   const persistPicks = options.persistPicks ?? true;
   const today = kstDateOf();
@@ -627,17 +633,67 @@ export async function buildDaily30CandidatePoolResponse(targetCount = 50): Promi
   return buildDaily30ResponseWithOptions({ targetCount, persistPicks: false });
 }
 
+export function daily30CardCount(response: Daily30Response | null | undefined): number {
+  if (!response) return 0;
+  return Math.max(response.cards?.length ?? 0, response.stocks?.length ?? 0);
+}
+
+function withFallbackMeta(
+  response: Daily30Response,
+  stale: NonNullable<Daily30Response["meta"]["stale"]>
+): Daily30Response {
+  return { ...response, meta: { ...response.meta, stale } };
+}
+
+export interface Daily30FallbackDependencies {
+  today?: string;
+  readToday?: () => Promise<PublishedCommitteeSnapshot | null>;
+  readRecent?: (today: string, maxAgeDays: number) => Promise<PublishedCommitteeSnapshot | null>;
+  buildDirect?: () => Promise<Daily30Response>;
+}
+
+/**
+ * 공개 요청의 공급 체인. 위원회 장애는 사용자 장애로 전파하지 않고 최근 승인본,
+ * 결정론 엔진 순서로 격리한다. 20장 미만 응답은 빈 덱과 동일하게 다음 단계로 넘긴다.
+ */
+export async function resolveDaily30Response(
+  dependencies: Daily30FallbackDependencies = {}
+): Promise<Daily30Response> {
+  const today = dependencies.today ?? kstDateOf();
+  const readToday = dependencies.readToday ?? readPublishedCommitteeSnapshot;
+  const readRecent = dependencies.readRecent ?? readRecentPublishedCommitteeSnapshot;
+  const buildDirect =
+    dependencies.buildDirect ?? (() => buildDaily30ResponseWithOptions({ targetCount: DAILY_CARD_TARGET }));
+
+  const active = await readToday().catch((error) => {
+    console.warn("[daily-30] active committee snapshot unavailable", (error as Error)?.message);
+    return null;
+  });
+  if (active?.report.date === today && daily30CardCount(active.response) >= 20) {
+    return active.response;
+  }
+
+  const recent = await readRecent(today, 3).catch((error) => {
+    console.warn("[daily-30] recent committee snapshot unavailable", (error as Error)?.message);
+    return null;
+  });
+  if (recent && recent.report.date !== today && daily30CardCount(recent.response) >= 20) {
+    return withFallbackMeta(recent.response, "committee-yesterday");
+  }
+
+  const direct = await buildDirect();
+  const directCount = daily30CardCount(direct);
+  if (directCount >= 20) return withFallbackMeta(direct, "engine-direct");
+  throw new Error(`daily-30 fallback exhausted: engine produced ${directCount}/20 cards`);
+}
+
 /**
  * 공유 캐시 getter — daily-30 라우트와 feed-hub 가 같은 캐시 엔트리를 쓴다(중복 빌드 방지).
  * feed-content 크론이 tags 로 즉시 무효화한다.
  */
 export async function getCachedDaily30Response(): Promise<Daily30Response> {
   const load = unstable_cache(
-    async () => {
-      const snapshot = await readPublishedCommitteeSnapshot();
-      if (!snapshot?.response) throw new Error("expert committee has not published a deck yet");
-      return snapshot.response;
-    },
+    resolveDaily30Response,
     ["fomo-daily-30-approved", cacheVersion(), kstDateOf()],
     { revalidate: 60 * 5, tags: ["daily-30"] }
   );

--- a/apps/web/lib/expert-review-store.ts
+++ b/apps/web/lib/expert-review-store.ts
@@ -3,6 +3,7 @@ import { readFeedContent, readFeedContentByPrefix, writeFeedContent } from "./fe
 
 const ACTIVE_ID = "expert-committee:active";
 const RUN_PREFIX = "expert-committee:run:";
+const SNAPSHOT_PREFIX = "expert-committee:snapshot:";
 
 export type CommitteeRunStatus = "published" | "failed";
 
@@ -53,12 +54,50 @@ export async function readPublishedCommitteeSnapshot(): Promise<PublishedCommitt
   return readFeedContent<PublishedCommitteeSnapshot>(ACTIVE_ID);
 }
 
+function snapshotAgeDays(snapshot: PublishedCommitteeSnapshot, today: string): number {
+  const snapshotDate = snapshot.report.date || snapshot.reviewedAt.slice(0, 10);
+  const todayMs = Date.parse(`${today}T00:00:00.000Z`);
+  const snapshotMs = Date.parse(`${snapshotDate}T00:00:00.000Z`);
+  if (!Number.isFinite(todayMs) || !Number.isFinite(snapshotMs)) return Number.POSITIVE_INFINITY;
+  return Math.floor((todayMs - snapshotMs) / 86_400_000);
+}
+
+/**
+ * 활성 포인터와 날짜별 발행 이력을 함께 조회한다. 오늘 날짜 캐시 키와 무관하게
+ * 최근 승인본을 찾기 때문에 위원회가 하루 실패해도 전일 덱을 계속 서빙할 수 있다.
+ */
+export async function readRecentPublishedCommitteeSnapshot(
+  today: string,
+  maxAgeDays = 3
+): Promise<PublishedCommitteeSnapshot | null> {
+  const [active, history] = await Promise.all([
+    readPublishedCommitteeSnapshot().catch(() => null),
+    readFeedContentByPrefix<PublishedCommitteeSnapshot>(SNAPSHOT_PREFIX, 10).catch(
+      () => [] as Array<{ id: string; row: PublishedCommitteeSnapshot }>
+    ),
+  ]);
+  const candidates = [active, ...history.map((entry) => entry.row)].filter(
+    (snapshot): snapshot is PublishedCommitteeSnapshot =>
+      !!snapshot?.response &&
+      Math.max(snapshot.response.cards?.length ?? 0, snapshot.response.stocks?.length ?? 0) >= 20 &&
+      snapshotAgeDays(snapshot, today) >= 0 &&
+      snapshotAgeDays(snapshot, today) <= maxAgeDays
+  );
+  const byRunId = new Map(candidates.map((snapshot) => [snapshot.runId, snapshot]));
+  return (
+    [...byRunId.values()].sort(
+      (a, b) => Date.parse(b.reviewedAt) - Date.parse(a.reviewedAt)
+    )[0] ?? null
+  );
+}
+
 export async function publishCommitteeSnapshot(
   snapshot: PublishedCommitteeSnapshot,
   report: CommitteeRunReport
 ): Promise<void> {
   // 이력부터 남기고 활성 포인터를 마지막에 교체한다. 중간 실패 시 전일 활성본이 그대로 유지된다.
   await writeFeedContent(`${RUN_PREFIX}${report.date}:${report.runId}`, report);
+  await writeFeedContent(`${SNAPSHOT_PREFIX}${report.date}:${report.runId}`, snapshot);
   await writeFeedContent(ACTIVE_ID, snapshot);
 }
 


### PR DESCRIPTION
## Summary
- add today committee -> recent 3-day snapshot -> direct engine fallback chain
- persist versioned committee snapshots and expose quiet stale status in both web layouts
- enforce 20-card post-publish and scheduled GitHub Actions availability checks

## Verification
- npm run typecheck
- npm run test (127 files, 1187 tests)
- npm run build:web
- npm run build:fomo-web