### PR TITLE
fix: materialize ledger outcomes from trusted candles

### DIFF
--- a/apps/web/__tests__/lib/judgment-ledger.test.ts
+++ b/apps/web/__tests__/lib/judgment-ledger.test.ts
@@ -12,6 +12,7 @@ import {
   type LedgerSelectionView,
 } from "../../lib/judgment-ledger";
 import { buildTrackRecord, type OutcomePayload } from "../../lib/ledger-track-record";
+import { fetchHistoricalPrices } from "../../lib/quote-prices";
 
 function selection(overrides: Partial<LedgerSelectionView> = {}): LedgerSelectionView {
   return {
@@ -128,5 +129,21 @@ describe("track record fixed-window aggregation", () => {
     const record = buildTrackRecord([]);
     expect(record.windows.map((window) => window.days)).toEqual([7, 30, 90]);
     expect(record.windows.every((window) => window.overall.n === 0 && window.overall.winRate === null)).toBe(true);
+  });
+
+  it("선정 당시 박제된 캔들에서 목표일 또는 다음 거래일 종가를 먼저 사용한다", async () => {
+    const prices = await fetchHistoricalPrices([{
+      key: "selection-1:7",
+      stock: "ACME",
+      symbol: "ACME",
+      country: "US",
+      market: "NASDAQ",
+      targetDate: "2026-07-12",
+      candles: [
+        { date: "20260710", open: 98, high: 101, low: 97, close: 100, volume: 10 },
+        { date: "20260713", open: 101, high: 105, low: 100, close: 104, volume: 20 },
+      ],
+    }]);
+    expect(prices.get("selection-1:7")).toEqual({ date: "2026-07-13", price: 104 });
   });
 });

--- a/apps/web/lib/ledger-track-record.ts
+++ b/apps/web/lib/ledger-track-record.ts
@@ -82,6 +82,7 @@ function quoteFor(selection: LedgerSelectionView, windowDays: TrackWindow): Hist
     ...(selection.payload.naverCode ? { naverCode: selection.payload.naverCode } : {}),
     ...(selection.payload.market ? { market: selection.payload.market } : {}),
     ...(selection.payload.country ? { country: selection.payload.country } : {}),
+    ...(selection.payload.front?.candles?.length ? { candles: selection.payload.front.candles } : {}),
   };
 }
 

--- a/apps/web/lib/quote-prices.ts
+++ b/apps/web/lib/quote-prices.ts
@@ -4,8 +4,11 @@
  * 어제의 영수증 등 서버 콘텐츠가 "발견가 대비 지금" 성과를 계산할 때 쓴다. 소급 조작 없음(실시세만).
  */
 
-import type { StockCountry, StockMarket } from "@fomo/core";
+import type { DailyOhlcv, StockCountry, StockMarket } from "@fomo/core";
 import { readCoinMarketSnapshots } from "./coin-market-source";
+import { readKrCandleCache } from "./kr-candle-cache";
+import { fetchStockDaily } from "./stock-front";
+import { fetchNasdaqDailyCandles } from "./us-market-source";
 
 const YAHOO_HOSTS = ["https://query1.finance.yahoo.com", "https://query2.finance.yahoo.com"];
 const YAHOO_UA =
