### PR TITLE
feat: add judgment review loop

### DIFF
--- a/apps/fomo-web/__tests__/browser-auth-security.test.ts
+++ b/apps/fomo-web/__tests__/browser-auth-security.test.ts
@@ -48,6 +48,7 @@ describe("FOMO Web browser auth security", () => {
     expect(isAllowedProxyRequest("stock-front", "GET")).toBe(true);
     expect(isAllowedProxyRequest("emotions/calendar", "GET")).toBe(true);
     expect(isAllowedProxyRequest("account", "DELETE")).toBe(true);
+    expect(isAllowedProxyRequest("ledger/review", "GET")).toBe(true);
     expect(isAllowedProxyRequest("auth/login", "GET")).toBe(false);
     expect(isAllowedProxyRequest("discovery", "POST")).toBe(false);
     expect(isAllowedProxyRequest("performance-prices", "GET")).toBe(false);

--- a/apps/fomo-web/__tests__/judgmentReview.test.ts
+++ b/apps/fomo-web/__tests__/judgmentReview.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { prioritizeStrongSignalCards } from "../lib/judgmentReview";
+import type { FrontEntry } from "../components/StockSwipeDeck";
+import type { DeckCard, DeckStock } from "../lib/discoveryDeck";
+
+function card(canonical: string): DeckCard {
+  return {
+    type: "stock",
+    data: {
+      canonical,
+      market: "NASDAQ",
+      country: "US",
+      sector: "AI",
+      marquee: false,
+      symbol: canonical,
+    } satisfies DeckStock,
+  };
+}
+
+function front(signalTypes: NonNullable<FrontEntry["signalTypes"]>): FrontEntry {
+  return { signals: {}, fomo: {} as never, sparkline: [], signalTypes };
+}
+
+describe("judgment review taste seed", () => {
+  it("원장에서 검증된 강한 신호 카드만 안정적으로 앞쪽에 배치한다", () => {
+    const cards = [card("A"), card("B"), card("C"), card("D")];
+    const fronts = {
+      A: front(["impulse"]),
+      B: front(["material_contract"]),
+      C: front(["material_contract"]),
+      D: front(["foreign_streak"]),
+    };
+    const ranked = prioritizeStrongSignalCards(cards, fronts, ["material_contract"]);
+    expect(ranked.map((item) => item.type === "stock" ? item.data.canonical : "")).toEqual(["B", "C", "A", "D"]);
+    expect(prioritizeStrongSignalCards(cards, fronts, [])).toEqual(cards);
+  });
+});

--- a/apps/fomo-web/components/FeedView.tsx
+++ b/apps/fomo-web/components/FeedView.tsx
@@ -9,6 +9,7 @@ import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
 import { SectorCard } from "@/components/SectorCard";
 import { FeedDepthPage } from "@/components/FeedDepthPage";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
+import { JudgmentReviewPanel } from "@/components/JudgmentReviewPanel";
 import { fetchFeedHub, type FeedHubItem } from "@/lib/fomoApi";
 import { feedItemKey, useFeedArchive } from "@/lib/useFeedArchive";
 import type { DeckCard, DeckNarrative, DeckSectorCardData } from "@/lib/discoveryDeck";
@@ -142,6 +143,7 @@ export function FeedView() {
 
   return (
     <div className="space-y-3 pb-4">
+      <JudgmentReviewPanel weeklyOnly />
       {items.map(renderItem)}
 
       {/* 무한 피드(2026-07-18) — 오늘치가 끝나면 지난 브리핑·버즈·회고를 계속 이어 붙인다. */}

--- a/apps/fomo-web/components/JudgmentReviewPanel.tsx
+++ b/apps/fomo-web/components/JudgmentReviewPanel.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  fetchJudgmentReview,
+  type JudgmentReviewResponse,
+  type JudgmentReviewRow,
+  type ReviewAction,
+  type ReviewStance,
+} from "@/lib/fomoApi";
+
+const NEON = "#D8FF3A";
+const MUTED = "#A3A3A0";
+
+function signed(value: number): string {
+  return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
+}
+
+function stanceLabel(stance: ReviewStance): string {
+  if (stance === "enter") return "카드 진입";
+  if (stance === "avoid") return "카드 비진입";
+  return "카드 관찰";
+}
+
+function actionLabel(action: ReviewAction): string {
+  if (action === "star") return "내가 담음";
+  if (action === "pass") return "내가 넘김";
+  return "내가 봄";
+}
+
+function reportText(review: JudgmentReviewResponse): string {
+  const weekly = review.weekly;
+  if (!weekly) return "포모클럽 판단 복기 · 30일 결과를 축적 중이에요.";
+  const parts = [`포모클럽 주간 판단 복기 · 결과 ${weekly.count}건`];
+  if (weekly.best) parts.push(`잘한 판단 ${weekly.best.canonical} ${signed(weekly.best.returnPct)}`);
+  if (weekly.missed) parts.push(`아까운 판단 ${weekly.missed.canonical} ${signed(weekly.missed.returnPct)}`);
+  return parts.join("\n");
+}
+
+async function shareReview(review: JudgmentReviewResponse): Promise<void> {
+  const text = reportText(review);
+  const data = { title: "포모클럽 주간 판단 복기", text, ...(typeof window !== "undefined" ? { url: window.location.href } : {}) };
+  if (typeof navigator !== "undefined" && "share" in navigator) {
+    try {
+      await navigator.share(data);
+      return;
+    } catch {
+      // Share-sheet cancellation and unsupported payloads use the same clipboard fallback.
+    }
+  }
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    await navigator.clipboard.writeText(`${text}\n${"url" in data ? data.url : ""}`.trim());
+  }
+}
+
+function ReviewRow({ row }: { row: JudgmentReviewRow }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-hairline py-2.5 first:border-t-0">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-whiteout">{row.canonical}</p>
+        <p className="mt-0.5 text-[10px] text-muted">{stanceLabel(row.stance)} · {actionLabel(row.action)}</p>
+      </div>
+      <span className="shrink-0 font-number text-sm font-bold" style={{ color: row.returnPct > 0 ? NEON : MUTED }}>
+        {signed(row.returnPct)}
+      </span>
+    </div>
+  );
+}
+
+function WeeklyCard({ review }: { review: JudgmentReviewResponse }) {
+  const weekly = review.weekly;
+  if (!weekly) return null;
+  return (
+    <section className="w-full rounded-lg border border-hairline bg-surface px-5 py-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-pixel text-[10px] text-muted">WEEKLY REVIEW · 30D</p>
+          <h2 className="mt-2 text-lg font-bold text-whiteout">이번 주 판단 복기</h2>
+          <p className="mt-1 text-xs text-muted">결과가 확정된 {weekly.count}건을 카드·내 판단·결과로 대조했어요.</p>
+        </div>
+        <button type="button" onClick={() => void shareReview(review)} className="shrink-0 border-b border-hairline pb-0.5 text-xs text-whiteout">
+          공유
+        </button>
+      </div>
+      <div className="mt-4">
+        {weekly.best && (
+          <p className="text-sm leading-6 text-whiteout">잘한 판단 · <b>{weekly.best.canonical}</b> {signed(weekly.best.returnPct)}</p>
+        )}
+        {weekly.missed && (
+          <p className="text-sm leading-6 text-whiteout">아까운 판단 · <b>{weekly.missed.canonical}</b> {signed(weekly.missed.returnPct)}</p>
+        )}
+        {weekly.disagreements.length > 0 && (
+          <p className="mt-1 text-xs leading-5 text-muted">카드와 갈린 판단 {weekly.disagreements.length}건 · 결과를 다음 선택의 기록으로 남겼어요.</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function HistoryReview({ review }: { review: JudgmentReviewResponse }) {
+  const comparison = useMemo(() => {
+    const user = review.userRate.winRate;
+    const card = review.cardRate.winRate;
+    if (user === null || card === null) return "30일 결과가 쌓이면 두 판단을 같은 기준으로 비교해요.";
+    if (user === card) return "현재 표본에서는 두 판단의 적중률이 같아요.";
+    const gap = Math.abs(user - card).toFixed(1);
+    return user > card ? `현재 표본에서 내 판단이 ${gap}%p 높아요.` : `현재 표본에서 카드 판단이 ${gap}%p 높아요.`;
+  }, [review.cardRate.winRate, review.userRate.winRate]);
+
+  return (
+    <section className="mb-6">
+      <div className="mb-3 flex items-center justify-between px-1">
+        <p className="text-xs text-muted">내 판단 · 카드 · 30일 결과</p>
+        <span className="text-[10px] text-muted">확정 {review.rows.length} · 대기 {review.pendingCount}</span>
+      </div>
+
+      <div className="rounded-lg border border-hairline bg-surface-raised p-4">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <p className="text-[10px] text-muted">내 판단 승률</p>
+            <p className="mt-1 text-2xl font-bold text-whiteout">{review.userRate.winRate === null ? "축적 중" : `${review.userRate.winRate}%`}</p>
+            <p className="text-[9px] text-muted">명시적 선택 n={review.userRate.n}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-muted">카드 판단 승률</p>
+            <p className="mt-1 text-2xl font-bold text-whiteout">{review.cardRate.winRate === null ? "축적 중" : `${review.cardRate.winRate}%`}</p>
+            <p className="text-[9px] text-muted">enter/avoid n={review.cardRate.n}</p>
+          </div>
+        </div>
+        <p className="mt-3 text-xs leading-5 text-muted">{comparison}</p>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        {review.matrix.map((cell) => (
+          <div key={cell.key} className="min-h-[72px] rounded-lg border border-hairline bg-surface px-3 py-2.5">
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-xs font-semibold leading-4 text-whiteout">{cell.label}</p>
+              <span className="font-number text-base font-bold text-whiteout">{cell.count}</span>
+            </div>
+            <p className="mt-1 text-[9px] leading-4 text-muted">{cell.note}</p>
+          </div>
+        ))}
+      </div>
+
+      {review.strongSignals.length > 0 && (
+        <div className="mt-3 rounded-lg border border-hairline bg-surface px-4 py-3">
+          <p className="text-xs font-semibold text-whiteout">당신이 강한 신호</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {review.strongSignals.map((signal) => (
+              <span key={signal.code} className="rounded-full border border-hairline-soft px-2.5 py-1 text-[10px] text-whiteout">
+                {signal.label} · {signal.winRate}% · n={signal.n}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {review.weekly && (
+        <div className="mt-3"><WeeklyCard review={review} /></div>
+      )}
+
+      {review.rows.length > 0 && (
+        <div className="mt-3 rounded-lg border border-hairline bg-surface px-4">
+          {review.rows.slice(0, 8).map((row) => <ReviewRow key={`${row.selectionId}-${row.actionAt}`} row={row} />)}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function JudgmentReviewPanel({ weeklyOnly = false }: { weeklyOnly?: boolean }) {
+  const [review, setReview] = useState<JudgmentReviewResponse | null>(null);
+  useEffect(() => {
+    let alive = true;
+    void fetchJudgmentReview().then((value) => alive && setReview(value)).catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  if (!review) return null;
+  return weeklyOnly ? <WeeklyCard review={review} /> : <HistoryReview review={review} />;
+}

--- a/apps/fomo-web/components/KeywordHistory.tsx
+++ b/apps/fomo-web/components/KeywordHistory.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { MOCK_KEYWORD_CARDS, type KeywordCard } from "@fomo/core";
 import { KeywordDepthPage, StockInsightView } from "@/components/KeywordDepthPage";
 import { MyDiscoveryPreview } from "@/components/MyDiscoveryPreview";
+import { JudgmentReviewPanel } from "@/components/JudgmentReviewPanel";
 import { PerformanceProofPanel } from "@/components/PerformanceProofPanel";
 import { RegretReceiptPanel } from "@/components/RegretReceiptPanel";
 import { getHistory } from "@/lib/keywordHistory";
@@ -77,6 +78,7 @@ export function KeywordHistory() {
 
   return (
     <div className="w-full">
+      <JudgmentReviewPanel />
       <RegretReceiptPanel items={seenItems} />
       <PerformanceProofPanel items={seenItems} />
       <MyDiscoveryPreview items={watchlist} onOpen={setStockSel} />

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -9,6 +9,7 @@ import {
   isSignalTypeCode,
   normalizeSignalTypeCodes,
   selectFomoHook,
+  signalTypeLabel,
 } from "@fomo/core";
 import type {
   AxisSignal,
@@ -324,6 +325,7 @@ function StockCardFace({
   discoveryContext,
   verdict,
   signalTrack,
+  personalStrongSignal,
   progress,
 }: {
   stock: DeckStock;
@@ -341,6 +343,7 @@ function StockCardFace({
   discoveryContext?: string | undefined;
   verdict?: CardVerdict | undefined;
   signalTrack?: { code: SignalTypeCode; metric: TrackMetric } | undefined;
+  personalStrongSignal?: SignalTypeCode | undefined;
   progress?: string | undefined;
 }) {
   const displayChangeText = normalizeChangeText(changeText);
@@ -423,6 +426,12 @@ function StockCardFace({
         </p>
       )}
 
+      {personalStrongSignal && (
+        <p className="mt-1 shrink-0 text-[11px] font-semibold leading-4" style={{ color: NEON }}>
+          당신이 강한 신호 · {signalTypeLabel(personalStrongSignal)}
+        </p>
+      )}
+
       <div className="mt-auto flex shrink-0 items-center justify-between pt-2">
         <span className="font-pixel text-[11px] text-muted">더보기 →</span>
         {progress && <span className="text-[11px] font-medium text-muted">{progress}</span>}
@@ -488,6 +497,7 @@ interface StockSwipeDeckProps {
   loggedIn?: boolean | undefined;
   onRequireLogin?: (() => void) | undefined;
   signalHistory30?: Record<string, TrackMetric> | undefined;
+  strongSignalCodes?: string[] | undefined;
 }
 
 export function StockSwipeDeck({
@@ -498,6 +508,7 @@ export function StockSwipeDeck({
   loggedIn,
   onRequireLogin,
   signalHistory30,
+  strongSignalCodes = [],
 }: StockSwipeDeckProps) {
   const deckCards = useMemo(() => cards ?? stockDeckCards(stocks ?? []), [cards, stocks]);
   // 무한: 풀을 순환(modulo)해 끝나지 않는다(§7 "무한히 풀만큼").
@@ -709,6 +720,7 @@ export function StockSwipeDeck({
         discoveryContext={discoveryContext}
         verdict={e?.verdict}
         signalTrack={signalTrackFor(stock, e)}
+        personalStrongSignal={normalizeSignalTypeCodes(e.signalTypes ?? []).find((code) => strongSignalCodes.includes(code))}
         progress={progress}
       />
     );

--- a/apps/fomo-web/components/UnifiedDailyDeck.tsx
+++ b/apps/fomo-web/components/UnifiedDailyDeck.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useState } from "react";
 import { StockSwipeDeck } from "@/components/StockSwipeDeck";
 import { FullPageLoading, LOADING_PRESETS } from "@/components/FullPageLoading";
-import { fetchDaily30, fetchMyRequests, fetchTrackRecord, type Daily30Response, type MyRequestRow, type TrackMetric } from "@/lib/fomoApi";
+import { fetchDaily30, fetchJudgmentReview, fetchMyRequests, fetchTrackRecord, type Daily30Response, type MyRequestRow, type TrackMetric } from "@/lib/fomoApi";
 import { stockDeckCards, type DeckCard, type DeckStock, type DiscoveryDeckCard } from "@/lib/discoveryDeck";
 import { stockOnlyDeckCards } from "@/components/FeedView";
 import { getSessionId } from "@/lib/session";
+import { prioritizeStrongSignalCards } from "@/lib/judgmentReview";
 import type { FrontEntry } from "@/components/StockSwipeDeck";
 
 interface UnifiedDailyDeckProps {
@@ -81,7 +82,7 @@ function Daily30Empty({ onRetry }: { onRetry: () => void }) {
   );
 }
 
-function cardsFromDaily30(discovery: Daily30Response): { cards: DeckCard[]; fronts: Record<string, FrontEntry> } {
+function cardsFromDaily30(discovery: Daily30Response, strongSignalCodes: readonly string[] = []): { cards: DeckCard[]; fronts: Record<string, FrontEntry> } {
   const rawCards = ((discovery.cards?.length ? discovery.cards : discovery.stocks) ?? []) as DiscoveryDeckCard[];
   const metaById = new Map((discovery.meta?.cards ?? []).map((card) => [card.id, card]));
   const fronts = Object.fromEntries(Object.entries(discovery.fronts).map(([canonical, front]) => {
@@ -92,7 +93,8 @@ function cardsFromDaily30(discovery: Daily30Response): { cards: DeckCard[]; fron
     return [canonical, { ...front, ...(signalTypes?.length ? { signalTypes } : {}) } as FrontEntry];
   }));
   // 메인 덱 = 종목 발굴 전용(WO-GNB). 콘텐츠·내러티브는 피드 표면으로 이관.
-  return { cards: stockOnlyDeckCards(stockDeckCards(rawCards)).slice(0, 30), fronts };
+  const cards = stockOnlyDeckCards(stockDeckCards(rawCards)).slice(0, 30);
+  return { cards: prioritizeStrongSignalCards(cards, fronts, strongSignalCodes), fronts };
 }
 
 export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDailyDeckProps) {
@@ -104,6 +106,7 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
         kind: "ready";
         cards: DeckCard[];
         fronts: Record<string, FrontEntry>;
+        strongSignalCodes: string[];
         stale?: "committee-yesterday" | "engine-direct";
       }
   >({ kind: "loading" });
@@ -134,9 +137,13 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
       let lastError: unknown = null;
       for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
         try {
-          const discovery = await fetchDaily30();
+          const [discovery, review] = await Promise.all([
+            fetchDaily30(),
+            fetchJudgmentReview().catch(() => null),
+          ]);
           if (!alive) return;
-          const next = cardsFromDaily30(discovery);
+          const strongSignalCodes = review?.strongSignals.map((signal) => signal.code) ?? [];
+          const next = cardsFromDaily30(discovery, strongSignalCodes);
           if (next.cards.length === 0) {
             setState({ kind: "error" });
             return;
@@ -159,6 +166,7 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
             kind: "ready",
             cards: [...requestCards, ...next.cards],
             fronts: next.fronts,
+            strongSignalCodes,
             ...(discovery.meta?.stale ? { stale: discovery.meta.stale } : {}),
           });
           return;
@@ -224,6 +232,7 @@ export function UnifiedDailyDeck({ loggedIn = true, onRequireLogin }: UnifiedDai
         loggedIn={loggedIn}
         onRequireLogin={onRequireLogin}
         signalHistory30={signalHistory30}
+        strongSignalCodes={state.strongSignalCodes}
       />
     </div>
   );

--- a/apps/fomo-web/lib/auth-proxy.ts
+++ b/apps/fomo-web/lib/auth-proxy.ts
@@ -13,6 +13,7 @@ const ALLOWED_PROXY_REQUESTS = new Map<string, ReadonlySet<string>>([
   ["performance-prices", new Set(["POST"])],
   ["ledger/actions", new Set(["POST"])],
   ["ledger/history", new Set(["GET"])],
+  ["ledger/review", new Set(["GET"])],
   ["ledger/timeline", new Set(["GET"])],
   ["track-record", new Set(["GET"])],
   ["stock-front", new Set(["GET"])],

--- a/apps/fomo-web/lib/judgmentLedgerClient.ts
+++ b/apps/fomo-web/lib/judgmentLedgerClient.ts
@@ -62,6 +62,42 @@ export interface LedgerTimelineEntry {
   payload: Record<string, unknown>;
 }
 
+export type ReviewStance = "enter" | "watch" | "avoid";
+export type ReviewAction = "star" | "pass" | "seen";
+
+export interface JudgmentReviewRow {
+  selectionId: string;
+  canonical: string;
+  symbol?: string;
+  asset: LedgerAsset;
+  selectionDate: string;
+  actionAt: string;
+  stance: ReviewStance;
+  action: ReviewAction;
+  returnPct: number;
+  outcome: "up" | "down";
+  signalTypes: string[];
+}
+
+export interface JudgmentReviewResponse {
+  generatedAt: string;
+  windowDays: 30;
+  rows: JudgmentReviewRow[];
+  pendingCount: number;
+  matrix: Array<{ key: string; label: string; note: string; count: number }>;
+  userRate: { n: number; winRate: number | null };
+  cardRate: { n: number; winRate: number | null };
+  weekly: null | {
+    from: string;
+    to: string;
+    count: number;
+    best?: JudgmentReviewRow;
+    missed?: JudgmentReviewRow;
+    disagreements: JudgmentReviewRow[];
+  };
+  strongSignals: Array<{ code: string; label: string; n: number; winRate: number }>;
+}
+
 export async function recordJudgmentActions(entries: readonly JudgmentActionInput[]): Promise<{ appended: number }> {
   if (entries.length === 0) return { appended: 0 };
   const res = await fetch("/api/fomo/ledger/actions", {
@@ -89,6 +125,15 @@ export async function fetchJudgmentHistory(): Promise<{ items: JudgmentHistoryIt
   });
   if (!res.ok) throw new Error(`GET /api/fomo/ledger/history ${res.status}`);
   return res.json() as Promise<{ items: JudgmentHistoryItem[] }>;
+}
+
+export async function fetchJudgmentReview(): Promise<JudgmentReviewResponse> {
+  const res = await fetch(`/api/fomo/ledger/review?sessionId=${encodeURIComponent(getSessionId())}`, {
+    credentials: "same-origin",
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`GET /api/fomo/ledger/review ${res.status}`);
+  return res.json() as Promise<JudgmentReviewResponse>;
 }
 
 export async function fetchTrackRecord(): Promise<TrackRecordResponse> {

--- a/apps/fomo-web/lib/judgmentReview.ts
+++ b/apps/fomo-web/lib/judgmentReview.ts
@@ -1,0 +1,19 @@
+import type { DeckCard } from "./discoveryDeck";
+
+export function prioritizeStrongSignalCards(
+  cards: readonly DeckCard[],
+  fronts: Readonly<Record<string, { signalTypes?: readonly string[] }>>,
+  strongSignalCodes: readonly string[]
+): DeckCard[] {
+  if (strongSignalCodes.length === 0) return [...cards];
+  const strong = new Set(strongSignalCodes);
+  return cards
+    .map((card, index) => ({ card, index }))
+    .sort((a, b) => {
+      const score = (entry: { card: DeckCard }) => entry.card.type === "stock"
+        ? Number(fronts[entry.card.data.canonical]?.signalTypes?.some((code) => strong.has(code)) ?? false)
+        : 0;
+      return score(b) - score(a) || a.index - b.index;
+    })
+    .map(({ card }) => card);
+}

--- a/apps/web/__tests__/lib/judgment-review.test.ts
+++ b/apps/web/__tests__/lib/judgment-review.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { LedgerSelectionView } from "../../lib/judgment-ledger";
+import { buildJudgmentReview, REVIEW_MATRIX_KEYS, type ReviewUserAction } from "../../lib/judgment-review";
+import type { OutcomePayload } from "../../lib/ledger-track-record";
+
+function selection(index: number, stance: "enter" | "watch" | "avoid" = "enter"): LedgerSelectionView {
+  const canonical = `STOCK-${index}`;
+  return {
+    id: `selection-${index}`,
+    date: "2026-06-01",
+    ts: new Date(`2026-06-01T00:${String(index).padStart(2, "0")}:00.000Z`),
+    subject: { asset: "us-stock", canonical, symbol: `S${index}` },
+    priceAt: 100,
+    actor: "committee",
+    payload: {
+      signalTypes: ["material_contract"],
+      front: {
+        verdict: { stance, stanceText: "테스트 판단", evidence: [], confidence: "medium" },
+      } as never,
+    },
+  };
+}
+
+function action(index: number, value: "star" | "pass" | "seen"): ReviewUserAction {
+  return {
+    id: `action-${index}`,
+    actor: "user:session:test",
+    canonical: `STOCK-${index}`,
+    ts: new Date(`2026-06-01T01:${String(index).padStart(2, "0")}:00.000Z`),
+    action: value,
+  };
+}
+
+function outcome(index: number, returnPct: number): OutcomePayload {
+  return {
+    selectionId: `selection-${index}`,
+    selectionDate: "2026-06-01",
+    windowDays: 30,
+    evaluationDate: "2026-07-01",
+    selectedPrice: 100,
+    returnPct,
+    asset: "us-stock",
+    signalTypes: ["material_contract"],
+  };
+}
+
+describe("judgment review ledger projection", () => {
+  it("카드 선택 × 사용자 선택 × 결과를 고정 8칸으로 정직하게 분류한다", () => {
+    const selections = [
+      selection(0, "enter"), selection(1, "enter"), selection(2, "enter"), selection(3, "enter"),
+      selection(4, "avoid"), selection(5, "watch"), selection(6, "avoid"), selection(7, "watch"),
+    ];
+    const actions = [
+      action(0, "star"), action(1, "star"), action(2, "pass"), action(3, "seen"),
+      action(4, "star"), action(5, "star"), action(6, "pass"), action(7, "seen"),
+    ];
+    const outcomes = [outcome(0, 5), outcome(1, -5), outcome(2, 5), outcome(3, -5), outcome(4, 5), outcome(5, -5), outcome(6, 5), outcome(7, -5)];
+    const review = buildJudgmentReview(selections, actions, outcomes, new Date("2026-07-02T00:00:00.000Z"));
+
+    expect(review.matrix.map((cell) => cell.key)).toEqual(REVIEW_MATRIX_KEYS);
+    expect(review.matrix.map((cell) => cell.count)).toEqual([1, 1, 1, 1, 1, 1, 1, 1]);
+    expect(review.userRate).toEqual({ n: 6, winRate: 33.3 });
+    expect(review.cardRate).toEqual({ n: 6, winRate: 33.3 });
+    expect(review.weekly?.count).toBe(8);
+  });
+
+  it("30일 outcome이 없는 판단은 성적에서 제외하고 대기 건수로만 남긴다", () => {
+    const review = buildJudgmentReview([selection(0)], [action(0, "star")], []);
+    expect(review.rows).toEqual([]);
+    expect(review.pendingCount).toBe(1);
+    expect(review.userRate).toEqual({ n: 0, winRate: null });
+    expect(review.cardRate).toEqual({ n: 0, winRate: null });
+  });
+
+  it("강한 신호는 명시적 판단 표본 10개부터만 노출한다", () => {
+    const selections = Array.from({ length: 10 }, (_, index) => selection(index, "enter"));
+    const actions = Array.from({ length: 10 }, (_, index) => action(index, "star"));
+    const outcomes = Array.from({ length: 10 }, (_, index) => outcome(index, index < 8 ? 4 : -2));
+    const review = buildJudgmentReview(selections, actions, outcomes);
+    expect(review.strongSignals).toEqual([{
+      code: "material_contract",
+      label: "계약·수주 재료",
+      n: 10,
+      winRate: 80,
+    }]);
+    expect(buildJudgmentReview(selections.slice(0, 9), actions.slice(0, 9), outcomes.slice(0, 9)).strongSignals).toEqual([]);
+  });
+
+  it("seen과 watch는 매트릭스에는 남기되 개인·카드 승률 계산에서 제외한다", () => {
+    const review = buildJudgmentReview([selection(0, "watch")], [action(0, "seen")], [outcome(0, 8)]);
+    expect(review.matrix.find((cell) => cell.key === "neither-up")?.count).toBe(1);
+    expect(review.userRate.n).toBe(0);
+    expect(review.cardRate.n).toBe(0);
+  });
+});

--- a/apps/web/app/api/fomo/ledger/review/route.ts
+++ b/apps/web/app/api/fomo/ledger/review/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { extractBearerToken, verifyToken } from "@/lib/auth/jwt";
+import { corsJson, withCors } from "@/lib/fomo";
+import { userLedgerActor } from "@/lib/judgment-ledger";
+import { readJudgmentReview } from "@/lib/judgment-review";
+
+export const dynamic = "force-dynamic";
+
+export function OPTIONS() {
+  return withCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function GET(req: NextRequest) {
+  const sessionId = req.nextUrl.searchParams.get("sessionId")?.trim() ?? "";
+  if (sessionId.length > 128) return corsJson({ error: "입력이 너무 깁니다" }, { status: 400 });
+  const userId = verifyToken(extractBearerToken(req.headers.get("authorization")) ?? "");
+  const actors = [userLedgerActor({ userId }), userLedgerActor({ sessionId })]
+    .filter((actor): actor is `user:${string}` => !!actor);
+  try {
+    const review = await readJudgmentReview([...new Set(actors)]);
+    return corsJson(review, { headers: { "Cache-Control": "private, no-store" } });
+  } catch (error) {
+    console.warn("[ledger/review] read failed", error);
+    return corsJson({ error: "판단 복기 조회 실패" }, { status: 500 });
+  }
+}

--- a/apps/web/lib/judgment-review.ts
+++ b/apps/web/lib/judgment-review.ts
@@ -1,0 +1,271 @@
+import { signalTypeLabel, type SignalTypeCode, type VerdictStance } from "@fomo/core";
+import { prisma } from "./prisma";
+import { asOutcome, type OutcomePayload } from "./ledger-track-record";
+import { readLedgerSelections, type LedgerAsset, type LedgerSelectionView } from "./judgment-ledger";
+
+export type ReviewAction = "star" | "pass" | "seen";
+export type ReviewOutcome = "up" | "down";
+
+export interface ReviewUserAction {
+  id: string;
+  actor: string;
+  canonical: string;
+  ts: Date;
+  action: ReviewAction;
+}
+
+export interface JudgmentReviewRow {
+  selectionId: string;
+  canonical: string;
+  symbol?: string;
+  asset: LedgerAsset;
+  selectionDate: string;
+  actionAt: string;
+  stance: VerdictStance;
+  action: ReviewAction;
+  returnPct: number;
+  outcome: ReviewOutcome;
+  signalTypes: SignalTypeCode[];
+}
+
+export const REVIEW_MATRIX_KEYS = [
+  "both-selected-up",
+  "both-selected-down",
+  "card-selected-user-not-up",
+  "card-selected-user-not-down",
+  "card-not-user-selected-up",
+  "card-not-user-selected-down",
+  "neither-up",
+  "neither-down",
+] as const;
+
+export type ReviewMatrixKey = (typeof REVIEW_MATRIX_KEYS)[number];
+
+export interface ReviewMatrixCell {
+  key: ReviewMatrixKey;
+  label: string;
+  note: string;
+  count: number;
+}
+
+export interface ReviewRate {
+  n: number;
+  winRate: number | null;
+}
+
+export interface StrongSignal {
+  code: SignalTypeCode;
+  label: string;
+  n: number;
+  winRate: number;
+}
+
+export interface WeeklyReview {
+  from: string;
+  to: string;
+  count: number;
+  best?: JudgmentReviewRow;
+  missed?: JudgmentReviewRow;
+  disagreements: JudgmentReviewRow[];
+}
+
+export interface JudgmentReviewResponse {
+  generatedAt: string;
+  windowDays: 30;
+  rows: JudgmentReviewRow[];
+  pendingCount: number;
+  matrix: ReviewMatrixCell[];
+  userRate: ReviewRate;
+  cardRate: ReviewRate;
+  weekly: WeeklyReview | null;
+  strongSignals: StrongSignal[];
+}
+
+const MATRIX_COPY: Record<ReviewMatrixKey, { label: string; note: string }> = {
+  "both-selected-up": { label: "합작 성공", note: "카드 진입 · 내가 담음 · 상승" },
+  "both-selected-down": { label: "함께 점검", note: "카드 진입 · 내가 담음 · 하락" },
+  "card-selected-user-not-up": { label: "아까운 판단", note: "카드 진입 · 내가 비담음 · 상승" },
+  "card-selected-user-not-down": { label: "넘김이 지킨 판단", note: "카드 진입 · 내가 비담음 · 하락" },
+  "card-not-user-selected-up": { label: "나만의 발견", note: "카드 비진입 · 내가 담음 · 상승" },
+  "card-not-user-selected-down": { label: "엇갈린 판단", note: "카드 비진입 · 내가 담음 · 하락" },
+  "neither-up": { label: "함께 지나친 상승", note: "카드 비진입 · 내가 비담음 · 상승" },
+  "neither-down": { label: "함께 피한 하락", note: "카드 비진입 · 내가 비담음 · 하락" },
+};
+
+function roundRate(wins: number, n: number): number | null {
+  return n === 0 ? null : Math.round((wins / n) * 1_000) / 10;
+}
+
+function isoDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function addDays(date: string, days: number): string {
+  const value = new Date(`${date}T00:00:00.000Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+}
+
+function selectionStance(selection: LedgerSelectionView): VerdictStance | null {
+  const stance = selection.payload.front?.verdict?.stance;
+  return stance === "enter" || stance === "watch" || stance === "avoid" ? stance : null;
+}
+
+function matrixKey(row: JudgmentReviewRow): ReviewMatrixKey {
+  const cardSelected = row.stance === "enter";
+  const userSelected = row.action === "star";
+  if (cardSelected && userSelected) return row.outcome === "up" ? "both-selected-up" : "both-selected-down";
+  if (cardSelected) return row.outcome === "up" ? "card-selected-user-not-up" : "card-selected-user-not-down";
+  if (userSelected) return row.outcome === "up" ? "card-not-user-selected-up" : "card-not-user-selected-down";
+  return row.outcome === "up" ? "neither-up" : "neither-down";
+}
+
+function closestSelection(action: ReviewUserAction, selections: readonly LedgerSelectionView[]): LedgerSelectionView | null {
+  const candidates = selections.filter((selection) => selection.subject.canonical === action.canonical);
+  const before = candidates.filter((selection) => selection.ts.getTime() <= action.ts.getTime() + 60_000);
+  return (before.length > 0 ? before : candidates)
+    .sort((a, b) => Math.abs(action.ts.getTime() - a.ts.getTime()) - Math.abs(action.ts.getTime() - b.ts.getTime()))[0] ?? null;
+}
+
+function primaryActions(actions: readonly ReviewUserAction[]): ReviewUserAction[] {
+  const grouped = new Map<string, ReviewUserAction[]>();
+  for (const action of actions) {
+    // uid와 현재 익명 session actor를 함께 읽을 때 같은 종목을 두 번 채점하지 않는다.
+    const key = action.canonical;
+    const rows = grouped.get(key) ?? [];
+    rows.push(action);
+    grouped.set(key, rows);
+  }
+  return [...grouped.values()].map((rows) => {
+    const ordered = [...rows].sort((a, b) => a.ts.getTime() - b.ts.getTime());
+    const explicit = ordered.filter((row) => row.action === "star" || row.action === "pass");
+    return explicit.at(-1) ?? ordered.find((row) => row.action === "seen")!;
+  }).filter(Boolean);
+}
+
+export function buildJudgmentReview(
+  selections: readonly LedgerSelectionView[],
+  actions: readonly ReviewUserAction[],
+  outcomes: readonly OutcomePayload[],
+  now = new Date()
+): JudgmentReviewResponse {
+  const outcomeBySelection = new Map(
+    outcomes.filter((outcome) => outcome.windowDays === 30).map((outcome) => [outcome.selectionId, outcome])
+  );
+  let pendingCount = 0;
+  const rows = primaryActions(actions).flatMap((action): JudgmentReviewRow[] => {
+    const selection = closestSelection(action, selections);
+    const stance = selection ? selectionStance(selection) : null;
+    if (!selection || !stance) return [];
+    const outcome = outcomeBySelection.get(selection.id);
+    if (!outcome) {
+      pendingCount += 1;
+      return [];
+    }
+    return [{
+      selectionId: selection.id,
+      canonical: selection.subject.canonical,
+      ...(selection.subject.symbol ? { symbol: selection.subject.symbol } : {}),
+      asset: selection.subject.asset,
+      selectionDate: selection.date,
+      actionAt: action.ts.toISOString(),
+      stance,
+      action: action.action,
+      returnPct: Math.round(outcome.returnPct * 100) / 100,
+      outcome: outcome.returnPct > 0 ? "up" : "down",
+      signalTypes: selection.payload.signalTypes,
+    }];
+  }).sort((a, b) => b.actionAt.localeCompare(a.actionAt));
+
+  const counts = new Map<ReviewMatrixKey, number>(REVIEW_MATRIX_KEYS.map((key) => [key, 0]));
+  for (const row of rows) counts.set(matrixKey(row), (counts.get(matrixKey(row)) ?? 0) + 1);
+  const matrix = REVIEW_MATRIX_KEYS.map((key) => ({ key, ...MATRIX_COPY[key], count: counts.get(key) ?? 0 }));
+
+  const userJudgments = rows.filter((row) => row.action === "star" || row.action === "pass");
+  const userWins = userJudgments.filter((row) => row.action === "star" ? row.outcome === "up" : row.outcome === "down").length;
+  const cardJudgments = rows.filter((row) => row.stance === "enter" || row.stance === "avoid");
+  const cardWins = cardJudgments.filter((row) => row.stance === "enter" ? row.outcome === "up" : row.outcome === "down").length;
+
+  const signalGroups = new Map<SignalTypeCode, { n: number; wins: number }>();
+  for (const row of userJudgments) {
+    const won = row.action === "star" ? row.outcome === "up" : row.outcome === "down";
+    for (const code of row.signalTypes) {
+      const metric = signalGroups.get(code) ?? { n: 0, wins: 0 };
+      metric.n += 1;
+      if (won) metric.wins += 1;
+      signalGroups.set(code, metric);
+    }
+  }
+  const strongSignals = [...signalGroups.entries()]
+    .filter(([, metric]) => metric.n >= 10)
+    .map(([code, metric]) => ({ code, label: signalTypeLabel(code), n: metric.n, winRate: roundRate(metric.wins, metric.n)! }))
+    .sort((a, b) => b.winRate - a.winRate || b.n - a.n || a.code.localeCompare(b.code))
+    .slice(0, 3);
+
+  const today = isoDate(now);
+  const weekStart = addDays(today, -6);
+  const weeklyRows = rows.filter((row) => {
+    const outcome = outcomeBySelection.get(row.selectionId);
+    return !!outcome && outcome.evaluationDate >= weekStart && outcome.evaluationDate <= today;
+  });
+  const best = [...weeklyRows]
+    .filter((row) => (row.action === "star" && row.outcome === "up") || (row.action === "pass" && row.outcome === "down"))
+    .sort((a, b) => Math.abs(b.returnPct) - Math.abs(a.returnPct))[0];
+  const missed = [...weeklyRows]
+    .filter((row) => row.action !== "star" && row.outcome === "up")
+    .sort((a, b) => b.returnPct - a.returnPct)[0];
+  const disagreements = weeklyRows
+    .filter((row) => row.action !== "seen" && (row.stance === "enter") !== (row.action === "star"))
+    .sort((a, b) => Math.abs(b.returnPct) - Math.abs(a.returnPct))
+    .slice(0, 3);
+
+  return {
+    generatedAt: now.toISOString(),
+    windowDays: 30,
+    rows,
+    pendingCount,
+    matrix,
+    userRate: { n: userJudgments.length, winRate: roundRate(userWins, userJudgments.length) },
+    cardRate: { n: cardJudgments.length, winRate: roundRate(cardWins, cardJudgments.length) },
+    weekly: weeklyRows.length > 0 ? {
+      from: weekStart,
+      to: today,
+      count: weeklyRows.length,
+      ...(best ? { best } : {}),
+      ...(missed ? { missed } : {}),
+      disagreements,
+    } : null,
+    strongSignals,
+  };
+}
+
+export async function readJudgmentReview(actors: readonly `user:${string}`[]): Promise<JudgmentReviewResponse> {
+  if (actors.length === 0) return buildJudgmentReview([], [], []);
+  const actionRows = await prisma.judgmentLedger.findMany({
+    where: { kind: "user_action", actor: { in: [...actors] } },
+    orderBy: { ts: "asc" },
+    take: 5_000,
+  });
+  const actions = actionRows.flatMap((row): ReviewUserAction[] => {
+    if (!row.payload || typeof row.payload !== "object" || Array.isArray(row.payload)) return [];
+    const action = (row.payload as Record<string, unknown>).action;
+    if (!(action === "seen" || action === "pass" || action === "star")) return [];
+    return [{ id: row.id, actor: row.actor, canonical: row.canonical, ts: row.ts, action }];
+  });
+  if (actions.length === 0) return buildJudgmentReview([], [], []);
+  const earliest = isoDate(actions.reduce((min, row) => row.ts < min ? row.ts : min, actions[0]!.ts));
+  const [selections, outcomeRows] = await Promise.all([
+    readLedgerSelections({ fromDate: addDays(earliest, -7), take: 10_000 }),
+    prisma.judgmentLedger.findMany({
+      where: { kind: "outcome", actor: "engine" },
+      select: { payload: true },
+      orderBy: { ts: "asc" },
+      take: 20_000,
+    }),
+  ]);
+  const outcomes = outcomeRows.flatMap((row) => {
+    const parsed = asOutcome(row.payload);
+    return parsed ? [parsed] : [];
+  });
+  return buildJudgmentReview(selections, actions, outcomes);
+}

--- a/apps/web/lib/ledger-track-record.ts
+++ b/apps/web/lib/ledger-track-record.ts
@@ -57,7 +57,7 @@ function addDays(date: string, days: number): string {
   return value.toISOString().slice(0, 10);
 }
 
-function asOutcome(payload: Prisma.JsonValue): OutcomePayload | null {
+export function asOutcome(payload: Prisma.JsonValue): OutcomePayload | null {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
   const value = payload as Record<string, unknown>;
   if (


### PR DESCRIPTION
## What changed
- build an M1-ledger-only 30-day judgment review projection
- add the 2x2x2 judgment matrix, user vs card win rates, weekly review, sharing, and strong-signal badges
- use qualified personal signal history (n>=10) as an in-memory daily deck ranking seed
- expose the private no-store ledger review API through the web BFF

## Integrity
- fixed 30-day outcomes only; pending outcomes do not enter rates
- seen/watch observations remain visible but do not count as explicit judgment wins
- no separate performance or preference storage

## Validation
- 42 related tests passed
- backend and web typechecks passed
- backend and web production builds passed