### PR TITLE
feat: add daily quality SLO ledger

### DIFF
--- a/.github/workflows/quality-slo-bootstrap.yml
+++ b/.github/workflows/quality-slo-bootstrap.yml
@@ -1,0 +1,34 @@
+name: Quality SLO Ledger Bootstrap
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Apply append-only quality ledger schema
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx prisma db execute --file prisma/sql/2026-07-20_quality_slo_ledger.sql --schema prisma/schema.prisma
+
+      - name: Materialize two immutable daily snapshots
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx tsx scripts/materialize-quality-slo.ts --limit=2
+
+      - name: Verify append-only enforcement
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx tsx scripts/verify-quality-ledger-append-only.ts

--- a/.github/workflows/quality-slo-monitor.yml
+++ b/.github/workflows/quality-slo-monitor.yml
@@ -1,0 +1,45 @@
+name: Quality SLO Monitor
+
+on:
+  schedule:
+    - cron: "35 21 * * *" # 06:35 KST, committee editor and quality cron 이후
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Materialize and read latest quality row
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          URL="https://fomo-club-backend.vercel.app/api/fomo/cron/quality-slo"
+          if [ -n "${CRON_SECRET:-}" ]; then
+            curl -fsS "$URL" -H "Authorization: Bearer ${CRON_SECRET}" > /tmp/quality-slo.json
+          else
+            curl -fsS "$URL" > /tmp/quality-slo.json
+          fi
+
+      - name: Enforce fixed SLO targets
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const result = JSON.parse(fs.readFileSync("/tmp/quality-slo.json", "utf8"));
+          const latest = result.latest;
+          if (!result.ok || !latest) {
+            console.log("::error title=Quality SLO ledger::Latest quality row is unavailable");
+            process.exit(1);
+          }
+          const failures = Array.isArray(latest.failures) ? latest.failures : [];
+          const summary = `${latest.date}: ${latest.passed ? "PASS" : `FAIL (${failures.join(", ")})`}`;
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Quality SLO\n\n${summary}\n`);
+          if (!latest.passed) {
+            console.log(`::warning title=Quality SLO missed::${summary}`);
+            process.exit(1);
+          }
+          console.log(summary);
+          NODE

--- a/apps/web/__tests__/lib/quality-slo-ledger.test.ts
+++ b/apps/web/__tests__/lib/quality-slo-ledger.test.ts
@@ -1,0 +1,193 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Daily30Response } from "../../lib/daily-30";
+import type { CommitteeRunReport } from "../../lib/expert-review-store";
+import {
+  QUALITY_SLO_TARGETS,
+  calculateQualitySloSnapshot,
+} from "../../lib/quality-slo-ledger";
+
+function healthyResponse(): Daily30Response {
+  const stocks = Array.from({ length: 30 }, (_, index) => {
+    const asset = index < 15 ? "kr" : index < 25 ? "us" : "coin";
+    return {
+      canonical: `종목-${index}`,
+      marquee: false,
+      sector: asset === "coin" ? "코인" : `테마-${index % 6}`,
+      country: asset === "us" ? "US" as const : "KR" as const,
+      market: asset === "coin" ? "COIN" as const : asset === "us" ? "NASDAQ" as const : "KOSPI" as const,
+      ...(asset === "us" ? { symbol: `US${index}` } : { naverCode: String(index).padStart(6, "0") }),
+      headline: `확인된 계약 재료 ${index}`,
+      sourceLabel: "공식 공시",
+      sourceUrl: `https://example.com/${index}`,
+    };
+  });
+  const fronts = Object.fromEntries(stocks.map((stock, index) => [stock.canonical, {
+    signals: { changePct: index % 2 === 0 ? 4 : -4 },
+    fomo: { score: 50, label: "관찰", breakdown: [] },
+    sparkline: [100 + index, 101 + index, 102 + index],
+    priceText: stock.market === "COIN" ? `${1000 + index}원` : stock.country === "US" ? `$${100 + index}` : `${10000 + index}원`,
+    verdict: {
+      stance: index % 3 === 0 ? "enter" : index % 3 === 1 ? "watch" : "avoid",
+      stanceText: `결정론 판정 문장 ${index}`,
+      evidence: [`근거 ${index}`],
+      confidence: "medium",
+    },
+    companyScore: {
+      score: 70,
+      label: `점수 라벨 ${index}`,
+      interpretation: `기업 해석 문장 ${index}`,
+      axes: [{ key: "valuation", label: "밸류에이션", score: 70, evidence: [`실수치 ${index}`] }],
+      availableAxisCount: 1,
+      omittedAxes: ["growth", "profitability", "flow", "chart", "quiet"],
+    },
+    committeeReview: {
+      runId: "run-healthy",
+      reviewedAt: "2026-07-20T00:00:00.000Z",
+      tradingView: `트레이딩 검수 ${index}`,
+      fundamentalView: `재무 검수 ${index}`,
+      timingGrade: "B",
+      valuationGrade: "B",
+      factChecked: true,
+    },
+  }]));
+  return {
+    asOf: "2026-07-20T00:00:00.000Z",
+    country: "all",
+    stocks,
+    cards: stocks.map((stock) => ({ kind: "stock" as const, ...stock })),
+    fronts: fronts as unknown as Daily30Response["fronts"],
+    confidence: "H",
+    source: "test",
+    meta: {
+      targetCount: 30,
+      cards: stocks.map((stock) => ({
+        id: `stock:${stock.country}:${"symbol" in stock ? stock.symbol : stock.naverCode}:${stock.canonical}`,
+        assetClass: stock.market === "COIN" ? "coin" : stock.country === "US" ? "us-stock" : "kr-stock",
+        quietScore: 50,
+        signalScore: 60,
+        hypePenalty: 10,
+        signalTypes: ["material_contract"],
+      })),
+      assetCounts: { "kr-stock": 15, "us-stock": 10, coin: 5, macro: 0 },
+      repeatRatio: 0.4,
+      committee: {
+        runId: "run-healthy",
+        version: "s3.v1",
+        reviewedAt: "2026-07-20T00:00:00.000Z",
+        candidateCount: 40,
+        selectedCount: 30,
+        callCount: 80,
+      },
+    },
+  };
+}
+
+function report(): CommitteeRunReport {
+  return {
+    runId: "run-healthy",
+    version: "s3.v1",
+    date: "2026-07-20",
+    status: "published",
+    startedAt: "2026-07-20T00:00:00.000Z",
+    completedAt: "2026-07-20T00:10:00.000Z",
+    model: "test",
+    callCount: 80,
+    candidateCount: 40,
+    selectedCount: 30,
+    selectedIds: [],
+    reviews: [{
+      candidateId: "candidate-1",
+      canonical: "종목-1",
+      approved: true,
+      timingGrade: "B",
+      valuationGrade: "B",
+      tradingView: "검수",
+      fundamentalView: "검수",
+      rejectionReasons: [],
+      factGate: { tradingFallback: false, financialFallback: false, invalidNumbers: [] },
+    }],
+    compositionSummary: "test",
+    assetCounts: { "kr-stock": 15, "us-stock": 10, coin: 5 },
+  };
+}
+
+describe("quality SLO ledger", () => {
+  it("고정된 8개 목표를 만족하는 30장 스냅샷을 통과시킨다", () => {
+    const result = calculateQualitySloSnapshot({
+      date: "2026-07-20",
+      response: healthyResponse(),
+      committeeReport: report(),
+      computedAt: "2026-07-20T00:20:00.000Z",
+    });
+    expect(result.passed).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.metrics.causeExplanation).toMatchObject({ ratio: 1, passed: true });
+    expect(result.metrics.marketData).toMatchObject({ ratio: 1, passed: true });
+    expect(result.metrics.verdict.uniqueTextCount).toBe(30);
+    expect(result.metrics.assets).toMatchObject({ kr: 15, us: 10, coin: 5, passed: true });
+    expect(result.metrics.depthCoverage).toMatchObject({ complete: 30, ratio: 1, passed: true });
+    expect(result.metrics.committee).toMatchObject({ published: true, rejectedCount: 10, factGateDiscardCount: 0 });
+  });
+
+  it("의도적 회귀는 전 SLO를 실패시키고 목표를 완화하지 않는다", () => {
+    const response = healthyResponse();
+    response.stocks = response.stocks.slice(0, 10).map(({ sourceLabel: _sourceLabel, sourceUrl: _sourceUrl, ...stock }) => {
+      void _sourceLabel;
+      void _sourceUrl;
+      return {
+        ...stock,
+        sector: "기타 업종",
+        headline: "원인을 알 수 없는 변동",
+        country: "KR",
+        market: "KOSPI",
+      };
+    });
+    response.fronts = Object.fromEntries(response.stocks.map((stock, index) => [stock.canonical, {
+      signals: { changePct: 5 },
+      fomo: { score: 0, label: "관찰", breakdown: [] },
+      sparkline: index === 0 ? [0] : [],
+      verdict: { stance: "watch", stanceText: "모두 같은 판정", evidence: [], confidence: "low" },
+    }])) as unknown as Daily30Response["fronts"];
+    response.meta.cards = [];
+    response.meta.assetCounts = { "kr-stock": 10, "us-stock": 0, coin: 0, macro: 0 };
+    response.meta.repeatRatio = 0.8;
+    delete response.meta.committee;
+    const result = calculateQualitySloSnapshot({ date: "2026-07-20", response });
+    expect(result.passed).toBe(false);
+    expect(result.failures).toEqual([
+      "cause-explanation",
+      "market-data",
+      "verdict-discrimination",
+      "template-diversity",
+      "freshness",
+      "asset-mix",
+      "committee",
+      "depth-coverage",
+    ]);
+    expect(QUALITY_SLO_TARGETS).toEqual({
+      causeExplanationRate: 0.9,
+      marketDataRate: 1,
+      verdictUniqueTextMin: 10,
+      maxSentenceRepeat: 3,
+      repeatRatioMax: 0.5,
+      usStockMin: 8,
+      coinMin: 3,
+      coinMax: 5,
+      depthCoverageRate: 0.9,
+      committeePublished: true,
+    });
+  });
+
+  it("운영 SQL과 Action이 append-only·미달 경고를 강제한다", () => {
+    const sql = readFileSync(resolve(process.cwd(), "prisma/sql/2026-07-20_quality_slo_ledger.sql"), "utf8");
+    const workflow = readFileSync(resolve(process.cwd(), ".github/workflows/quality-slo-monitor.yml"), "utf8");
+    expect(sql).toContain("BEFORE UPDATE OR DELETE");
+    expect(sql).toContain("QualityLedger is append-only");
+    expect(sql).toContain("FORCE ROW LEVEL SECURITY");
+    expect(sql).toContain("quality:' || \"date\"");
+    expect(workflow).toContain("::warning title=Quality SLO missed::");
+    expect(workflow).toContain("process.exit(1)");
+  });
+});

