### PR TITLE
feat: 쉬운말 카드 후킹과 점수 근거 강화

### DIFF
--- a/apps/fomo-web/__tests__/cardHookLayout.test.ts
+++ b/apps/fomo-web/__tests__/cardHookLayout.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const card = readFileSync(new URL("../components/StockSwipeDeck.tsx", import.meta.url), "utf8");
+const depth = readFileSync(new URL("../components/KeywordDepthPage.tsx", import.meta.url), "utf8");
+
+describe("메인 카드 후킹 구조", () => {
+  it("실제 30거래일 스파크라인과 신호 칩, 후킹 한 줄을 함께 렌더한다", () => {
+    expect(card).toContain("<Sparkline series={sparkline.slice(-30)}");
+    expect(card).toContain("hookCopy.chips.map");
+    expect(card).toContain("왜 봐야 하나");
+  });
+
+  it("점수는 점수대 사후 성과나 축적 상태와 함께만 노출한다", () => {
+    expect(card).toContain("이 점수대 역대 30일 승률");
+    expect(card).toContain("이 점수대 성과 축적 중");
+    expect(card).toContain("가용 분석축이 3개 미만이라 점수를 내지 않았어요");
+    expect(card).toContain("scoreTrack={scoreTrackFor(e)}");
+  });
+});
+
+describe("뎁스 쉬운말 레이어", () => {
+  it("실제 분석에 등장한 용어만 설명 칩과 탭 툴팁으로 제공한다", () => {
+    expect(depth).toContain("termKeysForAnalysis");
+    expect(depth).toContain('aria-label="차트 용어 쉬운 설명"');
+    expect(depth).toContain("term.explanation");
+    expect(depth).toContain('easyMarketCopy(event.label, "detail")');
+  });
+});

--- a/apps/fomo-web/__tests__/easyMarketCopy.test.ts
+++ b/apps/fomo-web/__tests__/easyMarketCopy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildCardHookCopy, easyMarketCopy, scoreSignalType, termKeysForAnalysis } from "../lib/easyMarketCopy";
+
+describe("easy market copy", () => {
+  it("카드는 쉬운말을 우선하고 숫자를 보존한다", () => {
+    expect(easyMarketCopy("매집 구간 7주차에 스프링 후보, RSI 75 과열", "card")).toBe(
+      "조용히 사 모으는 구간 7주차에 바닥 다지는 반등 시도, 단기 과열 75"
+    );
+  });
+
+  it("뎁스는 첫 전문용어를 쉬운말과 함께 병기한다", () => {
+    expect(easyMarketCopy("정배열 뒤 눌림목과 임펄스", "detail")).toBe(
+      "이평선이 위로 정렬(정배열) 뒤 상승 후 잠깐 쉬는 구간(눌림목)과 급등 파동(임펄스)"
+    );
+    expect(easyMarketCopy("하방 임펄스 뒤 업스러스트 후보", "detail")).toBe(
+      "급락 파동(하방 임펄스) 뒤 고점 이탈 실패(업스러스트)"
+    );
+  });
+
+  it("실제 수급·구간 수치로 카드 훅과 칩을 조립한다", () => {
+    const result = buildCardHookCopy({
+      signals: { foreignNetStreak: 5 },
+      signalTypes: ["foreign_streak", "score_60_79"],
+      wyckoff: {
+        sourceLength: 100,
+        zones: [],
+        events: [],
+        currentZone: {
+          kind: "accumulation",
+          startIndex: 70,
+          endIndex: 99,
+          weeks: 6,
+          low: 90,
+          high: 110,
+          rangePct: 20,
+          priceChangePct: 3,
+          label: "매집 추정 6주차",
+          evidence: [],
+        },
+      },
+    });
+    expect(result.chips).toEqual(["외국인 5일", "사 모으는 구간 6주차"]);
+    expect(result.hook).toBe("조용히 사 모으는 6주차에 외국인 순매수가 5일째 이어져요.");
+  });
+
+  it("점수대와 실제 분석 용어를 결정론으로 분류한다", () => {
+    expect([scoreSignalType(80), scoreSignalType(70), scoreSignalType(59)]).toEqual([
+      "score_80_plus",
+      "score_60_79",
+      "score_below_60",
+    ]);
+    expect(termKeysForAnalysis(undefined, 75, true)).toEqual(["alignment", "rsiHot"]);
+  });
+
+  it("이벤트 날짜와 실수치만 짧게 노출한다", () => {
+    const result = buildCardHookCopy({
+      signals: {},
+      wyckoff: {
+        sourceLength: 100,
+        zones: [],
+        events: [{ kind: "impulse", index: 99, date: "20260716", price: 120, direction: "up", movePct: 12.34, label: "", explanation: "" }],
+      },
+    });
+    expect(result.hook).toBe("7/16 급등 파동(+12.3%)이 발생했어요.");
+  });
+});

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -34,6 +34,12 @@ import { CompanyScoreRadar } from "@/components/CompanyScoreRadar";
 import { JudgmentTimeline } from "@/components/JudgmentTimeline";
 import { DepthFold, DepthLine, DepthSection } from "@/components/DepthSection";
 import { chartTokens } from "@/lib/chartTokens";
