### PR TITLE
fix: complete partial editor selections

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   applyAnalystFactGate,
+  completeEditorSelectedIds,
   parseEditorOutput,
   runExpertReviewCommittee,
   runExpertReviewCommitteeStage,
@@ -114,6 +115,13 @@ describe("expert committee orchestration", () => {
       rejected: [],
       compositionSummary: "자산군·등급·조용함을 함께 보고 중복을 줄인 구성입니다.",
     });
+  });
+
+  it("편집장이 20개 이상 고른 경우에만 결정론 순위로 30개를 완성한다", () => {
+    const ranked = Array.from({ length: 35 }, (_, index) => `candidate-${index}`);
+    expect(completeEditorSelectedIds(ranked.slice(0, 28), ranked)).toEqual(ranked.slice(0, 30));
+    expect(completeEditorSelectedIds(ranked.slice(0, 19), ranked)).toHaveLength(19);
+    expect(completeEditorSelectedIds([ranked[0]!, ranked[0]!, "unknown", ...ranked.slice(1, 20)], ranked)).toHaveLength(30);
   });
 
   it("후보 40장을 두 분석가와 편집장이 검수해 승인 30장만 발행한다", async () => {

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -542,6 +542,22 @@ export function parseEditorOutput(text: string): EditorOutput {
   return { selectedIds, rejected, compositionSummary };
 }
 
+export function completeEditorSelectedIds(
+  selectedIds: readonly string[],
+  rankedEligibleIds: readonly string[],
+  targetCount = FINAL_TARGET,
+  minimumModelSelections = 20
+): string[] {
+  const eligible = new Set(rankedEligibleIds);
+  const selected = [...new Set(selectedIds)].filter((id) => eligible.has(id));
+  if (selected.length < minimumModelSelections) return selected;
+  for (const id of rankedEligibleIds) {
+    if (selected.length >= targetCount) break;
+    if (!selected.includes(id)) selected.push(id);
+  }
+  return selected.slice(0, targetCount);
+}
+
 async function runEditor(
   candidates: readonly CandidateRecord[],
   trading: Map<string, CheckedAnalystReview>,
@@ -584,9 +600,25 @@ async function runEditor(
   };
   const text = await callWithRetry(caller, { role: "editor", system: EDITOR_SYSTEM, input, trace: "expert-committee-editor" }, state);
   const output = parseEditorOutput(text);
-  const known = new Set(eligible.map((candidate) => candidate.id));
-  const selected = [...new Set(output.selectedIds)];
-  if (selected.length !== FINAL_TARGET || selected.some((id) => !known.has(id))) {
+  const gradeScore = (grade: Grade) => grade === "A" ? 3 : grade === "B" ? 2 : 1;
+  const rankedEligibleIds = [...eligible]
+    .sort((a, b) => {
+      const aTrading = trading.get(a.id)!;
+      const bTrading = trading.get(b.id)!;
+      const aFinancial = financial.get(a.id)!;
+      const bFinancial = financial.get(b.id)!;
+      const aRank = gradeScore(aTrading.grade) + gradeScore(aFinancial.grade)
+        + (aTrading.approved ? 1 : 0) + (aFinancial.approved ? 1 : 0);
+      const bRank = gradeScore(bTrading.grade) + gradeScore(bFinancial.grade)
+        + (bTrading.approved ? 1 : 0) + (bFinancial.approved ? 1 : 0);
+      return bRank - aRank
+        || (b.front.companyScore?.score ?? -1) - (a.front.companyScore?.score ?? -1)
+        || b.quietScore - a.quietScore
+        || a.id.localeCompare(b.id);
+    })
+    .map((candidate) => candidate.id);
+  const selected = completeEditorSelectedIds(output.selectedIds, rankedEligibleIds);
+  if (selected.length !== FINAL_TARGET) {
     throw new Error(`editor selection invalid: ${selected.length}/${FINAL_TARGET}`);
   }
   const summaryInvalid = validateAgentNumbers(output.compositionSummary, input);


### PR DESCRIPTION
Preserves 20+ valid editor choices and deterministically fills only omitted slots from analyst grades, approvals, company score, and quietScore. Unknown IDs are discarded; fewer than 20 valid choices still fail closed.