--- a/apps/web/app/admin/committee/page.tsx
+++ b/apps/web/app/admin/committee/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { readCommitteeRunReports, readPublishedCommitteeSnapshot } from "../../../lib/expert-review-store";
 
@@ -23,6 +24,10 @@ export default async function CommitteeAuditPage() {
           <h1 style={{ marginTop: 8, fontSize: 28 }}>전문가 위원회 감사</h1>
         </div>
         <div style={{ textAlign: "right", color: "#a6acb6", fontFamily: "var(--font-mono)", fontSize: 12 }}>
+          <nav style={{ display: "flex", justifyContent: "flex-end", gap: 16, marginBottom: 8 }}>
+            <Link href="/admin/committee" style={{ color: "#d8ff3a" }}>위원회</Link>
+            <Link href="/admin/quality" style={{ color: "#a6acb6" }}>품질 SLO</Link>
+          </nav>
           <div>{active ? `ACTIVE ${active.runId}` : "NO ACTIVE RUN"}</div>
           <div style={{ marginTop: 5 }}>{active?.reviewedAt ?? "-"}</div>
         </div>

--- a/apps/web/app/admin/quality/page.tsx
+++ b/apps/web/app/admin/quality/page.tsx
@@ -1,0 +1,154 @@
+import { cookies } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import type { CSSProperties } from "react";
+import { readQualityLedger, type QualityLedgerEntry } from "../../../lib/quality-slo-ledger";
+
+const PASS = "#d8ff3a";
+const FAIL = "#f07a6a";
+const MUTED = "#8a8f98";
+const HAIRLINE = "#25262a";
+
+function percent(value: number): string {
+  return `${Math.round(value * 1_000) / 10}%`;
+}
+
+function TrendChart({
+  title,
+  entries,
+  value,
+  target,
+  max,
+  lowerIsBetter = false,
+  format = (number) => String(Math.round(number * 100) / 100),
+}: {
+  title: string;
+  entries: readonly QualityLedgerEntry[];
+  value: (entry: QualityLedgerEntry) => number;
+  target: number;
+  max: number;
+  lowerIsBetter?: boolean;
+  format?: (value: number) => string;
+}) {
+  const width = 620;
+  const height = 150;
+  const pad = 24;
+  const range = Math.max(max, target, ...entries.map(value), 1);
+  const point = (entry: QualityLedgerEntry, index: number) => {
+    const x = entries.length <= 1 ? width / 2 : pad + (index / (entries.length - 1)) * (width - pad * 2);
+    const y = height - pad - (Math.max(0, value(entry)) / range) * (height - pad * 2);
+    return { x, y, raw: value(entry), passed: lowerIsBetter ? value(entry) <= target : value(entry) >= target };
+  };
+  const points = entries.map(point);
+  const targetY = height - pad - (target / range) * (height - pad * 2);
+  const path = points.map((item, index) => `${index === 0 ? "M" : "L"}${item.x.toFixed(1)},${item.y.toFixed(1)}`).join(" ");
+  const latest = points.at(-1);
+  return (
+    <section style={{ minWidth: 0, padding: "18px 0", borderTop: `1px solid ${HAIRLINE}` }}>
+      <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 16 }}>
+        <h2 style={{ fontSize: 14, fontWeight: 700 }}>{title}</h2>
+        <span style={{ color: latest?.passed ? PASS : FAIL, fontFamily: "var(--font-mono)", fontSize: 12 }}>
+          {latest ? format(latest.raw) : "-"}
+        </span>
+      </div>
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`${title} 일별 추이`} style={{ display: "block", width: "100%", height: 150, marginTop: 10 }}>
+        <line x1={pad} y1={targetY} x2={width - pad} y2={targetY} stroke="#59606b" strokeDasharray="5 5" />
+        <text x={width - pad} y={Math.max(12, targetY - 6)} textAnchor="end" fill={MUTED} fontSize="10">목표 {format(target)}</text>
+        {path && <path d={path} fill="none" stroke="#f4f5f7" strokeWidth="2" />}
+        {points.map((item, index) => (
+          <circle key={`${entries[index]!.date}-${title}`} cx={item.x} cy={item.y} r="4" fill={item.passed ? PASS : FAIL} />
+        ))}
+        {entries.map((entry, index) => {
+          if (entries.length > 8 && index % Math.ceil(entries.length / 6) !== 0 && index !== entries.length - 1) return null;
+          return <text key={entry.date} x={points[index]!.x} y={height - 5} textAnchor="middle" fill={MUTED} fontSize="9">{entry.date.slice(5)}</text>;
+        })}
+      </svg>
+    </section>
+  );
+}
+
+function cell(passed: boolean): CSSProperties {
+  return {
+    padding: "12px 10px",
+    color: passed ? "#d5d7dc" : FAIL,
+    background: passed ? "transparent" : "#241315",
+    borderBottom: `1px solid ${HAIRLINE}`,
+    fontFamily: "var(--font-mono)",
+    fontSize: 12,
+    whiteSpace: "nowrap",
+  };
+}
+
+export default async function QualitySloPage() {
+  const password = process.env.DASHBOARD_PASSWORD;
+  const session = (await cookies()).get("dashboard_session")?.value;
+  if (!password || session !== password) redirect("/login");
+  const newest = await readQualityLedger(45).catch(() => [] as QualityLedgerEntry[]);
+  const entries = [...newest].reverse();
+  const latest = newest[0];
+
+  return (
+    <main style={{ minHeight: "100vh", padding: "28px clamp(18px, 4vw, 56px)", background: "#050506", color: "#f4f5f7" }}>
+      <header style={{ display: "flex", alignItems: "end", justifyContent: "space-between", gap: 24, borderBottom: `1px solid ${HAIRLINE}`, paddingBottom: 18 }}>
+        <div>
+          <p className="eyebrow">FOMO CLUB / QUALITY LEDGER</p>
+          <h1 style={{ marginTop: 8, fontSize: 28 }}>품질 SLO 원장</h1>
+        </div>
+        <nav style={{ display: "flex", gap: 16, fontSize: 12 }}>
+          <Link href="/admin/committee" style={{ color: MUTED }}>위원회</Link>
+          <Link href="/admin/quality" style={{ color: PASS }}>품질 SLO</Link>
+        </nav>
+      </header>
+
+      <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", borderBottom: `1px solid ${HAIRLINE}` }}>
+        {[
+          ["최신 날짜", latest?.date ?? "-"],
+          ["상태", latest ? (latest.passed ? "PASS" : "MISSED") : "NO DATA"],
+          ["미달", latest?.failures.join(" · ") || "0"],
+          ["기록 일수", newest.length],
+        ].map(([label, value]) => (
+          <div key={String(label)} style={{ padding: "18px 16px", borderRight: `1px solid ${HAIRLINE}` }}>
+            <div className="eyebrow">{label}</div>
+            <div style={{ marginTop: 8, color: label === "상태" ? (latest?.passed ? PASS : FAIL) : "inherit", fontFamily: "var(--font-mono)", fontSize: 16 }}>{String(value)}</div>
+          </div>
+        ))}
+      </section>
+
+      <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", columnGap: 28, paddingTop: 8 }}>
+        <TrendChart title="원인 설명률" entries={entries} value={(entry) => entry.metrics.causeExplanation.ratio} target={0.9} max={1} format={percent} />
+        <TrendChart title="시세 성공률" entries={entries} value={(entry) => entry.metrics.marketData.ratio} target={1} max={1} format={percent} />
+        <TrendChart title="verdict 문장 유니크" entries={entries} value={(entry) => entry.metrics.verdict.uniqueTextCount} target={10} max={30} />
+        <TrendChart title="최다 문장 반복" entries={entries} value={(entry) => entry.metrics.templateDiversity.maxRepeatCount} target={3} max={12} lowerIsBetter />
+        <TrendChart title="전일 중복률" entries={entries} value={(entry) => entry.metrics.freshness.repeatRatio} target={0.5} max={1} lowerIsBetter format={percent} />
+        <TrendChart title="뎁스 완결률" entries={entries} value={(entry) => entry.metrics.depthCoverage.ratio} target={0.9} max={1} format={percent} />
+      </section>
+
+      <section style={{ padding: "24px 0" }}>
+        <p className="eyebrow">DAILY SLO MATRIX</p>
+        <div style={{ marginTop: 12, overflowX: "auto", borderTop: `1px solid ${HAIRLINE}` }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 1080 }}>
+            <thead>
+              <tr>{["날짜", "원인", "시세", "verdict", "반복", "신선도", "자산", "위원회", "뎁스"].map((label) => <th key={label} style={{ padding: "10px", textAlign: "left", color: MUTED, fontSize: 10 }}>{label}</th>)}</tr>
+            </thead>
+            <tbody>
+              {newest.map((entry) => (
+                <tr key={entry.date}>
+                  <td style={cell(entry.passed)}>{entry.date}</td>
+                  <td style={cell(entry.metrics.causeExplanation.passed)}>{percent(entry.metrics.causeExplanation.ratio)} ({entry.metrics.causeExplanation.explained}/{entry.metrics.causeExplanation.movers})</td>
+                  <td style={cell(entry.metrics.marketData.passed)}>{percent(entry.metrics.marketData.ratio)} ({entry.metrics.marketData.pricedAndCharted}/{entry.metrics.marketData.cards})</td>
+                  <td style={cell(entry.metrics.verdict.passed)}>유니크 {entry.metrics.verdict.uniqueTextCount} · W {percent(entry.metrics.verdict.watchRatio)}</td>
+                  <td style={cell(entry.metrics.templateDiversity.passed)}>최다 {entry.metrics.templateDiversity.maxRepeatCount}회</td>
+                  <td style={cell(entry.metrics.freshness.passed)}>{percent(entry.metrics.freshness.repeatRatio)}</td>
+                  <td style={cell(entry.metrics.assets.passed)}>KR {entry.metrics.assets.kr} · US {entry.metrics.assets.us} · C {entry.metrics.assets.coin}</td>
+                  <td style={cell(entry.metrics.committee.passed)}>{entry.metrics.committee.published ? "발행" : "미발행"} · 반려 {entry.metrics.committee.rejectedCount ?? "-"} · 폐기 {entry.metrics.committee.factGateDiscardCount ?? "-"}</td>
+                  <td style={cell(entry.metrics.depthCoverage.passed)}>{percent(entry.metrics.depthCoverage.ratio)} ({entry.metrics.depthCoverage.complete}/{entry.metrics.depthCoverage.cards})</td>
+                </tr>
+              ))}
+              {newest.length === 0 && <tr><td colSpan={9} style={{ padding: 18, color: MUTED }}>품질 원장 기록이 없습니다.</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/api/fomo/cron/daily-30/route.ts
+++ b/apps/web/app/api/fomo/cron/daily-30/route.ts
@@ -3,6 +3,7 @@ import { revalidateTag } from "next/cache";
 import { withCors, kstDate } from "../../../../../lib/fomo";
 import { runExpertReviewCommitteeStage, type CommitteeStage } from "../../../../../lib/expert-review-committee";
 import { daily30CardCount, resolveDaily30Response } from "../../../../../lib/daily-30";
+import { recordQualityForPublishedResponse, type QualityLedgerEntry } from "../../../../../lib/quality-slo-ledger";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -26,12 +27,20 @@ export async function GET(request: Request) {
     const stage = requestedStage as CommitteeStage;
     const result = await runExpertReviewCommitteeStage(stage);
     let verifiedCards: number | undefined;
+    let quality: QualityLedgerEntry | undefined;
+    let qualityError: string | undefined;
     if (result.ok && stage === "editor") {
       revalidateTag("daily-30", { expire: 0 });
       const published = await resolveDaily30Response();
       verifiedCards = daily30CardCount(published);
       if (verifiedCards < 20) {
         throw new Error(`daily-30 post-publish verification failed: ${verifiedCards}/20 cards`);
+      }
+      try {
+        quality = (await recordQualityForPublishedResponse(kstDate(), published)).entry;
+      } catch (error) {
+        qualityError = error instanceof Error ? error.message : String(error);
+        console.warn("[fomo/cron/daily-30] quality ledger deferred", qualityError);
       }
     }
     return withCors(
@@ -46,6 +55,8 @@ export async function GET(request: Request) {
           candidates: result.candidateCount,
           selected: result.selectedCount,
           ...(verifiedCards !== undefined ? { verifiedCards } : {}),
+          ...(quality ? { quality: { passed: quality.passed, failures: quality.failures } } : {}),
+          ...(qualityError ? { qualityError } : {}),
           previousRunRetained: result.previousRunRetained,
           ...(result.error ? { error: result.error } : {}),
           elapsedMs: Date.now() - startedAt,

--- a/apps/web/app/api/fomo/cron/quality-slo/route.ts
+++ b/apps/web/app/api/fomo/cron/quality-slo/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../../lib/fomo";
+import { materializeRecentQualitySnapshots } from "../../../../../lib/quality-slo-ledger";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return true;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return withCors(NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 }));
+  }
+  try {
+    const result = await materializeRecentQualitySnapshots(2);
+    const latest = result.entries[0];
+    if (!latest) throw new Error("quality SLO source snapshots unavailable");
+    return withCors(NextResponse.json({
+      ok: true,
+      appended: result.appended,
+      latest: {
+        date: latest.date,
+        passed: latest.passed,
+        failures: latest.failures,
+      },
+      entries: result.entries,
+    }, { headers: { "Cache-Control": "no-store" } }));
+  } catch (error) {
+    console.warn("[fomo/cron/quality-slo] failed", error instanceof Error ? error.message : String(error));
+    return withCors(NextResponse.json({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }, { status: 500, headers: { "Cache-Control": "no-store" } }));
+  }
+}

--- a/apps/web/app/api/fomo/quality-slo/route.ts
+++ b/apps/web/app/api/fomo/quality-slo/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { withCors } from "../../../../lib/fomo";
+import { readQualityLedger } from "../../../../lib/quality-slo-ledger";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const rawLimit = Number(new URL(request.url).searchParams.get("limit") ?? 45);
+  const limit = Number.isInteger(rawLimit) ? Math.max(1, Math.min(rawLimit, 366)) : 45;
+  try {
+    const entries = await readQualityLedger(limit);
+    return withCors(NextResponse.json({ entries }, { headers: { "Cache-Control": "no-store" } }));
+  } catch (error) {
+    return withCors(NextResponse.json({
+      entries: [],
+      error: error instanceof Error ? error.message : String(error),
+    }, { status: 503, headers: { "Cache-Control": "no-store" } }));
+  }
+}