+import {
+  MARKET_TERM_GLOSSARY,
+  easyMarketCopy,
+  termKeysForAnalysis,
+  type MarketTermKey,
+} from "@/lib/easyMarketCopy";
 import { markDiscoverySeenAction, recordDiscoveryDepth, recordDiscoverySeen } from "@/lib/discoveryPerformance";
 
 /**
@@ -1671,7 +1677,7 @@ function AnalysisChart({
   });
   const H = visibleQuietEvents.length > 0 ? QUIET_LANE_TOP + QUIET_LANE_GAP * 4 + 12 : VOL_TOP + VOL_H + 12;
   const zoneName = (kind: (typeof visibleZones)[number]["kind"]) =>
-    kind === "accumulation" ? "매집" : kind === "distribution" ? "분산" : kind === "markup" ? "상승" : "하락";
+    kind === "accumulation" ? "사 모으는 구간" : kind === "distribution" ? "고점 정체 구간" : kind === "markup" ? "상승" : "하락";
   const zoneColor = (kind: (typeof visibleZones)[number]["kind"]) => chartTokens.zone[kind];
   const markerText = (kind: WyckoffEvent["kind"]) =>
     kind === "spring" ? "S" : kind === "upthrust" ? "UT" : kind === "impulse" ? "I" : "P";
@@ -1819,7 +1825,7 @@ function AnalysisChart({
               key={`${event.kind}-${event.index}`}
               role="button"
               tabIndex={0}
-              aria-label={`${event.label}: ${event.explanation}`}
+              aria-label={`${easyMarketCopy(event.label, "detail")}: ${easyMarketCopy(event.explanation, "detail")}`}
               onClick={() => setSelectedEvent(selectedEvent?.kind === event.kind && selectedEvent.index === event.index ? null : event)}
               onKeyDown={(keyboardEvent) => {
                 if (keyboardEvent.key === "Enter" || keyboardEvent.key === " ") setSelectedEvent(event);
@@ -1879,8 +1885,8 @@ function AnalysisChart({
           onClick={() => setSelectedEvent(null)}
           className="mt-2 w-full rounded-md border border-white/15 bg-black/50 px-3 py-2 text-left"
         >
-          <span className="block text-[11px] font-bold text-whiteout">{selectedEvent.label}</span>
-          <span className="mt-1 block text-[10px] leading-4 text-muted">{selectedEvent.explanation}</span>
+          <span className="block text-[11px] font-bold text-whiteout">{easyMarketCopy(selectedEvent.label, "detail")}</span>
+          <span className="mt-1 block text-[10px] leading-4 text-muted">{easyMarketCopy(selectedEvent.explanation, "detail")}</span>
         </button>
       )}
       <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted">
@@ -1960,7 +1966,9 @@ function structureMetrics(front: StockFrontResponse | null): StructureMetric[] {
     .join(" · ") || "레벨 축적 중";
   const latest = front?.ta?.latest;
   const momentumValue = finiteNumber(latest?.rsi14)
-    ? `RSI ${Math.round(latest.rsi14)}`
+    ? latest.rsi14 >= 70
+      ? `단기 과열(RSI ${Math.round(latest.rsi14)})`
+      : `RSI ${Math.round(latest.rsi14)}`
     : finiteNumber(latest?.atrPct)
       ? `변동폭 ${latest.atrPct.toFixed(1)}%`
       : finiteNumber(front?.signals?.volumeRatio) && front.signals.volumeRatio >= 0.1
@@ -1982,7 +1990,7 @@ function structureMetrics(front: StockFrontResponse | null): StructureMetric[] {
       title: "모멘텀",
       value: momentumValue,
       body: finiteNumber(latest?.rsi14)
-        ? `RSI 14 기준 ${Math.round(latest.rsi14)}예요.${finiteNumber(latest?.atrPct) ? ` 최근 하루 변동폭은 ${latest.atrPct.toFixed(1)}%예요.` : ""}`
+        ? `${latest.rsi14 >= 70 ? `단기 과열(RSI ${Math.round(latest.rsi14)})` : `RSI 14 기준 ${Math.round(latest.rsi14)}`}예요.${finiteNumber(latest?.atrPct) ? ` 최근 하루 변동폭은 ${latest.atrPct.toFixed(1)}%예요.` : ""}`
         : "현재 연결된 변동성·모멘텀 관측값을 보여줘요.",
     },
   ];
@@ -2020,6 +2028,14 @@ function ChartAnalysisTab({
     () => front?.candles?.filter((c) => [c.open, c.high, c.low, c.close].every((v) => Number.isFinite(v) && v > 0)).slice(-rangeDays),
     [front?.candles, rangeDays]
   );
+  const termKeys = useMemo(
+    () => termKeysForAnalysis(wyckoff, ta?.latest?.rsi14, verdict?.phase === "markup"),
+    [ta?.latest?.rsi14, verdict?.phase, wyckoff]
+  );
+  const showTerm = (key: MarketTermKey) => {
+    const term = MARKET_TERM_GLOSSARY[key];
+    setStructureTooltip({ title: term.detail, body: term.explanation });
+  };
 
   return (
     <section className="mt-2">
@@ -2040,8 +2056,10 @@ function ChartAnalysisTab({
             className="shrink-0 rounded-md border border-whiteout/20 px-2 py-1 text-[10px] font-bold text-whiteout"
           >
             {currentZone
-              ? currentZone.label
-              : `${verdict!.phase === "accumulation" ? "축적" : verdict!.phase === "markup" ? "상승" : verdict!.phase === "distribution" ? "분산" : "하락"} 국면`}
+              ? easyMarketCopy(currentZone.label, "detail")
+              : verdict!.phase === "accumulation"
+                ? "조용히 사 모으는 구간(매집)"
+                : `${verdict!.phase === "markup" ? "상승" : verdict!.phase === "distribution" ? "분산" : "하락"} 국면`}
           </button>
         )}
       </div>
@@ -2049,7 +2067,22 @@ function ChartAnalysisTab({
       {wyckoff?.summary && (
         <div className="mb-3 border-l-2 px-3 py-3" style={{ borderColor: chartTokens.zone.border, backgroundColor: chartTokens.zone.accumulation }}>
           <p className="font-pixel text-[10px]" style={{ color: chartTokens.up }}>지금 구간 요약</p>
-          <p className="mt-1.5 text-sm font-medium leading-6 text-whiteout">{wyckoff.summary}</p>
+          <p className="mt-1.5 text-sm font-medium leading-6 text-whiteout">{easyMarketCopy(wyckoff.summary, "detail")}</p>
+        </div>
+      )}
+
+      {termKeys.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5" aria-label="차트 용어 쉬운 설명">
+          {termKeys.map((key) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => showTerm(key)}
+              className="rounded-full border border-hairline-soft bg-white/[0.03] px-2.5 py-1 text-[10px] text-whiteout transition-colors hover:border-whiteout/30"
+            >
+              {MARKET_TERM_GLOSSARY[key].detail}
+            </button>
+          ))}
         </div>
       )}
 
@@ -2127,11 +2160,11 @@ function ChartAnalysisTab({
               <button
                 key={`${event.kind}-${event.index}`}
                 type="button"
-                onClick={() => setStructureTooltip({ title: event.label, body: event.explanation })}
+                onClick={() => setStructureTooltip({ title: easyMarketCopy(event.label, "detail") ?? event.label, body: easyMarketCopy(event.explanation, "detail") ?? event.explanation })}
                 className="w-full border-l border-white/20 px-3 py-1.5 text-left transition-colors hover:border-whiteout"
               >
-                <span className="block text-xs font-bold text-whiteout">{event.label}</span>
-                <span className="mt-0.5 block text-[11px] leading-5 text-muted">{event.explanation}</span>
+                <span className="block text-xs font-bold text-whiteout">{easyMarketCopy(event.label, "detail")}</span>
+                <span className="mt-0.5 block text-[11px] leading-5 text-muted">{easyMarketCopy(event.explanation, "detail")}</span>
               </button>
             ))}
           </div>
@@ -2203,8 +2236,8 @@ function ChartAnalysisTab({
 
 // 판단 층(WO Phase 1) — 와이코프 국면 표기(뎁스 문단용).
 const DEPTH_PHASE_TEXT: Record<string, string> = {
-  accumulation: "저점권 횡보에 거래가 수축된 축적형 구조",
-  markup: "이동평균 정배열에 거래량이 붙은 상승 국면",
+  accumulation: "저점권 횡보에 거래가 줄어드는 조용히 사 모으는 구간(매집)",
+  markup: "이평선이 위로 정렬(정배열)되고 거래량이 붙은 상승 국면",
   distribution: "고점권에서 거래는 늘고 가격은 정체된 분산형 구조",
   markdown: "이동평균 역배열에 저점을 갱신 중인 하락 국면",
 };
@@ -2319,7 +2352,7 @@ function ConvictionParagraphs({
               </span>
             )}
           </div>
-          <p className="mt-2 text-sm leading-6 text-whiteout">{s.stanceText}</p>
+          <p className="mt-2 text-sm leading-6 text-whiteout">{easyMarketCopy(s.stanceText, "detail")}</p>
           {s.confidenceText && <p className="mt-1 text-[12px] leading-5 text-muted">{s.confidenceText}</p>}
         </div>
       )}
@@ -2330,7 +2363,7 @@ function ConvictionParagraphs({
           <ul className="mt-2 space-y-1.5">
             {s.evidence.map((line, i) => (
               <li key={`vd-ev-${i}`} className="text-sm leading-6 text-whiteout">
-                · {line}
+                · {easyMarketCopy(line, "detail")}
               </li>
             ))}
           </ul>

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@fomo/core";
 import { StockInsightView } from "@/components/KeywordDepthPage";
 import { ContentCard } from "@/components/ContentCard";
+import { Sparkline } from "@/components/Sparkline";
 import { NarrativeCard } from "@/components/NarrativeCard";
 import { NarrativeDepthPage } from "@/components/NarrativeDepthPage";
 import { SectorCard } from "@/components/SectorCard";
@@ -35,6 +36,7 @@ import { isKrStockCode, stockLogoApiSrcForStock } from "@/lib/stockLogo";
 import { verdictBalance } from "@/lib/discoveryPresentation";
 import { GemIcon, StarIcon, CaretUpIcon, CaretDownIcon, UndoIcon, HeartIcon, XMarkIcon } from "@/components/icons";
 import { chartTokens } from "@/lib/chartTokens";
+import { buildCardHookCopy, easyMarketCopy, scoreSignalType, type CardHookCopy } from "@/lib/easyMarketCopy";
 
 /**
  * 공통 종목 무한 스와이프 덱.
@@ -266,44 +268,46 @@ function BundleCardFace({ bundle, progress }: { bundle: DeckThemeBundle; progres
 function CompanyScoreBlock({
   score,
   verdict,
-  contextLine,
+  scoreTrack,
 }: {
   score?: CompanyScoreResult | undefined;
   verdict?: CardVerdict | undefined;
-  contextLine?: string | undefined;
+  scoreTrack?: TrackMetric | undefined;
 }) {
   const balance = verdictBalance(verdict);
+  const metric = scoreTrack ?? { n: 0, winRate: null, medianReturn: null };
+  const historyText =
+    score?.score == null
+      ? "가용 분석축이 3개 미만이라 점수를 내지 않았어요."
+      : metric.n >= 30 && metric.winRate !== null
+      ? `이 점수대 역대 30일 승률 ${Number.isInteger(metric.winRate) ? metric.winRate.toFixed(0) : metric.winRate.toFixed(1)}% · n=${metric.n}`
+      : `이 점수대 성과 축적 중 · n=${metric.n}`;
   return (
-    <div className="mt-2.5 shrink-0 border-y border-hairline py-2.5">
-      <div className="flex items-end justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-baseline gap-1.5">
+    <div className="mt-2 shrink-0 border-y border-hairline py-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="flex shrink-0 items-baseline gap-1">
             <span
-              className={`font-number font-bold leading-none ${score?.score == null ? "text-lg" : "text-3xl"}`}
+              className={`font-number font-bold leading-none ${score?.score == null ? "text-sm" : "text-xl"}`}
               style={{ color: NEON }}
             >
               {score?.score ?? "분석 축적 중"}
             </span>
-            {score?.score != null && <span className="text-xs font-semibold text-muted">점</span>}
+            {score?.score != null && <span className="text-[10px] font-semibold text-muted">점</span>}
           </div>
-          <p className="mt-1 truncate text-sm font-semibold text-whiteout">
+          <p className="min-w-0 truncate text-xs font-semibold text-whiteout">
             {score?.score == null ? `가용 분석축 ${score?.availableAxisCount ?? 0}/6` : score.label}
           </p>
         </div>
         {balance && <span className="text-[10px] font-medium" style={{ color: balance.color }}>{balance.label}</span>}
       </div>
-      {contextLine && (
-        <p className="mt-1.5 text-xs leading-4 text-whiteout" style={clampStyle(1)}>
-          <span className="text-muted">포착 근거 · </span>{contextLine}
-        </p>
-      )}
+      <p className="mt-1 text-[10px] leading-4 text-muted">{historyText}</p>
     </div>
   );
 }
 
 /**
- * 종목 카드 앞면 — 백엔드가 확정한 종합점수·라벨·헤드라인을 그대로 표시한다.
- * 정체성 / 현재가 / 테마태그 / 헤드라인 / 발견 상태 / 근거. 차트는 뎁스에서만 보여준다.
+ * 종목 카드 앞면 — 오늘의 훅을 주인공으로 두고 백엔드 점수·성과 이력은 보조 근거로 표시한다.
  */
 function StockCardFace({
   stock,
@@ -316,10 +320,11 @@ function StockCardFace({
   subLine,
   feedBull,
   feedBear,
-  why,
   score,
-  discoveryContext,
+  sparkline,
+  hookCopy,
   verdict,
+  scoreTrack,
   signalTrack,
   personalStrongSignal,
   progress,
@@ -334,10 +339,11 @@ function StockCardFace({
   subLine?: string | undefined;
   feedBull?: FeedSignalPoint | undefined;
   feedBear?: FeedSignalPoint | undefined;
-  why?: string | undefined;
   score?: CompanyScoreResult | undefined;
-  discoveryContext?: string | undefined;
+  sparkline?: number[] | undefined;
+  hookCopy: CardHookCopy;
   verdict?: CardVerdict | undefined;
+  scoreTrack?: TrackMetric | undefined;
   signalTrack?: { code: SignalTypeCode; metric: TrackMetric } | undefined;
   personalStrongSignal?: SignalTypeCode | undefined;
   progress?: string | undefined;
@@ -384,25 +390,37 @@ function StockCardFace({
       {/* 헤드라인 = 종목별 후킹 사실 1개. 색 강조는 점수/미터/CTA에만 둔다. */}
       <p className="mt-3 shrink-0 text-lg font-bold leading-7 text-whiteout" style={clampStyle(2)}>
         {view.isLeading && <GemIcon size={18} className="mr-1 inline-block align-[-2px]" />}
-        {view.headline}
+        {easyMarketCopy(view.headline, "card")}
       </p>
 
-      <CompanyScoreBlock score={score} verdict={verdict} contextLine={discoveryContext} />
+      {hookCopy.chips.length > 0 && (
+        <div className="mt-2 flex shrink-0 flex-wrap gap-1.5">
+          {hookCopy.chips.map((chip) => (
+            <span key={chip} className="rounded-full border border-hairline-soft bg-white/[0.04] px-2 py-1 text-[10px] font-semibold text-whiteout">
+              {chip}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {sparkline && sparkline.length >= 2 && (
+        <div className="mt-2 shrink-0 border-y border-hairline-soft py-1" aria-label="최근 30거래일 가격 흐름">
+          <Sparkline series={sparkline.slice(-30)} height={38} />
+        </div>
+      )}
+
+      <div className="mt-2 shrink-0 rounded-lg bg-black/15 px-3 py-2">
+        <span className="block text-[10px] font-semibold text-muted">왜 봐야 하나</span>
+        <p className="mt-0.5 text-sm font-semibold leading-5 text-whiteout" style={clampStyle(2)}>{hookCopy.hook}</p>
+      </div>
+
+      <CompanyScoreBlock score={score} verdict={verdict} scoreTrack={scoreTrack} />
 
       {!verdict && (
         <>
-          {why && (
-            <div className="mt-2.5 flex shrink-0 items-start gap-2 rounded-lg border border-hairline bg-white/[0.035] px-3 py-1.5">
-              <span className="shrink-0 text-[10px] leading-5 text-muted">이유</span>
-              <span className="min-w-0 flex-1 text-sm leading-5 text-whiteout" style={clampStyle(1)}>
-                {why}
-              </span>
-            </div>
-          )}
-
           <FeedSignalStrip bull={feedBull} bear={feedBear} />
 
-          {subLine && !why && !feedBull && !feedBear && (
+          {subLine && !feedBull && !feedBear && (
             <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
               <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
                 {subLine}
@@ -644,8 +662,12 @@ export function StockSwipeDeck({
           ...(entry.wyckoff ? { wyckoff: entry.wyckoff } : {}),
           ...(typeof entry.score?.score === "number" ? { companyScore: entry.score.score } : {}),
         });
-    const code = candidates.find((value) => isSignalTypeCode(value) && signalHistory30[value]);
+    const code = candidates.find((value) => !value.startsWith("score_") && isSignalTypeCode(value) && signalHistory30[value]);
     return code ? { code, metric: signalHistory30[code]! } : undefined;
+  };
+  const scoreTrackFor = (entry: FrontEntry | undefined): TrackMetric | undefined => {
+    if (typeof entry?.score?.score !== "number") return undefined;
+    return signalHistory30?.[scoreSignalType(entry.score.score)];
   };
   const renderFace = (card: DeckCard, progress?: string) => {
     if (card.type === "sector") return <SectorCard card={card.data} progress={progress} />;
@@ -673,6 +695,14 @@ export function StockSwipeDeck({
       (groundedContext && groundedContext.replace(/\s+/g, "").toLowerCase() !== normalizedHeadline
         ? groundedContext
         : undefined);
+    const signalTypes = normalizeSignalTypeCodes(e.signalTypes ?? []);
+    const hookCopy = buildCardHookCopy({
+      signals: e.signals,
+      signalTypes,
+      ...(e.wyckoff ? { wyckoff: e.wyckoff } : {}),
+      ...(e.verdict ? { verdict: e.verdict } : {}),
+      ...(discoveryContext ? { fallback: discoveryContext } : {}),
+    });
     return (
       <StockCardFace
         stock={stock}
@@ -685,12 +715,13 @@ export function StockSwipeDeck({
         subLine={deduped.subLine}
         feedBull={deduped.feedBull}
         feedBear={deduped.feedBear}
-        why={deduped.why}
         score={e.score}
-        discoveryContext={discoveryContext}
+        sparkline={e.sparkline}
+        hookCopy={hookCopy}
         verdict={e?.verdict}
+        scoreTrack={scoreTrackFor(e)}
         signalTrack={signalTrackFor(stock, e)}
-        personalStrongSignal={normalizeSignalTypeCodes(e.signalTypes ?? []).find((code) => strongSignalCodes.includes(code))}
+        personalStrongSignal={signalTypes.find((code) => strongSignalCodes.includes(code))}
         progress={progress}
       />
     );

--- a/apps/fomo-web/lib/easyMarketCopy.ts
+++ b/apps/fomo-web/lib/easyMarketCopy.ts
@@ -1,0 +1,202 @@
+import type {
+  CardFrontSignals,
+  CardVerdict,
+  SignalTypeCode,
+  WyckoffAnalysis,
+  WyckoffEvent,
+} from "@fomo/core";
+
+export type MarketTermKey =
+  | "impulse"
+  | "downImpulse"
+  | "pullback"
+  | "accumulation"
+  | "spring"
+  | "upthrust"
+  | "alignment"
+  | "rsiHot";
+
+export const MARKET_TERM_GLOSSARY: Record<MarketTermKey, { card: string; detail: string; explanation: string }> = {
+  impulse: {
+    card: "급등 파동",
+    detail: "급등 파동(임펄스)",
+    explanation: "짧은 기간에 가격과 거래량이 함께 강하게 위로 움직인 구간이에요.",
+  },
+  downImpulse: {
+    card: "급락 파동",
+    detail: "급락 파동(하방 임펄스)",
+    explanation: "짧은 기간에 가격이 큰 폭으로 아래로 움직인 구간이에요.",
+  },
+  pullback: {
+    card: "상승 후 잠깐 쉬는 구간",
+    detail: "상승 후 잠깐 쉬는 구간(눌림목)",
+    explanation: "상승 뒤 가격이 일부 되돌리며 지지 여부를 확인하는 구간이에요.",
+  },
+  accumulation: {
+    card: "조용히 사 모으는 구간",
+    detail: "조용히 사 모으는 구간(매집)",
+    explanation: "가격 변동폭과 거래량이 줄면서 저점이 높아지는 구간을 뜻해요.",
+  },
+  spring: {
+    card: "바닥 다지는 반등 시도",
+    detail: "바닥 다지는 반등 시도(스프링)",
+    explanation: "구간 하단을 잠깐 이탈한 뒤 1~3일 안에 회복한 움직임이에요.",
+  },
+  upthrust: {
+    card: "고점 이탈 실패",
+    detail: "고점 이탈 실패(업스러스트)",
+    explanation: "구간 상단을 돌파했다가 다시 안으로 밀린 움직임이에요.",
+  },
+  alignment: {
+    card: "이평선이 위로 정렬",
+    detail: "이평선이 위로 정렬(정배열)",
+    explanation: "단기 이동평균선이 중·장기선 위에 놓인 상승 추세 배열이에요.",
+  },
+  rsiHot: {
+    card: "단기 과열",
+    detail: "단기 과열(RSI)",
+    explanation: "RSI가 70을 넘은 상태로, 최근 상승 속도가 빨랐다는 뜻이에요.",
+  },
+};
+
+type CopyMode = "card" | "detail";
+
+/** 카드에서는 쉬운말만, 뎁스에서는 첫 전문용어를 쉬운말과 함께 보여준다. */
+export function easyMarketCopy(text: string | undefined, mode: CopyMode): string | undefined {
+  if (!text?.trim()) return undefined;
+  let output = text;
+  const tokens: Array<{ token: string; replacement: string }> = [];
+  const mark = (replacement: string): string => {
+    const token = `__FOMO_EASY_TERM_${tokens.length}__`;
+    tokens.push({ token, replacement });
+    return token;
+  };
+  const replace = (pattern: RegExp, key: MarketTermKey) => {
+    output = output.replace(pattern, () => mark(MARKET_TERM_GLOSSARY[key][mode]));
+  };
+  replace(/하방\s*임펄스/, "downImpulse");
+  replace(/임펄스/, "impulse");
+  replace(/눌림목/, "pullback");
+  replace(/매집(?:\s*추정)?\s*구간|매집\s*구간|매집/, "accumulation");
+  replace(/스프링(?:\s*후보)?/, "spring");
+  replace(/업스러스트(?:\s*후보)?/, "upthrust");
+  replace(/정배열/, "alignment");
+  output = output.replace(/RSI\s*(\d+(?:\.\d+)?)\s*(?:과열|과열권|과열 영역)/, (_match, value: string) =>
+    mark(mode === "card" ? `단기 과열 ${value}` : `단기 과열(RSI ${value})`)
+  );
+  for (const item of tokens) output = output.replace(item.token, item.replacement);
+  return output;
+}
+
+function latestEvents(analysis: WyckoffAnalysis | undefined): WyckoffEvent[] {
+  if (!analysis) return [];
+  const cutoff = Math.max(0, analysis.sourceLength - 20);
+  return analysis.events.filter((event) => event.index >= cutoff).sort((a, b) => b.index - a.index);
+}
+
+function compactMove(value: number | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+}
+
+function shortDate(date: string | undefined): string {
+  if (!date) return "최근";
+  const compact = date.match(/^\d{4}(\d{2})(\d{2})$/);
+  if (compact) return `${Number(compact[1])}/${Number(compact[2])}`;
+  const dashed = date.match(/(?:\d{4}-)?(\d{2})-(\d{2})/);
+  return dashed ? `${Number(dashed[1])}/${Number(dashed[2])}` : date;
+}
+
+function unique(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value?.trim())))];
+}
+
+export interface CardHookInput {
+  signals: Partial<CardFrontSignals>;
+  signalTypes?: readonly SignalTypeCode[];
+  wyckoff?: WyckoffAnalysis;
+  verdict?: CardVerdict;
+  fallback?: string;
+}
+
+export interface CardHookCopy {
+  chips: string[];
+  hook: string;
+}
+
+/** 숫자와 판정은 입력값만 사용한다. 카드용 신호 칩과 '왜 봐야 하나'를 결정론으로 조립한다. */
+export function buildCardHookCopy(input: CardHookInput): CardHookCopy {
+  const signals = input.signals;
+  const types = new Set(input.signalTypes ?? []);
+  const events = latestEvents(input.wyckoff);
+  const currentZone = input.wyckoff?.currentZone;
+  const foreign = signals.foreignNetStreak ?? 0;
+  const institution = signals.institutionNetStreak ?? 0;
+  const impulse = events.find((event) => event.kind === "impulse");
+  const spring = events.find((event) => event.kind === "spring");
+  const pullback = events.find((event) => event.kind === "pullback");
+  const upthrust = events.find((event) => event.kind === "upthrust");
+
+  const chips = unique([
+    types.has("cluster_multi") ? "여러 주체 동시 유입" : undefined,
+    types.has("insider_cluster") ? "내부자 동반 매수" : undefined,
+    foreign >= 3 ? `외국인 ${foreign}일` : undefined,
+    institution >= 3 ? `기관 ${institution}일` : undefined,
+    currentZone?.kind === "accumulation" ? `사 모으는 구간 ${currentZone.weeks}주차` : undefined,
+    spring ? MARKET_TERM_GLOSSARY.spring.card : undefined,
+    pullback ? MARKET_TERM_GLOSSARY.pullback.card : undefined,
+    impulse ? (impulse.direction === "down" ? MARKET_TERM_GLOSSARY.downImpulse.card : MARKET_TERM_GLOSSARY.impulse.card) : undefined,
+    upthrust ? MARKET_TERM_GLOSSARY.upthrust.card : undefined,
+    typeof signals.volumeRatio === "number" && signals.volumeRatio >= 1.5 ? `거래량 ${signals.volumeRatio.toFixed(1)}배` : undefined,
+    types.has("whale_inflow") ? "고래 유입" : undefined,
+    types.has("material_contract") ? "계약·수주" : undefined,
+    types.has("material_earnings") ? "실적 변화" : undefined,
+    types.has("material_regulatory") ? "승인·규제" : undefined,
+  ]).slice(0, 2);
+
+  let hook: string | undefined;
+  if (types.has("cluster_multi")) {
+    hook = "서로 다른 자금 주체가 같은 기간에 함께 들어왔어요.";
+  } else if (currentZone?.kind === "accumulation" && foreign >= 3) {
+    hook = `조용히 사 모으는 ${currentZone.weeks}주차에 외국인 순매수가 ${foreign}일째 이어져요.`;
+  } else if (currentZone?.kind === "accumulation" && institution >= 3) {
+    hook = `조용히 사 모으는 ${currentZone.weeks}주차에 기관 순매수가 ${institution}일째 이어져요.`;
+  } else if (foreign >= 3) {
+    hook = `조용한 흐름 속 외국인이 ${foreign}일째 순매수 중이에요.`;
+  } else if (institution >= 3) {
+    hook = `조용한 흐름 속 기관이 ${institution}일째 순매수 중이에요.`;
+  } else if (spring) {
+    hook = `${shortDate(spring.date)} 바닥 다지는 반등 시도가 포착됐어요.`;
+  } else if (pullback) {
+    const retracement = typeof pullback.retracementPct === "number" ? ` · ${pullback.retracementPct.toFixed(1)}% 되돌림` : "";
+    hook = `상승 후 잠깐 쉬는 구간이에요${retracement}.`;
+  } else if (impulse) {
+    const direction = impulse.direction === "down" ? "급락" : "급등";
+    const move = compactMove(impulse.movePct);
+    hook = `${shortDate(impulse.date)} ${direction} 파동${move ? `(${move})` : ""}이 발생했어요.`;
+  } else if (signals.newsEventLabel) {
+    hook = `지금 확인할 변화 · ${signals.newsEventLabel}`;
+  } else {
+    hook = input.verdict?.stanceText ?? input.fallback ?? "가격·거래량에서 오늘 달라진 점을 확인해 보세요.";
+  }
+
+  return { chips, hook: easyMarketCopy(hook, "card") ?? hook };
+}
+
+export function scoreSignalType(score: number): SignalTypeCode {
+  return score >= 80 ? "score_80_plus" : score >= 60 ? "score_60_79" : "score_below_60";
+}
+
+export function termKeysForAnalysis(analysis: WyckoffAnalysis | undefined, rsi14?: number, hasAlignment = false): MarketTermKey[] {
+  const keys: MarketTermKey[] = [];
+  if (analysis?.currentZone?.kind === "accumulation") keys.push("accumulation");
+  for (const event of analysis?.events ?? []) {
+    if (event.kind === "spring") keys.push("spring");
+    if (event.kind === "upthrust") keys.push("upthrust");
+    if (event.kind === "pullback") keys.push("pullback");
+    if (event.kind === "impulse") keys.push(event.direction === "down" ? "downImpulse" : "impulse");
+  }
+  if (hasAlignment) keys.push("alignment");
+  if (typeof rsi14 === "number" && rsi14 >= 70) keys.push("rsiHot");
+  return [...new Set(keys)];
+}


### PR DESCRIPTION
## 변경\n- 카드 전문용어를 쉬운말 우선으로 바꾸고 뎁스에는 병기 및 탭 툴팁 추가\n- 메인 카드에 최근 30거래일 스파크라인, 실데이터 신호 칩 1~2개, 왜 봐야 하나 한 줄 추가\n- 점수를 보조 크기로 낮추고 점수대 30일 성과 또는 축적 상태를 항상 결합\n\n## 검증\n- npm run test -- apps/fomo-web/__tests__/easyMarketCopy.test.ts apps/fomo-web/__tests__/cardHookLayout.test.ts apps/fomo-web/__tests__/depthLayout.test.ts apps/fomo-web/__tests__/depthCopy.test.ts packages/fomo-core/__tests__/signal-resume.test.ts\n- npm run typecheck\n- npm run build:fomo-web\n- 모바일 실데이터 카드 및 차트 용어 툴팁 육안 확인