### PR TITLE
fix: 카드 전문용어 잔재 쉬운말 전환

### DIFF
--- a/apps/fomo-web/__tests__/cardHookLayout.test.ts
+++ b/apps/fomo-web/__tests__/cardHookLayout.test.ts
@@ -9,6 +9,8 @@ describe("메인 카드 후킹 구조", () => {
     expect(card).toContain("<Sparkline series={sparkline.slice(-30)}");
     expect(card).toContain("hookCopy.chips.map");
     expect(card).toContain("왜 봐야 하나");
+    expect(card).toContain('easyMarketCopy(score.label, "card")');
+    expect(card).toContain('easyMarketCopy(formatSignalResumeBadge(signalTrack.code, signalTrack.metric), "card")');
   });
 
   it("점수는 점수대 사후 성과나 축적 상태와 함께만 노출한다", () => {

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -178,7 +178,7 @@ function FeedSignalStrip({
             {row.label}
           </span>
           <span className="min-w-0 flex-1 text-muted" style={clampStyle(1)}>
-            {row.point.text}
+            {easyMarketCopy(row.point.text, "card")}
           </span>
           <span className="shrink-0 text-[10px] text-muted/80">{row.point.source}</span>
         </div>
@@ -296,7 +296,7 @@ function CompanyScoreBlock({
             {score?.score != null && <span className="text-[10px] font-semibold text-muted">점</span>}
           </div>
           <p className="min-w-0 truncate text-xs font-semibold text-whiteout">
-            {score?.score == null ? `가용 분석축 ${score?.availableAxisCount ?? 0}/6` : score.label}
+            {score?.score == null ? `가용 분석축 ${score?.availableAxisCount ?? 0}/6` : easyMarketCopy(score.label, "card")}
           </p>
         </div>
         {balance && <span className="text-[10px] font-medium" style={{ color: balance.color }}>{balance.label}</span>}
@@ -422,8 +422,8 @@ function StockCardFace({
 
           {subLine && !feedBull && !feedBear && (
             <div className="mt-2 shrink-0 rounded-lg border border-hairline bg-black/10 px-3 py-1.5">
-              <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
-                {subLine}
+                <span className="text-sm leading-5 text-muted" style={clampStyle(1)}>
+                {easyMarketCopy(subLine, "card")}
               </span>
             </div>
           )}
@@ -434,13 +434,13 @@ function StockCardFace({
 
       {signalTrack && (
         <p className="mt-2 shrink-0 text-[11px] leading-4 text-muted">
-          {formatSignalResumeBadge(signalTrack.code, signalTrack.metric)}
+          {easyMarketCopy(formatSignalResumeBadge(signalTrack.code, signalTrack.metric), "card")}
         </p>
       )}
 
       {personalStrongSignal && (
         <p className="mt-1 shrink-0 text-[11px] font-semibold leading-4" style={{ color: NEON }}>
-          당신이 강한 신호 · {signalTypeLabel(personalStrongSignal)}
+          당신이 강한 신호 · {easyMarketCopy(signalTypeLabel(personalStrongSignal), "card")}
         </p>
       )}
 


### PR DESCRIPTION
## 변경\n- 점수 조합 라벨, 강·약세 스트립, 보조 문구, 신호 이력 라벨까지 카드 쉬운말 변환 적용\n- Datadog에서 확인된 '매집 추정 4주차' 잔재를 '조용히 사 모으는 구간 4주차'로 전환\n\n## 검증\n- 관련 테스트 8개 통과\n- fomo-web typecheck 통과\n- 프로덕션 5종목 실측 중 발견한 잔재 후속 수정