### PR TITLE
Unify stock depth information architecture

### DIFF
--- a/apps/fomo-web/__tests__/depthLayout.test.ts
+++ b/apps/fomo-web/__tests__/depthLayout.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const component = readFileSync(new URL("../components/KeywordDepthPage.tsx", import.meta.url), "utf8");
+const section = readFileSync(new URL("../components/DepthSection.tsx", import.meta.url), "utf8");
+const sparkline = readFileSync(new URL("../components/Sparkline.tsx", import.meta.url), "utf8");
+const chartCard = readFileSync(new URL("../components/cards/ChartCardBody.tsx", import.meta.url), "utf8");
+const tokens = readFileSync(new URL("../lib/chartTokens.ts", import.meta.url), "utf8");
+
+describe("종목 뎁스 정보 구조", () => {
+  it("판단을 기본으로 열고 네 개의 sticky 탭을 고정한다", () => {
+    expect(component).toContain('useState<DepthTab>("judgment")');
+    expect(component).toContain("sticky top-0 z-30");
+    for (const label of ["판단", "차트·구간", "기업·재무", "신호 이력"]) {
+      expect(component).toContain(`label: "${label}"`);
+    }
+    expect(component).not.toContain('useState<"why" | "ta">');
+  });
+
+  it("탭별 콘텐츠를 독립 패널로만 렌더한다", () => {
+    for (const tab of ["judgment", "chart", "company", "history"]) {
+      expect(component).toContain(`depthTab === "${tab}"`);
+    }
+    expect(component).toContain('role="tabpanel"');
+    expect(component).toContain('<DepthFold title="재료·가격 반응"');
+    expect(component).toContain('<DepthFold title="추가 근거·원문"');
+  });
+
+  it("요약은 카드형, 목록은 라인형 공용 컴포넌트를 제공한다", () => {
+    expect(section).toContain('variant === "card"');
+    expect(section).toContain('variant === "list"');
+    expect(section).toContain("export function DepthLine");
+    expect(component).toContain('variant="list" title="재무 한눈에"');
+  });
+});
+
+describe("차트 색 토큰", () => {
+  it("상승·하락·MA·무효선·구간·거래량을 한 소스에 둔다", () => {
+    for (const key of ["up", "down", "ma20", "ma60", "ma120", "invalidation", "volumeUp", "volumeDown", "zone", "marker"]) {
+      expect(tokens).toMatch(new RegExp(`\\b${key}:`));
+    }
+  });
+
+  it("미니 차트와 카드 차트가 같은 토큰을 쓴다", () => {
+    expect(sparkline).toContain('from "@/lib/chartTokens"');
+    expect(chartCard).toContain('from "@/lib/chartTokens"');
+    expect(sparkline).toContain("chartTokens.up");
+    expect(sparkline).toContain("chartTokens.down");
+    expect(chartCard).toContain("chartTokens.up");
+    expect(chartCard).toContain("chartTokens.down");
+  });
+
+  it("상세 차트에 과거 로컬 색 상수가 남지 않는다", () => {
+    expect(component).not.toContain("CHART_COLOR");
+    expect(component).not.toContain('bg-[#050706]');
+  });
+});

--- a/apps/fomo-web/components/CompanyScoreRadar.tsx
+++ b/apps/fomo-web/components/CompanyScoreRadar.tsx
@@ -2,8 +2,9 @@
 
 import { useMemo, useState } from "react";
 import type { CompanyScoreAxisKey, CompanyScoreResult } from "@fomo/core";
+import { DepthSection } from "@/components/DepthSection";
+import { chartTokens } from "@/lib/chartTokens";
 
