### PR TITLE
ci: alias existing Vercel deployments

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -11,8 +11,16 @@ on:
         description: "Existing backend deployment URL to promote without creating a deployment"
         required: false
         default: ""
+      backend_alias:
+        description: "Alias target for an existing backend deployment (bypasses promotion limits)"
+        required: false
+        default: ""
       web_deployment:
         description: "Existing web deployment URL to promote without creating a deployment"
+        required: false
+        default: ""
+      web_alias:
+        description: "Alias target for an existing web deployment (bypasses promotion limits)"
         required: false
         default: ""
 
@@ -40,8 +48,12 @@ jobs:
         run: npx --yes vercel@latest deploy --prod --token="${{ secrets.VERCEL_TOKEN }}"
 
       - name: Promote existing deployment
-        if: ${{ inputs.backend_deployment != '' }}
+        if: ${{ inputs.backend_deployment != '' && inputs.backend_alias == '' }}
         run: npx --yes vercel@latest promote "${{ inputs.backend_deployment }}" --yes --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Alias existing deployment
+        if: ${{ inputs.backend_deployment != '' && inputs.backend_alias != '' }}
+        run: npx --yes vercel@latest alias set "${{ inputs.backend_deployment }}" "${{ inputs.backend_alias }}" --token="${{ secrets.VERCEL_TOKEN }}"
 
   deploy-fomo-web:
     runs-on: ubuntu-latest
@@ -62,5 +74,9 @@ jobs:
         run: npx --yes vercel@latest deploy --prod --token="${{ secrets.VERCEL_TOKEN }}"
 
       - name: Promote existing deployment
-        if: ${{ inputs.web_deployment != '' }}
+        if: ${{ inputs.web_deployment != '' && inputs.web_alias == '' }}
         run: npx --yes vercel@latest promote "${{ inputs.web_deployment }}" --yes --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Alias existing deployment
+        if: ${{ inputs.web_deployment != '' && inputs.web_alias != '' }}
+        run: npx --yes vercel@latest alias set "${{ inputs.web_deployment }}" "${{ inputs.web_alias }}" --token="${{ secrets.VERCEL_TOKEN }}"


### PR DESCRIPTION
## Why
Vercel applies the free daily deployment limit to both deploy and promote operations. The exact feature commit already has successful preview deployments.

## Change
Add optional alias inputs to the production workflow. With a deployment URL and alias supplied, the workflow repoints the existing production hostname without creating or promoting a deployment. Default deploy and promote behavior remains unchanged.

## Validation
- workflow diff check passed
- `vercel alias set deployment alias` CLI contract verified locally