### PR TITLE
ci: promote existing Vercel deployments

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -7,6 +7,14 @@ on:
         description: "Branch or SHA to deploy"
         required: false
         default: main
+      backend_deployment:
+        description: "Existing backend deployment URL to promote without creating a deployment"
+        required: false
+        default: ""
+      web_deployment:
+        description: "Existing web deployment URL to promote without creating a deployment"
+        required: false
+        default: ""
 
 concurrency:
   group: vercel-production-deploy
@@ -28,7 +36,12 @@ jobs:
         run: npx --yes vercel@latest pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
 
       - name: Deploy with Vercel production runtime
+        if: ${{ inputs.backend_deployment == '' }}
         run: npx --yes vercel@latest deploy --prod --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Promote existing deployment
+        if: ${{ inputs.backend_deployment != '' }}
+        run: npx --yes vercel@latest promote "${{ inputs.backend_deployment }}" --yes --token="${{ secrets.VERCEL_TOKEN }}"
 
   deploy-fomo-web:
     runs-on: ubuntu-latest
@@ -45,4 +58,9 @@ jobs:
         run: npx --yes vercel@latest pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
 
       - name: Deploy with Vercel production runtime
+        if: ${{ inputs.web_deployment == '' }}
         run: npx --yes vercel@latest deploy --prod --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Promote existing deployment
+        if: ${{ inputs.web_deployment != '' }}
+        run: npx --yes vercel@latest promote "${{ inputs.web_deployment }}" --yes --token="${{ secrets.VERCEL_TOKEN }}"


### PR DESCRIPTION
## Why
Vercel rejected new production deployments after the free daily deployment-creation limit was reached, even though the exact commit already had successful preview deployments.

## Change
Add optional backend/web deployment URL inputs to the existing production workflow. When supplied, the workflow promotes the already-built deployment instead of creating another one. The default deploy behavior is unchanged.

## Validation
- workflow syntax and diff check passed
- `vercel promote` CLI contract verified locally