### PR TITLE
fix: isolate judgment ledger database bootstrap

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -67,20 +67,4 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: |
-          npx prisma db execute --file prisma/sql/2026-07-20_judgment_ledger.sql --schema prisma/schema.prisma
-          npx prisma db push
-
-      - name: Backfill immutable selections and due outcomes
-        if: ${{ !inputs.dry_run }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: |
-          npx tsx scripts/migrate-judgment-ledger.ts
-          npx tsx scripts/materialize-ledger-outcomes.ts
-
-      - name: Verify append-only enforcement
-        if: ${{ !inputs.dry_run }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: npx tsx scripts/verify-judgment-ledger-append-only.ts
+        run: npx prisma db push

--- a/.github/workflows/judgment-ledger-bootstrap.yml
+++ b/.github/workflows/judgment-ledger-bootstrap.yml
@@ -1,0 +1,38 @@
+name: Judgment Ledger Bootstrap
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci
+
+      # The partitioned table is intentionally managed by exact SQL. Running a whole-schema
+      # `prisma db push` here could touch unrelated cache tables in a drifted production DB.
+      - name: Apply append-only ledger schema
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx prisma db execute --file prisma/sql/2026-07-20_judgment_ledger.sql --schema prisma/schema.prisma
+
+      - name: Backfill immutable selections and due outcomes
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          npx tsx scripts/migrate-judgment-ledger.ts
+          npx tsx scripts/materialize-ledger-outcomes.ts
+
+      - name: Verify append-only enforcement
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx tsx scripts/verify-judgment-ledger-append-only.ts

--- a/docs/JUDGMENT_LEDGER.md
+++ b/docs/JUDGMENT_LEDGER.md
@@ -35,10 +35,11 @@ FOMO Club의 신호, 판단, 점수, 선정, 사용자 행동, 성과를 당시 
 
 ## 배포 순서
 
-1. `prisma/sql/2026-07-20_judgment_ledger.sql`로 파티션 테이블과 불변 트리거를 먼저 만든다.
-2. `prisma db push`로 Prisma 스키마를 동기화한다.
-3. `npm run ledger:migrate`로 가격이 있는 `daily30-picks:` 레거시 선정분을 백필한다.
-4. `npm run ledger:outcomes`로 기한이 지난 고정창 성과를 생성한다.
-5. `npm run ledger:verify`로 UPDATE/DELETE 거부를 실제 DB에서 확인한다. 검증 probe도 삭제하지 않는다.
+1. `Judgment Ledger Bootstrap` 워크플로가 `prisma/sql/2026-07-20_judgment_ledger.sql`로 파티션 테이블과 불변 트리거를 만든다.
+2. 같은 워크플로가 `npm run ledger:migrate`로 가격이 있는 `daily30-picks:` 레거시 선정분을 백필한다.
+3. `npm run ledger:outcomes`로 기한이 지난 고정창 성과를 생성한다.
+4. `npm run ledger:verify`로 UPDATE/DELETE 거부를 실제 DB에서 확인한다. 검증 probe도 삭제하지 않는다.
+
+원장은 Prisma가 직접 표현하지 못하는 파티션·RLS·트리거를 포함하므로 정확한 SQL만 적용한다. 이 작업에서 전체 `prisma db push`를 실행하지 않는다. 운영 스키마 드리프트가 있는 경우 원장과 무관한 캐시 테이블 삭제를 제안할 수 있기 때문이다.
 
 `TasteSignal`은 발견가가 없어 소급 가격을 만들 수 없으므로 백필 대상에서 제외한다. 신규 쓰기는 410으로 닫혀 있으며, 브라우저의 기존 `fomo_discovery_seen` 중 실제 발견가가 있는 행만 첫 방문 때 원장으로 옮긴 뒤 삭제한다.


### PR DESCRIPTION
## Root cause

The ledger SQL succeeded in production, but the shared `db-push` workflow then ran a whole-schema `prisma db push`. Production schema drift caused Prisma to propose deleting three unrelated, populated market cache tables, so the existing data-loss guard correctly stopped the run.

## Fix

- Restore the generic DB Push workflow to its previous behavior.
- Add a dedicated, idempotent Judgment Ledger Bootstrap workflow.
- Apply only the exact partition/RLS/trigger SQL, then run the legacy selection backfill, due outcome materialization, and real UPDATE/DELETE rejection probe.
- Document why a whole-schema push is forbidden for this bootstrap.

No data-loss override is used and no unrelated schema is changed.
