### PR TITLE
fix: serve committee deck atomically

### DIFF
--- a/apps/web/__tests__/lib/daily-30-fallback.test.ts
+++ b/apps/web/__tests__/lib/daily-30-fallback.test.ts
@@ -70,6 +70,19 @@ describe("daily-30 availability fallback", () => {
     expect(result.meta.stale).toBeUndefined();
   });
 
+  it("오늘 엔진 원장 투영본을 위원회 승인본으로 오인하지 않는다", async () => {
+    const engineProjection = response(24);
+    const direct = response(30);
+    const result = await resolveDaily30Response({
+      today: "2026-07-20",
+      readToday: vi.fn().mockResolvedValue(engineProjection),
+      readRecent: vi.fn().mockResolvedValue(null),
+      buildDirect: vi.fn().mockResolvedValue(direct),
+    });
+    expect(result.meta.stale).toBe("engine-direct");
+    expect(result.stocks).toHaveLength(30);
+  });
+
   it("오늘 발행 실패 시 최근 3일 승인본을 stale 표시와 함께 반환한다", async () => {
     const recent = snapshot("2026-07-19");
     const buildDirect = vi.fn();

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -26,7 +26,11 @@ import {
   readLatestSelectionSnapshotBefore,
   writeDaily30Ledger,
 } from "./judgment-ledger";
-import type { PublishedCommitteeSnapshot } from "./expert-review-store";
+import {
+  readPublishedCommitteeSnapshot,
+  readRecentPublishedCommitteeSnapshot,
+  type PublishedCommitteeSnapshot,
+} from "./expert-review-store";
 import { getCachedTrackRecord } from "./ledger-track-record";
 
 export type Daily30AssetClass = "kr-stock" | "us-stock" | "coin" | "macro";
@@ -690,6 +694,10 @@ function storedDaily30Date(value: PublishedCommitteeSnapshot | Daily30Response):
   return "report" in value ? value.report.date : value.asOf.slice(0, 10);
 }
 
+function isCommitteeApproved(value: PublishedCommitteeSnapshot | Daily30Response): boolean {
+  return "report" in value ? value.report.status === "published" : Boolean(value.meta.committee?.runId);
+}
+
 function dateMinusDays(date: string, days: number): string {
   const value = new Date(`${date}T00:00:00.000Z`);
   value.setUTCDate(value.getUTCDate() - days);
@@ -704,9 +712,18 @@ export async function resolveDaily30Response(
   dependencies: Daily30FallbackDependencies = {}
 ): Promise<Daily30Response> {
   const today = dependencies.today ?? kstDateOf();
-  const readToday = dependencies.readToday ?? (() => readDaily30ResponseFromLedger({ date: today }));
-  const readRecent = dependencies.readRecent ?? ((date, maxAgeDays) =>
-    readDaily30ResponseFromLedger({ fromDate: dateMinusDays(date, maxAgeDays) }));
+  const readToday = dependencies.readToday ?? (async () => {
+    const published = await readPublishedCommitteeSnapshot().catch(() => null);
+    if (published && storedDaily30Date(published) === today) return published;
+    const ledger = await readDaily30ResponseFromLedger({ date: today }).catch(() => null);
+    return ledger?.meta.committee ? ledger : null;
+  });
+  const readRecent = dependencies.readRecent ?? (async (date, maxAgeDays) => {
+    const published = await readRecentPublishedCommitteeSnapshot(date, maxAgeDays).catch(() => null);
+    if (published && storedDaily30Date(published) !== date) return published;
+    const ledger = await readDaily30ResponseFromLedger({ fromDate: dateMinusDays(date, maxAgeDays) }).catch(() => null);
+    return ledger?.meta.committee && storedDaily30Date(ledger) !== date ? ledger : null;
+  });
   const buildDirect =
     dependencies.buildDirect ?? (() => buildDaily30ResponseWithOptions({ targetCount: DAILY_CARD_TARGET }));
 
@@ -714,7 +731,12 @@ export async function resolveDaily30Response(
     console.warn("[daily-30] active committee snapshot unavailable", (error as Error)?.message);
     return null;
   });
-  if (active && storedDaily30Date(active) === today && daily30CardCount(storedDaily30Response(active)) >= 20) {
+  if (
+    active &&
+    isCommitteeApproved(active) &&
+    storedDaily30Date(active) === today &&
+    daily30CardCount(storedDaily30Response(active)) >= 20
+  ) {
     return storedDaily30Response(active);
   }
 
@@ -722,7 +744,12 @@ export async function resolveDaily30Response(
     console.warn("[daily-30] recent committee snapshot unavailable", (error as Error)?.message);
     return null;
   });
-  if (recent && storedDaily30Date(recent) !== today && daily30CardCount(storedDaily30Response(recent)) >= 20) {
+  if (
+    recent &&
+    isCommitteeApproved(recent) &&
+    storedDaily30Date(recent) !== today &&
+    daily30CardCount(storedDaily30Response(recent)) >= 20
+  ) {
     return withFallbackMeta(storedDaily30Response(recent), "committee-yesterday");
   }
 


### PR DESCRIPTION
## Summary
- prefer the published committee snapshot as the atomic daily deck
- accept ledger projections as approved only when committee metadata is present
- keep yesterday/direct-engine fallbacks and mark engine results stale

## Verification
- npm run test -- daily-30-fallback judgment-ledger
- npm run typecheck
- npm run lint