--- a/apps/web/lib/quality-slo-ledger.ts
+++ b/apps/web/lib/quality-slo-ledger.ts
@@ -1,0 +1,446 @@
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
+import { inferStandardSignalTypes } from "@fomo/core";
+import type { Daily30Response } from "./daily-30";
+import type { CommitteeRunReport } from "./expert-review-store";
+import { readCommitteeRunReports } from "./expert-review-store";
+import {
+  daily30ResponseFromSelections,
+  readDaily30ResponseFromLedger,
+  readLatestSelectionSnapshotBefore,
+} from "./judgment-ledger";
+import { parsePriceText } from "./quote-prices";
+import { prisma } from "./prisma";
+
+export const QUALITY_SLO_VERSION = "m3.v1" as const;
+export const QUALITY_SLO_TARGETS = {
+  causeExplanationRate: 0.9,
+  marketDataRate: 1,
+  verdictUniqueTextMin: 10,
+  maxSentenceRepeat: 3,
+  repeatRatioMax: 0.5,
+  usStockMin: 8,
+  coinMin: 3,
+  coinMax: 5,
+  depthCoverageRate: 0.9,
+  committeePublished: true,
+} as const;
+
+export type QualitySloKey =
+  | "cause-explanation"
+  | "market-data"
+  | "verdict-discrimination"
+  | "template-diversity"
+  | "freshness"
+  | "asset-mix"
+  | "committee"
+  | "depth-coverage";
+
+export interface QualitySloSnapshot {
+  version: typeof QUALITY_SLO_VERSION;
+  date: string;
+  computedAt: string;
+  sourceAsOf: string;
+  sourceRunId?: string;
+  passed: boolean;
+  failures: QualitySloKey[];
+  metrics: {
+    causeExplanation: {
+      movers: number;
+      explained: number;
+      ratio: number;
+      target: number;
+      passed: boolean;
+    };
+    marketData: {
+      cards: number;
+      pricedAndCharted: number;
+      ratio: number;
+      target: number;
+      passed: boolean;
+    };
+    verdict: {
+      cards: number;
+      stanceCounts: { enter: number; watch: number; avoid: number; missing: number };
+      watchRatio: number;
+      uniqueTextCount: number;
+      targetUniqueTextMin: number;
+      passed: boolean;
+    };
+    templateDiversity: {
+      sentenceCount: number;
+      maxRepeatCount: number;
+      mostRepeatedSentence: string | null;
+      targetMaxRepeat: number;
+      passed: boolean;
+    };
+    freshness: {
+      repeatRatio: number;
+      previousDate: string | null;
+      targetMax: number;
+      passed: boolean;
+    };
+    assets: {
+      kr: number;
+      us: number;
+      coin: number;
+      total: number;
+      targetUsMin: number;
+      targetCoinMin: number;
+      targetCoinMax: number;
+      passed: boolean;
+    };
+    committee: {
+      published: boolean;
+      runId: string | null;
+      candidateCount: number | null;
+      selectedCount: number;
+      rejectedCount: number | null;
+      factGateDiscardCount: number | null;
+      factGateFallbackCount: number | null;
+      passed: boolean;
+    };
+    depthCoverage: {
+      cards: number;
+      financial: number;
+      theme: number;
+      signalHistory: number;
+      complete: number;
+      ratio: number;
+      target: number;
+      passed: boolean;
+    };
+  };
+}
+
+export interface QualityLedgerEntry extends QualitySloSnapshot {
+  recordedAt: string;
+}
+
+const CAUSE_PATTERN = /공시|실적|계약|수주|투자|증자|자사주|인수|합병|승인|허가|매출|가이던스|발표|보도|리포트|임상|내부자|매수|매도|배당|출시|filing|contract|earnings|approval|guidance/i;
+const FINANCIAL_AXES = new Set(["valuation", "growth", "profitability"]);
+
+function roundedRatio(count: number, total: number, emptyValue: number): number {
+  if (total === 0) return emptyValue;
+  return Math.round((count / total) * 10_000) / 10_000;
+}
+
+function normalizedSentence(value: string | undefined): string | null {
+  const sentence = value?.replace(/\s+/g, " ").trim();
+  return sentence ? sentence : null;
+}
+
+function stockText(stock: Daily30Response["stocks"][number]): string {
+  return [stock.headline, stock.whyShown, stock.reason, stock.insightTag, stock.sourceLabel]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+}
+
+function isExplained(stock: Daily30Response["stocks"][number]): boolean {
+  return Boolean(stock.sourceUrl) || CAUSE_PATTERN.test(stockText(stock));
+}
+
+function hasRealMarketData(front: Daily30Response["fronts"][string] | undefined): boolean {
+  const price = parsePriceText(front?.priceText);
+  return Boolean(
+    price &&
+    price > 0 &&
+    front &&
+    front.sparkline.length >= 2 &&
+    front.sparkline.every((value) => Number.isFinite(value) && value > 0)
+  );
+}
+
+function stockAsset(stock: Daily30Response["stocks"][number]): "kr" | "us" | "coin" {
+  if (stock.market === "COIN") return "coin";
+  return stock.country === "US" ? "us" : "kr";
+}
+
+function previousRepeatRatio(response: Daily30Response, previous: Daily30Response | null): number {
+  if (typeof response.meta.repeatRatio === "number" && Number.isFinite(response.meta.repeatRatio)) {
+    return Math.max(0, Math.min(1, response.meta.repeatRatio));
+  }
+  if (!previous || response.stocks.length === 0) return 0;
+  const prior = new Set(previous.stocks.map((stock) => stock.canonical));
+  return roundedRatio(response.stocks.filter((stock) => prior.has(stock.canonical)).length, response.stocks.length, 0);
+}
+
+function reportFactGate(report: CommitteeRunReport | undefined): {
+  discarded: number | null;
+  fallback: number | null;
+} {
+  if (!report) return { discarded: null, fallback: null };
+  return {
+    discarded: report.reviews.filter((review) => review.factGate.invalidNumbers.length > 0).length,
+    fallback: report.reviews.filter(
+      (review) => review.factGate.tradingFallback || review.factGate.financialFallback
+    ).length,
+  };
+}
+
+export function calculateQualitySloSnapshot(input: {
+  date: string;
+  response: Daily30Response;
+  previousResponse?: Daily30Response | null;
+  committeeReport?: CommitteeRunReport;
+  computedAt?: string;
+}): QualitySloSnapshot {
+  const { response } = input;
+  const stocks = response.stocks;
+  const movers = stocks.filter((stock) => {
+    const change = response.fronts[stock.canonical]?.signals.changePct;
+    return typeof change === "number" && Number.isFinite(change) && Math.abs(change) >= 3;
+  });
+  const explained = movers.filter(isExplained).length;
+  const causeRatio = roundedRatio(explained, movers.length, 1);
+  const causePassed = causeRatio >= QUALITY_SLO_TARGETS.causeExplanationRate;
+
+  const pricedAndCharted = stocks.filter((stock) => hasRealMarketData(response.fronts[stock.canonical])).length;
+  const marketDataRatio = roundedRatio(pricedAndCharted, stocks.length, 0);
+  const marketDataPassed = marketDataRatio >= QUALITY_SLO_TARGETS.marketDataRate;
+
+  const stanceCounts = { enter: 0, watch: 0, avoid: 0, missing: 0 };
+  const verdictTexts: string[] = [];
+  const sentences: string[] = [];
+  stocks.forEach((stock) => {
+    const front = response.fronts[stock.canonical];
+    const stance = front?.verdict?.stance;
+    if (stance === "enter" || stance === "watch" || stance === "avoid") stanceCounts[stance] += 1;
+    else stanceCounts.missing += 1;
+    const verdictText = normalizedSentence(front?.verdict?.stanceText);
+    if (verdictText) verdictTexts.push(verdictText);
+    for (const value of [stock.headline, stock.whyShown, stock.reason, front?.verdict?.stanceText, front?.companyScore?.interpretation]) {
+      const sentence = normalizedSentence(value);
+      if (sentence) sentences.push(sentence);
+    }
+  });
+  const uniqueTextCount = new Set(verdictTexts).size;
+  const verdictPassed = uniqueTextCount >= QUALITY_SLO_TARGETS.verdictUniqueTextMin;
+
+  const sentenceCounts = new Map<string, number>();
+  sentences.forEach((sentence) => sentenceCounts.set(sentence, (sentenceCounts.get(sentence) ?? 0) + 1));
+  const repeated = [...sentenceCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
+  const maxRepeatCount = repeated?.[1] ?? 0;
+  const templatePassed = maxRepeatCount <= QUALITY_SLO_TARGETS.maxSentenceRepeat;
+
+  const repeatRatio = previousRepeatRatio(response, input.previousResponse ?? null);
+  const freshnessPassed = repeatRatio <= QUALITY_SLO_TARGETS.repeatRatioMax;
+  const previousDate = input.previousResponse?.asOf?.slice(0, 10) ?? null;
+
+  const assetCounts = stocks.reduce(
+    (counts, stock) => ({ ...counts, [stockAsset(stock)]: counts[stockAsset(stock)] + 1 }),
+    { kr: 0, us: 0, coin: 0 }
+  );
+  const assetPassed = assetCounts.us >= QUALITY_SLO_TARGETS.usStockMin &&
+    assetCounts.coin >= QUALITY_SLO_TARGETS.coinMin &&
+    assetCounts.coin <= QUALITY_SLO_TARGETS.coinMax;
+
+  const report = input.committeeReport;
+  const runId = report?.runId ?? response.meta.committee?.runId ?? null;
+  const committeePublished = (report?.status ?? (response.meta.committee ? "published" : "missing")) === "published";
+  const factGate = reportFactGate(report);
+  const rejectedCount = report ? Math.max(0, report.candidateCount - report.selectedCount) : null;
+
+  let financial = 0;
+  let theme = 0;
+  let signalHistory = 0;
+  let complete = 0;
+  stocks.forEach((stock, index) => {
+    const front = response.fronts[stock.canonical];
+    const hasFinancial = Boolean(front?.committeeReview?.fundamentalView?.trim()) || Boolean(
+      front?.companyScore?.axes.some((axis) => FINANCIAL_AXES.has(axis.key))
+    );
+    const hasTheme = Boolean(stock.sector?.trim()) && stock.sector !== "기타 업종";
+    const storedTypes = response.meta.cards[index]?.signalTypes ?? [];
+    const inferredTypes = storedTypes.length > 0 ? storedTypes : inferStandardSignalTypes({
+      ...(stock.headline ? { headline: stock.headline } : {}),
+      ...(stock.reason ?? stock.whyShown ? { reason: stock.reason ?? stock.whyShown } : {}),
+      ...(stock.sourceLabel ? { sourceLabel: stock.sourceLabel } : {}),
+      ...(stock.sourceUrl ? { sourceUrl: stock.sourceUrl } : {}),
+      ...(front?.signals ? { signals: front.signals } : {}),
+      ...(front?.wyckoff ? { wyckoff: front.wyckoff } : {}),
+      ...(typeof front?.companyScore?.score === "number" ? { companyScore: front.companyScore.score } : {}),
+    });
+    const hasSignalHistory = inferredTypes.length > 0;
+    if (hasFinancial) financial += 1;
+    if (hasTheme) theme += 1;
+    if (hasSignalHistory) signalHistory += 1;
+    if (hasFinancial && hasTheme && hasSignalHistory) complete += 1;
+  });
+  const depthRatio = roundedRatio(complete, stocks.length, 0);
+  const depthPassed = depthRatio >= QUALITY_SLO_TARGETS.depthCoverageRate;
+
+  const failures: QualitySloKey[] = [];
+  if (!causePassed) failures.push("cause-explanation");
+  if (!marketDataPassed) failures.push("market-data");
+  if (!verdictPassed) failures.push("verdict-discrimination");
+  if (!templatePassed) failures.push("template-diversity");
+  if (!freshnessPassed) failures.push("freshness");
+  if (!assetPassed) failures.push("asset-mix");
+  if (!committeePublished) failures.push("committee");
+  if (!depthPassed) failures.push("depth-coverage");
+
+  return {
+    version: QUALITY_SLO_VERSION,
+    date: input.date,
+    computedAt: input.computedAt ?? new Date().toISOString(),
+    sourceAsOf: response.asOf,
+    ...(runId ? { sourceRunId: runId } : {}),
+    passed: failures.length === 0,
+    failures,
+    metrics: {
+      causeExplanation: {
+        movers: movers.length,
+        explained,
+        ratio: causeRatio,
+        target: QUALITY_SLO_TARGETS.causeExplanationRate,
+        passed: causePassed,
+      },
+      marketData: {
+        cards: stocks.length,
+        pricedAndCharted,
+        ratio: marketDataRatio,
+        target: QUALITY_SLO_TARGETS.marketDataRate,
+        passed: marketDataPassed,
+      },
+      verdict: {
+        cards: stocks.length,
+        stanceCounts,
+        watchRatio: roundedRatio(stanceCounts.watch, stocks.length, 0),
+        uniqueTextCount,
+        targetUniqueTextMin: QUALITY_SLO_TARGETS.verdictUniqueTextMin,
+        passed: verdictPassed,
+      },
+      templateDiversity: {
+        sentenceCount: sentences.length,
+        maxRepeatCount,
+        mostRepeatedSentence: repeated?.[0] ?? null,
+        targetMaxRepeat: QUALITY_SLO_TARGETS.maxSentenceRepeat,
+        passed: templatePassed,
+      },
+      freshness: {
+        repeatRatio,
+        previousDate,
+        targetMax: QUALITY_SLO_TARGETS.repeatRatioMax,
+        passed: freshnessPassed,
+      },
+      assets: {
+        ...assetCounts,
+        total: stocks.length,
+        targetUsMin: QUALITY_SLO_TARGETS.usStockMin,
+        targetCoinMin: QUALITY_SLO_TARGETS.coinMin,
+        targetCoinMax: QUALITY_SLO_TARGETS.coinMax,
+        passed: assetPassed,
+      },
+      committee: {
+        published: committeePublished,
+        runId,
+        candidateCount: report?.candidateCount ?? response.meta.committee?.candidateCount ?? null,
+        selectedCount: report?.selectedCount ?? response.meta.committee?.selectedCount ?? stocks.length,
+        rejectedCount,
+        factGateDiscardCount: factGate.discarded,
+        factGateFallbackCount: factGate.fallback,
+        passed: committeePublished,
+      },
+      depthCoverage: {
+        cards: stocks.length,
+        financial,
+        theme,
+        signalHistory,
+        complete,
+        ratio: depthRatio,
+        target: QUALITY_SLO_TARGETS.depthCoverageRate,
+        passed: depthPassed,
+      },
+    },
+  };
+}
+
+function asQualitySnapshot(payload: Prisma.JsonValue): QualitySloSnapshot | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const value = payload as unknown as QualitySloSnapshot;
+  return value.version === QUALITY_SLO_VERSION && typeof value.date === "string" && value.metrics
+    ? value
+    : null;
+}
+
+async function appendQualitySnapshot(snapshot: QualitySloSnapshot): Promise<number> {
+  const key = `quality:${snapshot.date}`;
+  const result = await prisma.qualityLedger.createMany({
+    data: [{
+      id: randomUUID(),
+      date: snapshot.date,
+      idempotencyKey: key,
+      payload: snapshot as unknown as Prisma.InputJsonObject,
+      actor: "engine",
+    }],
+    skipDuplicates: true,
+  });
+  return result.count;
+}
+
+export async function readQualityLedger(limit = 45): Promise<QualityLedgerEntry[]> {
+  const rows = await prisma.qualityLedger.findMany({
+    where: { idempotencyKey: { startsWith: "quality:" } },
+    orderBy: [{ date: "desc" }, { ts: "desc" }],
+    take: Math.max(1, Math.min(limit, 366)),
+  });
+  return rows.flatMap((row) => {
+    const snapshot = asQualitySnapshot(row.payload);
+    return snapshot ? [{ ...snapshot, date: row.date, recordedAt: row.ts.toISOString() }] : [];
+  });
+}
+
+async function committeeReportForDate(date: string, reports?: readonly CommitteeRunReport[]): Promise<CommitteeRunReport | undefined> {
+  const values = reports ?? await readCommitteeRunReports(45).catch(() => []);
+  return values.find((report) => report.date === date && report.status === "published");
+}
+
+export async function recordQualityForPublishedResponse(
+  date: string,
+  response: Daily30Response,
+  report?: CommitteeRunReport
+): Promise<{ entry: QualityLedgerEntry; appended: boolean }> {
+  const existing = (await readQualityLedger(366)).find((entry) => entry.date === date);
+  if (existing) return { entry: existing, appended: false };
+  const previousSelections = await readLatestSelectionSnapshotBefore(date);
+  const previousResponse = daily30ResponseFromSelections(previousSelections);
+  const resolvedReport = report ?? await committeeReportForDate(date);
+  const snapshot = calculateQualitySloSnapshot({
+    date,
+    response,
+    previousResponse,
+    ...(resolvedReport ? { committeeReport: resolvedReport } : {}),
+  });
+  const appended = await appendQualitySnapshot(snapshot);
+  return { entry: { ...snapshot, recordedAt: snapshot.computedAt }, appended: appended > 0 };
+}
+
+/** Catch-up only appends missing rows from immutable selection snapshots; it never recalculates existing days. */
+export async function materializeRecentQualitySnapshots(limit = 2): Promise<{
+  entries: QualityLedgerEntry[];
+  appended: number;
+}> {
+  const dates = await prisma.judgmentLedger.findMany({
+    where: { kind: "selection", actor: { in: ["engine", "committee"] } },
+    select: { date: true },
+    distinct: ["date"],
+    orderBy: { date: "desc" },
+    take: Math.max(1, Math.min(limit, 30)),
+  });
+  const reports = await readCommitteeRunReports(45).catch(() => []);
+  const entries: QualityLedgerEntry[] = [];
+  let appended = 0;
+  for (const date of dates.map((row) => row.date).sort()) {
+    const response = await readDaily30ResponseFromLedger({ date });
+    if (!response) continue;
+    const result = await recordQualityForPublishedResponse(
+      date,
+      response,
+      await committeeReportForDate(date, reports)
+    );
+    entries.push(result.entry);
+    if (result.appended) appended += 1;
+  }
+  return { entries: entries.sort((a, b) => b.date.localeCompare(a.date)), appended };
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -17,6 +17,10 @@
       "schedule": "20 21 * * *"
     },
     {
+      "path": "/api/fomo/cron/quality-slo",
+      "schedule": "30 21 * * *"
+    },
+    {
       "path": "/api/fomo/cron/ledger-outcomes",
       "schedule": "40 21 * * *"
     }

