### PR TITLE
fix: preserve asset floors after committee review

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyAnalystFactGate,
   completeEditorSelectedIds,
+  enforceEditorAssetFloors,
   parseEditorOutput,
   runExpertReviewCommittee,
   runExpertReviewCommitteeStage,
@@ -122,6 +123,24 @@ describe("expert committee orchestration", () => {
     expect(completeEditorSelectedIds(ranked.slice(0, 28), ranked)).toEqual(ranked.slice(0, 30));
     expect(completeEditorSelectedIds(ranked.slice(0, 19), ranked)).toHaveLength(19);
     expect(completeEditorSelectedIds([ranked[0]!, ranked[0]!, "unknown", ...ranked.slice(1, 20)], ranked)).toHaveLength(30);
+  });
+
+  it("위원회 최종 30장에 가용한 미장 8장·코인 3장 바닥을 복원한다", () => {
+    const kr = Array.from({ length: 25 }, (_, index) => `kr-${index}`);
+    const us = Array.from({ length: 10 }, (_, index) => `us-${index}`);
+    const coin = Array.from({ length: 5 }, (_, index) => `coin-${index}`);
+    const ranked = [...kr, ...us, ...coin];
+    const assets = Object.fromEntries([
+      ...kr.map((id) => [id, "kr-stock"]),
+      ...us.map((id) => [id, "us-stock"]),
+      ...coin.map((id) => [id, "coin"]),
+    ]);
+
+    const selected = enforceEditorAssetFloors([...kr, ...us.slice(0, 5)], ranked, assets);
+
+    expect(selected).toHaveLength(30);
+    expect(selected.filter((id) => assets[id] === "us-stock")).toHaveLength(8);
+    expect(selected.filter((id) => assets[id] === "coin")).toHaveLength(3);
   });
 
   it("후보 35장이면 반려 여유 5장을 두고 승인 30장을 발행한다", async () => {

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -23,6 +23,10 @@ const FINAL_TARGET = 30;
 // 최종 30장보다 5장 많은 품질 후보면 편집 검수에 충분하다. 후보 40개 하드 게이트는
 // 소스가 얇은 날 35개 실후보가 있어도 분석가 호출 전에 전일본으로 후퇴시켰다.
 const MIN_CANDIDATES = FINAL_TARGET + 5;
+const COMMITTEE_ASSET_FLOORS: Readonly<Record<string, number>> = {
+  "us-stock": 8,
+  coin: 3,
+};
 // Groq free/developer 조직의 TPM을 넘지 않도록 입력을 압축하고 호출 수를 줄인다.
 // 후보 50장 기준 분석가 7콜 + 7콜, 편집장 1콜이다. 작은 배치와 25초 간격으로
 // 무료 조직 TPM을 시간축에 분산하고 각 Vercel stage는 300초 안에 끝낸다.
@@ -560,6 +564,47 @@ export function completeEditorSelectedIds(
   return selected.slice(0, targetCount);
 }
 
+/** 편집장 선택 뒤에도 daily-30 자산 다양성 바닥을 유지한다. 가용 후보 이상은 채우지 않는다. */
+export function enforceEditorAssetFloors(
+  selectedIds: readonly string[],
+  rankedEligibleIds: readonly string[],
+  assetById: Readonly<Record<string, string>>,
+  floors: Readonly<Record<string, number>> = COMMITTEE_ASSET_FLOORS
+): string[] {
+  const selected = [...selectedIds];
+  const availableCounts = rankedEligibleIds.reduce<Record<string, number>>((counts, id) => {
+    const asset = assetById[id];
+    if (asset) counts[asset] = (counts[asset] ?? 0) + 1;
+    return counts;
+  }, {});
+  const selectedCounts = selected.reduce<Record<string, number>>((counts, id) => {
+    const asset = assetById[id];
+    if (asset) counts[asset] = (counts[asset] ?? 0) + 1;
+    return counts;
+  }, {});
+
+  for (const [asset, requestedFloor] of Object.entries(floors)) {
+    const floor = Math.min(requestedFloor, availableCounts[asset] ?? 0);
+    for (const candidateId of rankedEligibleIds) {
+      if ((selectedCounts[asset] ?? 0) >= floor) break;
+      if (assetById[candidateId] !== asset || selected.includes(candidateId)) continue;
+      const removableIndex = [...selected].reverse().findIndex((selectedId) => {
+        const selectedAsset = assetById[selectedId];
+        if (!selectedAsset) return true;
+        const selectedFloor = Math.min(floors[selectedAsset] ?? 0, availableCounts[selectedAsset] ?? 0);
+        return (selectedCounts[selectedAsset] ?? 0) > selectedFloor;
+      });
+      if (removableIndex < 0) break;
+      const index = selected.length - 1 - removableIndex;
+      const removedAsset = assetById[selected[index]!];
+      if (removedAsset) selectedCounts[removedAsset] = (selectedCounts[removedAsset] ?? 1) - 1;
+      selected[index] = candidateId;
+      selectedCounts[asset] = (selectedCounts[asset] ?? 0) + 1;
+    }
+  }
+  return selected;
+}
+
 async function runEditor(
   candidates: readonly CandidateRecord[],
   trading: Map<string, CheckedAnalystReview>,
@@ -619,7 +664,11 @@ async function runEditor(
         || a.id.localeCompare(b.id);
     })
     .map((candidate) => candidate.id);
-  const selected = completeEditorSelectedIds(output.selectedIds, rankedEligibleIds);
+  const selected = enforceEditorAssetFloors(
+    completeEditorSelectedIds(output.selectedIds, rankedEligibleIds),
+    rankedEligibleIds,
+    Object.fromEntries(eligible.map((candidate) => [candidate.id, candidate.assetClass]))
+  );
   if (selected.length !== FINAL_TARGET) {
     throw new Error(`editor selection invalid: ${selected.length}/${FINAL_TARGET}`);
   }


### PR DESCRIPTION
## Summary
- enforce the existing daily-30 US and coin diversity floors after editor selection
- replace only lower-ranked overrepresented assets with eligible reviewed candidates
- never exceed available candidates and keep the final count at 30

## Production evidence
The successful 2026-07-21 committee run published 18 KR and 12 US stock fronts but selected zero eligible coin fronts.

## Verification
- npm run typecheck
- npm run test -- expert-review-committee daily-30-schema