### PR TITLE
feat: expose one-year Wyckoff chart range

### DIFF
--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1979,7 +1979,7 @@ function taFactValueSuffix(kind: string, latest: NonNullable<StockFrontResponse[
 }
 
 type StructureMetric = ChartTooltip & { value: string };
-type StructureRange = "1m" | "3m" | "6m";
+type StructureRange = "3m" | "1y";
 
 function sliceChartSeries(
   series: NonNullable<StockFrontResponse["chartSeries"]>,
@@ -2073,7 +2073,7 @@ function ChartAnalysisTab({
   const [structureTooltip, setStructureTooltip] = useState<ChartTooltip | null>(null);
   const [range, setRange] = useState<StructureRange>("3m");
   const metrics = structureMetrics(front);
-  const rangeDays = range === "1m" ? 22 : range === "3m" ? 66 : 120;
+  const rangeDays = range === "3m" ? 66 : 260;
   const visibleSeries = useMemo(() => (series ? sliceChartSeries(series, rangeDays) : undefined), [series, rangeDays]);
   const visibleCandles = useMemo(
     () => front?.candles?.filter((c) => [c.open, c.high, c.low, c.close].every((v) => Number.isFinite(v) && v > 0)).slice(-rangeDays),
@@ -2143,9 +2143,9 @@ function ChartAnalysisTab({
       {visibleSeries && visibleSeries.closes.length >= 2 ? (
         <div className="rounded-lg border border-white/15 bg-[#050706] px-3 pb-3 pt-3 shadow-inner">
           <div className="mb-2 flex items-center justify-between gap-3">
-            <span className="font-pixel text-[10px] text-muted">일봉 · {range === "1m" ? "1개월" : range === "3m" ? "3개월" : "6개월"}</span>
+            <span className="font-pixel text-[10px] text-muted">일봉 · {range === "3m" ? "3개월" : "1년"}</span>
             <div className="flex rounded-md border border-white/10 p-0.5">
-              {(["1m", "3m", "6m"] as const).map((key) => (
+              {(["3m", "1y"] as const).map((key) => (
                 <button
                   key={key}
                   type="button"
@@ -2153,7 +2153,7 @@ function ChartAnalysisTab({
                   className="rounded px-2 py-1 text-[9px] font-bold"
                   style={{ backgroundColor: range === key ? "#F4F4EF" : "transparent", color: range === key ? "#050706" : "#8A8A86" }}
                 >
-                  {key === "1m" ? "1M" : key === "3m" ? "3M" : "6M"}
+                  {key === "3m" ? "3M" : "1Y"}
                 </button>
               ))}
             </div>

--- a/apps/web/__tests__/lib/stock-front-chart.test.ts
+++ b/apps/web/__tests__/lib/stock-front-chart.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChartSeries } from "../../lib/stock-front";
+
+describe("buildChartSeries", () => {
+  it("1년 차트와 와이코프 이벤트가 같은 260거래일 축을 사용한다", () => {
+    const candles = Array.from({ length: 320 }, (_, index) => {
+      const close = 100 + index * 0.2;
+      return {
+        date: new Date(Date.UTC(2025, 0, 1 + index)).toISOString().slice(0, 10),
+        open: close - 0.1,
+        high: close + 0.5,
+        low: close - 0.5,
+        close,
+        volume: 1_000 + index,
+      };
+    });
+
+    const series = buildChartSeries(candles);
+
+    expect(series?.closes).toHaveLength(260);
+    expect(series?.closes[0]).toBe(candles[60]!.close);
+    expect(series?.closes.at(-1)).toBe(candles.at(-1)!.close);
+    expect(series?.ma120.slice(0, 59).every((value) => value === null)).toBe(true);
+    expect(series?.ma120.slice(59).every((value) => typeof value === "number")).toBe(true);
+  });
+
+  it("명시한 창 크기는 그대로 존중한다", () => {
+    const candles = Array.from({ length: 80 }, (_, index) => ({
+      open: 100 + index,
+      high: 101 + index,
+      low: 99 + index,
+      close: 100 + index,
+      volume: 1_000,
+    }));
+
+    expect(buildChartSeries(candles, 66)?.closes).toHaveLength(66);
+  });
+});

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -106,7 +106,7 @@ export interface StockChartSeries {
   ma120: Array<number | null>;
 }
 
-export function buildChartSeries(candles: readonly DailyOhlcv[], window = 120): StockChartSeries | undefined {
+export function buildChartSeries(candles: readonly DailyOhlcv[], window = 260): StockChartSeries | undefined {
   const clean = candles.filter((c) => Number.isFinite(c.close) && c.close > 0);
   if (clean.length < 20) return undefined;
   const closes = clean.map((c) => c.close);


### PR DESCRIPTION
## Summary
- expose the existing deterministic Wyckoff zones and events over a full 260-trading-day chart window
- replace the depth chart 1M/3M/6M selector with the required 3M/1Y selector
- add regression coverage for the default 260-day chart series and explicit window overrides

## Existing S1 coverage verified
- accumulation/distribution zones with period labels
- spring/upthrust candidates
- impulse/pullback events and retracement ratios
- per-stock current-zone summary
- SVG zone bands and interactive event markers

## Verification
- npm run test -- wyckoff-analysis stock-front-chart stock-front-lite
- npm run typecheck
- git diff --check