### PR TITLE
[Auto] #928 — cron: fallback confidence 스냅샷 저장 차단 + 파이프라인 실패로 가시화(마지막 정상 스냅샷 보존 → 카드 신뢰도 저하 방지)

### DIFF
--- a/scripts/keywords-generate.ts
+++ b/scripts/keywords-generate.ts
@@ -29,6 +29,17 @@ async function main() {
     JSON.stringify({ date, count: cards.length, confidence }, null, 2)
   );
 
+  // 정직한 숫자: confidence="fallback" = 실 키워드 0건 → mock 카드다(KEYWORD_ENGINE_SPEC §5).
+  // 이걸 오늘 스냅샷으로 저장하면 (a) 마지막 정상 스냅샷을 mock 으로 덮어써 사용자가 보는 카드 신뢰도가 떨어지고,
+  // (b) 라우트 path 1 이 이 mock 을 stale=false 로 서빙해 "오늘 신선한 데이터"로 위장된다.
+  // → 저장을 건너뛰고 비정상 종료로 가시화한다. API 는 readLatestKeywordSnapshot(path 2)로
+  //   마지막 정상 스냅샷을 stale=true 로 계속 서빙하고, 파이프라인은 빨간불 + Slack 실패 알림으로 원인(수집 저하)을 노출한다.
+  if (confidence === "fallback") {
+    throw new Error(
+      `confidence=fallback (실 키워드 0건) — 스냅샷 저장 건너뜀(마지막 정상 스냅샷 보존). 수집 소스 점검 필요.`
+    );
+  }
+
   if (!process.env.DATABASE_URL) {
     console.log("[keywords:generate] DATABASE_URL 없음 — 드라이런(저장 안 함).");
     return;


### PR DESCRIPTION
## 프로젝트 task #928 자동 구현

Closes #928

- 에이전트: Claude Code (구독 인증)
- 검증: ✅ lint/typecheck 통과(자가수정 포함).
- 작업: cron: fallback confidence 스냅샷 저장 차단 + 파이프라인 실패로 가시화(마지막 정상 스냅샷 보존 → 카드 신뢰도 저하 방지)
- 자동 구현 가드: max_turns=30, timeout=25m, changed_files=1/12, added_lines=11/900
- 허용 경로: .github,apps/web,scripts,packages/fomo-core,packages/shared


