### PR TITLE
ci: bootstrap ledger in Vercel production database

### DIFF
--- a/.github/workflows/vercel-production-deploy.yml
+++ b/.github/workflows/vercel-production-deploy.yml
@@ -23,6 +23,11 @@ on:
         description: "Alias target for an existing web deployment (bypasses promotion limits)"
         required: false
         default: ""
+      bootstrap_ledger:
+        description: "Apply and verify the append-only Judgment Ledger in the backend production database"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: vercel-production-deploy
@@ -42,6 +47,23 @@ jobs:
 
       - name: Pull Vercel environment
         run: npx --yes vercel@latest pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Install dependencies for ledger bootstrap
+        if: ${{ inputs.bootstrap_ledger }}
+        run: npm ci
+
+      - name: Bootstrap ledger in backend production database
+        if: ${{ inputs.bootstrap_ledger }}
+        shell: bash
+        run: |
+          set -a
+          source .vercel/.env.production.local
+          set +a
+          : "${DATABASE_URL:?DATABASE_URL is missing from the backend production environment}"
+          npx prisma db execute --file prisma/sql/2026-07-20_judgment_ledger.sql --schema prisma/schema.prisma
+          npx tsx scripts/migrate-judgment-ledger.ts
+          npx tsx scripts/materialize-ledger-outcomes.ts
+          npx tsx scripts/verify-judgment-ledger-append-only.ts
 
       - name: Deploy with Vercel production runtime
         if: ${{ inputs.backend_deployment == '' }}


### PR DESCRIPTION
## Root cause
The Judgment Ledger bootstrap ran successfully against the repository DATABASE_URL, while every production ledger endpoint still returned 500. The backend runtime therefore uses a different production database URL.

## Change
Add an opt-in production workflow step that loads the backend Vercel production environment, applies the append-only ledger SQL, backfills immutable selections/outcomes, and runs the mutation rejection verification against the runtime database.

## Safety
- opt-in only; default deployment behavior is unchanged
- exact idempotent SQL and append-only migration scripts already used by the dedicated bootstrap workflow
- fails closed when DATABASE_URL is absent