### PR TITLE
fix: normalize quiet money trading dates

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -12,6 +12,7 @@ import {
   translateTaFact,
   confidenceGrade,
   mergeCompanyScoreResults,
+  normalizeQuietMoneyDate,
   type DailyOhlcv,
   type KeywordCard,
   type FomoTone,
@@ -1718,7 +1719,10 @@ function AnalysisChart({
   const priceTicks = [rawMax, (rawMax + rawMin) / 2, rawMin];
   const visibleZones = (analysis?.zones ?? []).filter((zone) => zone.endIndex >= visibleStart && zone.startIndex <= visibleStart + n - 1);
   const visibleEvents = (analysis?.events ?? []).filter((event) => event.index >= visibleStart && event.index <= visibleStart + n - 1);
-  const candleIndexByDate = new Map(renderedCandles.flatMap((candle, index) => candle.date ? [[candle.date, index] as const] : []));
+  const candleIndexByDate = new Map(renderedCandles.flatMap((candle, index) => {
+    const date = normalizeQuietMoneyDate(candle.date);
+    return date ? [[date, index] as const] : [];
+  }));
   const quietActors = ["insider", "institution", "foreign", "whale"] as const;
   const visibleQuietEvents = (quietMoney?.events ?? []).flatMap((event) => {
     const index = candleIndexByDate.get(event.date);

--- a/apps/web/lib/coin-discovery.ts
+++ b/apps/web/lib/coin-discovery.ts
@@ -1,4 +1,4 @@
-import { buildQuietMoneyTimeline, computeCardVerdict, computeCompanyScore, computeFomoScore, computeWyckoffAnalysis, isFrontHookSafe } from "@fomo/core";
+import { buildQuietMoneyTimeline, computeCardVerdict, computeCompanyScore, computeFomoScore, computeWyckoffAnalysis, isFrontHookSafe, normalizeQuietMoneyDate } from "@fomo/core";
 import type { CardFrontSignals, QuietMoneyEvent } from "@fomo/core";
 import { kstDate } from "./fomo";
 import { readCoinMarketSnapshots, type CoinMarketSnapshot } from "./coin-market-source";
@@ -145,7 +145,7 @@ export function coinFrontSeed(
     const outflow = /(?:고래.{0,18}(?:매도|분배|순유출)|(?:매도|분배|순유출).{0,18}고래|whale.{0,18}(?:sell|distribut|outflow))/i.test(issue.title);
     if (!inflow && !outflow) return [];
     const date = issue.publishedAt.slice(0, 10);
-    const priceAt = snapshot.candles.find((candle) => candle.date === date)?.close;
+    const priceAt = snapshot.candles.find((candle) => normalizeQuietMoneyDate(candle.date) === date)?.close;
     return [{
       date,
       actor: "whale",
@@ -159,7 +159,7 @@ export function coinFrontSeed(
   const quietMoney = buildQuietMoneyTimeline({
     asOf: snapshot.fetchedAt.slice(0, 10),
     events: quietMoneyEvents,
-    tradingDates: snapshot.candles.flatMap((candle) => candle.date ? [candle.date] : []),
+    tradingDates: snapshot.candles.flatMap((candle) => normalizeQuietMoneyDate(candle.date) ?? []),
   });
   return {
     signals: {

--- a/apps/web/lib/discovery-supply.ts
+++ b/apps/web/lib/discovery-supply.ts
@@ -22,6 +22,7 @@ import {
   computeCompanyScore,
   computeWyckoffAnalysis,
   buildQuietMoneyTimeline,
+  normalizeQuietMoneyDate,
   type CardVerdict,
   type CompanyScoreResult,
   type DailyOhlcv,
@@ -1783,7 +1784,8 @@ function verdictForCandidate(candidate: DiscoveryCandidate, candles: readonly Da
 }
 
 function candlePriceAt(candles: readonly DailyOhlcv[], date: string): number | undefined {
-  const exact = candles.find((candle) => candle.date === date)?.close;
+  const target = normalizeQuietMoneyDate(date);
+  const exact = candles.find((candle) => normalizeQuietMoneyDate(candle.date) === target)?.close;
   if (typeof exact === "number" && Number.isFinite(exact) && exact > 0) return exact;
   return undefined;
 }
@@ -1846,7 +1848,7 @@ function candidateQuietMoneyTimeline(
   return buildQuietMoneyTimeline({
     asOf: candidate.asOf,
     events: [...structured, ...historyEvents, ...fallbackFlows],
-    tradingDates: candles.flatMap((candle) => candle.date ? [candle.date] : []),
+    tradingDates: candles.flatMap((candle) => normalizeQuietMoneyDate(candle.date) ?? []),
     windowTradingDays: 10,
   });
 }

--- a/packages/fomo-core/__tests__/quiet-money.test.ts
+++ b/packages/fomo-core/__tests__/quiet-money.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildQuietMoneyTimeline, quietMoneyStrength, type QuietMoneyEvent } from "../src";
+import { buildQuietMoneyTimeline, normalizeQuietMoneyDate, quietMoneyStrength, type QuietMoneyEvent } from "../src";
 
 const tradingDates = [
   "2026-07-06", "2026-07-07", "2026-07-08", "2026-07-09", "2026-07-10",
@@ -19,6 +19,12 @@ function event(actor: QuietMoneyEvent["actor"], date: string, overrides: Partial
 }
 
 describe("quiet money timeline", () => {
+  it("KR 캔들 날짜 포맷을 ISO 거래일로 정규화한다", () => {
+    expect(normalizeQuietMoneyDate("20260716")).toBe("2026-07-16");
+    expect(normalizeQuietMoneyDate("2026.07.16")).toBe("2026-07-16");
+    expect(normalizeQuietMoneyDate("2026-07-16")).toBe("2026-07-16");
+  });
+
   it("10거래일 안 서로 다른 주체 2개부터 cluster_multi를 만든다", () => {
     const timeline = buildQuietMoneyTimeline({
       asOf: "2026-07-17",

--- a/packages/fomo-core/src/keyword-cards/quiet-money.ts
+++ b/packages/fomo-core/src/keyword-cards/quiet-money.ts
@@ -51,8 +51,17 @@ const ACTOR_LABEL: Record<QuietMoneyActor, string> = {
   whale: "고래",
 };
 
+export function normalizeQuietMoneyDate(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+  const digits = raw.replace(/[^\d]/g, "");
+  if (digits.length !== 8) return undefined;
+  const normalized = `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+  return Number.isFinite(Date.parse(`${normalized}T00:00:00Z`)) ? normalized : undefined;
+}
+
 function validDate(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value) && Number.isFinite(Date.parse(`${value}T00:00:00Z`));
+  return normalizeQuietMoneyDate(value) !== undefined;
 }
 
 function clampStrength(value: number): 1 | 2 | 3 | 4 | 5 {
@@ -60,7 +69,7 @@ function clampStrength(value: number): 1 | 2 | 3 | 4 | 5 {
 }
 
 function recentCutoff(asOf: string, tradingDates: readonly string[] | undefined, window: number): string {
-  const dates = [...new Set((tradingDates ?? []).filter(validDate))].sort();
+  const dates = [...new Set((tradingDates ?? []).flatMap((date) => normalizeQuietMoneyDate(date) ?? []))].sort();
   const eligible = dates.filter((date) => date <= asOf);
   if (eligible.length > 0) return eligible[Math.max(0, eligible.length - window)]!;
   const cutoff = new Date(`${asOf}T00:00:00Z`);
@@ -89,8 +98,13 @@ export function quietMoneyStrength(events: readonly QuietMoneyEvent[], actorCoun
 export function buildQuietMoneyTimeline(input: BuildQuietMoneyTimelineInput): QuietMoneyTimeline {
   const window = Math.max(2, Math.floor(input.windowTradingDays ?? 10));
   const seen = new Set<string>();
+  const normalizedAsOf = normalizeQuietMoneyDate(input.asOf) ?? input.asOf;
   const events = input.events
-    .filter((event) => validDate(event.date) && validDate(input.asOf) && event.date <= input.asOf)
+    .flatMap((event) => {
+      const date = normalizeQuietMoneyDate(event.date);
+      return date ? [{ ...event, date }] : [];
+    })
+    .filter((event) => validDate(normalizedAsOf) && event.date <= normalizedAsOf)
     .filter((event) => {
       const key = eventKey(event);
       if (seen.has(key)) return false;
@@ -99,10 +113,10 @@ export function buildQuietMoneyTimeline(input: BuildQuietMoneyTimelineInput): Qu
     })
     .sort((a, b) => b.date.localeCompare(a.date) || ACTOR_ORDER.indexOf(a.actor) - ACTOR_ORDER.indexOf(b.actor));
 
-  const cutoff = recentCutoff(input.asOf, input.tradingDates, window);
+  const cutoff = recentCutoff(normalizedAsOf, input.tradingDates, window);
   const recentInflows = events.filter((event) => event.direction === "inflow" && event.date >= cutoff);
   const actors = ACTOR_ORDER.filter((actor) => recentInflows.some((event) => event.actor === actor));
-  if (actors.length < 2) return { asOf: input.asOf, events };
+  if (actors.length < 2) return { asOf: normalizedAsOf, events };
 
   const strength = quietMoneyStrength(recentInflows, actors.length);
   const startDate = recentInflows.reduce((min, event) => (event.date < min ? event.date : min), recentInflows[0]!.date);
@@ -123,7 +137,7 @@ export function buildQuietMoneyTimeline(input: BuildQuietMoneyTimelineInput): Qu
     headline: `${actorLabels(actors)} 동시 유입 · ${window}거래일 내 ${actors.length}개 주체`,
     evidence,
   };
-  return { asOf: input.asOf, events, cluster };
+  return { asOf: normalizedAsOf, events, cluster };
 }
 
 export function quietMoneyActorLabel(actor: QuietMoneyActor): string {


### PR DESCRIPTION
## Production finding
KR cached candle dates are YYYYMMDD while quiet-money events are ISO dates. Timeline events were emitted, but historical-price joins and chart markers did not match.

## Fix
- normalize YYYYMMDD, YYYY.MM.DD, and ISO dates to YYYY-MM-DD in the core contract
- use the normalized date for stock/coin price joins, 10-trading-day windows, and frontend chart lanes

## Verification
- npm run typecheck
- npm run test -- quiet-money discovery-supply coin-discovery feed-hub judgment-ledger (79 tests)