### PR TITLE
fix: project legacy signals onto resumes

### DIFF
--- a/apps/web/__tests__/lib/judgment-ledger.test.ts
+++ b/apps/web/__tests__/lib/judgment-ledger.test.ts
@@ -7,6 +7,7 @@ import {
   daily30ResponseFromSelections,
   inferSignalTypes,
   ledgerKey,
+  projectTimelineSignalTypes,
   scoreBand,
   userLedgerActor,
   type LedgerSelectionView,
@@ -57,6 +58,16 @@ describe("Judgment Ledger", () => {
       "0-59",
       undefined,
     ]);
+  });
+
+  it("레거시 타임라인 신호는 같은 선정 스냅샷의 표준 유형으로 보강한다", () => {
+    expect(projectTimelineSignalTypes({
+      types: ["chart", "herd"],
+      headline: "클라우드 대표주",
+    }, ["score_60_79"])).toEqual(["score_60_79"]);
+    expect(projectTimelineSignalTypes({
+      headline: "대형 공급계약 공시",
+    }, ["score_80_plus"])).toEqual(["material_contract", "score_80_plus"]);
   });
 
   it("익명 식별자는 안정적으로 해시하고 원문 sessionId를 actor에 노출하지 않는다", () => {

--- a/apps/web/lib/judgment-ledger.ts
+++ b/apps/web/lib/judgment-ledger.ts
@@ -550,6 +550,19 @@ export interface LedgerTimelineEntry {
   payload: Record<string, unknown>;
 }
 
+export function projectTimelineSignalTypes(
+  payload: Record<string, unknown>,
+  selectionTypes: readonly SignalTypeCode[] = []
+): SignalTypeCode[] {
+  const stored = normalizeSignalTypeCodes(Array.isArray(payload.signalTypes) ? payload.signalTypes : []);
+  const inferred = inferStandardSignalTypes({
+    ...(typeof payload.headline === "string" ? { headline: payload.headline } : {}),
+    ...(typeof payload.sourceLabel === "string" ? { sourceLabel: payload.sourceLabel } : {}),
+    ...(typeof payload.sourceUrl === "string" ? { sourceUrl: payload.sourceUrl } : {}),
+  });
+  return normalizeSignalTypeCodes([...stored, ...inferred, ...selectionTypes]);
+}
+
 export async function readSubjectTimeline(
   canonical: string,
   take = 80,
@@ -563,18 +576,22 @@ export async function readSubjectTimeline(
     orderBy: { ts: "desc" },
     take: Math.max(1, Math.min(take, 200)),
   });
+  const selectionTypes = new Map<string, SignalTypeCode[]>();
+  for (const row of rows) {
+    if (row.kind !== "selection") continue;
+    const selection = asSelection(row);
+    if (!selection) continue;
+    selectionTypes.set(`${row.date}\u001f${row.actor}`, selection.payload.signalTypes);
+    if (!selectionTypes.has(row.date)) selectionTypes.set(row.date, selection.payload.signalTypes);
+  }
   return rows.map((row) => {
     const payload = row.payload as Record<string, unknown>;
-    const signalTypes = row.kind === "signal"
-      ? normalizeSignalTypeCodes(Array.isArray(payload.signalTypes) ? payload.signalTypes : [])
+    const projected = row.kind === "signal"
+      ? projectTimelineSignalTypes(
+          payload,
+          selectionTypes.get(`${row.date}\u001f${row.actor}`) ?? selectionTypes.get(row.date) ?? []
+        )
       : [];
-    const projected = row.kind === "signal" && signalTypes.length === 0
-      ? inferStandardSignalTypes({
-          ...(typeof payload.headline === "string" ? { headline: payload.headline } : {}),
-          ...(typeof payload.sourceLabel === "string" ? { sourceLabel: payload.sourceLabel } : {}),
-          ...(typeof payload.sourceUrl === "string" ? { sourceUrl: payload.sourceUrl } : {}),
-        })
-      : signalTypes;
     return {
       id: row.id,
       date: row.date,


### PR DESCRIPTION
## Summary
- enrich legacy signal timeline rows from the immutable same-date selection snapshot
- keep the append-only ledger untouched while exposing standardized M2 signal resumes
- cover legacy chart/herd rows and combined material/score signals

## Validation
- npm run typecheck
- npm run test -- judgment-ledger signal-resume