### PR TITLE
fix: restore minimum score axes in legacy decks

### DIFF
--- a/apps/web/__tests__/lib/daily-30-schema.test.ts
+++ b/apps/web/__tests__/lib/daily-30-schema.test.ts
@@ -3,7 +3,7 @@ import { computeCompanyScore, withCompanyQuietScore } from "@fomo/core";
 
 vi.mock("next/cache", () => ({ unstable_cache: (factory: () => unknown) => factory }));
 
-import { buildUnifiedCardSnapshot, type Daily30AssetClass } from "../../lib/daily-30";
+import { buildUnifiedCardSnapshot, normalizeDaily30Response, type Daily30AssetClass, type Daily30Response } from "../../lib/daily-30";
 import type { DiscoveryFrontSeed, DiscoveryStockPayload } from "../../lib/discovery-supply";
 
 function stock(assetClass: Daily30AssetClass): DiscoveryStockPayload {
@@ -40,5 +40,45 @@ describe("daily-30 unified card schema", () => {
       "assetClass", "canonical", "changeDir", "changeText", "country", "headline", "market", "priceText", "score", "sparkline", "tag", "verdict",
     ]);
     expect(cards.every((card) => card.score.status === "ready" && card.sparkline.length > 0)).toBe(true);
+  });
+
+  it("upgrades legacy snapshots with flow, chart, and quiet as guaranteed minimum axes", () => {
+    const legacy = {
+      asOf: "2026-07-20",
+      country: "all",
+      stocks: [stock("us-stock")],
+      cards: [],
+      fronts: {
+        "us-stock": {
+          signals: {},
+          sparkline: [100, 101],
+          companyScore: {
+            score: 70,
+            label: "legacy",
+            interpretation: "legacy",
+            axes: [
+              { key: "growth", label: "성장", score: 70, evidence: ["실적"] },
+              { key: "chart", label: "차트", score: 60, evidence: ["구간"] },
+              { key: "quiet", label: "조용함", score: 80, evidence: ["조용함"] },
+            ],
+            availableAxisCount: 3,
+            omittedAxes: ["valuation", "profitability", "flow"],
+          },
+        },
+      },
+      confidence: "M",
+      source: "legacy",
+      meta: {
+        targetCount: 1,
+        cards: [{ id: "legacy", assetClass: "us-stock", quietScore: 64, signalScore: 70, hypePenalty: 6 }],
+        assetCounts: { "kr-stock": 0, "us-stock": 1, coin: 0, macro: 0 },
+      },
+    } as unknown as Daily30Response;
+    const normalized = normalizeDaily30Response(legacy).fronts["us-stock"]!;
+    expect(normalized.score?.axisStates.filter((axis) => ["flow", "chart", "quiet"].includes(axis.key)).map((axis) => axis.status)).toEqual([
+      "available", "available", "available",
+    ]);
+    expect(normalized).not.toHaveProperty("fomo");
+    expect(normalized).not.toHaveProperty("companyScore");
   });
 });

--- a/apps/web/lib/daily-30.ts
+++ b/apps/web/lib/daily-30.ts
@@ -718,19 +718,29 @@ export function normalizeDaily30Response(response: Daily30Response): Daily30Resp
       companyScore?: NonNullable<DiscoveryFrontSeed["score"]>;
     }) | undefined;
     const meta = response.meta.cards[index];
-    const base = raw?.score ?? raw?.companyScore ?? computeCompanyScore({
+    const legacyScore = raw?.score ?? raw?.companyScore;
+    const deterministicBase = computeCompanyScore({
       signals: raw?.signals ?? {},
       ...(raw?.verdict ? { verdict: raw.verdict } : {}),
       ...(raw?.wyckoff ? { wyckoff: raw.wyckoff } : {}),
       asOf: response.asOf,
     });
+    const legacyFinancialAxes = legacyScore?.axes.filter((axis) =>
+      axis.key === "valuation" || axis.key === "growth" || axis.key === "profitability"
+    ) ?? [];
+    const base = legacyScore
+      ? { ...deterministicBase, axes: [...legacyFinancialAxes, ...deterministicBase.axes] }
+      : deterministicBase;
+    const legacyQuiet = legacyScore?.axes.find((axis) => axis.key === "quiet");
     const score = meta
       ? withCompanyQuietScore(base, {
           quietScore: meta.quietScore,
           signalScore: meta.signalScore,
           hypePenalty: meta.hypePenalty,
         }, response.asOf)
-      : base;
+      : legacyQuiet
+        ? withCompanyQuietScore(base, { quietScore: legacyQuiet.score * 0.8 }, response.asOf)
+        : deterministicBase;
     const { fomo: _legacyFomo, companyScore: _legacyScore, ...clean } = raw ?? { signals: {}, sparkline: [] };
     const assetClass = meta?.assetClass ?? (stock.market === "COIN" ? "coin" : stock.country === "US" ? "us-stock" : "kr-stock");
     normalizedFronts[stock.canonical] = {
@@ -831,7 +841,7 @@ export async function resolveDaily30Response(
 export async function getCachedDaily30Response(): Promise<Daily30Response> {
   const load = unstable_cache(
     resolveDaily30Response,
-    ["fomo-daily-30-approved", cacheVersion(), kstDateOf()],
+    ["fomo-daily-30-approved", "score-schema-v2", cacheVersion(), kstDateOf()],
     { revalidate: 60 * 5, tags: ["daily-30"] }
   );
   return load();


### PR DESCRIPTION
## Summary
- normalize legacy daily-30 committee snapshots with deterministic flow and chart axes
- preserve legacy financial axes and recompute quiet from snapshot metadata
- version the daily-30 cache key so production stops serving the old score schema
- cover legacy snapshot upgrades with a regression test

## Verification
- npm run typecheck
- npm run test -- daily-30-schema daily-30-fallback company-score judgment-ledger
- npm test (135 files, 1229 tests)