--- a/docs/QUALITY_SLO_LEDGER.md
+++ b/docs/QUALITY_SLO_LEDGER.md
@@ -1,0 +1,33 @@
+# Quality SLO Ledger
+
+daily-30 발행 품질을 매일 같은 결정론 규칙으로 계산해 보존하는 append-only 원장이다.
+
+## 고정 목표
+
+| SLO | 목표 |
+|---|---:|
+| ±3% 카드 원인 설명률 | 90% 이상 |
+| 가격·sparkline 실값 | 100% |
+| verdict 문장 유니크 | 10개 이상 |
+| 동일 문장 최다 반복 | 3회 이하 |
+| 전일 종목 중복률 | 50% 이하 |
+| 자산 구성 | US 8개 이상, 코인 3~5개 |
+| 위원회 | 발행 성공 |
+| 재무·테마·신호이력 뎁스 완결률 | 90% 이상 |
+
+목표는 `QUALITY_SLO_TARGETS` 단일 상수에 고정하며 운영 상태에 맞춰 자동 완화하지 않는다.
+
+## 기록 규약
+
+- idempotency key는 `quality:YYYY-MM-DD`이고 날짜마다 한 행만 허용한다.
+- 위원회 editor 발행 직후 계산하며, 10분 뒤 품질 크론이 최근 2개 immutable selection 날짜의 누락 행만 보충한다.
+- catch-up은 당시 selection/front/committee 스냅샷으로 다시 계산한 신규 append다. 기존 품질 행은 재계산·수정하지 않는다.
+- PostgreSQL 트리거와 RLS가 `UPDATE`, `DELETE`, `TRUNCATE`를 거부한다.
+- 품질 미달은 daily-30 공급을 중단하지 않지만 `Quality SLO Monitor` Action을 실패시켜 경고한다.
+
+## 운영
+
+1. `Quality SLO Ledger Bootstrap`을 실행해 정확한 파티션 SQL을 적용한다.
+2. 같은 워크플로가 최근 2개 날짜를 자동 materialize하고 UPDATE/DELETE 거부를 검증한다.
+3. `/admin/quality`에서 추이와 미달 셀을 확인한다.
+4. `/api/fomo/quality-slo`는 운영 실측용 read-only projection이다.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "ledger:migrate": "tsx scripts/migrate-judgment-ledger.ts",
     "ledger:outcomes": "tsx scripts/materialize-ledger-outcomes.ts",
     "ledger:verify": "tsx scripts/verify-judgment-ledger-append-only.ts",
