### PR TITLE
ci: add committee recovery runner

### DIFF
--- a/.github/workflows/committee-recovery.yml
+++ b/.github/workflows/committee-recovery.yml
@@ -1,0 +1,51 @@
+name: Committee Recovery
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: expert-committee-production
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      GROQ_MODEL: llama-3.1-8b-instant
+      COMMITTEE_AI_MODEL: llama-3.1-8b-instant
+      COMMITTEE_MIN_CALL_INTERVAL_MS: "25000"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+
+      - name: Trading analyst
+        run: npx tsx scripts/run-expert-committee-stage.ts trading
+
+      - name: Financial analyst
+        run: npx tsx scripts/run-expert-committee-stage.ts financial
+
+      - name: Editor and publish
+        run: npx tsx scripts/run-expert-committee-stage.ts editor
+
+      - name: Report published run
+        if: always()
+        run: |
+          npx tsx -e '
+            import { readCommitteeRunReports, readPublishedCommitteeSnapshot } from "./apps/web/lib/expert-review-store";
+            import { prisma } from "./apps/web/lib/prisma";
+            void (async () => {
+              const [active, runs] = await Promise.all([readPublishedCommitteeSnapshot(), readCommitteeRunReports(3)]);
+              const report = { active: active?.report ?? null, latest: runs[0] ?? null };
+              console.log(JSON.stringify(report));
+              await prisma.$disconnect();
+            })();
+          '

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ledger:outcomes": "tsx scripts/materialize-ledger-outcomes.ts",
     "ledger:verify": "tsx scripts/verify-judgment-ledger-append-only.ts",
     "ledger:verify-backfill": "tsx scripts/verify-ledger-backfill.ts",
+    "committee:stage": "tsx scripts/run-expert-committee-stage.ts",
     "quality-slo:materialize": "tsx scripts/materialize-quality-slo.ts",
     "quality-slo:verify": "tsx scripts/verify-quality-ledger-append-only.ts",
     "prisma:generate": "prisma generate",

--- a/scripts/run-expert-committee-stage.ts
+++ b/scripts/run-expert-committee-stage.ts
@@ -1,0 +1,26 @@
+import {
+  runExpertReviewCommitteeStage,
+  type CommitteeStage,
+} from "../apps/web/lib/expert-review-committee";
+import { prisma } from "../apps/web/lib/prisma";
+
+const stage = process.argv[2] as CommitteeStage | undefined;
+
+async function main() {
+  if (!stage || !(["trading", "financial", "editor"] as string[]).includes(stage)) {
+    throw new Error("usage: run-expert-committee-stage.ts trading|financial|editor");
+  }
+  const result = await runExpertReviewCommitteeStage(stage);
+  console.log(JSON.stringify(result));
+  if (!result.ok) throw new Error(`${stage} failed at ${result.error ?? "unknown step"}`);
+  if (stage === "editor" && result.selectedCount < 20) {
+    throw new Error(`editor published ${result.selectedCount}/20 cards`);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Runs the three committee stages directly against the production database from a manually triggered GitHub Action. This bypasses the current Vercel deployment quota while retaining the same main code, Groq 8B model, 25s throttle, report persistence, and active snapshot publication.