### PR TITLE
feat: backfill judgment ledger and revive committee

### DIFF
--- a/.github/workflows/judgment-ledger-bootstrap.yml
+++ b/.github/workflows/judgment-ledger-bootstrap.yml
@@ -36,3 +36,8 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npx tsx scripts/verify-judgment-ledger-append-only.ts
+
+      - name: Verify historical sample and signal resume badges
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx tsx scripts/verify-ledger-backfill.ts

--- a/.github/workflows/quality-slo-monitor.yml
+++ b/.github/workflows/quality-slo-monitor.yml
@@ -12,6 +12,31 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
+      - name: Expose latest committee run report
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          set -euo pipefail
+          URL="https://fomo-club-backend.vercel.app/api/fomo/committee-report?limit=3"
+          if [ -n "${CRON_SECRET:-}" ]; then
+            curl -fsS "$URL" -H "Authorization: Bearer ${CRON_SECRET}" > /tmp/committee-report.json
+          else
+            curl -fsS "$URL" > /tmp/committee-report.json
+          fi
+          node - <<'NODE'
+          const fs = require("fs");
+          const result = JSON.parse(fs.readFileSync("/tmp/committee-report.json", "utf8"));
+          const run = result.runs?.[0];
+          if (!result.ok || !run) {
+            console.log("::warning title=Committee report::No committee run report is available");
+            process.exit(0);
+          }
+          const line = `${run.date} ${run.status} stage=${run.stage ?? "unknown"} step=${run.failureStep ?? "-"} calls=${run.callCount} candidates=${run.candidateCount} selected=${run.selectedCount}${run.error ? ` error=${run.error}` : ""}`;
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Committee run\n\n${line}\n`);
+          console.log(line);
+          if (run.status === "failed") console.log(`::warning title=Committee failed::${line}`);
+          NODE
+
       - name: Materialize and read latest quality row
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}

--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -9,6 +9,7 @@ import {
   type CommitteeCandidateInput,
 } from "../../lib/expert-review-committee";
 import type { Daily30Response } from "../../lib/daily-30";
+import type { CommitteeRunReport } from "../../lib/expert-review-store";
 
 const input: CommitteeCandidateInput = {
   candidateId: "stock:KR:000000:테스트",
@@ -150,7 +151,7 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     expect(result.report.candidateCount).toBe(40);
     expect(result.report.selectedCount).toBe(30);
-    expect(result.report.callCount).toBe(9);
+    expect(result.report.callCount).toBe(11);
     expect(result.response?.stocks).toHaveLength(30);
     expect(result.response?.fronts["테스트코인0"]?.committeeReview?.factChecked).toBe(true);
     expect(publish).toHaveBeenCalledOnce();
@@ -208,8 +209,8 @@ describe("expert committee orchestration", () => {
     expect(result.ok).toBe(true);
     const trading = (stored as { trading: Array<[string, { approved: boolean; grade: string; concerns: string[] }]> }).trading;
     expect(trading).toHaveLength(40);
-    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(4);
-    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(4);
+    expect(trading.filter(([, review]) => !review.approved)).toHaveLength(5);
+    expect(trading.filter(([, review]) => review.grade === "C")).toHaveLength(5);
   });
 
   it("분석가가 candidateId를 생략해도 배치 순서로 정상 응답을 복원한다", async () => {
@@ -296,16 +297,42 @@ describe("expert committee orchestration", () => {
     };
 
     const trading = await runExpertReviewCommitteeStage("trading", common);
-    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 4 });
+    expect(trading).toMatchObject({ ok: true, stage: "trading", candidateCount: 40, callCount: 5 });
     expect(publish).not.toHaveBeenCalled();
 
     const financial = await runExpertReviewCommitteeStage("financial", common);
-    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 8 });
+    expect(financial).toMatchObject({ ok: true, stage: "financial", callCount: 10 });
     expect(publish).not.toHaveBeenCalled();
 
     const editor = await runExpertReviewCommitteeStage("editor", common);
-    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 9 });
+    expect(editor).toMatchObject({ ok: true, stage: "editor", selectedCount: 30, callCount: 11 });
     expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it("단계 실패 리포트에 실제 후보 수와 실패 지점을 남긴다", async () => {
+    let stored: unknown = null;
+    const reports: CommitteeRunReport[] = [];
+    const result = await runExpertReviewCommitteeStage("trading", {
+      caller: async () => ({ ok: false, content: "", model: "test-model", status: 429, retryAfterMs: 61_000 }),
+      buildPool: async () => fakePool(),
+      readPrevious: async () => null,
+      writeFailure: async (report) => { reports.push(report); },
+      writePicks: async () => {},
+      minCallIntervalMs: 0,
+      stageStorage: {
+        read: async () => stored,
+        write: async (_date, value) => { stored = value; },
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, stage: "trading", candidateCount: 40, callCount: 1 });
+    expect(reports[0]).toMatchObject({
+      status: "failed",
+      stage: "trading",
+      failureStep: "trading-agent",
+      candidateCount: 40,
+      callCount: 1,
+    });
   });
 
   it("분석가가 같은 문장을 반복해도 승인 후보를 전부 잃지 않고 엔진 문장으로 보강한다", async () => {

--- a/apps/web/__tests__/lib/judgment-ledger.test.ts
+++ b/apps/web/__tests__/lib/judgment-ledger.test.ts
@@ -13,6 +13,7 @@ import {
   type LedgerSelectionView,
 } from "../../lib/judgment-ledger";
 import { buildTrackRecord, type OutcomePayload } from "../../lib/ledger-track-record";
+import { buildLegacyDaily30BackfillEntries } from "../../lib/ledger-backfill";
 import { fetchHistoricalPrices } from "../../lib/quote-prices";
 import { SIGNAL_TAXONOMY_VERSION, SIGNAL_TYPE_CODES } from "@fomo/core";
 
@@ -39,6 +40,38 @@ describe("Judgment Ledger", () => {
     });
     expect(finalSelections([engine, committee])).toEqual([committee]);
     expect(finalSelections([{ ...engine, ts: new Date("2026-07-20T02:00:00Z") }, committee])).toEqual([committee]);
+  });
+
+  it("백필 선정은 원본 시각·가격을 보존하고 실시간 선정본을 덮지 않는다", () => {
+    const updatedAt = new Date("2026-06-18T21:03:04.000Z");
+    const entries = buildLegacyDaily30BackfillEntries([{
+      id: "daily30-picks:2026-06-19",
+      updatedAt,
+      row: {
+        date: "2026-06-19",
+        picks: [
+          { canonical: "ACME", headline: "대형 공급계약 체결", price: 101.25, symbol: "ACME", country: "US", market: "NASDAQ" },
+          { canonical: "NO-PRICE" },
+        ],
+      },
+    }]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      date: "2026-06-19",
+      ts: updatedAt,
+      actor: "backfill",
+      priceAt: 101.25,
+      payload: {
+        signalTypes: ["material_contract"],
+        sourceSnapshotId: "daily30-picks:2026-06-19",
+        sourceSnapshotUpdatedAt: updatedAt.toISOString(),
+      },
+    });
+    const backfill = selection({ id: "selection-backfill", actor: "backfill", ts: updatedAt });
+    const engine = selection({ ts: new Date("2026-06-19T00:00:00.000Z") });
+    const committee = selection({ id: "selection-committee", actor: "committee", ts: new Date("2026-06-19T01:00:00.000Z") });
+    expect(finalSelections([backfill, engine])).toEqual([engine]);
+    expect(finalSelections([committee, backfill, engine])).toEqual([committee]);
   });
 
   it("신호 유형과 점수대를 결정론적으로 분류한다", () => {
@@ -84,6 +117,7 @@ describe("Judgment Ledger", () => {
     expect(sql).toContain("JudgmentLedger is append-only");
     expect(sql).toContain("FORCE ROW LEVEL SECURITY");
     expect(sql).toContain("REVOKE UPDATE, DELETE, TRUNCATE");
+    expect(sql).toContain("'backfill'");
   });
 
   it("후보는 신호·판단·점수만, 최종 선정은 selection까지 모두 당시 가격으로 만든다", () => {

--- a/apps/web/app/admin/committee/page.tsx
+++ b/apps/web/app/admin/committee/page.tsx
@@ -41,6 +41,7 @@ export default async function CommitteeAuditPage() {
             ["승인", latest.selectedCount],
             ["AI 호출", latest.callCount],
             ["모델", latest.model],
+            ["실패 지점", latest.failureStep ?? "-"],
           ].map(([label, value]) => (
             <div key={String(label)} style={{ padding: "18px 16px", borderRight: "1px solid #25262a" }}>
               <div className="eyebrow">{label}</div>
@@ -54,10 +55,11 @@ export default async function CommitteeAuditPage() {
         <p className="eyebrow">RUN HISTORY</p>
         <div style={{ marginTop: 12, display: "grid", gap: 1, background: "#25262a" }}>
           {runs.map((run) => (
-            <div key={run.runId} style={{ display: "grid", gridTemplateColumns: "140px minmax(180px, 1fr) 90px 90px 90px", gap: 12, padding: "12px 14px", background: "#0c0d10", fontSize: 13 }}>
+            <div key={`${run.runId}:${run.completedAt}`} style={{ display: "grid", gridTemplateColumns: "110px minmax(180px, 1fr) 80px 90px 90px minmax(140px, 1fr)", gap: 12, padding: "12px 14px", background: "#0c0d10", fontSize: 13 }}>
               <span>{run.date}</span><span style={{ fontFamily: "var(--font-mono)", color: "#a6acb6" }}>{run.runId}</span>
-              <span style={{ color: run.status === "published" ? "#d8ff3a" : "#e16a5a" }}>{run.status}</span>
-              <span>{run.selectedCount}/{run.candidateCount}</span><span>{run.callCount} calls</span>
+              <span style={{ color: run.status === "published" ? "#d8ff3a" : run.status === "ready" ? "#f4f5f7" : "#e16a5a" }}>{run.status}</span>
+              <span>{run.stage ?? "-"}</span><span>{run.callCount} calls</span>
+              <span style={{ color: run.error ? "#e16a5a" : "#8a8f98", overflowWrap: "anywhere" }}>{run.failureStep ?? run.error ?? `${run.selectedCount}/${run.candidateCount}`}</span>
             </div>
           ))}
           {runs.length === 0 && <div style={{ padding: 18, background: "#0c0d10", color: "#8a8f98" }}>실행 이력이 없습니다.</div>}
@@ -67,6 +69,7 @@ export default async function CommitteeAuditPage() {
       {latest && (
         <section style={{ padding: "24px 0" }}>
           <p className="eyebrow">LATEST DECISIONS</p>
+          {latest.error && <p style={{ marginTop: 10, color: "#e16a5a", lineHeight: 1.7 }}>{latest.failureStep ?? latest.stage ?? "unknown"}: {latest.error}</p>}
           <p style={{ marginTop: 10, color: "#a6acb6", lineHeight: 1.7 }}>{latest.compositionSummary}</p>
           <div style={{ marginTop: 18, borderTop: "1px solid #25262a" }}>
             {latest.reviews.map((review) => (

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -6,7 +6,9 @@ import type { DiscoveryDeckCardPayload, DiscoveryFrontSeed, DiscoveryStockPayloa
 import {
   publishCommitteeSnapshot,
   readPublishedCommitteeSnapshot,
+  writeCommitteeRunReport,
   writeFailedCommitteeRun,
+  type CommitteeFailureStep,
   type CommitteeReviewAudit,
   type CommitteeRunReport,
   type PublishedCommitteeSnapshot,
@@ -20,12 +22,13 @@ const CANDIDATE_TARGET = 50;
 const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
 // Groq free/developer 조직의 TPM을 넘지 않도록 입력을 압축하고 호출 수를 줄인다.
-// 후보 50장 기준 분석가 5콜 + 5콜, 편집장 1콜로 일일 11콜이다.
-const BATCH_SIZE = 10;
+// 후보 50장 기준 분석가 7콜 + 7콜, 편집장 1콜이다. 작은 배치와 25초 간격으로
+// 무료 조직 TPM을 시간축에 분산하고 각 Vercel stage는 300초 안에 끝낸다.
+const BATCH_SIZE = 8;
 const BATCH_CONCURRENCY = 1;
 const MAX_CALLS = 110;
 const DEFAULT_COMMITTEE_MODEL = "llama-3.1-8b-instant";
-const DEFAULT_CALL_INTERVAL_MS = 3_000;
+const DEFAULT_CALL_INTERVAL_MS = 25_000;
 
 function committeeModel(): string {
   const configured = process.env.COMMITTEE_AI_MODEL?.trim();
@@ -335,7 +338,7 @@ async function defaultAgentCaller(args: Parameters<CommitteeAgentCaller>[0]) {
       { role: "user", content: JSON.stringify(args.input) },
     ],
     temperature: 0.1,
-    maxTokens: args.role === "editor" ? 900 : 1_500,
+    maxTokens: 900,
     jsonMode: true,
     timeoutMs: 45_000,
     trace: args.trace,
@@ -360,7 +363,7 @@ async function callWithRetry(
     if (result.model) state.model = result.model;
     if (result.ok && result.content.trim()) return result.content;
     if (result.status === 429) {
-      if (!result.retryAfterMs || result.retryAfterMs > 15_000) {
+      if (!result.retryAfterMs || result.retryAfterMs > 60_000) {
         const retryAfter = result.retryAfterMs ? `; retry after ${Math.ceil(result.retryAfterMs / 1_000)}s` : "";
         throw new Error(`${args.role} agent rate limited${retryAfter}`);
       }
@@ -832,6 +835,7 @@ export async function runExpertReviewCommittee(options: CommitteeRunOptions = {}
       version: COMMITTEE_VERSION,
       date,
       status: "published",
+      stage: "full",
       startedAt: startedAt.toISOString(),
       completedAt,
       model: state.model,
@@ -862,6 +866,8 @@ export async function runExpertReviewCommittee(options: CommitteeRunOptions = {}
       version: COMMITTEE_VERSION,
       date,
       status: "failed",
+      stage: "full",
+      failureStep: state.callCount === 0 ? "configuration" : "fact-gate",
       startedAt: startedAt.toISOString(),
       completedAt,
       model: state.model,
@@ -964,6 +970,14 @@ export async function runExpertReviewCommitteeStage(
   const fallbackRunId = `${date}-${now.getTime().toString(36)}-${crypto.randomUUID().slice(0, 8)}`;
   const state = callState(options, stage === "trading" ? undefined : stored?.model);
   const caller = options.caller ?? (isAiConfigured() ? defaultAgentCaller : undefined);
+  let stageCandidateCount = stored?.candidates.length ?? 0;
+  let failureStep: CommitteeFailureStep = !caller
+    ? "configuration"
+    : stage === "trading"
+      ? "candidate-load"
+      : stage === "financial"
+        ? "financial-agent"
+        : "editor-agent";
 
   try {
     if (!caller) throw new Error("committee AI is not configured");
@@ -975,7 +989,9 @@ export async function runExpertReviewCommitteeStage(
       );
       await writeCandidates(pool);
       const candidates = await candidateRecords(pool);
+      stageCandidateCount = candidates.length;
       if (candidates.length < MIN_CANDIDATES) throw new Error(`committee candidate pool ${candidates.length}/${MIN_CANDIDATES}`);
+      failureStep = "trading-agent";
       const trading = enforceAnalystCopyQuality("trading", await runAnalyst("trading", candidates, caller, state), candidates);
       stored = {
         runId: fallbackRunId,
@@ -988,8 +1004,28 @@ export async function runExpertReviewCommitteeStage(
         candidates,
         trading: [...trading],
       };
+      failureStep = "stage-persist";
       if (options.stageStorage) await options.stageStorage.write(date, stored);
       else await writeFeedContent(committeeStageId(date), stored);
+      const report: CommitteeRunReport = {
+        runId: stored.runId,
+        version: COMMITTEE_VERSION,
+        date,
+        status: "ready",
+        stage,
+        startedAt: stored.startedAt,
+        completedAt: new Date().toISOString(),
+        model: stored.model,
+        callCount: stored.totalCallCount,
+        candidateCount: candidates.length,
+        selectedCount: 0,
+        selectedIds: [],
+        reviews: [],
+        compositionSummary: "트레이딩 검수 완료 · 재무 검수 대기",
+        assetCounts: pool.meta.assetCounts,
+        previousRunRetained: Boolean(previous),
+      };
+      await (options.writeFailure ?? writeCommitteeRunReport)(report).catch(() => {});
       return { ok: true, stage, runId: stored.runId, candidateCount: candidates.length, selectedCount: 0, callCount: stored.totalCallCount, previousRunRetained: Boolean(previous) };
     }
 
@@ -997,6 +1033,7 @@ export async function runExpertReviewCommitteeStage(
     const trading = new Map(stored.trading);
 
     if (stage === "financial") {
+      failureStep = "financial-agent";
       const financial = enforceAnalystCopyQuality("financial", await runAnalyst("financial", stored.candidates, caller, state), stored.candidates);
       stored = {
         ...stored,
@@ -1004,13 +1041,34 @@ export async function runExpertReviewCommitteeStage(
         totalCallCount: stored.totalCallCount + state.callCount,
         financial: [...financial],
       };
+      failureStep = "stage-persist";
       if (options.stageStorage) await options.stageStorage.write(date, stored);
       else await writeFeedContent(committeeStageId(date), stored);
+      const report: CommitteeRunReport = {
+        runId: stored.runId,
+        version: COMMITTEE_VERSION,
+        date,
+        status: "ready",
+        stage,
+        startedAt: stored.startedAt,
+        completedAt: new Date().toISOString(),
+        model: stored.model,
+        callCount: stored.totalCallCount,
+        candidateCount: stored.candidates.length,
+        selectedCount: 0,
+        selectedIds: [],
+        reviews: [],
+        compositionSummary: "트레이딩·재무 검수 완료 · 편집장 발행 대기",
+        assetCounts: stored.pool.meta.assetCounts,
+        previousRunRetained: Boolean(previous),
+      };
+      await (options.writeFailure ?? writeCommitteeRunReport)(report).catch(() => {});
       return { ok: true, stage, runId: stored.runId, candidateCount: stored.candidates.length, selectedCount: 0, callCount: stored.totalCallCount, previousRunRetained: Boolean(previous) };
     }
 
     if (!stored.financial?.length) throw new Error("financial stage is not ready");
     const financial = new Map(stored.financial);
+    failureStep = "editor-agent";
     const editor = await runEditor(stored.candidates, trading, financial, caller, state);
     const totalCallCount = stored.totalCallCount + state.callCount;
     const completedAt = new Date().toISOString();
@@ -1024,11 +1082,14 @@ export async function runExpertReviewCommitteeStage(
     };
     const response = finalResponse(stored.pool, stored.candidates, editor.selectedIds, trading, financial, committeeMeta);
     const reviews = reviewAudits(stored.candidates, editor.selectedIds, editor, trading, financial);
+    const factGateFallbacks = reviews.filter((review) => review.factGate.tradingFallback || review.factGate.financialFallback).length;
+    const factGateInvalidNumberCount = reviews.reduce((sum, review) => sum + review.factGate.invalidNumbers.length, 0);
     const report: CommitteeRunReport = {
       runId: stored.runId,
       version: COMMITTEE_VERSION,
       date,
       status: "published",
+      stage,
       startedAt: stored.startedAt,
       completedAt,
       model: state.model,
@@ -1039,6 +1100,8 @@ export async function runExpertReviewCommitteeStage(
       reviews,
       compositionSummary: editor.compositionSummary,
       assetCounts: response.meta.assetCounts,
+      factGateFallbacks,
+      factGateInvalidNumberCount,
     };
     const { reviews: _reviews, ...reportSummary } = report;
     void _reviews;
@@ -1049,7 +1112,9 @@ export async function runExpertReviewCommitteeStage(
       response,
       report: reportSummary,
     };
+    failureStep = "ledger-write";
     await (options.writePicks ?? ((value) => writeDaily30Ledger(value, "committee")))(response);
+    failureStep = "publish";
     await (options.publish ?? publishCommitteeSnapshot)(snapshot, report);
     return { ok: true, stage, runId: stored.runId, candidateCount: stored.candidates.length, selectedCount: editor.selectedIds.length, callCount: totalCallCount, previousRunRetained: false };
   } catch (error) {
@@ -1060,11 +1125,13 @@ export async function runExpertReviewCommitteeStage(
       version: COMMITTEE_VERSION,
       date,
       status: "failed",
+      stage,
+      failureStep,
       startedAt: stored?.startedAt ?? now.toISOString(),
       completedAt: new Date().toISOString(),
       model: state.model,
       callCount: totalCallCount,
-      candidateCount: stored?.candidates.length ?? 0,
+      candidateCount: stageCandidateCount,
       selectedCount: 0,
       selectedIds: [],
       reviews: [],

--- a/apps/web/lib/expert-review-store.ts
+++ b/apps/web/lib/expert-review-store.ts
@@ -5,7 +5,18 @@ const ACTIVE_ID = "expert-committee:active";
 const RUN_PREFIX = "expert-committee:run:";
 const SNAPSHOT_PREFIX = "expert-committee:snapshot:";
 
-export type CommitteeRunStatus = "published" | "failed";
+export type CommitteeRunStatus = "ready" | "published" | "failed";
+export type CommitteeRunStage = "full" | "trading" | "financial" | "editor";
+export type CommitteeFailureStep =
+  | "configuration"
+  | "candidate-load"
+  | "trading-agent"
+  | "financial-agent"
+  | "editor-agent"
+  | "fact-gate"
+  | "stage-persist"
+  | "ledger-write"
+  | "publish";
 
 export interface CommitteeReviewAudit {
   candidateId: string;
@@ -28,6 +39,8 @@ export interface CommitteeRunReport {
   version: string;
   date: string;
   status: CommitteeRunStatus;
+  stage?: CommitteeRunStage;
+  failureStep?: CommitteeFailureStep;
   startedAt: string;
   completedAt: string;
   model: string;
@@ -38,6 +51,8 @@ export interface CommitteeRunReport {
   reviews: CommitteeReviewAudit[];
   compositionSummary: string;
   assetCounts: Record<string, number>;
+  factGateFallbacks?: number;
+  factGateInvalidNumberCount?: number;
   error?: string;
   previousRunRetained?: boolean;
 }
@@ -128,6 +143,11 @@ export async function publishCommitteeSnapshot(
 }
 
 export async function writeFailedCommitteeRun(report: CommitteeRunReport): Promise<void> {
+  await writeFeedContent(`${RUN_PREFIX}${report.date}:${report.runId}`, report);
+}
+
+/** Intermediate stages overwrite only their own run report; the active approved deck is untouched. */
+export async function writeCommitteeRunReport(report: CommitteeRunReport): Promise<void> {
   await writeFeedContent(`${RUN_PREFIX}${report.date}:${report.runId}`, report);
 }
 

--- a/apps/web/lib/feed-content-store.ts
+++ b/apps/web/lib/feed-content-store.ts
@@ -68,3 +68,29 @@ export async function readFeedContentByPrefix<T>(prefix: string, limit = 10): Pr
     return [];
   }
 }
+
+/**
+ * One-off migrations need the persisted timestamp, not a synthesized date. Keep this separate
+ * from the hot-path reader so normal requests retain the small 50-row ceiling.
+ */
+export async function readFeedContentHistoryByPrefix<T>(
+  prefix: string,
+  limit = 5_000
+): Promise<Array<{ id: string; row: T; updatedAt: Date }>> {
+  try {
+    const records = await prisma.$queryRaw<Array<{ id: string; row: unknown; updatedAt: Date }>>`
+      SELECT "id", "row", "updatedAt" FROM "FeedContentCache"
+      WHERE "id" LIKE ${`${prefix}%`}
+      ORDER BY "updatedAt" ASC, "id" ASC
+      LIMIT ${Math.max(1, Math.min(5_000, limit))}
+    `;
+    return records.map((record) => ({
+      id: record.id,
+      row: record.row as T,
+      updatedAt: record.updatedAt,
+    }));
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2010") return [];
+    return [];
+  }
+}

--- a/apps/web/lib/judgment-ledger.ts
+++ b/apps/web/lib/judgment-ledger.ts
@@ -18,7 +18,7 @@ import type { DiscoveryFrontSeed, DiscoveryStockPayload } from "./discovery-supp
 export const LEDGER_KINDS = ["signal", "verdict", "score", "selection", "user_action", "outcome"] as const;
 export type LedgerKind = (typeof LEDGER_KINDS)[number];
 export type LedgerAsset = Daily30AssetClass;
-export type LedgerActor = "engine" | "committee" | `user:${string}`;
+export type LedgerActor = "engine" | "committee" | "backfill" | `user:${string}`;
 
 export interface LedgerSubject {
   asset: LedgerAsset;
@@ -113,7 +113,7 @@ function assertAppendInput(input: LedgerAppendInput): void {
   if (!ASSET_SET.has(input.subject.asset)) throw new Error(`invalid ledger asset: ${input.subject.asset}`);
   if (!input.subject.canonical.trim()) throw new Error("ledger canonical is required");
   if (!Number.isFinite(input.priceAt) || input.priceAt <= 0) throw new Error("ledger priceAt must be positive");
-  if (!(input.actor === "engine" || input.actor === "committee" || input.actor.startsWith("user:"))) {
+  if (!(input.actor === "engine" || input.actor === "committee" || input.actor === "backfill" || input.actor.startsWith("user:"))) {
     throw new Error(`invalid ledger actor: ${input.actor}`);
   }
   if (!input.idempotencyKey.trim()) throw new Error("ledger idempotencyKey is required");
@@ -337,7 +337,7 @@ function asSelection(row: {
   actor: string;
   payload: Prisma.JsonValue;
 }): LedgerSelectionView | null {
-  if (!ASSET_SET.has(row.asset) || !(row.actor === "engine" || row.actor === "committee")) return null;
+  if (!ASSET_SET.has(row.asset) || !(row.actor === "engine" || row.actor === "committee" || row.actor === "backfill")) return null;
   const payload = row.payload && typeof row.payload === "object" && !Array.isArray(row.payload)
     ? (row.payload as unknown as LedgerSelectionPayload)
     : null;
@@ -366,18 +366,21 @@ function asSelection(row: {
       ...(row.symbol ? { symbol: row.symbol } : {}),
     },
     priceAt: row.priceAt.toNumber(),
-    actor: row.actor as "engine" | "committee",
+    actor: row.actor as "engine" | "committee" | "backfill",
     payload: { ...payload, signalTypes: projectedSignalTypes },
   };
 }
 
-/** One final pick per date/subject. Committee approval supersedes the engine emergency selection. */
+const selectionActorPriority = (actor: LedgerActor): number =>
+  actor === "committee" ? 3 : actor === "engine" ? 2 : actor === "backfill" ? 1 : 0;
+
+/** One final pick per date/subject. Live publication always supersedes an imported snapshot. */
 export function finalSelections(rows: readonly LedgerSelectionView[]): LedgerSelectionView[] {
   const selected = new Map<string, LedgerSelectionView>();
   for (const row of rows) {
     const key = `${row.date}\u001f${row.subject.asset}\u001f${row.subject.canonical}`;
     const current = selected.get(key);
-    const actorWins = current?.actor === "engine" && row.actor === "committee";
+    const actorWins = current ? selectionActorPriority(row.actor) > selectionActorPriority(current.actor) : false;
     const sameActorIsNewer = current?.actor === row.actor && row.ts > current.ts;
     if (!current || actorWins || sameActorIsNewer) {
       selected.set(key, row);
@@ -395,7 +398,7 @@ export async function readLedgerSelections(options: {
   const rows = await prisma.judgmentLedger.findMany({
     where: {
       kind: "selection",
-      actor: { in: ["engine", "committee"] },
+      actor: { in: ["engine", "committee", "backfill"] },
       ...(options.date
         ? { date: options.date }
         : options.beforeDate || options.fromDate

--- a/apps/web/lib/ledger-backfill.ts
+++ b/apps/web/lib/ledger-backfill.ts
@@ -1,0 +1,72 @@
+import { inferStandardSignalTypes, SIGNAL_TAXONOMY_VERSION } from "@fomo/core";
+import { assetForStock, ledgerKey, type LedgerAppendInput } from "./judgment-ledger";
+
+export interface LegacyDaily30Pick {
+  canonical?: string;
+  headline?: string;
+  price?: number;
+  symbol?: string;
+  naverCode?: string;
+  market?: string;
+  country?: string;
+}
+
+export interface LegacyDaily30Snapshot {
+  date?: string;
+  picks?: LegacyDaily30Pick[];
+}
+
+export interface LegacyDaily30SnapshotRow {
+  id: string;
+  row: LegacyDaily30Snapshot;
+  updatedAt: Date;
+}
+
+/**
+ * Project only fields that were actually persisted in the legacy snapshot. Signal taxonomy is
+ * a deterministic classification of its stored headline, not a reconstructed event.
+ */
+export function buildLegacyDaily30BackfillEntries(
+  snapshots: readonly LegacyDaily30SnapshotRow[]
+): LedgerAppendInput[] {
+  return snapshots.flatMap(({ id, row, updatedAt }) => {
+    const date = row.date;
+    if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return [];
+    if (!(updatedAt instanceof Date) || !Number.isFinite(updatedAt.getTime())) return [];
+    return (row.picks ?? []).flatMap((pick) => {
+      if (!pick.canonical?.trim() || typeof pick.price !== "number" || !Number.isFinite(pick.price) || pick.price <= 0) return [];
+      const canonical = pick.canonical.trim();
+      const asset = assetForStock({
+        ...(pick.country ? { country: pick.country } : {}),
+        ...(pick.market ? { market: pick.market } : {}),
+      });
+      const signalTypes = inferStandardSignalTypes({
+        ...(pick.headline ? { headline: pick.headline } : {}),
+      });
+      return [{
+        date,
+        ts: updatedAt,
+        subject: {
+          asset,
+          canonical,
+          ...(pick.symbol || pick.naverCode ? { symbol: pick.symbol ?? pick.naverCode } : {}),
+        },
+        kind: "selection" as const,
+        payload: {
+          ...(pick.headline ? { headline: pick.headline } : {}),
+          ...(pick.market ? { market: pick.market } : {}),
+          ...(pick.country ? { country: pick.country } : {}),
+          ...(pick.naverCode ? { naverCode: pick.naverCode } : {}),
+          taxonomyVersion: SIGNAL_TAXONOMY_VERSION,
+          signalTypes,
+          migratedFrom: "daily30-picks",
+          sourceSnapshotId: id,
+          sourceSnapshotUpdatedAt: updatedAt.toISOString(),
+        },
+        priceAt: pick.price,
+        actor: "backfill" as const,
+        idempotencyKey: ledgerKey("legacy-daily30-backfill", id, asset, canonical),
+      }];
+    });
+  });
+}

--- a/apps/web/lib/ledger-track-record.ts
+++ b/apps/web/lib/ledger-track-record.ts
@@ -160,7 +160,7 @@ export async function materializeLedgerOutcomes(today = kstDate(), maxOutcomes =
       kind: "outcome" as const,
       payload: payload as unknown as Record<string, unknown>,
       priceAt,
-      actor: "engine" as const,
+      actor: selection.actor === "backfill" ? "backfill" as const : "engine" as const,
       idempotencyKey: ledgerKey("outcome", selection.id, windowDays),
     }];
   });
@@ -209,7 +209,7 @@ function signalMetrics(outcomes: readonly OutcomePayload[]): Record<SignalTypeCo
 
 export async function readTrackRecord(): Promise<TrackRecordResponse> {
   const rows = await prisma.judgmentLedger.findMany({
-    where: { kind: "outcome", actor: "engine" },
+    where: { kind: "outcome", actor: { in: ["engine", "backfill"] } },
     select: { payload: true },
     orderBy: { ts: "asc" },
   });

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ledger:migrate": "tsx scripts/migrate-judgment-ledger.ts",
     "ledger:outcomes": "tsx scripts/materialize-ledger-outcomes.ts",
     "ledger:verify": "tsx scripts/verify-judgment-ledger-append-only.ts",
+    "ledger:verify-backfill": "tsx scripts/verify-ledger-backfill.ts",
     "quality-slo:materialize": "tsx scripts/materialize-quality-slo.ts",
     "quality-slo:verify": "tsx scripts/verify-quality-ledger-append-only.ts",
     "prisma:generate": "prisma generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -853,7 +853,7 @@ model JudgmentLedger {
   kind           String // signal | verdict | score | selection | user_action | outcome
   payload        Json
   priceAt        Decimal  @db.Decimal(30, 10)
-  actor          String // engine | committee | user:session:* | user:uid:*
+  actor          String // engine | committee | backfill | user:session:* | user:uid:*
   idempotencyKey String
 
   @@id([id, date])

--- a/prisma/sql/2026-07-20_judgment_ledger.sql
+++ b/prisma/sql/2026-07-20_judgment_ledger.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS "JudgmentLedger" (
     "kind" IN ('signal', 'verdict', 'score', 'selection', 'user_action', 'outcome')
   ),
   CONSTRAINT "JudgmentLedger_actor_valid" CHECK (
-    "actor" IN ('engine', 'committee') OR "actor" LIKE 'user:%'
+    "actor" IN ('engine', 'committee', 'backfill') OR "actor" LIKE 'user:%'
   )
 ) PARTITION BY RANGE ("date");
 
@@ -57,6 +57,13 @@ CREATE INDEX IF NOT EXISTS "JudgmentLedger_canonical_date_idx"
 CREATE INDEX IF NOT EXISTS "JudgmentLedger_actor_date_idx"
   ON "JudgmentLedger" ("actor", "date");
 
+-- Existing production ledgers predate the transparent backfill actor. Reapply the parent
+-- constraint idempotently before the one-off historical import.
+ALTER TABLE "JudgmentLedger" DROP CONSTRAINT IF EXISTS "JudgmentLedger_actor_valid";
+ALTER TABLE "JudgmentLedger" ADD CONSTRAINT "JudgmentLedger_actor_valid" CHECK (
+  "actor" IN ('engine', 'committee', 'backfill') OR "actor" LIKE 'user:%'
+);
+
 CREATE OR REPLACE FUNCTION fomo_reject_judgment_ledger_mutation()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -83,7 +90,7 @@ DROP POLICY IF EXISTS "JudgmentLedger_insert" ON "JudgmentLedger";
 CREATE POLICY "JudgmentLedger_insert" ON "JudgmentLedger"
   FOR INSERT WITH CHECK (
     "priceAt" > 0
-    AND ("actor" IN ('engine', 'committee') OR "actor" LIKE 'user:%')
+    AND ("actor" IN ('engine', 'committee', 'backfill') OR "actor" LIKE 'user:%')
   );
 
 REVOKE UPDATE, DELETE, TRUNCATE ON "JudgmentLedger" FROM PUBLIC;

--- a/scripts/materialize-ledger-outcomes.ts
+++ b/scripts/materialize-ledger-outcomes.ts
@@ -1,8 +1,23 @@
 import { materializeLedgerOutcomes } from "../apps/web/lib/ledger-track-record";
 import { prisma } from "../apps/web/lib/prisma";
 
-materializeLedgerOutcomes(undefined, 1_000)
-  .then((result) => console.log(JSON.stringify(result)))
+async function main() {
+  const runs = [];
+  for (let round = 0; round < 10; round += 1) {
+    const result = await materializeLedgerOutcomes(undefined, 1_000);
+    runs.push(result);
+    if (result.due === 0 || result.appended === 0) break;
+  }
+  console.log(JSON.stringify({
+    rounds: runs.length,
+    due: runs.reduce((sum, run) => sum + run.due, 0),
+    priced: runs.reduce((sum, run) => sum + run.priced, 0),
+    appended: runs.reduce((sum, run) => sum + run.appended, 0),
+    unpricedLastRound: runs.at(-1)?.unpriced ?? 0,
+  }));
+}
+
+main()
   .catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/scripts/migrate-judgment-ledger.ts
+++ b/scripts/migrate-judgment-ledger.ts
@@ -1,58 +1,28 @@
-import { readFeedContentByPrefix } from "../apps/web/lib/feed-content-store";
-import { appendJudgmentLedger, assetForStock, ledgerKey } from "../apps/web/lib/judgment-ledger";
+import { readFeedContentHistoryByPrefix } from "../apps/web/lib/feed-content-store";
+import { appendJudgmentLedger } from "../apps/web/lib/judgment-ledger";
+import {
+  buildLegacyDaily30BackfillEntries,
+  type LegacyDaily30Snapshot,
+} from "../apps/web/lib/ledger-backfill";
 import { prisma } from "../apps/web/lib/prisma";
 
-interface LegacyPick {
-  canonical?: string;
-  headline?: string;
-  price?: number;
-  symbol?: string;
-  naverCode?: string;
-  market?: string;
-  country?: string;
-}
-
-interface LegacySnapshot {
-  date?: string;
-  picks?: LegacyPick[];
-}
-
 async function main() {
-  const snapshots = await readFeedContentByPrefix<LegacySnapshot>("daily30-picks:", 50);
-  const entries = snapshots.flatMap(({ row }) => {
-    if (!row.date || !/^\d{4}-\d{2}-\d{2}$/.test(row.date)) return [];
-    return (row.picks ?? []).flatMap((pick) => {
-      if (!pick.canonical || typeof pick.price !== "number" || pick.price <= 0) return [];
-      const asset = assetForStock({ country: pick.country, market: pick.market });
-      return [{
-        date: row.date,
-        ts: new Date(`${row.date}T12:00:00+09:00`),
-        subject: {
-          asset,
-          canonical: pick.canonical,
-          ...(pick.symbol || pick.naverCode ? { symbol: pick.symbol ?? pick.naverCode } : {}),
-        },
-        kind: "selection" as const,
-        payload: {
-          ...(pick.headline ? { headline: pick.headline } : {}),
-          ...(pick.market ? { market: pick.market } : {}),
-          ...(pick.country ? { country: pick.country } : {}),
-          ...(pick.naverCode ? { naverCode: pick.naverCode } : {}),
-          signalTypes: [],
-          migratedFrom: "daily30-picks",
-        },
-        priceAt: pick.price,
-        actor: "engine" as const,
-        idempotencyKey: ledgerKey("legacy-daily30", row.date, asset, pick.canonical),
-      }];
-    });
-  });
+  const snapshots = await readFeedContentHistoryByPrefix<LegacyDaily30Snapshot>("daily30-picks:", 5_000);
+  const entries = buildLegacyDaily30BackfillEntries(snapshots);
   let appended = 0;
   for (let index = 0; index < entries.length; index += 500) {
     appended += await appendJudgmentLedger(entries.slice(index, index + 500));
   }
   const tasteRows = await prisma.tasteSignal.count().catch(() => 0);
-  console.log(JSON.stringify({ snapshots: snapshots.length, eligibleSelections: entries.length, appended, legacyTasteRowsWithoutPriceSkipped: tasteRows }));
+  console.log(JSON.stringify({
+    snapshots: snapshots.length,
+    eligibleSelections: entries.length,
+    appended,
+    actor: "backfill",
+    earliestSnapshotAt: snapshots[0]?.updatedAt.toISOString() ?? null,
+    latestSnapshotAt: snapshots.at(-1)?.updatedAt.toISOString() ?? null,
+    legacyTasteRowsWithoutPriceSkipped: tasteRows,
+  }));
 }
 
 main()

--- a/scripts/verify-ledger-backfill.ts
+++ b/scripts/verify-ledger-backfill.ts
@@ -1,0 +1,42 @@
+import { readTrackRecord } from "../apps/web/lib/ledger-track-record";
+import { prisma } from "../apps/web/lib/prisma";
+
+async function main() {
+  const [selectionCount, sample, trackRecord] = await Promise.all([
+    prisma.judgmentLedger.count({ where: { kind: "selection", actor: "backfill" } }),
+    prisma.judgmentLedger.findFirst({
+      where: { kind: "selection", actor: "backfill" },
+      orderBy: { ts: "asc" },
+      select: { ts: true, priceAt: true, payload: true },
+    }),
+    readTrackRecord(),
+  ]);
+  const sourceTimestamp = sample?.payload && typeof sample.payload === "object" && !Array.isArray(sample.payload)
+    ? (sample.payload as Record<string, unknown>).sourceSnapshotUpdatedAt
+    : undefined;
+  const timestampPreserved = typeof sourceTimestamp === "string" && sample?.ts.toISOString() === sourceTimestamp;
+  const maxOverallN = Math.max(...trackRecord.windows.map((window) => window.overall.n));
+  const litSignals = Object.entries(trackRecord.signalHistory30)
+    .filter(([, metric]) => metric.n >= trackRecord.signalMinimumSample && metric.winRate !== null)
+    .map(([signal]) => signal);
+  const result = {
+    selectionCount,
+    maxOverallN,
+    windows: trackRecord.windows.map((window) => ({ days: window.days, ...window.overall })),
+    litSignals,
+    timestampPreserved,
+    samplePriceAt: sample?.priceAt.toNumber() ?? null,
+  };
+  console.log(JSON.stringify(result));
+  if (selectionCount < 200) throw new Error(`backfill selections ${selectionCount}/200`);
+  if (maxOverallN < 200) throw new Error(`track record sample ${maxOverallN}/200`);
+  if (!timestampPreserved) throw new Error("backfill source timestamp was not preserved");
+  if (litSignals.length === 0) throw new Error("no M2 signal resume badge reached the minimum sample");
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- backfill all persisted daily30 snapshots with original timestamp/price and transparent `backfill` actor
- materialize fixed-window outcomes until drained and verify n>=200 plus first M2 signal badge
- expose committee stage/failure telemetry in admin and Actions
- fix confirmed Groq rate limit by smaller batches, 25s throttling, bounded 429 backoff

## Verification
- `npm run test` (134 files, 1221 tests)
- `npm run lint`
- `npm run typecheck`
- production reproduction before fix: trading stage failed on call 3 with `rate limited; retry after 20s`

## Rollout
- run Judgment Ledger Bootstrap after merge
- retain daily-30 engine-direct fallback
- Vercel backend deployment currently rate-limited by plan; production publish follows when deployment quota permits