+    "quality-slo:materialize": "tsx scripts/materialize-quality-slo.ts",
+    "quality-slo:verify": "tsx scripts/verify-quality-ledger-append-only.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -720,7 +720,7 @@ model AdminLoginAttempt {
 // 어드민 액션 감사 로그 — 모든 변경 사항 기록
 model AdminAuditLog {
   id         String   @id @default(cuid())
-  action     String   // "card.update", "prompt.activate", "report.resolve" 등
+  action     String // "card.update", "prompt.activate", "report.resolve" 등
   targetId   String?
   targetType String?
   before     Json?
@@ -862,6 +862,22 @@ model JudgmentLedger {
   @@index([canonical, date])
   @@index([actor, date])
   @@map("JudgmentLedger")
+}
+
+// FOMO Club 품질 SLO 원장 — 일별 daily-30 스냅샷에서 결정론적으로 계산한 품질 지표를 박제한다.
+// 운영 DB에서는 date RANGE 파티션 테이블이며, SQL 트리거가 UPDATE/DELETE를 항상 거부한다.
+model QualityLedger {
+  id             String   @default(cuid())
+  date           String // YYYY-MM-DD (KST), 파티션 키
+  ts             DateTime @default(now())
+  idempotencyKey String // quality:YYYY-MM-DD
+  payload        Json
+  actor          String   @default("engine")
+
+  @@id([id, date])
+  @@unique([idempotencyKey, date])
+  @@index([date])
+  @@map("QualityLedger")
 }
 
 // 일별 투자자 수급(외국인·기관 순매매) 누적 — SUPPLY DEMAND SCORE HANDOFF §2.

--- a/prisma/sql/2026-07-20_quality_slo_ledger.sql
+++ b/prisma/sql/2026-07-20_quality_slo_ledger.sql
@@ -1,0 +1,77 @@
+-- WO-M3 Quality SLO Ledger bootstrap.
+-- One immutable daily row is appended from the published daily-30 snapshot.
+
+CREATE TABLE IF NOT EXISTS "QualityLedger" (
+  "id" TEXT NOT NULL,
+  "date" TEXT NOT NULL,
+  "ts" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "idempotencyKey" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "actor" TEXT NOT NULL DEFAULT 'engine',
+  CONSTRAINT "QualityLedger_pkey" PRIMARY KEY ("id", "date"),
+  CONSTRAINT "QualityLedger_actor_valid" CHECK ("actor" = 'engine'),
+  CONSTRAINT "QualityLedger_key_valid" CHECK (
+    "idempotencyKey" = ('quality:' || "date") OR "idempotencyKey" = '__QUALITY_LEDGER_PROBE__'
+  )
+) PARTITION BY RANGE ("date");
+
+CREATE TABLE IF NOT EXISTS "QualityLedger_default"
+  PARTITION OF "QualityLedger" DEFAULT;
+
+DO $$
+DECLARE
+  month_start DATE := DATE '2025-01-01';
+  month_end DATE;
+  partition_name TEXT;
+BEGIN
+  WHILE month_start < (CURRENT_DATE + INTERVAL '18 months')::DATE LOOP
+    month_end := (month_start + INTERVAL '1 month')::DATE;
+    partition_name := 'QualityLedger_' || TO_CHAR(month_start, 'YYYY_MM');
+    EXECUTE FORMAT(
+      'CREATE TABLE IF NOT EXISTS %I PARTITION OF "QualityLedger" FOR VALUES FROM (%L) TO (%L)',
+      partition_name,
+      TO_CHAR(month_start, 'YYYY-MM-DD'),
+      TO_CHAR(month_end, 'YYYY-MM-DD')
+    );
+    month_start := month_end;
+  END LOOP;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "QualityLedger_idempotencyKey_date_key"
+  ON "QualityLedger" ("idempotencyKey", "date");
+CREATE INDEX IF NOT EXISTS "QualityLedger_date_idx"
+  ON "QualityLedger" ("date");
+
+CREATE OR REPLACE FUNCTION fomo_reject_quality_ledger_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'QualityLedger is append-only: % is forbidden', TG_OP
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "QualityLedger_append_only" ON "QualityLedger";
+CREATE TRIGGER "QualityLedger_append_only"
+BEFORE UPDATE OR DELETE ON "QualityLedger"
+FOR EACH ROW EXECUTE FUNCTION fomo_reject_quality_ledger_mutation();
+
+ALTER TABLE "QualityLedger" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "QualityLedger" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "QualityLedger_select" ON "QualityLedger";
+CREATE POLICY "QualityLedger_select" ON "QualityLedger"
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "QualityLedger_insert" ON "QualityLedger";
+CREATE POLICY "QualityLedger_insert" ON "QualityLedger"
+  FOR INSERT WITH CHECK (
+    "actor" = 'engine'
+    AND ("idempotencyKey" = ('quality:' || "date") OR "idempotencyKey" = '__QUALITY_LEDGER_PROBE__')
+  );
+
+REVOKE UPDATE, DELETE, TRUNCATE ON "QualityLedger" FROM PUBLIC;
+
+COMMENT ON TABLE "QualityLedger" IS
+  'Append-only daily quality SLO ledger. UPDATE/DELETE are rejected by trigger.';

--- a/scripts/materialize-quality-slo.ts
+++ b/scripts/materialize-quality-slo.ts
@@ -1,0 +1,28 @@
+import { materializeRecentQualitySnapshots } from "../apps/web/lib/quality-slo-ledger";
+import { prisma } from "../apps/web/lib/prisma";
+
+async function main() {
+  const limitArg = process.argv.find((value) => value.startsWith("--limit="));
+  const parsed = Number(limitArg?.split("=")[1] ?? 2);
+  const limit = Number.isInteger(parsed) ? Math.max(1, Math.min(parsed, 30)) : 2;
+  const result = await materializeRecentQualitySnapshots(limit);
+  if (result.entries.length < limit) {
+    throw new Error(`quality SLO snapshots ${result.entries.length}/${limit}`);
+  }
+  console.log(JSON.stringify({
+    ok: true,
+    appended: result.appended,
+    entries: result.entries.map((entry) => ({
+      date: entry.date,
+      passed: entry.passed,
+      failures: entry.failures,
+    })),
+  }));
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/verify-quality-ledger-append-only.ts
+++ b/scripts/verify-quality-ledger-append-only.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "../apps/web/lib/prisma";
+
+async function mustReject(label: string, operation: () => Promise<unknown>): Promise<void> {
+  try {
+    await operation();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/append-only|forbidden|permission denied|row-level security/i.test(message)) return;
+    throw new Error(`${label} failed for an unexpected reason: ${message}`);
+  }
+  throw new Error(`${label} unexpectedly succeeded`);
+}
+
+async function main() {
+  const date = "1900-01-01";
+  const key = "__QUALITY_LEDGER_PROBE__";
+  await prisma.qualityLedger.createMany({
+    data: [{
+      id: randomUUID(),
+      date,
+      idempotencyKey: key,
+      actor: "engine",
+      payload: { probe: true, purpose: "append-only production verification" },
+    }],
+    skipDuplicates: true,
+  });
+  await mustReject("UPDATE", () => prisma.$executeRawUnsafe(
+    `UPDATE "QualityLedger" SET "actor" = 'mutated' WHERE "idempotencyKey" = $1`, key
+  ));
+  await mustReject("DELETE", () => prisma.$executeRawUnsafe(
+    `DELETE FROM "QualityLedger" WHERE "idempotencyKey" = $1`, key
+  ));
+  console.log(JSON.stringify({ ok: true, updateRejected: true, deleteRejected: true, probeRetained: true }));
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- compute all eight M3 quality SLOs deterministically at the end of the daily-30 publication flow
- append immutable `quality:{date}` snapshots with RLS and update/delete database guards
- add two-day catch-up materialization, public read API, and admin SVG trend dashboard
- fail the scheduled GitHub monitor on target misses without relaxing any approved threshold

## Fixed targets
- cause explanation >= 90%
- market data success = 100%
- verdict unique text >= 10
- repeated sentence <= 3
- previous-day overlap <= 50%
- US >= 8 and coin 3-5
- committee publication succeeds
- depth coverage >= 90%

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test` (1205 tests)
- `npm run build:web`
- `npm --workspace @fomo/web run build`
- `git diff --check`