@@ -33,6 +36,8 @@ export function yahooSymbolFor(item: QuoteRequestItem): string | null {
 
 export interface HistoricalQuoteRequestItem extends QuoteRequestItem {
   targetDate: string;
+  /** Selection-time immutable candles. Preferred over every network source when available. */
+  candles?: DailyOhlcv[];
 }
 
 export interface HistoricalPricePoint {
@@ -108,6 +113,24 @@ function isCoin(item: QuoteRequestItem): boolean {
   return item.market === "COIN" || item.country === "GLOBAL";
 }
 
+function candleDate(value: string | undefined): string | null {
+  if (!value) return null;
+  const digits = value.match(/^(\d{4})(\d{2})(\d{2})$/);
+  if (digits) return `${digits[1]}-${digits[2]}-${digits[3]}`;
+  const iso = value.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(iso) ? iso : null;
+}
+
+function historicalPoint(candles: readonly DailyOhlcv[] | undefined, targetDate: string): HistoricalPricePoint | null {
+  const point = (candles ?? [])
+    .flatMap((row) => {
+      const date = candleDate(row.date);
+      return date && date >= targetDate && Number.isFinite(row.close) && row.close > 0 ? [{ date, price: row.close }] : [];
+    })
+    .sort((a, b) => a.date.localeCompare(b.date))[0];
+  return point ?? null;
+}
+
 async function mapLimit<T, R>(items: readonly T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> {
   const out: R[] = [];
   for (let i = 0; i < items.length; i += limit) {
@@ -153,6 +176,11 @@ export async function fetchHistoricalPrices(items: readonly HistoricalQuoteReque
   const coinItems = items.filter(isCoin);
   const stockItems = items.filter((item) => !isCoin(item));
 
+  for (const item of items) {
+    const point = historicalPoint(item.candles, item.targetDate);
+    if (point) prices.set(item.key, point);
+  }
+
   if (coinItems.length > 0) {
     const snapshots = await readCoinMarketSnapshots().catch(() => []);
     const bySymbol = new Map(snapshots.map((snapshot) => [snapshot.symbol.toUpperCase(), snapshot] as const));
@@ -166,7 +194,37 @@ export async function fetchHistoricalPrices(items: readonly HistoricalQuoteReque
     }
   }
 
-  const jobs = stockItems.flatMap((item) => {
+  const unresolvedStocks = () => stockItems.filter((item) => !prices.has(item.key));
+
+  // KR prewarm candles are the primary legacy path. If the cache is stale/missing, the cron may
+  // fetch Naver once; public requests never execute this function.
+  await mapLimit(
+    unresolvedStocks().filter((item) => Boolean(item.naverCode) && item.country !== "US"),
+    3,
+    async (item) => {
+      const code = item.naverCode!;
+      const cached = await readKrCandleCache(code).catch(() => null);
+      const candles = cached ?? (await fetchStockDaily(code, 420)).candles;
+      const point = historicalPoint(candles, item.targetDate);
+      if (point) prices.set(item.key, point);
+    }
+  );
+
+  // Nasdaq historical is independent of Yahoo's shared edge quota and covers migrated US picks.
+  await mapLimit(
+    unresolvedStocks().filter((item) => item.country === "US" || item.market === "NASDAQ" || item.market === "NYSE"),
+    3,
+    async (item) => {
+      const symbol = yahooSymbolFor(item)?.replace(/\.(?:KS|KQ)$/i, "") ?? "";
+      if (!symbol) return;
+      const { candles } = await fetchNasdaqDailyCandles(symbol, 180);
+      const point = historicalPoint(candles, item.targetDate);
+      if (point) prices.set(item.key, point);
+    }
+  );
+
+  // Yahoo remains a last resort only. Its edge frequently returns 429 under batch workloads.
+  const jobs = unresolvedStocks().flatMap((item) => {
     const yahooSymbol = yahooSymbolFor(item);
     return yahooSymbol ? [{ item, yahooSymbol }] : [];
   });


### PR DESCRIPTION
## Root cause

Yahoo's shared chart edge returns HTTP 429 for the historical-price batch. The first production materializer found 30 due outcomes but could not append any, leaving the public track record empty.

## Fix

- Use the immutable 260-day candle snapshot embedded in every new ledger selection first.
- For migrated KR selections, use the KR prewarm cache and Naver daily candles as a cron-only fallback.
- For migrated US selections, use Nasdaq historical candles.
- Keep Yahoo as the final fallback only.
- Normalize both `YYYYMMDD` and ISO candle dates and select the target date or following first trading day.

## Validation

- `npm run typecheck`
- `npm run test` (128 files, 1,195 tests)
- `npm run build:web`
