### PR TITLE
fix: keep public ledger visible for anonymous sessions

### DIFF
--- a/apps/web/__tests__/lib/judgment-ledger-read.test.ts
+++ b/apps/web/__tests__/lib/judgment-ledger-read.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/prisma", () => ({
+  prisma: {
+    judgmentLedger: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { readSubjectTimeline } from "../../lib/judgment-ledger";
+import { prisma } from "../../lib/prisma";
+
+const findMany = vi.mocked(prisma.judgmentLedger.findMany);
+
+describe("readSubjectTimeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("사용자 범위 조회가 실패해도 공개 판단 기록을 반환한다", async () => {
+    findMany
+      .mockResolvedValueOnce([{
+        id: "public-score",
+        date: "2026-07-20",
+        ts: new Date("2026-07-20T00:00:00.000Z"),
+        canonical: "클라우드플레어",
+        symbol: "NET",
+        asset: "us-stock",
+        kind: "score",
+        actor: "committee",
+        payload: { score: 59, label: "매집 추정 3주차" },
+        priceAt: { toNumber: () => 277.66 },
+      }] as never)
+      .mockRejectedValueOnce(new Error("user actor lookup failed"));
+
+    const entries = await readSubjectTimeline("클라우드플레어", 80, ["user:anonymous"]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "public-score",
+      kind: "score",
+      actor: "committee",
+      priceAt: 277.66,
+      payload: { score: 59 },
+    });
+    expect(findMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      where: { canonical: "클라우드플레어", actor: { in: ["engine", "committee", "backfill"] } },
+    }));
+    expect(findMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      where: { canonical: "클라우드플레어", actor: "user:anonymous" },
+    }));
+  });
+});

--- a/apps/web/lib/judgment-ledger.ts
+++ b/apps/web/lib/judgment-ledger.ts
@@ -702,14 +702,36 @@ export async function readSubjectTimeline(
   take = 80,
   userActors: readonly `user:${string}`[] = []
 ): Promise<LedgerTimelineEntry[]> {
-  const rows = await prisma.judgmentLedger.findMany({
+  const boundedTake = Math.max(1, Math.min(take, 200));
+  const publicRows = await prisma.judgmentLedger.findMany({
     where: {
       canonical,
-      actor: { in: ["engine", "committee", "backfill", ...userActors] },
+      actor: { in: ["engine", "committee", "backfill"] },
     },
     orderBy: { ts: "desc" },
-    take: Math.max(1, Math.min(take, 200)),
+    take: boundedTake,
   });
+  let userRows: typeof publicRows = [];
+  if (userActors.length > 0) {
+    try {
+      const batches = await Promise.all(
+        [...new Set(userActors)].map((actor) =>
+          prisma.judgmentLedger.findMany({
+            where: { canonical, actor },
+            orderBy: { ts: "desc" },
+            take: boundedTake,
+          })
+        )
+      );
+      userRows = batches.flat();
+    } catch (error) {
+      // A user-scoped lookup must never hide the immutable public timeline.
+      console.warn("[judgment-ledger] user timeline read failed", error);
+    }
+  }
+  const rows = [...publicRows, ...userRows]
+    .sort((a, b) => b.ts.getTime() - a.ts.getTime())
+    .slice(0, boundedTake);
   const selectionTypes = new Map<string, SignalTypeCode[]>();
   for (const row of rows) {
     if (row.kind !== "selection") continue;


### PR DESCRIPTION
## Summary
- split immutable public timeline reads from user-scoped actor reads
- keep public judgment history visible when an anonymous user lookup fails
- add regression coverage for the production sessionId failure

## Verification
- npm run lint
- npm run typecheck
- npm run test -- judgment-ledger-read judgment-ledger