### PR TITLE
fix: backfill quality SLO from publication history

### DIFF
--- a/apps/web/lib/expert-review-store.ts
+++ b/apps/web/lib/expert-review-store.ts
@@ -54,6 +54,32 @@ export async function readPublishedCommitteeSnapshot(): Promise<PublishedCommitt
   return readFeedContent<PublishedCommitteeSnapshot>(ACTIVE_ID);
 }
 
+/** 날짜별 최종 위원회 발행본. M1 원장 도입 전의 실제 발행 이력도 보존한다. */
+export async function readPublishedCommitteeSnapshotHistory(
+  limit = 30
+): Promise<PublishedCommitteeSnapshot[]> {
+  const rows = await readFeedContentByPrefix<PublishedCommitteeSnapshot>(
+    SNAPSHOT_PREFIX,
+    Math.max(1, Math.min(limit * 3, 50))
+  );
+  const byDate = new Map<string, PublishedCommitteeSnapshot>();
+  for (const { row } of rows) {
+    const date = row?.report?.date || row?.response?.asOf || row?.reviewedAt?.slice(0, 10);
+    if (!date || row.report?.status !== "published" || !row.response) continue;
+    const current = byDate.get(date);
+    if (!current || Date.parse(row.reviewedAt) > Date.parse(current.reviewedAt)) {
+      byDate.set(date, row);
+    }
+  }
+  return [...byDate.values()]
+    .sort(
+      (a, b) =>
+        b.report.date.localeCompare(a.report.date) ||
+        Date.parse(b.reviewedAt) - Date.parse(a.reviewedAt)
+    )
+    .slice(0, Math.max(1, Math.min(limit, 30)));
+}
+
 function snapshotAgeDays(snapshot: PublishedCommitteeSnapshot, today: string): number {
   const snapshotDate = snapshot.report.date || snapshot.reviewedAt.slice(0, 10);
   const todayMs = Date.parse(`${today}T00:00:00.000Z`);

--- a/apps/web/lib/quality-slo-ledger.ts
+++ b/apps/web/lib/quality-slo-ledger.ts
@@ -3,7 +3,10 @@ import { Prisma } from "@prisma/client";
 import { inferStandardSignalTypes } from "@fomo/core";
 import type { Daily30Response } from "./daily-30";
 import type { CommitteeRunReport } from "./expert-review-store";
-import { readCommitteeRunReports } from "./expert-review-store";
+import {
+  readCommitteeRunReports,
+  readPublishedCommitteeSnapshotHistory,
+} from "./expert-review-store";
 import {
   daily30ResponseFromSelections,
   readDaily30ResponseFromLedger,
@@ -416,23 +419,39 @@ export async function recordQualityForPublishedResponse(
   return { entry: { ...snapshot, recordedAt: snapshot.computedAt }, appended: appended > 0 };
 }
 
-/** Catch-up only appends missing rows from immutable selection snapshots; it never recalculates existing days. */
+/** Catch-up appends only missing rows from immutable selection or committee publication history. */
 export async function materializeRecentQualitySnapshots(limit = 2): Promise<{
   entries: QualityLedgerEntry[];
   appended: number;
 }> {
-  const dates = await prisma.judgmentLedger.findMany({
-    where: { kind: "selection", actor: { in: ["engine", "committee"] } },
-    select: { date: true },
-    distinct: ["date"],
-    orderBy: { date: "desc" },
-    take: Math.max(1, Math.min(limit, 30)),
-  });
+  const requested = Math.max(1, Math.min(limit, 30));
+  const [ledgerDates, publishedHistory] = await Promise.all([
+    prisma.judgmentLedger.findMany({
+      where: { kind: "selection", actor: { in: ["engine", "committee"] } },
+      select: { date: true },
+      distinct: ["date"],
+      orderBy: { date: "desc" },
+      take: requested,
+    }),
+    readPublishedCommitteeSnapshotHistory(requested).catch(() => []),
+  ]);
+  const responses = new Map<string, Daily30Response>();
+  for (const snapshot of publishedHistory) {
+    responses.set(snapshot.report.date || snapshot.response.asOf, snapshot.response);
+  }
+  for (const { date } of ledgerDates) {
+    const response = await readDaily30ResponseFromLedger({ date });
+    if (response) responses.set(date, response);
+  }
+  const dates = [...responses.keys()]
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, requested)
+    .sort();
   const reports = await readCommitteeRunReports(45).catch(() => []);
   const entries: QualityLedgerEntry[] = [];
   let appended = 0;
-  for (const date of dates.map((row) => row.date).sort()) {
-    const response = await readDaily30ResponseFromLedger({ date });
+  for (const date of dates) {
+    const response = responses.get(date);
     if (!response) continue;
     const result = await recordQualityForPublishedResponse(
       date,


### PR DESCRIPTION
## Summary
- read the latest real committee publication for each historical date
- use M1 selection ledger responses first and pre-M1 committee snapshots only as catch-up fallback
- preserve append-only behavior: existing quality rows are never recalculated or updated

## Incident
The production bootstrap created 2026-07-20 successfully, then failed its 2-row assertion because M1 selection history only begins today. Historical committee publications remain available and are now used as immutable source artifacts.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run test -- quality-slo-ledger expert-review-committee daily-30-fallback` (17 tests)
- `git diff --check`