### PR TITLE
feat: unify quiet money signals

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -375,6 +375,7 @@ function mergeFrontSeed(
     // 시점·입력이 달라 "카드는 '가격 먼저'인데 뎁스는 '주목 집중'" 불일치를 만든다(2026-07-17 User Zero).
     fomo: seed.fomo ?? fresh.fomo,
     ...(companyScore ? { companyScore } : {}),
+    ...(fresh.quietMoney ?? seed.quietMoney ? { quietMoney: fresh.quietMoney ?? seed.quietMoney } : {}),
     ...(seed.committeeReview ?? fresh.committeeReview
       ? { committeeReview: seed.committeeReview ?? fresh.committeeReview }
       : {}),
@@ -1480,6 +1481,75 @@ function ExpertCommitteeReview({ review }: { review: StockFrontResponse["committ
   );
 }
 
+const QUIET_MONEY_ACTOR_LABEL = {
+  insider: "내부자",
+  institution: "기관",
+  foreign: "외국인",
+  whale: "고래",
+} as const;
+
+function quietMoneyAmount(event: NonNullable<StockFrontResponse["quietMoney"]>["events"][number]): string | undefined {
+  if (typeof event.amount !== "number" || !Number.isFinite(event.amount)) return undefined;
+  if (event.amountUnit === "KRW") {
+    return event.amount >= 100_000_000
+      ? `${(event.amount / 100_000_000).toLocaleString("ko-KR", { maximumFractionDigits: 1 })}억원`
+      : `${Math.round(event.amount).toLocaleString("ko-KR")}원`;
+  }
+  if (event.amountUnit === "USD") {
+    return event.amount >= 1_000_000
+      ? `$${(event.amount / 1_000_000).toLocaleString("en-US", { maximumFractionDigits: 1 })}M`
+      : `$${Math.round(event.amount).toLocaleString("en-US")}`;
+  }
+  if (event.amountUnit === "shares") return `${Math.round(event.amount).toLocaleString("ko-KR")}주`;
+  return event.amount.toLocaleString("ko-KR");
+}
+
+function QuietMoneyBlock({ timeline }: { timeline: StockFrontResponse["quietMoney"] | undefined }) {
+  if (!timeline?.events.length) return null;
+  return (
+    <section className="mt-4 border-y border-hairline py-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-pixel text-sm text-whiteout">조용한 돈</p>
+          <p className="mt-1 text-[11px] text-muted">공시·KRX 확정치·온체인 근거를 한 시간축으로 묶었어요.</p>
+        </div>
+        {timeline.cluster && (
+          <span className="shrink-0 rounded-md border border-[#D8FF3A]/50 px-2 py-1 text-[10px] font-bold text-[#D8FF3A]">
+            강도 {timeline.cluster.strength}/5
+          </span>
+        )}
+      </div>
+      {timeline.cluster && (
+        <div className="mt-3 border-l-2 border-[#D8FF3A] bg-[#D8FF3A]/[0.06] px-3 py-2.5">
+          <p className="text-sm font-bold text-whiteout">{cleanText(timeline.cluster.headline)}</p>
+          <p className="mt-1 text-[11px] leading-5 text-muted">{cleanText(timeline.cluster.evidence.join(" · "))}</p>
+        </div>
+      )}
+      <ol className="mt-3 space-y-0">
+        {timeline.events.slice(0, 12).map((event, index) => {
+          const amount = quietMoneyAmount(event);
+          const content = (
+            <>
+              <span className="block text-xs font-bold text-whiteout">
+                {QUIET_MONEY_ACTOR_LABEL[event.actor]} · 순{event.direction === "inflow" ? "유입" : "유출"}
+              </span>
+              <span className="mt-0.5 block text-[11px] leading-5 text-muted">{cleanText(event.label)}</span>
+              <span className="mt-0.5 block text-[10px] text-muted">
+                {event.date}{amount ? ` · ${amount}` : ""}{typeof event.priceAt === "number" ? ` · 당시가 ${formatChartPrice(event.priceAt)}` : ""} · {cleanText(event.source)}
+              </span>
+            </>
+          );
+          return (
+            <li key={`${event.date}-${event.actor}-${index}`} className="border-l border-white/15 px-3 py-2">
+              {event.sourceUrl ? <a href={event.sourceUrl} target="_blank" rel="noreferrer" className="block hover:border-[#D8FF3A]">{content}</a> : content}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
 function DiscoveryOverview({
   front,
   insight,
@@ -1562,11 +1632,13 @@ function AnalysisChart({
   invalidationLevel,
   candles,
   analysis,
+  quietMoney,
 }: {
   series: NonNullable<StockFrontResponse["chartSeries"]>;
   invalidationLevel?: number | undefined;
   candles?: DailyOhlcv[] | undefined;
   analysis?: WyckoffAnalysis | undefined;
+  quietMoney?: StockFrontResponse["quietMoney"] | undefined;
 }) {
   const [selectedEvent, setSelectedEvent] = useState<WyckoffEvent | null>(null);
   const W = 320;
@@ -1574,8 +1646,9 @@ function AnalysisChart({
   const PRICE_H = 166;
   const VOL_TOP = 178;
   const VOL_H = 42;
-  const H = VOL_TOP + VOL_H + 12;
-  const renderedCandles =
+  const QUIET_LANE_TOP = VOL_TOP + VOL_H + 10;
+  const QUIET_LANE_GAP = 8;
+  const renderedCandles: DailyOhlcv[] =
     candles?.filter((c) => [c.open, c.high, c.low, c.close].every((v) => Number.isFinite(v) && v > 0)).slice(-series.closes.length) ??
     series.closes.map((close, i, arr) => {
       const open = i > 0 ? arr[i - 1]! : close;
@@ -1645,6 +1718,13 @@ function AnalysisChart({
   const priceTicks = [rawMax, (rawMax + rawMin) / 2, rawMin];
   const visibleZones = (analysis?.zones ?? []).filter((zone) => zone.endIndex >= visibleStart && zone.startIndex <= visibleStart + n - 1);
   const visibleEvents = (analysis?.events ?? []).filter((event) => event.index >= visibleStart && event.index <= visibleStart + n - 1);
+  const candleIndexByDate = new Map(renderedCandles.flatMap((candle, index) => candle.date ? [[candle.date, index] as const] : []));
+  const quietActors = ["insider", "institution", "foreign", "whale"] as const;
+  const visibleQuietEvents = (quietMoney?.events ?? []).flatMap((event) => {
+    const index = candleIndexByDate.get(event.date);
+    return typeof index === "number" ? [{ event, index }] : [];
+  });
+  const H = visibleQuietEvents.length > 0 ? QUIET_LANE_TOP + QUIET_LANE_GAP * 4 + 12 : VOL_TOP + VOL_H + 12;
   const zoneName = (kind: (typeof visibleZones)[number]["kind"]) =>
     kind === "accumulation" ? "매집" : kind === "distribution" ? "분산" : kind === "markup" ? "상승" : "하락";
   const zoneColor = (kind: (typeof visibleZones)[number]["kind"]) => CHART_COLOR[kind];
@@ -1819,6 +1899,32 @@ function AnalysisChart({
             </g>
           );
         })}
+        {quietActors.map((actor, actorIndex) => {
+          const laneEvents = visibleQuietEvents.filter((item) => item.event.actor === actor);
+          if (laneEvents.length === 0) return null;
+          const laneY = QUIET_LANE_TOP + actorIndex * QUIET_LANE_GAP;
+          return (
+            <g key={`quiet-lane-${actor}`}>
+              <line x1="0" x2={PLOT_W} y1={laneY} y2={laneY} stroke="rgba(255,255,255,0.10)" strokeWidth="0.6" />
+              <text x={PLOT_W + 4} y={laneY + 2.5} fontSize="6.5" fill="rgba(250,250,250,0.52)">
+                {QUIET_MONEY_ACTOR_LABEL[actor]}
+              </text>
+              {laneEvents.map(({ event, index }, markerIndex) => (
+                <g key={`${actor}-${event.date}-${markerIndex}`}>
+                  <title>{`${event.date} · ${event.label}`}</title>
+                  <circle
+                    cx={x(index)}
+                    cy={laneY}
+                    r="2.6"
+                    fill={event.direction === "inflow" ? CHART_COLOR.up : CHART_COLOR.down}
+                    stroke="#050706"
+                    strokeWidth="0.8"
+                  />
+                </g>
+              ))}
+            </g>
+          );
+        })}
         <text x="0" y={H - 1} fontSize="8" fill="rgba(250,250,250,0.42)">{markerDateLabel(renderedCandles[0])}</text>
         <text x={PLOT_W} y={H - 1} textAnchor="end" fontSize="8" fill="rgba(250,250,250,0.42)">{markerDateLabel(latest)}</text>
       </svg>
@@ -1841,6 +1947,7 @@ function AnalysisChart({
         {includeLevel && <span><span style={{ color: CHART_COLOR.invalidation }}>┄</span> 관점 경계</span>}
         {visibleZones.length > 0 && <span>▧ 구간</span>}
         {visibleEvents.length > 0 && <span>◆ 이벤트</span>}
+        {visibleQuietEvents.length > 0 && <span>● 조용한 돈</span>}
       </div>
     </div>
   );
@@ -2047,7 +2154,7 @@ function ChartAnalysisTab({
               ))}
             </div>
           </div>
-          <AnalysisChart series={visibleSeries} invalidationLevel={verdict?.invalidationLevel} candles={visibleCandles} analysis={wyckoff} />
+          <AnalysisChart series={visibleSeries} invalidationLevel={verdict?.invalidationLevel} candles={visibleCandles} analysis={wyckoff} quietMoney={front?.quietMoney} />
           {invalidation && (
             <button
               type="button"
@@ -2584,6 +2691,7 @@ export function StockInsightView({
           <CompanyScoreRadar result={front?.companyScore} />
           <ExpertCommitteeReview review={front?.committeeReview} />
           <DiscoveryOverview front={front} insight={insight} context={context} />
+          <QuietMoneyBlock timeline={front?.quietMoney} />
           <JudgmentTimeline canonical={stock} />
           <DepthTabBar tab={depthTab} onChange={setDepthTab} />
           {depthTab === "ta" ? (

--- a/apps/fomo-web/lib/fomoApi.ts
+++ b/apps/fomo-web/lib/fomoApi.ts
@@ -515,6 +515,7 @@ export interface StockFrontResponse {
   signals: import("@fomo/core").CardFrontSignals;
   fomo: import("@fomo/core").FomoScoreResult;
   companyScore?: import("@fomo/core").CompanyScoreResult;
+  quietMoney?: import("@fomo/core").QuietMoneyTimeline;
   committeeReview?: {
     runId: string;
     reviewedAt: string;

--- a/apps/web/__tests__/lib/feed-hub.test.ts
+++ b/apps/web/__tests__/lib/feed-hub.test.ts
@@ -155,6 +155,33 @@ describe("daily-30 신선도 폴백 (30장 유지 > 신선도)", () => {
     expect(boosted.quietScore - baseline.quietScore).toBe(2);
     expect(smallSample.quietScore).toBe(baseline.quietScore);
   });
+
+  it("다중 주체 클러스터는 quietScore 강가점과 카드 헤드라인 승격을 받는다", () => {
+    const stock = stubStock("클러스터종목", "기존 재료");
+    const front: DiscoveryFrontSeed = {
+      ...stubFront(),
+      quietMoney: {
+        asOf: "2026-07-17",
+        events: [],
+        cluster: {
+          type: "cluster_multi",
+          windowTradingDays: 10,
+          actors: ["insider", "institution"],
+          actorCount: 2,
+          startDate: "2026-07-10",
+          endDate: "2026-07-17",
+          strength: 4,
+          headline: "내부자·기관 동시 유입 · 10거래일 내 2개 주체",
+          evidence: ["내부자 공개시장 매수", "기관 6일 지속"],
+        },
+      },
+    };
+    const baseline = stockCandidate(stock, stubFront())!;
+    const clustered = stockCandidate(stock, front)!;
+    expect(clustered.signalTypes).toContain("cluster_multi");
+    expect(clustered.quietScore - baseline.quietScore).toBe(18);
+    expect(clustered.stock?.headline).toBe("내부자·기관 동시 유입 · 10거래일 내 2개 주체");
+  });
 });
 
 describe("capFeedItemsByType (2026-07-11 베리에이션)", () => {

--- a/apps/web/__tests__/lib/judgment-ledger.test.ts
+++ b/apps/web/__tests__/lib/judgment-ledger.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../lib/judgment-ledger";
 import { buildTrackRecord, type OutcomePayload } from "../../lib/ledger-track-record";
 import { fetchHistoricalPrices } from "../../lib/quote-prices";
+import { SIGNAL_TAXONOMY_VERSION, SIGNAL_TYPE_CODES } from "@fomo/core";
 
 function selection(overrides: Partial<LedgerSelectionView> = {}): LedgerSelectionView {
   return {
@@ -104,7 +105,7 @@ describe("Judgment Ledger", () => {
     expect(selected.map((entry) => entry.kind)).toEqual(["signal", "verdict", "score", "selection"]);
     expect(selected.every((entry) => entry.priceAt === 123.45 && entry.actor === "committee")).toBe(true);
     expect(selected.find((entry) => entry.kind === "signal")?.payload).toMatchObject({
-      taxonomyVersion: "m2.v1",
+      taxonomyVersion: SIGNAL_TAXONOMY_VERSION,
       signalTypes: ["score_80_plus"],
     });
     const selectionEntry = selected.find((entry) => entry.kind === "selection")!;
@@ -151,7 +152,7 @@ describe("track record fixed-window aggregation", () => {
     const record = buildTrackRecord([]);
     expect(record.windows.map((window) => window.days)).toEqual([7, 30, 90]);
     expect(record.windows.every((window) => window.overall.n === 0 && window.overall.winRate === null)).toBe(true);
-    expect(Object.keys(record.signalHistory30)).toHaveLength(15);
+    expect(Object.keys(record.signalHistory30)).toHaveLength(SIGNAL_TYPE_CODES.length);
     expect(record.signalHistory30.insider_cluster).toEqual({ n: 0, winRate: null, medianReturn: null });
   });
 

--- a/apps/web/lib/coin-discovery.ts
+++ b/apps/web/lib/coin-discovery.ts
@@ -1,5 +1,5 @@
-import { computeCardVerdict, computeCompanyScore, computeFomoScore, computeWyckoffAnalysis, isFrontHookSafe } from "@fomo/core";
-import type { CardFrontSignals } from "@fomo/core";
+import { buildQuietMoneyTimeline, computeCardVerdict, computeCompanyScore, computeFomoScore, computeWyckoffAnalysis, isFrontHookSafe } from "@fomo/core";
+import type { CardFrontSignals, QuietMoneyEvent } from "@fomo/core";
 import { kstDate } from "./fomo";
 import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
 import {
@@ -139,6 +139,28 @@ export function coinFrontSeed(
   });
   const coinCause = buildCoinCause(snapshot, coinIssues);
   const primaryIssue = coinIssues.find((issue) => issue.scope === "coin");
+  const quietMoneyEvents = coinIssues.flatMap((issue): QuietMoneyEvent[] => {
+    if (issue.type !== "onchain" || !/고래|whale/i.test(issue.title)) return [];
+    const inflow = /(?:고래.{0,18}(?:매수|매집|축적|순유입)|(?:매수|매집|축적|순유입).{0,18}고래|whale.{0,18}(?:buy|accumulat|inflow))/i.test(issue.title);
+    const outflow = /(?:고래.{0,18}(?:매도|분배|순유출)|(?:매도|분배|순유출).{0,18}고래|whale.{0,18}(?:sell|distribut|outflow))/i.test(issue.title);
+    if (!inflow && !outflow) return [];
+    const date = issue.publishedAt.slice(0, 10);
+    const priceAt = snapshot.candles.find((candle) => candle.date === date)?.close;
+    return [{
+      date,
+      actor: "whale",
+      direction: inflow ? "inflow" : "outflow",
+      source: issue.source,
+      label: issue.title,
+      ...(typeof priceAt === "number" && priceAt > 0 ? { priceAt } : {}),
+      sourceUrl: issue.url,
+    }];
+  });
+  const quietMoney = buildQuietMoneyTimeline({
+    asOf: snapshot.fetchedAt.slice(0, 10),
+    events: quietMoneyEvents,
+    tradingDates: snapshot.candles.flatMap((candle) => candle.date ? [candle.date] : []),
+  });
   return {
     signals: {
       ...signals,
@@ -155,9 +177,11 @@ export function coinFrontSeed(
       signals,
       verdict,
       wyckoff,
+      ...(quietMoney.events.length ? { quietMoney } : {}),
       currentPrice: snapshot.price,
       asOf: snapshot.fetchedAt,
     }),
+    ...(quietMoney.events.length ? { quietMoney } : {}),
     candles,
     ...(chartSeries ? { chartSeries } : {}),
     ...(coinIssues.length ? { coinIssues: [...coinIssues].slice(0, 3) } : {}),

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -238,6 +238,7 @@ export interface FreshnessSnapshot {
 const STALE_REPEAT_PENALTY = 8;
 /** 이틀 연속 같은 문구 — 순위를 바닥으로 보내되 후보에서 빼지 않는다(30장 채움 폴백). */
 const STALE_REPEAT_FLOOR = -1000;
+const QUIET_MONEY_CLUSTER_BASE_BONUS = 10;
 
 function normalizeHeadline(text: string | undefined): string {
   return (text ?? "").replace(/\s+/g, " ").trim();
@@ -265,17 +266,28 @@ export function stockCandidate(
     ...(stock.sourceUrl ? { sourceUrl: stock.sourceUrl } : {}),
     ...(front?.signals ? { signals: front.signals } : {}),
     ...(front?.wyckoff ? { wyckoff: front.wyckoff } : {}),
+    ...(front?.quietMoney ? { quietMoney: front.quietMoney } : {}),
     ...(typeof front?.companyScore?.score === "number" ? { companyScore: front.companyScore.score } : {}),
   });
   const performanceBonus = signalPerformanceBonus(signalTypes, performance);
-  let quietScore = signalScore - hypePenalty + performanceBonus;
+  const cluster = front?.quietMoney?.cluster;
+  const clusterBonus = cluster ? QUIET_MONEY_CLUSTER_BASE_BONUS + cluster.strength * 2 : 0;
+  let quietScore = signalScore - hypePenalty + performanceBonus + clusterBonus;
   if (!repeatStale && quietScore < 6) return null;
   if (repeatStale) quietScore = STALE_REPEAT_FLOOR + quietScore; // 신선 후보가 전부 소진된 뒤에만 뽑힘
+  const elevatedStock: DiscoveryStockPayload = cluster
+    ? {
+        ...stock,
+        headline: cluster.headline,
+        whyShown: `${cluster.headline} · ${cluster.evidence.join(" · ")}`,
+        reason: `${cluster.headline} · ${cluster.evidence.join(" · ")}`,
+      }
+    : stock;
   return {
     kind: "stock",
     id: stockId(stock),
-    card: { kind: "stock", ...stock },
-    stock,
+    card: { kind: "stock", ...elevatedStock },
+    stock: elevatedStock,
     ...(front ? { front } : {}),
     assetClass: stockAssetClass(stock),
     sector: stock.sector,

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -21,6 +21,7 @@ import {
   computeCardVerdict,
   computeCompanyScore,
   computeWyckoffAnalysis,
+  buildQuietMoneyTimeline,
   type CardVerdict,
   type CompanyScoreResult,
   type DailyOhlcv,
@@ -34,6 +35,8 @@ import {
   type FomoScoreResult,
   type InvestorFlow,
   type MultiAxisHookSelection,
+  type QuietMoneyEvent,
+  type QuietMoneyTimeline,
   type WyckoffAnalysis,
   type SectorStock,
   type StockCountry,
@@ -136,6 +139,8 @@ export interface DiscoveryFrontSeed {
   signals: CardFrontSignals;
   fomo: FomoScoreResult;
   companyScore?: CompanyScoreResult;
+  /** 내부자·기관·외국인·고래의 실데이터 통합 타임라인. */
+  quietMoney?: QuietMoneyTimeline;
   /** 일일 위원회가 사실 게이트를 통과시킨 전문 분석. 요청 경로에서는 생성하지 않고 승인 스냅샷만 읽는다. */
   committeeReview?: {
     runId: string;
@@ -618,6 +623,7 @@ function materialEventFromArticle(article: RawArticle, asOf: string, sourceFallb
 
 function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEvent {
   const insiderPurchase = Boolean(disclosure.insiderPurchase);
+  const purchase = disclosure.insiderPurchase;
   return {
     kind: "disclosure",
     firstSeen: true,
@@ -630,6 +636,19 @@ function materialEventFromDisclosure(disclosure: DartDisclosureHit): DiscoveryEv
     summary: disclosure.label,
     sourceName: disclosure.source,
     ...(insiderPurchase ? { headlineHook: disclosure.label, insiderPurchase: true } : {}),
+    ...(purchase ? {
+      quietMoneyEvent: {
+        date: purchase.transactionDate,
+        actor: "insider",
+        direction: "inflow",
+        source: disclosure.source,
+        label: disclosure.label,
+        ...(typeof purchase.value === "number" ? { amount: purchase.value, amountUnit: "KRW" as const } :
+          typeof purchase.shares === "number" ? { amount: purchase.shares, amountUnit: "shares" as const } : {}),
+        ...(typeof purchase.price === "number" ? { priceAt: purchase.price } : {}),
+        ...(disclosure.url ? { sourceUrl: disclosure.url } : {}),
+      },
+    } : {}),
     ...(disclosure.url ? { sourceUrl: disclosure.url } : {}),
   };
 }
@@ -722,6 +741,7 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
     const filings = filingResult.status === "fulfilled" ? filingResult.value : [];
     const filing = filings.find((item) => item.insiderPurchase) ?? filings[0];
     if (filing) {
+      const purchase = filing.insiderPurchase;
       return {
         kind: "disclosure",
         firstSeen: true,
@@ -734,6 +754,19 @@ async function eventFromTargetedMaterial(row: DiscoveryMarketRow, asOf: string):
         summary: filing.label,
         sourceName: filing.source,
         ...(filing.insiderPurchase ? { headlineHook: filing.label, insiderPurchase: true } : {}),
+        ...(purchase ? {
+          quietMoneyEvent: {
+            date: purchase.transactionDate,
+            actor: "insider",
+            direction: "inflow",
+            source: filing.source,
+            label: filing.label,
+            amount: purchase.value,
+            amountUnit: "USD",
+            priceAt: purchase.price,
+            ...(filing.url ? { sourceUrl: filing.url } : {}),
+          },
+        } : {}),
         ...(filing.url ? { sourceUrl: filing.url } : {}),
       };
     }
@@ -831,6 +864,18 @@ function insiderClusterEvent(candidate: InsiderClusterCandidate, asOf: string): 
     sourceName: "SEC Form 4",
     headlineHook: label,
     insiderPurchase: true,
+    quietMoneyEvent: {
+      date: candidate.tradeDate,
+      actor: "insider",
+      direction: "inflow",
+      source: "SEC Form 4",
+      label,
+      amount: candidate.valueUsd,
+      amountUnit: "USD",
+      streakDays: 1,
+      ...(candidate.buyPrice ? { priceAt: candidate.buyPrice } : {}),
+      sourceUrl: `http://openinsider.com/${candidate.symbol}`,
+    },
     sourceUrl: `http://openinsider.com/${candidate.symbol}`,
   };
 }
@@ -1737,6 +1782,75 @@ function verdictForCandidate(candidate: DiscoveryCandidate, candles: readonly Da
   });
 }
 
+function candlePriceAt(candles: readonly DailyOhlcv[], date: string): number | undefined {
+  const exact = candles.find((candle) => candle.date === date)?.close;
+  if (typeof exact === "number" && Number.isFinite(exact) && exact > 0) return exact;
+  return undefined;
+}
+
+function flowQuietMoneyEvents(
+  history: readonly InvestorFlow[],
+  candles: readonly DailyOhlcv[]
+): QuietMoneyEvent[] {
+  const streak = investorNetStreak(history);
+  const newest = [...history].sort((a, b) => b.date.localeCompare(a.date))[0]?.date;
+  return history.flatMap((flow) => {
+    const priceAt = candlePriceAt(candles, flow.date);
+    const rows: QuietMoneyEvent[] = [];
+    const add = (actor: "institution" | "foreign", net: number, streakDays: number) => {
+      if (!Number.isFinite(net) || net === 0) return;
+      const actorLabel = actor === "institution" ? "기관" : "외국인";
+      const direction = net > 0 ? "inflow" : "outflow";
+      rows.push({
+        date: flow.date,
+        actor,
+        direction,
+        source: "KRX 확정 순매매",
+        label: `${actorLabel} ${Math.abs(net).toLocaleString("ko-KR")}주 순${net > 0 ? "매수" : "매도"}`,
+        amount: Math.abs(net),
+        amountUnit: "shares",
+        ...(flow.date === newest && Math.sign(streakDays) === Math.sign(net) ? { streakDays: Math.abs(streakDays) } : {}),
+        ...(priceAt ? { priceAt } : {}),
+      });
+    };
+    add("institution", flow.institutionNet, streak.institution);
+    add("foreign", flow.foreignNet, streak.foreign);
+    return rows;
+  });
+}
+
+function candidateQuietMoneyTimeline(
+  candidate: DiscoveryCandidate,
+  history: readonly InvestorFlow[],
+  candles: readonly DailyOhlcv[]
+): QuietMoneyTimeline {
+  const structured = candidate.events.flatMap((event) => event.quietMoneyEvent ? [event.quietMoneyEvent] : []);
+  const historyEvents = flowQuietMoneyEvents(history, candles);
+  const structuredActors = new Set([...structured, ...historyEvents].map((event) => event.actor));
+  const fallbackFlows = candidate.events.flatMap((event): QuietMoneyEvent[] => {
+    if (event.kind !== "flow_entry" || !event.flowActor || structuredActors.has(event.flowActor)) return [];
+    const days = event.flowDays ?? 0;
+    if (days === 0) return [];
+    const priceAt = candlePriceAt(candles, event.asOf);
+    return [{
+      date: event.asOf,
+      actor: event.flowActor,
+      direction: days > 0 ? "inflow" : "outflow",
+      source: event.source,
+      label: event.label ?? `${event.flowActor === "foreign" ? "외국인" : "기관"} ${Math.abs(days)}일 연속 순${days > 0 ? "매수" : "매도"}`,
+      streakDays: Math.abs(days),
+      ...(priceAt ? { priceAt } : {}),
+      ...(event.sourceUrl ? { sourceUrl: event.sourceUrl } : {}),
+    }];
+  });
+  return buildQuietMoneyTimeline({
+    asOf: candidate.asOf,
+    events: [...structured, ...historyEvents, ...fallbackFlows],
+    tradingDates: candles.flatMap((candle) => candle.date ? [candle.date] : []),
+    windowTradingDays: 10,
+  });
+}
+
 function relationCopy(relation: RelatedNode["relation"]): string {
   switch (relation) {
     case "customer":
@@ -2122,10 +2236,11 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     await hydrateUsMarketWideMaterial(byTicker, asOf);
   }
 
+  let flowHistories: Record<string, InvestorFlow[]> = {};
   if (DISCOVERY_FLOW_CACHE_ENABLED) {
     const krTickers = [...byTicker.entries()].filter(([, value]) => value.row.country === "KR").map(([ticker]) => ticker);
-    const histories = krTickers.length > 0 ? await readSupplyDemandHistoryByTickers(krTickers, 10) : {};
-    for (const [ticker, history] of Object.entries(histories)) {
+    flowHistories = krTickers.length > 0 ? await readSupplyDemandHistoryByTickers(krTickers, 10) : {};
+    for (const [ticker, history] of Object.entries(flowHistories)) {
       const event = eventFromFlowHistory(history);
       if (!event) continue;
       const current = byTicker.get(ticker);
@@ -2249,6 +2364,8 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
     const attention = attentionMap[candidate.ticker];
     const front = frontSeed(row, candidate, attention, themeSignals.get(candidate.ticker), sparklineByTicker.get(candidate.ticker) ?? []);
     const candidateCandles = dailyByTicker.get(candidate.ticker)?.candles ?? [];
+    const quietMoney = candidateQuietMoneyTimeline(candidate, flowHistories[candidate.ticker] ?? [], candidateCandles);
+    if (quietMoney.events.length > 0) front.quietMoney = quietMoney;
     front.verdict = verdictForCandidate(candidate, candidateCandles);
     const wyckoff = computeWyckoffAnalysis({
       candles: candidateCandles,
@@ -2263,6 +2380,7 @@ export async function buildDiscoveryResponse(options: BuildDiscoveryResponseOpti
       verdict: front.verdict,
       wyckoff,
       insiderPurchaseConfirmed: candidate.events.some((event) => event.insiderPurchase === true),
+      ...(front.quietMoney ? { quietMoney: front.quietMoney } : {}),
       ...(typeof candidateCandles.at(-1)?.close === "number" ? { currentPrice: candidateCandles.at(-1)!.close } : {}),
       asOf,
     });

--- a/apps/web/lib/judgment-ledger.ts
+++ b/apps/web/lib/judgment-ledger.ts
@@ -178,8 +178,10 @@ export function inferSignalTypes(input: {
   signals?: DiscoveryFrontSeed["signals"];
   wyckoff?: WyckoffAnalysis;
   companyScore?: number;
+  quietMoney?: DiscoveryFrontSeed["quietMoney"];
 }): SignalTypeCode[] {
-  return inferStandardSignalTypes(input);
+  const { quietMoney, ...rest } = input;
+  return inferStandardSignalTypes({ ...rest, ...(quietMoney ? { quietMoney } : {}) });
 }
 
 function cleanScore(score: CompanyScoreResult | undefined): Record<string, unknown> | null {
@@ -227,6 +229,7 @@ export function buildDaily30LedgerEntries(
       ...(front?.verdict ? { verdict: front.verdict } : {}),
       ...(front?.signals ? { signals: front.signals } : {}),
       ...(front?.wyckoff ? { wyckoff: front.wyckoff } : {}),
+      ...(front?.quietMoney ? { quietMoney: front.quietMoney } : {}),
       ...(typeof front?.companyScore?.score === "number" ? { companyScore: front.companyScore.score } : {}),
     });
     const score = cleanScore(front?.companyScore);
@@ -242,6 +245,7 @@ export function buildDaily30LedgerEntries(
         ...(stock.sourceLabel ? { sourceLabel: stock.sourceLabel } : {}),
         ...(stock.sourceUrl ? { sourceUrl: stock.sourceUrl } : {}),
         axisSignals: front?.axisSignals?.filter((item) => item.fired) ?? [],
+        ...(front?.quietMoney?.cluster ? { quietMoneyCluster: front.quietMoney.cluster } : {}),
       },
       priceAt,
       actor: resolvedActor,
@@ -349,6 +353,7 @@ function asSelection(row: {
         ...(payload.stock?.sourceUrl ?? payload.sourceUrl ? { sourceUrl: payload.stock?.sourceUrl ?? payload.sourceUrl } : {}),
         ...(payload.front?.signals ? { signals: payload.front.signals } : {}),
         ...(payload.front?.wyckoff ? { wyckoff: payload.front.wyckoff } : {}),
+        ...(payload.front?.quietMoney ? { quietMoney: payload.front.quietMoney } : {}),
         ...(typeof projectedCompanyScore === "number" ? { companyScore: projectedCompanyScore } : {}),
       });
   return {

--- a/apps/web/lib/quality-slo-ledger.ts
+++ b/apps/web/lib/quality-slo-ledger.ts
@@ -264,6 +264,7 @@ export function calculateQualitySloSnapshot(input: {
       ...(stock.sourceUrl ? { sourceUrl: stock.sourceUrl } : {}),
       ...(front?.signals ? { signals: front.signals } : {}),
       ...(front?.wyckoff ? { wyckoff: front.wyckoff } : {}),
+      ...(front?.quietMoney ? { quietMoney: front.quietMoney } : {}),
       ...(typeof front?.companyScore?.score === "number" ? { companyScore: front.companyScore.score } : {}),
     });
     const hasSignalHistory = inferredTypes.length > 0;

--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -84,6 +84,28 @@ describe("company score", () => {
     expect(result.axes.find((axis) => axis.key === "quiet")?.score).toBe(69);
   });
 
+  it("feeds verified multi-actor strength into the flow axis", () => {
+    const result = computeCompanyScore({
+      quietMoney: {
+        asOf: "2026-07-17",
+        events: [],
+        cluster: {
+          type: "cluster_multi",
+          windowTradingDays: 10,
+          actors: ["insider", "institution"],
+          actorCount: 2,
+          startDate: "2026-07-10",
+          endDate: "2026-07-17",
+          strength: 4,
+          headline: "내부자·기관 동시 유입 · 10거래일 내 2개 주체",
+          evidence: [],
+        },
+      },
+    });
+    expect(result.axes.find((axis) => axis.key === "flow")).toMatchObject({ score: 66 });
+    expect(result.axes.find((axis) => axis.key === "flow")?.evidence[0]).toContain("강도 4/5");
+  });
+
   it("keeps the daily card score stable when a fresh detail score arrives", () => {
     const seed = computeCompanyScore({
       signals: { foreignNetStreak: 5 },

--- a/packages/fomo-core/__tests__/quiet-money.test.ts
+++ b/packages/fomo-core/__tests__/quiet-money.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { buildQuietMoneyTimeline, quietMoneyStrength, type QuietMoneyEvent } from "../src";
+
+const tradingDates = [
+  "2026-07-06", "2026-07-07", "2026-07-08", "2026-07-09", "2026-07-10",
+  "2026-07-13", "2026-07-14", "2026-07-15", "2026-07-16", "2026-07-17",
+];
+
+function event(actor: QuietMoneyEvent["actor"], date: string, overrides: Partial<QuietMoneyEvent> = {}): QuietMoneyEvent {
+  return {
+    date,
+    actor,
+    direction: "inflow",
+    source: "확정 소스",
+    label: `${actor} 유입`,
+    priceAt: 100,
+    ...overrides,
+  };
+}
+
+describe("quiet money timeline", () => {
+  it("10거래일 안 서로 다른 주체 2개부터 cluster_multi를 만든다", () => {
+    const timeline = buildQuietMoneyTimeline({
+      asOf: "2026-07-17",
+      tradingDates,
+      events: [event("insider", "2026-07-10"), event("institution", "2026-07-16", { streakDays: 6 })],
+    });
+    expect(timeline.cluster).toMatchObject({
+      type: "cluster_multi",
+      actors: ["insider", "institution"],
+      actorCount: 2,
+      windowTradingDays: 10,
+    });
+    expect(timeline.cluster?.headline).toBe("내부자·기관 동시 유입 · 10거래일 내 2개 주체");
+    expect(timeline.cluster?.strength).toBeGreaterThanOrEqual(3);
+  });
+
+  it("같은 주체 여러 건이나 유출은 다중 주체 클러스터로 과장하지 않는다", () => {
+    const timeline = buildQuietMoneyTimeline({
+      asOf: "2026-07-17",
+      tradingDates,
+      events: [
+        event("insider", "2026-07-14"),
+        event("insider", "2026-07-16"),
+        event("foreign", "2026-07-17", { direction: "outflow" }),
+      ],
+    });
+    expect(timeline.events).toHaveLength(3);
+    expect(timeline.cluster).toBeUndefined();
+  });
+
+  it("규모 비율은 실값이 있을 때만 강도에 반영한다", () => {
+    const base = [event("insider", "2026-07-16"), event("institution", "2026-07-17")];
+    expect(quietMoneyStrength(base, 2)).toBe(2);
+    expect(quietMoneyStrength([...base, event("foreign", "2026-07-17", { marketCapRatioPct: 0.6 })], 3)).toBe(4);
+  });
+});

--- a/packages/fomo-core/__tests__/signal-resume.test.ts
+++ b/packages/fomo-core/__tests__/signal-resume.test.ts
@@ -52,4 +52,24 @@ describe("signal resume taxonomy", () => {
     expect(signalPerformanceBonus(["foreign_streak"], { foreign_streak: { n: 80, winRate: 95, medianReturn: 5 } })).toBe(3);
     expect(signalPerformanceBonus(["foreign_streak"], { foreign_streak: { n: 80, winRate: 42, medianReturn: -2 } })).toBe(0);
   });
+
+  it("다중 주체 클러스터를 독립 이력 코드로 기록한다", () => {
+    expect(inferStandardSignalTypes({
+      quietMoney: {
+        asOf: "2026-07-17",
+        events: [],
+        cluster: {
+          type: "cluster_multi",
+          windowTradingDays: 10,
+          actors: ["insider", "institution"],
+          actorCount: 2,
+          startDate: "2026-07-10",
+          endDate: "2026-07-17",
+          strength: 3,
+          headline: "내부자·기관 동시 유입 · 10거래일 내 2개 주체",
+          evidence: [],
+        },
+      },
+    })).toEqual(["cluster_multi"]);
+  });
 });

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -2,6 +2,7 @@ import type { StockBasics } from "../stock-basics";
 import type { CardFrontSignals } from "./card-front-hook";
 import type { CardVerdict } from "./verdict";
 import type { WyckoffAnalysis } from "./wyckoff-analysis";
+import type { QuietMoneyTimeline } from "./quiet-money";
 
 export type CompanyScoreAxisKey = "valuation" | "growth" | "profitability" | "flow" | "chart" | "quiet";
 
@@ -36,6 +37,7 @@ export interface CompanyScoreInput {
   signals?: Pick<CardFrontSignals, "foreignNetStreak" | "institutionNetStreak">;
   insiderPurchaseConfirmed?: boolean;
   whaleStrength?: number;
+  quietMoney?: QuietMoneyTimeline;
   verdict?: CardVerdict;
   wyckoff?: WyckoffAnalysis;
   currentPrice?: number;
@@ -165,7 +167,8 @@ function flowAxis(input: CompanyScoreInput): CompanyScoreAxis | undefined {
   const foreign = input.signals?.foreignNetStreak;
   const institution = input.signals?.institutionNetStreak;
   const whale = input.whaleStrength;
-  if (!finite(foreign) && !finite(institution) && input.insiderPurchaseConfirmed !== true && !finite(whale)) return undefined;
+  const quietMoney = input.quietMoney;
+  if (!finite(foreign) && !finite(institution) && input.insiderPurchaseConfirmed !== true && !finite(whale) && !quietMoney?.cluster) return undefined;
   let score = 50;
   const evidence: string[] = [];
   if (finite(foreign) && foreign !== 0) {
@@ -183,6 +186,10 @@ function flowAxis(input: CompanyScoreInput): CompanyScoreAxis | undefined {
   if (finite(whale)) {
     score += clamp(whale, -1, 1) * 25;
     evidence.push(`고래 신호 강도 ${whale.toFixed(2)}`);
+  }
+  if (quietMoney?.cluster) {
+    score += quietMoney.cluster.strength * 4;
+    evidence.push(`${quietMoney.cluster.headline} · 강도 ${quietMoney.cluster.strength}/5`);
   }
   return { key: "flow", label: AXIS_LABEL.flow, score: Math.round(clamp(score)), evidence };
 }

--- a/packages/fomo-core/src/keyword-cards/discovery-supply.ts
+++ b/packages/fomo-core/src/keyword-cards/discovery-supply.ts
@@ -1,4 +1,5 @@
 import type { StockCountry, StockMarket } from "./stocks";
+import type { QuietMoneyEvent } from "./quiet-money";
 
 export type DiscoveryMarket = Extract<StockMarket, "KOSPI" | "KOSDAQ" | "NASDAQ" | "NYSE">;
 
@@ -41,6 +42,8 @@ export interface DiscoveryEvent {
   flowAmountText?: string;
   /** Confirmed insider open-market purchase from SEC Form 4 or DART ownership report. */
   insiderPurchase?: boolean;
+  /** 조용한 돈 타임라인에 그대로 보존할 구조화 이벤트. */
+  quietMoneyEvent?: QuietMoneyEvent;
   themeRank?: number;
   themePeerCount?: number;
   themeAverageChangePct?: number;

--- a/packages/fomo-core/src/keyword-cards/index.ts
+++ b/packages/fomo-core/src/keyword-cards/index.ts
@@ -16,3 +16,4 @@ export * from "./verdict";
 export * from "./wyckoff-analysis";
 export * from "./company-score";
 export * from "./signal-resume";
+export * from "./quiet-money";

--- a/packages/fomo-core/src/keyword-cards/quiet-money.ts
+++ b/packages/fomo-core/src/keyword-cards/quiet-money.ts
@@ -1,0 +1,131 @@
+export type QuietMoneyActor = "insider" | "institution" | "foreign" | "whale";
+export type QuietMoneyDirection = "inflow" | "outflow";
+export type QuietMoneyAmountUnit = "KRW" | "USD" | "shares" | "coins";
+
+export interface QuietMoneyEvent {
+  date: string;
+  actor: QuietMoneyActor;
+  direction: QuietMoneyDirection;
+  source: string;
+  label: string;
+  amount?: number;
+  amountUnit?: QuietMoneyAmountUnit;
+  priceAt?: number;
+  streakDays?: number;
+  /** 시총 대비 비율을 실데이터로 계산할 수 있을 때만 채운다. */
+  marketCapRatioPct?: number;
+  sourceUrl?: string;
+}
+
+export interface QuietMoneyCluster {
+  type: "cluster_multi";
+  windowTradingDays: number;
+  actors: QuietMoneyActor[];
+  actorCount: number;
+  startDate: string;
+  endDate: string;
+  strength: 1 | 2 | 3 | 4 | 5;
+  headline: string;
+  evidence: string[];
+}
+
+export interface QuietMoneyTimeline {
+  asOf: string;
+  events: QuietMoneyEvent[];
+  cluster?: QuietMoneyCluster;
+}
+
+export interface BuildQuietMoneyTimelineInput {
+  asOf: string;
+  events: readonly QuietMoneyEvent[];
+  /** 실제 거래일 목록. 없으면 달력 14일을 10거래일의 보수적 근사로 사용한다. */
+  tradingDates?: readonly string[];
+  windowTradingDays?: number;
+}
+
+const ACTOR_ORDER: readonly QuietMoneyActor[] = ["insider", "institution", "foreign", "whale"];
+const ACTOR_LABEL: Record<QuietMoneyActor, string> = {
+  insider: "내부자",
+  institution: "기관",
+  foreign: "외국인",
+  whale: "고래",
+};
+
+function validDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && Number.isFinite(Date.parse(`${value}T00:00:00Z`));
+}
+
+function clampStrength(value: number): 1 | 2 | 3 | 4 | 5 {
+  return Math.max(1, Math.min(5, Math.round(value))) as 1 | 2 | 3 | 4 | 5;
+}
+
+function recentCutoff(asOf: string, tradingDates: readonly string[] | undefined, window: number): string {
+  const dates = [...new Set((tradingDates ?? []).filter(validDate))].sort();
+  const eligible = dates.filter((date) => date <= asOf);
+  if (eligible.length > 0) return eligible[Math.max(0, eligible.length - window)]!;
+  const cutoff = new Date(`${asOf}T00:00:00Z`);
+  cutoff.setUTCDate(cutoff.getUTCDate() - Math.ceil(window * 1.4));
+  return cutoff.toISOString().slice(0, 10);
+}
+
+function eventKey(event: QuietMoneyEvent): string {
+  return [event.date, event.actor, event.direction, event.amount ?? "", event.label, event.source].join("|");
+}
+
+function actorLabels(actors: readonly QuietMoneyActor[]): string {
+  return actors.map((actor) => ACTOR_LABEL[actor]).join("·");
+}
+
+/** 실데이터가 있는 축만 사용한다. 규모 비율이 없으면 주체 수·지속일만으로 보수적으로 등급화한다. */
+export function quietMoneyStrength(events: readonly QuietMoneyEvent[], actorCount: number): 1 | 2 | 3 | 4 | 5 {
+  const maxStreak = Math.max(1, ...events.map((event) => event.streakDays ?? 1));
+  const maxMarketCapRatio = Math.max(0, ...events.map((event) => event.marketCapRatioPct ?? 0));
+  const actorComponent = actorCount;
+  const persistenceComponent = Math.min(1.25, Math.max(0, maxStreak - 1) / 4);
+  const sizeComponent = Math.min(1.25, maxMarketCapRatio / 0.5);
+  return clampStrength(actorComponent + persistenceComponent + sizeComponent);
+}
+
+export function buildQuietMoneyTimeline(input: BuildQuietMoneyTimelineInput): QuietMoneyTimeline {
+  const window = Math.max(2, Math.floor(input.windowTradingDays ?? 10));
+  const seen = new Set<string>();
+  const events = input.events
+    .filter((event) => validDate(event.date) && validDate(input.asOf) && event.date <= input.asOf)
+    .filter((event) => {
+      const key = eventKey(event);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => b.date.localeCompare(a.date) || ACTOR_ORDER.indexOf(a.actor) - ACTOR_ORDER.indexOf(b.actor));
+
+  const cutoff = recentCutoff(input.asOf, input.tradingDates, window);
+  const recentInflows = events.filter((event) => event.direction === "inflow" && event.date >= cutoff);
+  const actors = ACTOR_ORDER.filter((actor) => recentInflows.some((event) => event.actor === actor));
+  if (actors.length < 2) return { asOf: input.asOf, events };
+
+  const strength = quietMoneyStrength(recentInflows, actors.length);
+  const startDate = recentInflows.reduce((min, event) => (event.date < min ? event.date : min), recentInflows[0]!.date);
+  const endDate = recentInflows.reduce((max, event) => (event.date > max ? event.date : max), recentInflows[0]!.date);
+  const evidence = actors.map((actor) => {
+    const actorEvents = recentInflows.filter((event) => event.actor === actor);
+    const streak = Math.max(...actorEvents.map((event) => event.streakDays ?? 1));
+    return `${ACTOR_LABEL[actor]} ${streak > 1 ? `${streak}일 지속` : actorEvents[0]!.label}`;
+  });
+  const cluster: QuietMoneyCluster = {
+    type: "cluster_multi",
+    windowTradingDays: window,
+    actors,
+    actorCount: actors.length,
+    startDate,
+    endDate,
+    strength,
+    headline: `${actorLabels(actors)} 동시 유입 · ${window}거래일 내 ${actors.length}개 주체`,
+    evidence,
+  };
+  return { asOf: input.asOf, events, cluster };
+}
+
+export function quietMoneyActorLabel(actor: QuietMoneyActor): string {
+  return ACTOR_LABEL[actor];
+}

--- a/packages/fomo-core/src/keyword-cards/signal-resume.ts
+++ b/packages/fomo-core/src/keyword-cards/signal-resume.ts
@@ -1,11 +1,13 @@
 import type { CardFrontSignals } from "./card-front-hook";
 import type { WyckoffAnalysis } from "./wyckoff-analysis";
+import type { QuietMoneyTimeline } from "./quiet-money";
 
-export const SIGNAL_TAXONOMY_VERSION = "m2.v1" as const;
+export const SIGNAL_TAXONOMY_VERSION = "m2.v2" as const;
 export const SIGNAL_RESUME_MIN_SAMPLE = 30;
 
 export const SIGNAL_TYPE_CODES = [
   "insider_cluster",
+  "cluster_multi",
   "institution_streak",
   "foreign_streak",
   "volume_vacuum",
@@ -26,6 +28,7 @@ export type SignalTypeCode = (typeof SIGNAL_TYPE_CODES)[number];
 
 export const SIGNAL_TYPE_LABELS: Record<SignalTypeCode, string> = {
   insider_cluster: "내부자 클러스터 매수",
+  cluster_multi: "다중 주체 클러스터",
   institution_streak: "기관 연속 순매수",
   foreign_streak: "외국인 연속 순매수",
   volume_vacuum: "거래량 진공",
@@ -58,6 +61,7 @@ export interface StandardSignalInput {
   signals?: Partial<CardFrontSignals>;
   wyckoff?: WyckoffAnalysis;
   companyScore?: number;
+  quietMoney?: QuietMoneyTimeline;
 }
 
 const CONTRACT = /계약|수주|공급|납품|파트너십|contract|order|supply|partnership/i;
@@ -91,6 +95,9 @@ export function inferStandardSignalTypes(input: StandardSignalInput): SignalType
 
   if (/내부자.{0,16}(?:클러스터|동반\s*매수)|(?:내부자|임원)\s*\d+\s*(?:명|인).{0,16}매수|insider.{0,16}cluster/i.test(text)) {
     types.push("insider_cluster");
+  }
+  if (input.quietMoney?.cluster?.type === "cluster_multi" || /(?:다중\s*주체|동시\s*유입).{0,20}(?:클러스터|주체)/i.test(text)) {
+    types.push("cluster_multi");
   }
   if ((input.signals?.institutionNetStreak ?? 0) >= 3 || /기관.{0,12}\d+일.{0,12}(?:연속\s*)?순매수/i.test(text)) {
     types.push("institution_streak");


### PR DESCRIPTION
## Summary
- unify SEC/DART insider, KRX institution/foreign, and verified on-chain whale events into one quiet-money timeline
- detect deterministic multi-actor clusters within 10 trading days and feed cluster strength into quietScore, headlines, M1 ledger, M2 taxonomy, and company score
- render the timeline in stock depth and actor lanes below the candle chart

## Fact safety
- no new paid source
- whale events require explicit on-chain whale inflow/outflow language
- amounts and historical prices are shown only when source/candle data exists

## Verification
- npm run typecheck
- npm run lint
- npm run test (131 files, 1211 tests)
- npm run build:web
- npm run build:fomo-web