-const NEON = "#D8FF3A";
 const ORDER: CompanyScoreAxisKey[] = ["valuation", "growth", "profitability", "flow", "chart", "quiet"];
 const LABEL: Record<CompanyScoreAxisKey, string> = {
   valuation: "밸류",
@@ -43,7 +44,7 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
   if (!result) return null;
 
   return (
-    <section className="mt-5 border-y border-hairline py-5" aria-labelledby="company-score-title">
+    <DepthSection className="mt-4" ariaLabelledby="company-score-title">
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="font-pixel text-[11px] text-muted">COMPANY SCORE</p>
@@ -51,7 +52,7 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
             <span
               id="company-score-title"
               className={`font-number font-bold leading-none ${result.score == null ? "text-xl" : "text-4xl"}`}
-              style={{ color: NEON }}
+              style={{ color: chartTokens.up }}
             >
               {result.score ?? "분석 축적 중"}
             </span>
@@ -64,13 +65,13 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
       <div className="mt-4 flex justify-center">
         <svg viewBox="0 0 220 220" className="h-[250px] w-[250px] max-w-full" role="img" aria-label="종합 기업 점수 6축 레이더">
           {[25, 50, 75, 100].map((level) => (
-            <polygon key={level} points={polygon(level)} fill="none" stroke="rgba(255,255,255,0.10)" strokeWidth="1" />
+            <polygon key={level} points={polygon(level)} fill="none" stroke={chartTokens.grid} strokeWidth="1" />
           ))}
           {ORDER.map((key, index) => {
             const [x, y] = point(index, 100);
-            return <line key={key} x1="110" y1="110" x2={x} y2={y} stroke="rgba(255,255,255,0.10)" strokeWidth="1" />;
+            return <line key={key} x1="110" y1="110" x2={x} y2={y} stroke={chartTokens.grid} strokeWidth="1" />;
           })}
-          <polygon points={dataPolygon} fill="rgba(216,255,58,0.16)" stroke={NEON} strokeWidth="2" />
+          <polygon points={dataPolygon} fill={chartTokens.zone.accumulation} stroke={chartTokens.up} strokeWidth="2" />
           {ORDER.map((key, index) => {
             const axis = byKey.get(key);
             const available = axis?.status === "available" && axis.score != null;
@@ -78,11 +79,11 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
             const [labelX, labelY] = point(index, 118);
             return (
               <g key={key}>
-                {available && <circle cx={x} cy={y} r="3.5" fill={NEON} />}
-                <text x={labelX} y={labelY} textAnchor="middle" dominantBaseline="middle" fill={available ? "#FAFAFA" : "#666"} fontSize="10">
+                {available && <circle cx={x} cy={y} r="3.5" fill={chartTokens.up} />}
+                <text x={labelX} y={labelY} textAnchor="middle" dominantBaseline="middle" fill={available ? chartTokens.marker.event : chartTokens.neutral} fontSize="10">
                   {LABEL[key]}
                 </text>
-                <text x={labelX} y={labelY + 12} textAnchor="middle" dominantBaseline="middle" fill={available ? NEON : "#666"} fontSize="9">
+                <text x={labelX} y={labelY + 12} textAnchor="middle" dominantBaseline="middle" fill={available ? chartTokens.up : chartTokens.neutral} fontSize="9">
                   {axis?.score ?? "없음"}
                 </text>
               </g>
@@ -111,7 +112,7 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
               aria-expanded={isActive}
             >
               <span className="text-xs text-muted">{LABEL[key]}</span>
-              <span className="font-number text-sm font-bold" style={{ color: available ? NEON : "#666" }}>
+              <span className="font-number text-sm font-bold" style={{ color: available ? chartTokens.up : chartTokens.neutral }}>
                 {axis?.score ?? "데이터 없음"}
               </span>
             </button>
@@ -120,13 +121,13 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
       </div>
 
       {active?.status === "available" && active.score != null && (
-        <div className="mt-3 border-l-2 pl-3" style={{ borderColor: NEON }}>
+        <div className="mt-3 border-l-2 pl-3" style={{ borderColor: chartTokens.up }}>
           <p className="text-xs font-semibold text-whiteout">{active.label} {active.score}점 근거</p>
           {active.evidence.map((evidence) => (
             <p key={evidence} className="mt-1 text-xs leading-5 text-muted">{evidence}</p>
           ))}
         </div>
       )}
-    </section>
+    </DepthSection>
   );
 }

--- a/apps/fomo-web/components/DepthSection.tsx
+++ b/apps/fomo-web/components/DepthSection.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties, ReactNode } from "react";
+
+type DepthSectionVariant = "card" | "list";
+
+export function DepthSection({
+  title,
+  description,
+  aside,
+  variant = "card",
+  children,
+  className = "",
+  ariaLabelledby,
+}: {
+  title?: string;
+  description?: string;
+  aside?: ReactNode;
+  variant?: DepthSectionVariant;
+  children: ReactNode;
+  className?: string;
+  ariaLabelledby?: string;
+}) {
+  const shell = variant === "card"
+    ? "rounded-lg border border-hairline bg-surface px-4 py-4"
+    : "border-y border-hairline";
+  const header = variant === "card" ? "mb-3" : "px-0 py-3";
+
+  return (
+    <section className={`${shell} ${className}`.trim()} aria-labelledby={ariaLabelledby}>
+      {(title || description || aside) && (
+        <div className={`flex items-start justify-between gap-3 ${header}`}>
+          <div className="min-w-0">
+            {title && <h2 className="font-pixel text-sm text-whiteout">{title}</h2>}
+            {description && <p className="mt-1 text-[11px] leading-5 text-muted">{description}</p>}
+          </div>
+          {aside && <div className="shrink-0">{aside}</div>}
+        </div>
+      )}
+      <div className={variant === "list" ? "divide-y divide-hairline" : ""}>{children}</div>
+    </section>
+  );
+}
+
+export function DepthLine({
+  children,
+  className = "",
+  style,
+}: {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return <div className={`py-3 ${className}`.trim()} style={style}>{children}</div>;
+}
+
+export function DepthFold({
+  title,
+  summary,
+  children,
+}: {
+  title: string;
+  summary?: string;
+  children: ReactNode;
+}) {
+  return (
+    <details className="group border-y border-hairline">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 py-3 text-sm font-semibold text-whiteout">
+        <span>
+          {title}
+          {summary && <span className="ml-2 text-[11px] font-normal text-muted">{summary}</span>}
+        </span>
+        <span aria-hidden className="text-muted transition-transform group-open:rotate-180">⌄</span>
+      </summary>
+      <div className="pb-4">{children}</div>
+    </details>
+  );
+}

--- a/apps/fomo-web/components/FeedDepthPage.tsx
+++ b/apps/fomo-web/components/FeedDepthPage.tsx
@@ -5,6 +5,7 @@ import { CalendarCard } from "@/components/CalendarCard";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import type { FeedHubItem, FeedHubSectorStockRef } from "@/lib/fomoApi";
 import { sparklinePath } from "@fomo/core";
+import { chartTokens } from "@/lib/chartTokens";
 
 /**
  * 피드 범용 뎁스 (WO 피드 통합 §3 — "탭했는데 안 가는 항목 0").
@@ -13,14 +14,12 @@ import { sparklinePath } from "@fomo/core";
  * 내러티브는 기존 NarrativeDepthPage 소관.
  */
 
-const NEON = "#D8FF3A";
-
 function valueTone(value: string): string {
   const number = Number.parseFloat(value.replace(/,/g, ""));
-  if (!Number.isFinite(number)) return "rgba(250,250,250,0.78)";
-  if (number > 0) return "#FF4D4D";
-  if (number < 0) return "#3B82F6";
-  return "#8A8A86";
+  if (!Number.isFinite(number)) return chartTokens.axis;
+  if (number > 0) return chartTokens.up;
+  if (number < 0) return chartTokens.down;
+  return chartTokens.neutral;
 }
 
 function TrendChart({ series }: { series: number[] }) {
@@ -34,7 +33,7 @@ function TrendChart({ series }: { series: number[] }) {
     <div className="mt-4 rounded-xl border border-hairline bg-white/[0.03] p-3">
       <p className="font-pixel text-[10px] uppercase tracking-wide text-muted">추이 (최근 구간)</p>
       <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="mt-2 h-16 w-full" aria-hidden>
-        <path d={paths.line} fill="none" stroke={NEON} strokeWidth={1.8} strokeLinejoin="round" strokeLinecap="round" />
+        <path d={paths.line} fill="none" stroke={chartTokens.up} strokeWidth={1.8} strokeLinejoin="round" strokeLinecap="round" />
       </svg>
     </div>
   );
@@ -155,7 +154,7 @@ export function FeedDepthPage({ item, onClose, inline = false }: { item: FeedHub
             {issue.source} · {issue.asOf}
           </p>
           {issue.url && (
-            <a href={issue.url} target="_blank" rel="noreferrer" className="mt-2 inline-block text-xs underline" style={{ color: NEON }}>
+            <a href={issue.url} target="_blank" rel="noreferrer" className="mt-2 inline-block text-xs underline" style={{ color: chartTokens.up }}>
               공시 원문 보기
             </a>
           )}
@@ -206,8 +205,8 @@ export function FeedDepthPage({ item, onClose, inline = false }: { item: FeedHub
         </div>
         {card.series && card.series.length >= 2 && <TrendChart series={card.series} />}
         {card.note && (
-          <div className="mt-4 rounded-xl px-4 py-3" style={{ backgroundColor: "rgba(216,255,58,0.12)" }}>
-            <p className="font-pixel text-[10px] uppercase tracking-wide" style={{ color: NEON }}>
+          <div className="mt-4 rounded-xl px-4 py-3" style={{ backgroundColor: chartTokens.zone.accumulation }}>
+            <p className="font-pixel text-[10px] uppercase tracking-wide" style={{ color: chartTokens.up }}>
               Editor&apos;s Note
             </p>
             <p className="mt-1 text-sm leading-6 text-whiteout">{card.note}</p>
@@ -217,7 +216,7 @@ export function FeedDepthPage({ item, onClose, inline = false }: { item: FeedHub
           {card.source} · {card.asOf}
         </p>
         {card.sourceUrl && (
-          <a href={card.sourceUrl} target="_blank" rel="noreferrer" className="mt-2 inline-block text-xs underline" style={{ color: NEON }}>
+          <a href={card.sourceUrl} target="_blank" rel="noreferrer" className="mt-2 inline-block text-xs underline" style={{ color: chartTokens.up }}>
             원문 보기
           </a>
         )}

--- a/apps/fomo-web/components/JudgmentTimeline.tsx
+++ b/apps/fomo-web/components/JudgmentTimeline.tsx
@@ -8,6 +8,8 @@ import {
   type SignalTypeCode,
 } from "@fomo/core";
 import { fetchLedgerTimeline, type LedgerTimelineEntry, type TrackMetric } from "@/lib/fomoApi";
+import { DepthLine, DepthSection } from "@/components/DepthSection";
+import { chartTokens } from "@/lib/chartTokens";
 
 const KIND_LABEL: Record<LedgerTimelineEntry["kind"], string> = {
   signal: "신호",
@@ -19,11 +21,11 @@ const KIND_LABEL: Record<LedgerTimelineEntry["kind"], string> = {
 };
 
 const KIND_STYLE: Record<LedgerTimelineEntry["kind"], { icon: string; color: string }> = {
-  signal: { icon: "●", color: "#D8FF3A" },
-  verdict: { icon: "V", color: "#60A5FA" },
-  score: { icon: "#", color: "#D8FF3A" },
-  selection: { icon: "✓", color: "#FAFAFA" },
-  user_action: { icon: "★", color: "#A78BFA" },
+  signal: { icon: "●", color: chartTokens.up },
+  verdict: { icon: "V", color: chartTokens.ma60 },
+  score: { icon: "#", color: chartTokens.up },
+  selection: { icon: "✓", color: chartTokens.marker.event },
+  user_action: { icon: "★", color: chartTokens.ma120 },
   outcome: { icon: "↗", color: "#C9C9C4" },
 };
 
@@ -82,17 +84,13 @@ export function JudgmentTimeline({ canonical }: { canonical: string }) {
   const visible = useMemo(() => entries.slice(0, 8), [entries]);
   if (visible.length === 0) return null;
   return (
-    <section className="mt-4 border-y border-hairline py-4">
-      <div>
-        <div className="flex items-center justify-between">
-          <p className="font-pixel text-sm text-whiteout">이 종목 판단 기록</p>
-          <span className="text-[10px] text-muted">지워지지 않는 시점 기록</span>
-        </div>
-        <p className="mt-2 text-[11px] leading-5 text-muted">
-          포모클럽이 이 종목을 언제 뭐라 봤는지, 그때 가격과 함께 지워지지 않게 남긴 기록이에요.
-        </p>
-      </div>
-      <div className="mt-3 divide-y divide-hairline">
+    <DepthSection
+      className="mt-4"
+      variant="list"
+      title="이 종목 판단 기록"
+      description="포모클럽이 이 종목을 언제 뭐라 봤는지, 그때 가격과 함께 지워지지 않게 남긴 기록이에요."
+      aside={<span className="text-[10px] text-muted">지워지지 않는 시점 기록</span>}
+    >
         {visible.map((entry) => {
           const style = KIND_STYLE[entry.kind];
           const resumes = signalTypes(entry).flatMap((code) => {
@@ -100,7 +98,7 @@ export function JudgmentTimeline({ canonical }: { canonical: string }) {
             return metric ? [{ code, metric }] : [];
           });
           return (
-            <div key={`${entry.id}-${entry.date}`} className="grid grid-cols-[70px_1fr] gap-3 py-2.5">
+            <DepthLine key={`${entry.id}-${entry.date}`} className="grid grid-cols-[70px_1fr] gap-3">
               <div>
                 <p className="flex items-center gap-1.5 text-[10px] font-semibold" style={{ color: style.color }}>
                   <span aria-hidden className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[9px]" style={{ borderColor: style.color }}>
@@ -119,10 +117,9 @@ export function JudgmentTimeline({ canonical }: { canonical: string }) {
                 ))}
                 <p className="mt-0.5 text-[10px] text-muted">당시 가격 {price(entry.priceAt)}</p>
               </div>
-            </div>
+            </DepthLine>
           );
         })}
-      </div>
-    </section>
+    </DepthSection>
   );
 }

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -32,6 +32,8 @@ import { verdictBalance } from "@/lib/discoveryPresentation";
 import { FlickerSpinner } from "@/components/FlickerSpinner";
 import { CompanyScoreRadar } from "@/components/CompanyScoreRadar";
 import { JudgmentTimeline } from "@/components/JudgmentTimeline";
+import { DepthFold, DepthLine, DepthSection } from "@/components/DepthSection";
+import { chartTokens } from "@/lib/chartTokens";
 import { markDiscoverySeenAction, recordDiscoveryDepth, recordDiscoverySeen } from "@/lib/discoveryPerformance";
 
 /**
@@ -435,7 +437,7 @@ function StockPriceHeader({ basics, front }: { basics: StockBasics | null; front
         <div className="mt-2">
           <span className="text-[32px] font-bold leading-none text-whiteout">{priceText}</span>
           {changeText && (
-            <span className="ml-2 align-baseline text-sm font-medium tabular-nums" style={up || down ? { color: up ? "#ff5a5f" : "#4f8cff" } : undefined}>
+            <span className="ml-2 align-baseline text-sm font-medium tabular-nums" style={up || down ? { color: up ? chartTokens.up : chartTokens.down } : undefined}>
               {up ? "▲" : down ? "▼" : ""} {changeText}
             </span>
           )}
@@ -627,22 +629,12 @@ function stockWatchPoint(front: StockFrontResponse | null): string {
 type MovementRange = "1m" | "3m";
 type ChartTooltip = { title: string; body: string };
 
-const DETAIL_CHART = {
+const DETAIL_CHART_LAYOUT = {
   W: 320,
   PRICE_H: 170,
   VOL_TOP: 180,
   VOL_H: 42,
   H: 228,
-  up: "#22C55E",
-  down: "#EF4444",
-  wick: "rgba(250,250,250,0.54)",
-  grid: "rgba(255,255,255,0.08)",
-  muted: "rgba(255,255,255,0.40)",
-  ma20: "#F59E0B",
-  ma60: "#60A5FA",
-  ma120: "#A78BFA",
-  invalidation: "#F59E0B",
-  flow: "#60A5FA",
 } as const;
 
 function finiteNumber(value: number | undefined): value is number {
@@ -800,12 +792,12 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
   const candles = useMemo(() => sourceCandles.slice(-(range === "1m" ? 22 : 66)), [sourceCandles, range]);
   if (candles.length < 2) return null;
 
-  const W = DETAIL_CHART.W;
+  const W = DETAIL_CHART_LAYOUT.W;
   const PLOT_W = 278;
-  const PRICE_H = DETAIL_CHART.PRICE_H;
-  const VOL_TOP = DETAIL_CHART.VOL_TOP;
-  const VOL_H = DETAIL_CHART.VOL_H;
-  const H = DETAIL_CHART.H;
+  const PRICE_H = DETAIL_CHART_LAYOUT.PRICE_H;
+  const VOL_TOP = DETAIL_CHART_LAYOUT.VOL_TOP;
+  const VOL_H = DETAIL_CHART_LAYOUT.VOL_H;
+  const H = DETAIL_CHART_LAYOUT.H;
   const priceValues = candles.flatMap((c) => [c.high, c.low]);
   const minRaw = Math.min(...priceValues);
   const maxRaw = Math.max(...priceValues);
@@ -821,7 +813,7 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
   const latest = candles[candles.length - 1];
   const rangeBase = candles[0]!.open;
   const rangePct = rangeBase > 0 ? ((latest!.close / rangeBase) - 1) * 100 : 0;
-  const rangeColor = rangePct >= 0 ? DETAIL_CHART.up : DETAIL_CHART.down;
+  const rangeColor = rangePct >= 0 ? chartTokens.up : chartTokens.down;
   const rangeLabel = range === "1m" ? "1개월" : "3개월";
   const priceTicks = [maxRaw, (maxRaw + minRaw) / 2, minRaw];
 
@@ -842,14 +834,14 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
                 setTooltip(null);
               }}
               className="rounded-full px-2.5 py-1 font-pixel text-[10px]"
-              style={{ backgroundColor: range === key ? "#D8FF3A" : "transparent", color: range === key ? "#0A0A0A" : "#9A9A96" }}
+              style={{ backgroundColor: range === key ? chartTokens.up : "transparent", color: range === key ? chartTokens.textOnAccent : chartTokens.neutral }}
             >
               {key === "1m" ? "1개월" : "3개월"}
             </button>
           ))}
         </div>
       </div>
-      <div className="relative mt-3 rounded-lg border border-white/15 bg-[#050706] px-3 py-3 shadow-inner">
+      <div className="relative mt-3 rounded-lg border border-white/15 px-3 py-3 shadow-inner" style={{ backgroundColor: chartTokens.surface }}>
         <div className="mb-2 flex items-center justify-between gap-3 border-b border-white/10 pb-2">
           <span className="font-pixel text-[10px] text-muted">{rangeLabel} · {markerDateLabel(latest)}</span>
           <span className="font-number text-xs font-bold" style={{ color: rangeColor }}>
@@ -860,13 +852,13 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
           <span>O <b className="text-whiteout">{formatAxisPrice(latest!.open)}</b></span>
           <span>H <b className="text-whiteout">{formatAxisPrice(latest!.high)}</b></span>
           <span>L <b className="text-whiteout">{formatAxisPrice(latest!.low)}</b></span>
-          <span>C <b style={{ color: latest!.close >= latest!.open ? DETAIL_CHART.up : DETAIL_CHART.down }}>{formatAxisPrice(latest!.close)}</b></span>
+          <span>C <b style={{ color: latest!.close >= latest!.open ? chartTokens.up : chartTokens.down }}>{formatAxisPrice(latest!.close)}</b></span>
         </div>
         <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label="최근 가격·거래량 반응 차트">
           {[0.25, 0.5, 0.75].map((ratio) => (
-            <line key={ratio} x1="0" x2={PLOT_W} y1={PRICE_H * ratio} y2={PRICE_H * ratio} stroke={DETAIL_CHART.grid} />
+            <line key={ratio} x1="0" x2={PLOT_W} y1={PRICE_H * ratio} y2={PRICE_H * ratio} stroke={chartTokens.grid} />
           ))}
-          <line x1="0" x2={PLOT_W} y1={PRICE_H} y2={PRICE_H} stroke="rgba(255,255,255,0.16)" />
+          <line x1="0" x2={PLOT_W} y1={PRICE_H} y2={PRICE_H} stroke={chartTokens.border} />
           <line
             x1="0"
             x2={PLOT_W}
@@ -877,7 +869,7 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
             strokeDasharray="2 3"
           />
           {priceTicks.map((price) => (
-            <text key={price} x={PLOT_W + 6} y={Math.max(8, Math.min(PRICE_H - 2, y(price) + 3))} fontSize="7.5" fill={DETAIL_CHART.muted}>
+            <text key={price} x={PLOT_W + 6} y={Math.max(8, Math.min(PRICE_H - 2, y(price) + 3))} fontSize="7.5" fill={chartTokens.axis}>
               {formatAxisPrice(price)}
             </text>
           ))}
@@ -885,7 +877,7 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
             const cx = x(i);
             const h = maxVol > 0 ? (c.volume / maxVol) * VOL_H : 0;
             const isUp = c.close >= c.open;
-            const fill = isUp ? "rgba(34,197,94,0.34)" : "rgba(239,68,68,0.28)";
+            const fill = isUp ? chartTokens.volumeUp : chartTokens.volumeDown;
             return (
               <rect
                 key={`vol-${i}`}
@@ -900,7 +892,7 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
           {candles.map((c, i) => {
             const cx = x(i);
             const isUp = c.close >= c.open;
-            const color = isUp ? DETAIL_CHART.up : DETAIL_CHART.down;
+            const color = isUp ? chartTokens.up : chartTokens.down;
             const top = y(Math.max(c.open, c.close));
             const bottom = y(Math.min(c.open, c.close));
             return (
@@ -912,7 +904,7 @@ function MovementResponseChart({ front }: { front: StockFrontResponse | null }) 
             );
           })}
           <rect x={PLOT_W + 1} y={Math.max(1, Math.min(PRICE_H - 16, y(latest!.close) - 8))} width="40" height="16" rx="2" fill={rangeColor} />
-          <text x={PLOT_W + 38} y={Math.max(12, Math.min(PRICE_H - 5, y(latest!.close) + 3))} textAnchor="end" fontSize="7.5" fontWeight="700" fill="#050706">
+          <text x={PLOT_W + 38} y={Math.max(12, Math.min(PRICE_H - 5, y(latest!.close) + 3))} textAnchor="end" fontSize="7.5" fontWeight="700" fill={chartTokens.textOnAccent}>
             {formatAxisPrice(latest!.close)}
           </text>
         </svg>
@@ -1366,62 +1358,82 @@ function CommunityWordingBlock({ insight }: { insight: CondensedInsight | null }
   );
 }
 
-/** 뎁스 2탭 바 — 발견 이유(재료·수급) / 차트 보기(TA). 기본은 발견 이유. */
-function DepthTabBar({ tab, onChange }: { tab: "why" | "ta"; onChange: (t: "why" | "ta") => void }) {
-  const tabs: Array<{ key: "why" | "ta"; label: string }> = [
-    { key: "why", label: "발견 이유" },
-    { key: "ta", label: "차트 보기" },
+type DepthTab = "judgment" | "chart" | "company" | "history";
+
+/** 상세 정보 위계를 고정하는 4축 탭. 스크롤 컨테이너 상단에 계속 남는다. */
+function DepthTabBar({ tab, onChange }: { tab: DepthTab; onChange: (tab: DepthTab) => void }) {
+  const tabs: Array<{ key: DepthTab; label: string }> = [
+    { key: "judgment", label: "판단" },
+    { key: "chart", label: "차트·구간" },
+    { key: "company", label: "기업·재무" },
+    { key: "history", label: "신호 이력" },
   ];
   return (
-    <div className="mt-6 mb-5 flex gap-1 rounded-full border border-hairline bg-surface p-1" role="tablist">
-      {tabs.map((t) => {
-        const active = tab === t.key;
-        return (
-          <button
-            key={t.key}
-            role="tab"
-            aria-selected={active}
-            onClick={() => onChange(t.key)}
-            className="flex-1 rounded-full px-3 py-1.5 text-sm font-medium transition-colors"
-            style={{
-              backgroundColor: active ? "#D8FF3A" : "transparent",
-              color: active ? "#0a0a0a" : "#94a3b8",
-            }}
-          >
-            {t.label}
-          </button>
-        );
-      })}
+    <div className="sticky top-0 z-30 -mx-6 mt-4 border-y border-hairline bg-black/95 px-6 py-2 backdrop-blur" role="tablist" aria-label="종목 상세">
+      <div className="grid h-10 grid-cols-4 gap-1 rounded-md bg-surface p-1">
+        {tabs.map((item) => {
+          const active = tab === item.key;
+          return (
+            <button
+              key={item.key}
+              role="tab"
+              aria-selected={active}
+              aria-controls={`depth-panel-${item.key}`}
+              onClick={() => onChange(item.key)}
+              className="min-w-0 rounded px-1 text-[11px] font-semibold transition-colors"
+              style={{
+                backgroundColor: active ? chartTokens.up : "transparent",
+                color: active ? chartTokens.textOnAccent : chartTokens.neutral,
+              }}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }
 
-function ExpertCommitteeReview({ review }: { review: StockFrontResponse["committeeReview"] | undefined }) {
+function ExpertCommitteeReview({
+  review,
+  view,
+}: {
+  review: StockFrontResponse["committeeReview"] | undefined;
+  view: "trading" | "financial";
+}) {
   if (!review) return null;
-  const gradeTone = (grade: "A" | "B" | "C") => grade === "A" ? "#D8FF3A" : grade === "B" ? "#f4f5f7" : "#8a8f98";
+  const gradeTone = (grade: "A" | "B" | "C") => grade === "A" ? chartTokens.up : grade === "B" ? chartTokens.marker.event : chartTokens.neutral;
+  const trading = view === "trading";
+  const grade = trading ? review.timingGrade : review.valuationGrade;
   return (
-    <section className="mt-4 border-y border-hairline bg-surface/70 px-4 py-4">
-      <div className="flex items-center justify-between gap-3">
-        <p className="font-pixel text-sm text-whiteout">전문 분석</p>
-        <span className="text-[10px] text-muted">사실 대조 완료 · {review.reviewedAt.slice(0, 10)}</span>
+    <DepthSection
+      className="mt-4"
+      title={trading ? "트레이딩 전문 분석" : "기업·재무 전문 분석"}
+      description={`사실 대조 완료 · ${review.reviewedAt.slice(0, 10)}`}
+      aside={<span className="font-pixel text-xs" style={{ color: gradeTone(grade) }}>{grade}</span>}
+    >
+      <p className="text-sm leading-6 text-whiteout">
+        {cleanText(trading ? review.tradingView : review.fundamentalView)}
+      </p>
+    </DepthSection>
+  );
+}
+
+function JudgmentDecision({ front }: { front: StockFrontResponse | null }) {
+  const verdict = front?.verdict;
+  return (
+    <DepthSection className="mt-4" title="현재 판단">
+      <p className="text-sm font-medium leading-6 text-whiteout">
+        {verdict?.stanceText ?? "판단에 필요한 차트·수급 근거를 축적하고 있어요."}
+      </p>
+      <div className="mt-4 border-t border-hairline pt-3">
+        <p className="text-[11px] font-semibold text-muted">무효선·다음 확인</p>
+        <p className="mt-1 text-sm leading-6 text-whiteout">
+          {verdict?.invalidation ?? "검증 가능한 무효화 가격은 아직 계산 중이에요."}
+        </p>
       </div>
-      <div className="mt-4 grid gap-4">
-        <div>
-          <div className="flex items-center gap-2">
-            <p className="text-xs font-bold text-muted">차트·타이밍</p>
-            <span className="font-pixel text-xs" style={{ color: gradeTone(review.timingGrade) }}>{review.timingGrade}</span>
-          </div>
-          <p className="mt-2 text-sm leading-6 text-whiteout">{cleanText(review.tradingView)}</p>
-        </div>
-        <div className="border-t border-hairline pt-4">
-          <div className="flex items-center gap-2">
-            <p className="text-xs font-bold text-muted">기업·재무</p>
-            <span className="font-pixel text-xs" style={{ color: gradeTone(review.valuationGrade) }}>{review.valuationGrade}</span>
-          </div>
-          <p className="mt-2 text-sm leading-6 text-whiteout">{cleanText(review.fundamentalView)}</p>
-        </div>
-      </div>
-    </section>
+    </DepthSection>
   );
 }
 
@@ -1451,25 +1463,20 @@ function quietMoneyAmount(event: NonNullable<StockFrontResponse["quietMoney"]>["
 function QuietMoneyBlock({ timeline }: { timeline: StockFrontResponse["quietMoney"] | undefined }) {
   if (!timeline?.events.length) return null;
   return (
-    <section className="mt-4 border-y border-hairline py-4">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="font-pixel text-sm text-whiteout">조용한 돈</p>
-          <p className="mt-1 text-[11px] text-muted">공시·KRX 확정치·온체인 근거를 한 시간축으로 묶었어요.</p>
-        </div>
-        {timeline.cluster && (
-          <span className="shrink-0 rounded-md border border-[#D8FF3A]/50 px-2 py-1 text-[10px] font-bold text-[#D8FF3A]">
-            강도 {timeline.cluster.strength}/5
-          </span>
-        )}
-      </div>
+    <DepthSection
+      className="mt-4"
+      variant="list"
+      title="조용한 돈"
+      description="공시·KRX 확정치·온체인 근거를 한 시간축으로 묶었어요."
+      aside={timeline.cluster ? <span className="text-[10px] font-bold" style={{ color: chartTokens.up }}>강도 {timeline.cluster.strength}/5</span> : undefined}
+    >
       {timeline.cluster && (
-        <div className="mt-3 border-l-2 border-[#D8FF3A] bg-[#D8FF3A]/[0.06] px-3 py-2.5">
+        <DepthLine className="border-l-2 px-3" style={{ borderColor: chartTokens.up }}>
           <p className="text-sm font-bold text-whiteout">{cleanText(timeline.cluster.headline)}</p>
           <p className="mt-1 text-[11px] leading-5 text-muted">{cleanText(timeline.cluster.evidence.join(" · "))}</p>
-        </div>
+        </DepthLine>
       )}
-      <ol className="mt-3 space-y-0">
+      <ol>
         {timeline.events.slice(0, 12).map((event, index) => {
           const amount = quietMoneyAmount(event);
           const content = (
@@ -1484,13 +1491,15 @@ function QuietMoneyBlock({ timeline }: { timeline: StockFrontResponse["quietMone
             </>
           );
           return (
-            <li key={`${event.date}-${event.actor}-${index}`} className="border-l border-white/15 px-3 py-2">
-              {event.sourceUrl ? <a href={event.sourceUrl} target="_blank" rel="noreferrer" className="block hover:border-[#D8FF3A]">{content}</a> : content}
+            <li key={`${event.date}-${event.actor}-${index}`} className="border-t border-hairline first:border-t-0">
+              <DepthLine className="px-0">
+                {event.sourceUrl ? <a href={event.sourceUrl} target="_blank" rel="noreferrer" className="block hover:text-whiteout">{content}</a> : content}
+              </DepthLine>
             </li>
           );
         })}
       </ol>
-    </section>
+    </DepthSection>
   );
 }
 
@@ -1522,13 +1531,13 @@ function DiscoveryOverview({
   ].filter((item): item is string => !!item);
 
   return (
-    <section className="mt-5 border-y border-hairline bg-black/20 px-4 py-4">
-      <div className="flex items-center justify-between gap-3">
-        <p className="font-pixel text-xs text-muted">오늘 발견 포인트</p>
-        <span className="rounded-full border px-2.5 py-1 text-[11px] font-bold" style={{ borderColor: status.color, color: status.color }}>
+    <DepthSection
+      className="mt-4"
+      title="오늘 발견 포인트"
+      aside={<span className="rounded-full border px-2.5 py-1 text-[11px] font-bold" style={{ borderColor: status.color, color: status.color }}>
           {status.label}
-        </span>
-      </div>
+        </span>}
+    >
       <p className="mt-2 text-base font-bold leading-6 text-whiteout">
         {trigger ?? status.summary}
       </p>
@@ -1549,7 +1558,7 @@ function DiscoveryOverview({
           <p className="mt-3 text-[10px] text-muted">{[source, asOf].filter(Boolean).join(" · ")}</p>
         )
       )}
-    </section>
+    </DepthSection>
   );
 }
 
@@ -1558,22 +1567,6 @@ const TA_ROLE_GROUPS: Array<{ role: "event" | "balance" | "confirmation"; label:
   { role: "balance", label: "균형·경계" },
   { role: "confirmation", label: "보조 확인" },
 ];
-
-const CHART_COLOR = {
-  up: "#D8FF3A",
-  down: "#777873",
-  wick: "rgba(250,250,250,0.52)",
-  ma20: "#F59E0B",
-  ma60: "#60A5FA",
-  ma120: "#A78BFA",
-  invalidation: "#F59E0B",
-  volumeUp: "rgba(216,255,58,0.34)",
-  volumeDown: "rgba(119,120,115,0.28)",
-  accumulation: "rgba(216,255,58,0.10)",
-  distribution: "rgba(148,163,184,0.12)",
-  markup: "rgba(216,255,58,0.07)",
-  markdown: "rgba(119,120,115,0.10)",
-} as const;
 
 /** 캔들+MA20/60/120+거래량+무효화 레벨선(WO 1.6 D-1) — 라인차트 금지, 라이브러리 없음. */
 function AnalysisChart({
@@ -1679,7 +1672,7 @@ function AnalysisChart({
   const H = visibleQuietEvents.length > 0 ? QUIET_LANE_TOP + QUIET_LANE_GAP * 4 + 12 : VOL_TOP + VOL_H + 12;
   const zoneName = (kind: (typeof visibleZones)[number]["kind"]) =>
     kind === "accumulation" ? "매집" : kind === "distribution" ? "분산" : kind === "markup" ? "상승" : "하락";
-  const zoneColor = (kind: (typeof visibleZones)[number]["kind"]) => CHART_COLOR[kind];
+  const zoneColor = (kind: (typeof visibleZones)[number]["kind"]) => chartTokens.zone[kind];
   const markerText = (kind: WyckoffEvent["kind"]) =>
     kind === "spring" ? "S" : kind === "upthrust" ? "UT" : kind === "impulse" ? "I" : "P";
 
@@ -1689,7 +1682,7 @@ function AnalysisChart({
         <span>O <b className="text-whiteout">{formatAxisPrice(latest.open)}</b></span>
         <span>H <b className="text-whiteout">{formatAxisPrice(latest.high)}</b></span>
         <span>L <b className="text-whiteout">{formatAxisPrice(latest.low)}</b></span>
-        <span>C <b style={{ color: latest.close >= latest.open ? CHART_COLOR.up : CHART_COLOR.down }}>{formatAxisPrice(latest.close)}</b></span>
+        <span>C <b style={{ color: latest.close >= latest.open ? chartTokens.up : chartTokens.down }}>{formatAxisPrice(latest.close)}</b></span>
       </div>
       <svg viewBox={`0 0 ${W} ${H}`} className="w-full" role="img" aria-label="캔들·이동평균·거래량 차트">
         {visibleZones.map((zone) => {
@@ -1707,22 +1700,22 @@ function AnalysisChart({
                 width={Math.max(2, right - left)}
                 height={Math.max(10, bottom - top)}
                 fill={zoneColor(zone.kind)}
-                stroke={zone.kind === "accumulation" ? "rgba(216,255,58,0.38)" : "rgba(250,250,250,0.22)"}
+                stroke={zone.kind === "accumulation" ? chartTokens.zone.border : chartTokens.zone.mutedBorder}
                 strokeWidth="0.7"
                 strokeDasharray="3 3"
               />
-              <text x={left + 3} y={Math.min(PRICE_H - 4, top + 10)} fontSize="7.5" fontWeight="700" fill="rgba(250,250,250,0.72)">
+              <text x={left + 3} y={Math.min(PRICE_H - 4, top + 10)} fontSize="7.5" fontWeight="700" fill={chartTokens.zone.label}>
                 {zoneName(zone.kind)} {zone.weeks}주차
               </text>
             </g>
           );
         })}
         {[0.2, 0.4, 0.6, 0.8].map((ratio) => (
-          <line key={ratio} x1="0" x2={PLOT_W} y1={PRICE_H * ratio} y2={PRICE_H * ratio} stroke="rgba(255,255,255,0.09)" />
+          <line key={ratio} x1="0" x2={PLOT_W} y1={PRICE_H * ratio} y2={PRICE_H * ratio} stroke={chartTokens.grid} />
         ))}
-        <line x1="0" x2={PLOT_W} y1={PRICE_H} y2={PRICE_H} stroke="rgba(255,255,255,0.16)" />
+        <line x1="0" x2={PLOT_W} y1={PRICE_H} y2={PRICE_H} stroke={chartTokens.border} />
         {priceTicks.map((price) => (
-          <text key={price} x={PLOT_W + 6} y={Math.max(8, Math.min(PRICE_H - 2, y(price) + 3))} fontSize="7.5" fill="rgba(250,250,250,0.45)">
+          <text key={price} x={PLOT_W + 6} y={Math.max(8, Math.min(PRICE_H - 2, y(price) + 3))} fontSize="7.5" fill={chartTokens.axis}>
             {formatAxisPrice(price)}
           </text>
         ))}
@@ -1736,13 +1729,13 @@ function AnalysisChart({
               y={VOL_TOP + (VOL_H - h)}
               width={barW}
               height={Math.max(0.5, h)}
-              fill={isUp ? CHART_COLOR.volumeUp : CHART_COLOR.volumeDown}
+              fill={isUp ? chartTokens.volumeUp : chartTokens.volumeDown}
             />
           );
         })}
-        <path d={linePath(series.ma120)} fill="none" stroke={CHART_COLOR.ma120} strokeWidth="1.1" />
-        <path d={linePath(series.ma60)} fill="none" stroke={CHART_COLOR.ma60} strokeWidth="1.1" />
-        <path d={linePath(series.ma20)} fill="none" stroke={CHART_COLOR.ma20} strokeWidth="1.2" />
+        <path d={linePath(series.ma120)} fill="none" stroke={chartTokens.ma120} strokeWidth="1.1" />
+        <path d={linePath(series.ma60)} fill="none" stroke={chartTokens.ma60} strokeWidth="1.1" />
+        <path d={linePath(series.ma20)} fill="none" stroke={chartTokens.ma20} strokeWidth="1.2" />
         {levels.map((level, index) => (
           <g key={`${level.kind}-${index}`}>
             <line
@@ -1750,11 +1743,11 @@ function AnalysisChart({
               x2={PLOT_W}
               y1={y(level.value)}
               y2={y(level.value)}
-              stroke="rgba(250,250,250,0.28)"
+              stroke={chartTokens.level}
               strokeWidth="0.8"
               strokeDasharray="3 4"
             />
-            <text x="4" y={Math.max(9, y(level.value) - 3)} fontSize="8" fill="rgba(250,250,250,0.48)">
+            <text x="4" y={Math.max(9, y(level.value) - 3)} fontSize="8" fill={chartTokens.levelLabel}>
               {level.kind === "support" ? "지지" : "저항"} {formatChartPrice(level.value)}
             </text>
           </g>
@@ -1762,7 +1755,7 @@ function AnalysisChart({
         {renderedCandles.map((c, i) => {
           const cx = x(i);
           const isUp = c.close >= c.open;
-          const color = isUp ? CHART_COLOR.up : CHART_COLOR.down;
+          const color = isUp ? chartTokens.up : chartTokens.down;
           const top = y(Math.max(c.open, c.close));
           const bottom = y(Math.min(c.open, c.close));
           return (
@@ -1778,7 +1771,7 @@ function AnalysisChart({
           x2={PLOT_W}
           y1={y(latest.close)}
           y2={y(latest.close)}
-          stroke={latest.close >= latest.open ? CHART_COLOR.up : CHART_COLOR.down}
+          stroke={latest.close >= latest.open ? chartTokens.up : chartTokens.down}
           strokeWidth="0.8"
           strokeDasharray="2 3"
           opacity="0.72"
@@ -1789,7 +1782,7 @@ function AnalysisChart({
           width="40"
           height="16"
           rx="2"
-          fill={latest.close >= latest.open ? CHART_COLOR.up : CHART_COLOR.down}
+          fill={latest.close >= latest.open ? chartTokens.up : chartTokens.down}
         />
         <text
           x={PLOT_W + 38}
@@ -1797,7 +1790,7 @@ function AnalysisChart({
           textAnchor="end"
           fontSize="7.5"
           fontWeight="700"
-          fill="#050706"
+          fill={chartTokens.textOnAccent}
         >
           {formatAxisPrice(latest.close)}
         </text>
@@ -1808,7 +1801,7 @@ function AnalysisChart({
               x2={PLOT_W}
               y1={y(invalidationLevel!)}
               y2={y(invalidationLevel!)}
-              stroke={CHART_COLOR.invalidation}
+              stroke={chartTokens.invalidation}
               strokeWidth="1.2"
               strokeDasharray="5 4"
             />
@@ -1819,8 +1812,8 @@ function AnalysisChart({
           const cy = Math.max(10, Math.min(PRICE_H - 10, y(event.price)));
           const isBoundary = event.kind === "spring" || event.kind === "upthrust";
           const fill = event.kind === "spring" || (event.kind === "impulse" && event.direction === "up") || event.kind === "pullback"
-            ? CHART_COLOR.up
-            : "#D5D6D1";
+            ? chartTokens.up
+            : chartTokens.marker.event;
           return (
             <g
               key={`${event.kind}-${event.index}`}
@@ -1837,15 +1830,15 @@ function AnalysisChart({
                 <polygon
                   points={event.kind === "spring" ? `${cx},${cy - 7} ${cx - 5},${cy + 3} ${cx + 5},${cy + 3}` : `${cx},${cy + 7} ${cx - 5},${cy - 3} ${cx + 5},${cy - 3}`}
                   fill={fill}
-                  stroke="#050706"
+                  stroke={chartTokens.surface}
                   strokeWidth="1"
                 />
               ) : event.kind === "impulse" ? (
-                <polygon points={`${cx},${cy - 6} ${cx + 5},${cy} ${cx},${cy + 6} ${cx - 5},${cy}`} fill={fill} stroke="#050706" strokeWidth="1" />
+                <polygon points={`${cx},${cy - 6} ${cx + 5},${cy} ${cx},${cy + 6} ${cx - 5},${cy}`} fill={fill} stroke={chartTokens.surface} strokeWidth="1" />
               ) : (
-                <circle cx={cx} cy={cy} r="5" fill={fill} stroke="#050706" strokeWidth="1" />
+                <circle cx={cx} cy={cy} r="5" fill={fill} stroke={chartTokens.surface} strokeWidth="1" />
               )}
-              <text x={cx} y={cy + 2.5} textAnchor="middle" fontSize={event.kind === "upthrust" ? "4.7" : "6"} fontWeight="900" fill="#050706">
+              <text x={cx} y={cy + 2.5} textAnchor="middle" fontSize={event.kind === "upthrust" ? "4.7" : "6"} fontWeight="900" fill={chartTokens.textOnAccent}>
                 {markerText(event.kind)}
               </text>
             </g>
@@ -1857,8 +1850,8 @@ function AnalysisChart({
           const laneY = QUIET_LANE_TOP + actorIndex * QUIET_LANE_GAP;
           return (
             <g key={`quiet-lane-${actor}`}>
-              <line x1="0" x2={PLOT_W} y1={laneY} y2={laneY} stroke="rgba(255,255,255,0.10)" strokeWidth="0.6" />
-              <text x={PLOT_W + 4} y={laneY + 2.5} fontSize="6.5" fill="rgba(250,250,250,0.52)">
+              <line x1="0" x2={PLOT_W} y1={laneY} y2={laneY} stroke={chartTokens.grid} strokeWidth="0.6" />
+              <text x={PLOT_W + 4} y={laneY + 2.5} fontSize="6.5" fill={chartTokens.axis}>
                 {QUIET_MONEY_ACTOR_LABEL[actor]}
               </text>
               {laneEvents.map(({ event, index }, markerIndex) => (
@@ -1868,8 +1861,8 @@ function AnalysisChart({
                     cx={x(index)}
                     cy={laneY}
                     r="2.6"
-                    fill={event.direction === "inflow" ? CHART_COLOR.up : CHART_COLOR.down}
-                    stroke="#050706"
+                    fill={event.direction === "inflow" ? chartTokens.marker.money : chartTokens.down}
+                    stroke={chartTokens.surface}
                     strokeWidth="0.8"
                   />
                 </g>
@@ -1877,8 +1870,8 @@ function AnalysisChart({
             </g>
           );
         })}
-        <text x="0" y={H - 1} fontSize="8" fill="rgba(250,250,250,0.42)">{markerDateLabel(renderedCandles[0])}</text>
-        <text x={PLOT_W} y={H - 1} textAnchor="end" fontSize="8" fill="rgba(250,250,250,0.42)">{markerDateLabel(latest)}</text>
+        <text x="0" y={H - 1} fontSize="8" fill={chartTokens.axis}>{markerDateLabel(renderedCandles[0])}</text>
+        <text x={PLOT_W} y={H - 1} textAnchor="end" fontSize="8" fill={chartTokens.axis}>{markerDateLabel(latest)}</text>
       </svg>
       {selectedEvent && (
         <button
@@ -1891,12 +1884,12 @@ function AnalysisChart({
         </button>
       )}
       <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted">
-        <span><span style={{ color: CHART_COLOR.up }}>■</span> 상승</span>
-        <span><span style={{ color: CHART_COLOR.down }}>■</span> 하락</span>
-        <span><span style={{ color: CHART_COLOR.ma20 }}>—</span> MA20</span>
-        <span><span style={{ color: CHART_COLOR.ma60 }}>—</span> MA60</span>
-        <span><span style={{ color: CHART_COLOR.ma120 }}>—</span> MA120</span>
-        {includeLevel && <span><span style={{ color: CHART_COLOR.invalidation }}>┄</span> 관점 경계</span>}
+        <span><span style={{ color: chartTokens.up }}>■</span> 상승</span>
+        <span><span style={{ color: chartTokens.down }}>■</span> 하락</span>
+        <span><span style={{ color: chartTokens.ma20 }}>—</span> MA20</span>
+        <span><span style={{ color: chartTokens.ma60 }}>—</span> MA60</span>
+        <span><span style={{ color: chartTokens.ma120 }}>—</span> MA120</span>
+        {includeLevel && <span><span style={{ color: chartTokens.invalidation }}>┄</span> 관점 경계</span>}
         {visibleZones.length > 0 && <span>▧ 구간</span>}
         {visibleEvents.length > 0 && <span>◆ 이벤트</span>}
         {visibleQuietEvents.length > 0 && <span>● 조용한 돈</span>}
@@ -2054,8 +2047,8 @@ function ChartAnalysisTab({
       </div>
 
       {wyckoff?.summary && (
-        <div className="mb-3 border-l-2 border-[#D8FF3A] bg-[#D8FF3A]/[0.06] px-3 py-3">
-          <p className="font-pixel text-[10px] text-[#D8FF3A]">지금 구간 요약</p>
+        <div className="mb-3 border-l-2 px-3 py-3" style={{ borderColor: chartTokens.zone.border, backgroundColor: chartTokens.zone.accumulation }}>
+          <p className="font-pixel text-[10px]" style={{ color: chartTokens.up }}>지금 구간 요약</p>
           <p className="mt-1.5 text-sm font-medium leading-6 text-whiteout">{wyckoff.summary}</p>
         </div>
       )}
@@ -2089,7 +2082,7 @@ function ChartAnalysisTab({
 
       {/* 실제 차트 — 뭘 보고 판단하는지 눈에 보이게. */}
       {visibleSeries && visibleSeries.closes.length >= 2 ? (
-        <div className="rounded-lg border border-white/15 bg-[#050706] px-3 pb-3 pt-3 shadow-inner">
+        <div className="rounded-lg border border-white/15 px-3 pb-3 pt-3 shadow-inner" style={{ backgroundColor: chartTokens.surface }}>
           <div className="mb-2 flex items-center justify-between gap-3">
             <span className="font-pixel text-[10px] text-muted">일봉 · {range === "3m" ? "3개월" : "1년"}</span>
             <div className="flex rounded-md border border-white/10 p-0.5">
@@ -2099,7 +2092,7 @@ function ChartAnalysisTab({
                   type="button"
                   onClick={() => setRange(key)}
                   className="rounded px-2 py-1 text-[9px] font-bold"
-                  style={{ backgroundColor: range === key ? "#F4F4EF" : "transparent", color: range === key ? "#050706" : "#8A8A86" }}
+                  style={{ backgroundColor: range === key ? chartTokens.up : "transparent", color: range === key ? chartTokens.textOnAccent : chartTokens.neutral }}
                 >
                   {key === "3m" ? "3M" : "1Y"}
                 </button>
@@ -2122,26 +2115,27 @@ function ChartAnalysisTab({
         basisDays > 0 && <p className="mb-3 text-[11px] text-muted">최근 {basisDays}거래일 종가·거래량 기준</p>
       )}
 
+      <div className="mt-4">
+        <DepthFold
+          title="세부 이벤트·판단 근거"
+          summary={wyckoff?.events.length ? `구간 이벤트 ${wyckoff.events.length}건` : "관측 근거"}
+        >
       {wyckoff && wyckoff.events.length > 0 && (
-        <div className="mt-4 border-y border-hairline py-3">
-          <div className="flex items-center justify-between gap-3">
-            <p className="font-pixel text-sm text-whiteout">구간 이벤트</p>
-            <span className="text-[10px] text-muted">실제 캔들·거래량 조건</span>
-          </div>
+        <DepthSection variant="list" title="구간 이벤트" description="실제 캔들·거래량 조건">
           <div className="mt-2 space-y-2">
             {wyckoff.events.slice(-4).reverse().map((event) => (
               <button
                 key={`${event.kind}-${event.index}`}
                 type="button"
                 onClick={() => setStructureTooltip({ title: event.label, body: event.explanation })}
-                className="w-full border-l border-white/20 px-3 py-1.5 text-left transition-colors hover:border-[#D8FF3A]"
+                className="w-full border-l border-white/20 px-3 py-1.5 text-left transition-colors hover:border-whiteout"
               >
                 <span className="block text-xs font-bold text-whiteout">{event.label}</span>
                 <span className="mt-0.5 block text-[11px] leading-5 text-muted">{event.explanation}</span>
               </button>
             ))}
           </div>
-        </div>
+        </DepthSection>
       )}
 
       {facts.length > 0 && !hasProfessionalAnalysis && (
@@ -2200,6 +2194,8 @@ function ChartAnalysisTab({
         </div>
       )}
       <ConvictionParagraphs front={front} insight={insight} />
+        </DepthFold>
+      </div>
       <p className="mt-4 text-center text-[11px] leading-5 text-muted">차트 신호는 관측값이에요. 가격 예측은 아니에요.</p>
     </section>
   );
@@ -2287,9 +2283,9 @@ function buildVerdictSections(
 }
 
 const STANCE_BADGE: Record<string, { label: string; color: string }> = {
-  enter: { label: "강세 신호 우세", color: "#22C55E" },
+  enter: { label: "강세 신호 우세", color: chartTokens.up },
   watch: { label: "신호 혼조", color: "#C9C9C4" },
-  avoid: { label: "약세 신호 우세", color: "#EF4444" },
+  avoid: { label: "약세 신호 우세", color: chartTokens.down },
 };
 
 /**
@@ -2477,18 +2473,31 @@ function FinanceGlanceBlock({ basics }: { basics: StockBasics | null }) {
   if (lines.length === 0) return null;
   const source = fin?.note?.includes("Nasdaq") ? "Nasdaq" : "네이버 금융";
   return (
-    <section className="mt-4 rounded-2xl border border-hairline bg-surface px-4 py-4">
-      <p className="font-pixel text-sm text-whiteout">재무 한눈에</p>
-      <ul className="mt-2 space-y-1.5">
+    <DepthSection className="mt-4" variant="list" title="재무 한눈에" description={`출처: ${source}`}>
+      <ul>
         {lines.slice(0, 5).map((line, i) => (
-          <li key={`fin-${i}`} className="flex items-baseline justify-between gap-3 text-sm leading-6">
-            <span className="shrink-0 text-muted">{line.label}</span>
-            <span className="min-w-0 text-right text-whiteout">{line.value}</span>
+          <li key={`fin-${i}`}>
+            <DepthLine className="flex items-baseline justify-between gap-3 text-sm leading-6">
+              <span className="shrink-0 text-muted">{line.label}</span>
+              <span className="min-w-0 text-right text-whiteout">{line.value}</span>
+            </DepthLine>
           </li>
         ))}
       </ul>
-      <p className="mt-2 text-[10px] leading-4 text-muted">출처: {source}</p>
-    </section>
+    </DepthSection>
+  );
+}
+
+function CompanyProfileBlock({ basics }: { basics: StockBasics | null }) {
+  if (!basics?.summary) return null;
+  return (
+    <DepthSection
+      className="mt-4"
+      title="어떤 회사예요"
+      aside={basics.sector ? <span className="text-[11px] text-muted">{cleanText(basics.sector)}</span> : undefined}
+    >
+      <p className="text-sm leading-6 text-whiteout">{cleanText(basics.summary)}</p>
+    </DepthSection>
   );
 }
 
@@ -2515,14 +2524,14 @@ export function StockInsightView({
   // 카드와 동일한 백엔드 점수 스냅샷을 상세에서도 유지한다.
   const [front, setFront] = useState<StockFrontResponse | null>(context?.frontSeed ?? null);
   const [frontLoaded, setFrontLoaded] = useState(!!context?.frontSeed);
-  // 뎁스 2탭 — 기본 '왜 움직였나'. 종목 바뀌면 리셋.
-  const [depthTab, setDepthTab] = useState<"why" | "ta">("why");
+  // 상세는 판단을 첫 화면으로 열고 나머지 정보는 독립 탭에서만 렌더한다.
+  const [depthTab, setDepthTab] = useState<DepthTab>("judgment");
   // 종목 관심(C) — 명시적 취향 입력. 진입 자체도 암묵 신호(view_depth)로 적재됨.
   const [watched, setWatchedState] = useState(false);
 
   useEffect(() => {
     setWatchedState(isWatched(stock));
-    setDepthTab("why");
+    setDepthTab("judgment");
   }, [stock]);
 
   const toggleWatched = () => {
@@ -2622,8 +2631,8 @@ export function StockInsightView({
             aria-label={watched ? "관심 해제" : "관심 등록"}
             className="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors"
             style={{
-              borderColor: watched ? "#D8FF3A" : "var(--hairline, #2a2a2a)",
-              color: watched ? "#D8FF3A" : "#94a3b8",
+              borderColor: watched ? chartTokens.up : "var(--hairline, #2a2a2a)",
+              color: watched ? chartTokens.up : chartTokens.neutral,
             }}
           >
             <span aria-hidden>{watched ? "♥" : "♡"}</span>
@@ -2640,56 +2649,61 @@ export function StockInsightView({
           <>
           {/* 가격 먼저 — 일반 주식 상세 화면의 첫 독해 지점. */}
           <StockPriceHeader basics={basics} front={front} />
-          <CompanyScoreRadar result={front?.score} />
-          <ExpertCommitteeReview review={front?.committeeReview} />
-          <DiscoveryOverview front={front} insight={insight} context={context} />
-          <QuietMoneyBlock timeline={front?.quietMoney} />
-          <JudgmentTimeline canonical={stock} />
           <DepthTabBar tab={depthTab} onChange={setDepthTab} />
-          {depthTab === "ta" ? (
-            <ChartAnalysisTab front={front} basisDays={front?.sparkline?.length ?? 0} insight={insight} />
-          ) : (
-          <>
-          {/* 재료와 같은 기간의 가격·거래 반응 — 기술적 구조는 차트분석 탭으로 분리. */}
-          <WhyMovementTab front={front} insight={insight} context={context} />
+          <div
+            id={`depth-panel-${depthTab}`}
+            role="tabpanel"
+            aria-label={depthTab === "judgment" ? "판단" : depthTab === "chart" ? "차트와 구간" : depthTab === "company" ? "기업과 재무" : "신호 이력"}
+          >
+            {depthTab === "judgment" && (
+              <>
+                <CompanyScoreRadar result={front?.score} />
+                <JudgmentDecision front={front} />
+              </>
+            )}
 
-          {(context?.market === "COIN" || context?.symbol?.toUpperCase().startsWith("KRW-") === true) && (
-            <CoinIssuesBlock issues={front?.coinIssues ?? []} />
-          )}
+            {depthTab === "chart" && (
+              <>
+                <ChartAnalysisTab front={front} basisDays={front?.sparkline?.length ?? 0} insight={insight} />
+                <ExpertCommitteeReview review={front?.committeeReview} view="trading" />
+              </>
+            )}
 
-          {/* 무슨 일이 있었나(WO-22) — 원문 인사이트 전체(양면·출처·공식지표). 카드 대비 뎁스의 정보 우위. */}
-          <StockWhyHappened insight={insight} />
+            {depthTab === "company" && (
+              <>
+                <CompanyProfileBlock basics={basics} />
+                <FinanceGlanceBlock basics={basics} />
+                <ExpertCommitteeReview review={front?.committeeReview} view="financial" />
+              </>
+            )}
 
-          {/* 어떤 회사예요 — 2026-07-18 User Zero "이 회사가 뭔데 왜 투자해볼 만한지 내용이 없다".
-              하단 한 줄 강등을 정식 섹션으로 승격. KR=네이버 기업개요, US=Nasdaq profile 한국어 요약. */}
-          {basics?.summary && (
-            <section className="mt-4 rounded-2xl border border-hairline bg-surface px-4 py-4">
-              <div className="flex items-center justify-between gap-3">
-                <p className="font-pixel text-sm text-whiteout">어떤 회사예요</p>
-                {basics.sector && (
-                  <span className="rounded-full border border-hairline px-2.5 py-1 text-[11px] text-muted">{cleanText(basics.sector)}</span>
-                )}
-              </div>
-              <p className="mt-2 text-sm leading-6 text-whiteout">{cleanText(basics.summary)}</p>
-            </section>
-          )}
+            {depthTab === "history" && (
+              <>
+                <DiscoveryOverview front={front} insight={insight} context={context} />
+                <JudgmentTimeline canonical={stock} />
+                <QuietMoneyBlock timeline={front?.quietMoney} />
 
-          {/* 재무 한눈에(WO 1.5 F) — 근거 아래. KR=네이버·US=Yahoo, 없으면 생략. */}
-          <FinanceGlanceBlock basics={basics} />
-
-          {showThinSourceFootnote && (
-            <p className="mt-5 text-[12px] leading-5 text-muted">
-              {hasVerifiedFloor
-                ? "원문 기반 요약은 아직 얇아요."
-                : "이 종목으로 모인 원문은 아직 적어요. 확인된 자료가 들어오면 이 화면에 붙어요."}
-            </p>
-          )}
-
-          <p className="mt-6 text-center text-[11px] leading-5 text-muted">
-            원문을 친구처럼 풀어드린 거예요. 투자 조언은 아니에요.
-          </p>
-          </>
-          )}
+                <div className="mt-4 space-y-3">
+                  <DepthFold title="재료·가격 반응" summary="선택 기간의 실데이터">
+                    <WhyMovementTab front={front} insight={insight} context={context} />
+                  </DepthFold>
+                  <DepthFold title="추가 근거·원문" summary="확인된 자료만">
+                    {(context?.market === "COIN" || context?.symbol?.toUpperCase().startsWith("KRW-") === true) && (
+                      <CoinIssuesBlock issues={front?.coinIssues ?? []} />
+                    )}
+                    <StockWhyHappened insight={insight} />
+                    {showThinSourceFootnote && (
+                      <p className="mt-4 text-[12px] leading-5 text-muted">
+                        {hasVerifiedFloor
+                          ? "원문 기반 요약은 아직 얇아요."
+                          : "이 종목으로 모인 원문은 아직 적어요. 확인된 자료가 들어오면 이 화면에 붙어요."}
+                      </p>
+                    )}
+                  </DepthFold>
+                </div>
+              </>
+            )}
+          </div>
           </>
           )}
         </div>

--- a/apps/fomo-web/components/Sparkline.tsx
+++ b/apps/fomo-web/components/Sparkline.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { sparklinePath, seriesIsUp } from "@fomo/core";
+import { chartTokens } from "@/lib/chartTokens";
 
 /**
  * 미니 추이선 — 종가 배열을 인라인 SVG로(라이브러리 없음). docs/PIVOT_FEED_FIRST.md.
- * 상승=빨강(과열), 하락=파랑(침체). 2점 미만이면 렌더 안 함(숫자 카드 폴백).
+ * 상승=라임, 하락=회색. 2점 미만이면 렌더 안 함(숫자 카드 폴백).
  */
 export function Sparkline({
   series,
@@ -18,7 +19,7 @@ export function Sparkline({
   const path = sparklinePath(series, width, height, 3);
   if (!path) return null;
   const up = seriesIsUp(series);
-  const color = up ? "#FF5A36" : "#38BDF8";
+  const color = up ? chartTokens.up : chartTokens.down;
   const gid = `spark-${up ? "up" : "down"}`;
 
   return (

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -34,6 +34,7 @@ import { recordDiscoveryEvent } from "@/lib/discoveryMetrics";
 import { isKrStockCode, stockLogoApiSrcForStock } from "@/lib/stockLogo";
 import { verdictBalance } from "@/lib/discoveryPresentation";
 import { GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
+import { chartTokens } from "@/lib/chartTokens";
 
 /**
  * 공통 종목 무한 스와이프 덱.
@@ -44,7 +45,7 @@ const THRESHOLD = 90;
 const UP_THRESHOLD = 90; // 위로 끌어 슈퍼관심(강한 관심)
 const EXIT_MS = 320;
 // DESIGN.md §2 브랜드 액센트(역할 인코딩). 오렌지=주목 열기/강도, 네온=발견·💎·CTA. 등락엔 절대 금지.
-const NEON = "#D8FF3A";
+const NEON = chartTokens.up;
 type CardFaceView = { headline: string; isLeading: boolean };
 
 /** 종목별 앞면 데이터(stock-front 응답 캐시). 종합점수·스파크라인·가격. */
@@ -139,8 +140,8 @@ function LogoBadge({
   );
 }
 
-/** 봉인색 — 등락 데이터 전용(DESIGN.md §2). 브랜드(오렌지/네온)와 분리. 상승 적·하락 청(KR 관습). */
-const DIR_COLOR: Record<string, string> = { up: "#FF4D4D", down: "#3B82F6", flat: "#8A8A86" };
+/** 상세·미니 차트와 같은 방향 토큰을 사용한다. */
+const DIR_COLOR: Record<string, string> = { up: chartTokens.up, down: chartTokens.down, flat: chartTokens.neutral };
 
 function clampStyle(lines: number): CSSProperties {
   return {
@@ -164,10 +165,9 @@ function FeedSignalStrip({
   bear?: FeedSignalPoint | undefined;
 }) {
   if (!bull && !bear) return null;
-  const rows = [
-    bull ? { label: "강세", tone: "#FF4D4D", point: bull } : undefined,
-    bear ? { label: "약세", tone: "#3B82F6", point: bear } : undefined,
-  ].filter((row): row is { label: string; tone: string; point: FeedSignalPoint } => !!row);
+  const rows: Array<{ label: string; tone: string; point: FeedSignalPoint }> = [];
+  if (bull) rows.push({ label: "강세", tone: chartTokens.up, point: bull });
+  if (bear) rows.push({ label: "약세", tone: chartTokens.down, point: bear });
   return (
     <div className="mt-2 grid shrink-0 gap-1 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
       {rows.map((row) => (

--- a/apps/fomo-web/components/cards/ChartCardBody.tsx
+++ b/apps/fomo-web/components/cards/ChartCardBody.tsx
@@ -3,6 +3,7 @@
 import { scoreToColor, assetHeatScore, scoreToFace, type ChartCard } from "@fomo/core";
 import { FomoFace } from "@/components/FomoFace";
 import { Sparkline } from "@/components/Sparkline";
+import { chartTokens } from "@/lib/chartTokens";
 
 /** 등락률 표기. */
 function pct(n: number): string {
@@ -16,11 +17,11 @@ function fmtValue(v: number): string {
 
 /**
  * 차트 카드 본문 — 포모 코멘트 + 자산명·현재가·등락% + 미니 추이선(있으면).
- * docs/PIVOT_FEED_FIRST.md. 등락 방향색(상승=빨강/하락=파랑). series 없으면 숫자만.
+ * docs/PIVOT_FEED_FIRST.md. 등락 방향색(상승=라임/하락=회색). series 없으면 숫자만.
  */
 export function ChartCardBody({ chart }: { chart: ChartCard }) {
   const up = chart.changePct >= 0;
-  const color = up ? "#FF5A36" : "#38BDF8";
+  const color = up ? chartTokens.up : chartTokens.down;
   const face = scoreToFace(assetHeatScore(chart.changePct));
 
   return (

--- a/apps/fomo-web/lib/chartTokens.ts
+++ b/apps/fomo-web/lib/chartTokens.ts
@@ -1,0 +1,32 @@
+/** 모든 미니·상세 차트가 공유하는 단일 색상 소스. */
+export const chartTokens = {
+  up: "#D8FF3A",
+  down: "#777873",
+  neutral: "#9A9A96",
+  surface: "#050706",
+  textOnAccent: "#050706",
+  grid: "rgba(255,255,255,0.09)",
+  axis: "rgba(250,250,250,0.45)",
+  border: "rgba(255,255,255,0.16)",
+  level: "rgba(250,250,250,0.28)",
+  levelLabel: "rgba(250,250,250,0.48)",
+  ma20: "#F59E0B",
+  ma60: "#60A5FA",
+  ma120: "#A78BFA",
+  invalidation: "#D8FF3A",
+  volumeUp: "rgba(216,255,58,0.34)",
+  volumeDown: "rgba(119,120,115,0.28)",
+  zone: {
+    accumulation: "rgba(216,255,58,0.10)",
+    distribution: "rgba(148,163,184,0.12)",
+    markup: "rgba(216,255,58,0.07)",
+    markdown: "rgba(119,120,115,0.10)",
+    border: "rgba(216,255,58,0.38)",
+    mutedBorder: "rgba(250,250,250,0.22)",
+    label: "rgba(250,250,250,0.72)",
+  },
+  marker: {
+    event: "#FAFAFA",
+    money: "#D8FF3A",
+  },
+} as const;


### PR DESCRIPTION
## What changed
- Reorganized stock depth into four sticky tabs: judgment, chart/zone, company/financials, and signal history.
- Added shared `DepthSection`, `DepthLine`, and collapsible detail primitives to enforce card-vs-list layout rules.
- Centralized chart colors in `chartTokens` and applied them to full candles, mini sparklines, feed charts, and deck direction colors.
- Collapsed secondary chart events and source material so each tab remains scannable.

## Why
The detail view rendered score, committee analysis, chart, financials, and ledger as one long stack. Tabs were pushed below content and chart colors diverged across surfaces.

## Validation
- `npm run typecheck`
- `npm run test -- depthLayout depthCopy discoveryDeck stock-front judgmentReview` (30 tests)
- `npm --workspace @fomo/web run build`
- Mobile visual verification at 390x844, including sticky tab position and all four panels.