### PR TITLE
fix: tolerate editor metadata omissions

### DIFF
--- a/.github/workflows/committee-recovery.yml
+++ b/.github/workflows/committee-recovery.yml
@@ -2,6 +2,15 @@ name: Committee Recovery
 
 on:
   workflow_dispatch:
+    inputs:
+      stage:
+        description: Reuse stored analyst stages and rerun only the editor when requested
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - editor
 
 permissions:
   contents: read
@@ -28,9 +37,11 @@ jobs:
       - run: npm ci
 
       - name: Trading analyst
+        if: inputs.stage == 'all'
         run: npx tsx scripts/run-expert-committee-stage.ts trading
 
       - name: Financial analyst
+        if: inputs.stage == 'all'
         run: npx tsx scripts/run-expert-committee-stage.ts financial
 
       - name: Editor and publish

--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   applyAnalystFactGate,
+  parseEditorOutput,
   runExpertReviewCommittee,
   runExpertReviewCommitteeStage,
   validateAgentNumbers,
@@ -107,6 +108,14 @@ function fakePool(count = 40): Daily30Response {
 }
 
 describe("expert committee orchestration", () => {
+  it("편집장 핵심 선정 ID가 있으면 누락된 부가 필드를 결정론 기본값으로 보완한다", () => {
+    expect(parseEditorOutput(JSON.stringify({ selected_ids: ["a", "b"] }))).toEqual({
+      selectedIds: ["a", "b"],
+      rejected: [],
+      compositionSummary: "자산군·등급·조용함을 함께 보고 중복을 줄인 구성입니다.",
+    });
+  });
+
   it("후보 40장을 두 분석가와 편집장이 검수해 승인 30장만 발행한다", async () => {
     const caller: CommitteeAgentCaller = async ({ role, input }) => {
       if (role === "editor") {

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -514,15 +514,23 @@ function enforceAnalystCopyQuality(
   }));
 }
 
-function parseEditor(text: string): EditorOutput {
-  const parsed = parseJsonObject(text) as Partial<EditorOutput>;
+export function parseEditorOutput(text: string): EditorOutput {
+  const parsed = parseJsonObject(text) as Partial<EditorOutput> & {
+    selected_ids?: unknown;
+    composition_summary?: unknown;
+  };
+  const selectedIds = Array.isArray(parsed.selectedIds) ? parsed.selectedIds : parsed.selected_ids;
+  const rejectedInput = Array.isArray(parsed.rejected) ? parsed.rejected : [];
+  const compositionSummary = typeof parsed.compositionSummary === "string"
+    ? parsed.compositionSummary
+    : typeof parsed.composition_summary === "string"
+      ? parsed.composition_summary
+      : "자산군·등급·조용함을 함께 보고 중복을 줄인 구성입니다.";
   if (
-    !Array.isArray(parsed.selectedIds) ||
-    !parsed.selectedIds.every((id) => typeof id === "string") ||
-    !Array.isArray(parsed.rejected) ||
-    typeof parsed.compositionSummary !== "string"
+    !Array.isArray(selectedIds) ||
+    !selectedIds.every((id) => typeof id === "string")
   ) throw new Error("editor output invalid");
-  const rejected = parsed.rejected.flatMap((item) => {
+  const rejected = rejectedInput.flatMap((item) => {
     if (
       !item ||
       typeof item.candidateId !== "string" ||
@@ -531,7 +539,7 @@ function parseEditor(text: string): EditorOutput {
     ) return [];
     return [{ candidateId: item.candidateId, reasons: item.reasons }];
   });
-  return { selectedIds: parsed.selectedIds, rejected, compositionSummary: parsed.compositionSummary };
+  return { selectedIds, rejected, compositionSummary };
 }
 
 async function runEditor(
@@ -575,7 +583,7 @@ async function runEditor(
     })),
   };
   const text = await callWithRetry(caller, { role: "editor", system: EDITOR_SYSTEM, input, trace: "expert-committee-editor" }, state);
-  const output = parseEditor(text);
+  const output = parseEditorOutput(text);
   const known = new Set(eligible.map((candidate) => candidate.id));
   const selected = [...new Set(output.selectedIds)];
   if (selected.length !== FINAL_TARGET || selected.some((id) => !known.has(id))) {


### PR DESCRIPTION
Keeps selected IDs strict while accepting snake_case and defaulting omitted rejected/summary metadata. Adds editor-only recovery mode so completed analyst stages are reused.