### PR TITLE
fix: allow committee review with reserve candidate pool

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -124,7 +124,7 @@ describe("expert committee orchestration", () => {
     expect(completeEditorSelectedIds([ranked[0]!, ranked[0]!, "unknown", ...ranked.slice(1, 20)], ranked)).toHaveLength(30);
   });
 
-  it("후보 40장을 두 분석가와 편집장이 검수해 승인 30장만 발행한다", async () => {
+  it("후보 35장이면 반려 여유 5장을 두고 승인 30장을 발행한다", async () => {
     const caller: CommitteeAgentCaller = async ({ role, input }) => {
       if (role === "editor") {
         const candidates = (input as { candidates: Array<{ candidateId: string }> }).candidates;
@@ -158,7 +158,7 @@ describe("expert committee orchestration", () => {
     const publish = vi.fn(async () => {});
     const result = await runExpertReviewCommittee({
       caller,
-      buildPool: async () => fakePool(),
+      buildPool: async () => fakePool(35),
       readPrevious: async () => null,
       publish,
       writeFailure: async () => {},
@@ -166,7 +166,7 @@ describe("expert committee orchestration", () => {
       minCallIntervalMs: 0,
     });
     expect(result.ok).toBe(true);
-    expect(result.report.candidateCount).toBe(40);
+    expect(result.report.candidateCount).toBe(35);
     expect(result.report.selectedCount).toBe(30);
     expect(result.report.callCount).toBe(11);
     expect(result.response?.stocks).toHaveLength(30);

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -19,8 +19,10 @@ import { readFeedContent, writeFeedContent } from "./feed-content-store";
 
 const COMMITTEE_VERSION = "committee-v1";
 const CANDIDATE_TARGET = 50;
-const MIN_CANDIDATES = 40;
 const FINAL_TARGET = 30;
+// 최종 30장보다 5장 많은 품질 후보면 편집 검수에 충분하다. 후보 40개 하드 게이트는
+// 소스가 얇은 날 35개 실후보가 있어도 분석가 호출 전에 전일본으로 후퇴시켰다.
+const MIN_CANDIDATES = FINAL_TARGET + 5;
 // Groq free/developer 조직의 TPM을 넘지 않도록 입력을 압축하고 호출 수를 줄인다.
 // 후보 50장 기준 분석가 7콜 + 7콜, 편집장 1콜이다. 작은 배치와 25초 간격으로
 // 무료 조직 TPM을 시간축에 분산하고 각 Vercel stage는 300초 안에 끝낸다.


### PR DESCRIPTION
## Summary
- replace the 40-card hard gate with final target plus five reserve candidates
- allow a real 35-card pool to proceed to analyst and editor review
- preserve the 30-card publication floor and existing quality gates

## Production evidence
Committee recovery run 29794677682 stopped before any AI calls with `committee candidate pool 35/40`.

## Verification
- npm run typecheck
- npm run test -- expert-review-committee