### PR TITLE
fix: 뎁스 동적 분석 문구 쉬운말 병기

### DIFF
--- a/apps/fomo-web/__tests__/cardHookLayout.test.ts
+++ b/apps/fomo-web/__tests__/cardHookLayout.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 const card = readFileSync(new URL("../components/StockSwipeDeck.tsx", import.meta.url), "utf8");
 const depth = readFileSync(new URL("../components/KeywordDepthPage.tsx", import.meta.url), "utf8");
+const radar = readFileSync(new URL("../components/CompanyScoreRadar.tsx", import.meta.url), "utf8");
+const timeline = readFileSync(new URL("../components/JudgmentTimeline.tsx", import.meta.url), "utf8");
 
 describe("메인 카드 후킹 구조", () => {
   it("실제 30거래일 스파크라인과 신호 칩, 후킹 한 줄을 함께 렌더한다", () => {
@@ -27,5 +29,8 @@ describe("뎁스 쉬운말 레이어", () => {
     expect(depth).toContain('aria-label="차트 용어 쉬운 설명"');
     expect(depth).toContain("term.explanation");
     expect(depth).toContain('easyMarketCopy(event.label, "detail")');
+    expect(depth).toContain('easyMarketCopy(cleanText(trading ? review.tradingView : review.fundamentalView), "detail")');
+    expect(radar).toContain('easyMarketCopy(result.interpretation, "detail")');
+    expect(timeline).toContain('easyMarketCopy(formatSignalResumeBadge(code, metric), "detail")');
   });
 });

--- a/apps/fomo-web/components/CompanyScoreRadar.tsx
+++ b/apps/fomo-web/components/CompanyScoreRadar.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import type { CompanyScoreAxisKey, CompanyScoreResult } from "@fomo/core";
 import { DepthSection } from "@/components/DepthSection";
 import { chartTokens } from "@/lib/chartTokens";
+import { easyMarketCopy } from "@/lib/easyMarketCopy";
 
 const ORDER: CompanyScoreAxisKey[] = ["valuation", "growth", "profitability", "flow", "chart", "quiet"];
 const LABEL: Record<CompanyScoreAxisKey, string> = {
@@ -59,7 +60,7 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
             {result.score != null && <span className="text-sm font-semibold text-muted">/ 100</span>}
           </div>
         </div>
-        <span className="max-w-[58%] text-right text-sm font-semibold leading-5 text-whiteout">{result.label}</span>
+        <span className="max-w-[58%] text-right text-sm font-semibold leading-5 text-whiteout">{easyMarketCopy(result.label, "detail")}</span>
       </div>
 
       <div className="mt-4 flex justify-center">
@@ -92,7 +93,7 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
         </svg>
       </div>
 
-      <p className="text-sm leading-6 text-whiteout">{result.interpretation}</p>
+      <p className="text-sm leading-6 text-whiteout">{easyMarketCopy(result.interpretation, "detail")}</p>
       <p className="mt-1 text-[10px] leading-4 text-muted">
         데이터가 없는 축은 명시적으로 제외하고, 가용한 {result.availableAxisCount}개 축을 같은 비중으로 계산했어요.
       </p>
@@ -124,7 +125,7 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
         <div className="mt-3 border-l-2 pl-3" style={{ borderColor: chartTokens.up }}>
           <p className="text-xs font-semibold text-whiteout">{active.label} {active.score}점 근거</p>
           {active.evidence.map((evidence) => (
-            <p key={evidence} className="mt-1 text-xs leading-5 text-muted">{evidence}</p>
+            <p key={evidence} className="mt-1 text-xs leading-5 text-muted">{easyMarketCopy(evidence, "detail")}</p>
           ))}
         </div>
       )}

--- a/apps/fomo-web/components/JudgmentTimeline.tsx
+++ b/apps/fomo-web/components/JudgmentTimeline.tsx
@@ -10,6 +10,7 @@ import {
 import { fetchLedgerTimeline, type LedgerTimelineEntry, type TrackMetric } from "@/lib/fomoApi";
 import { DepthLine, DepthSection } from "@/components/DepthSection";
 import { chartTokens } from "@/lib/chartTokens";
+import { easyMarketCopy } from "@/lib/easyMarketCopy";
 
 const KIND_LABEL: Record<LedgerTimelineEntry["kind"], string> = {
   signal: "신호",
@@ -109,10 +110,10 @@ export function JudgmentTimeline({ canonical }: { canonical: string }) {
                 <p className="mt-0.5 font-number text-[10px] text-muted">{entry.date.slice(5)}</p>
               </div>
               <div className="min-w-0">
-                <p className="text-xs leading-5 text-whiteout">{summary(entry)}</p>
+                <p className="text-xs leading-5 text-whiteout">{easyMarketCopy(summary(entry), "detail")}</p>
                 {resumes.map(({ code, metric }) => (
                   <p key={code} className="mt-1 text-[10px] leading-4 text-muted">
-                    {formatSignalResumeBadge(code, metric)}
+                    {easyMarketCopy(formatSignalResumeBadge(code, metric), "detail")}
                   </p>
                 ))}
                 <p className="mt-0.5 text-[10px] text-muted">당시 가격 {price(entry.priceAt)}</p>

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1420,7 +1420,7 @@ function ExpertCommitteeReview({
       aside={<span className="font-pixel text-xs" style={{ color: gradeTone(grade) }}>{grade}</span>}
     >
       <p className="text-sm leading-6 text-whiteout">
-        {cleanText(trading ? review.tradingView : review.fundamentalView)}
+        {easyMarketCopy(cleanText(trading ? review.tradingView : review.fundamentalView), "detail")}
       </p>
     </DepthSection>
   );
@@ -1431,7 +1431,7 @@ function JudgmentDecision({ front }: { front: StockFrontResponse | null }) {
   return (
     <DepthSection className="mt-4" title="현재 판단">
       <p className="text-sm font-medium leading-6 text-whiteout">
-        {verdict?.stanceText ?? "판단에 필요한 차트·수급 근거를 축적하고 있어요."}
+        {easyMarketCopy(verdict?.stanceText, "detail") ?? "판단에 필요한 차트·수급 근거를 축적하고 있어요."}
       </p>
       <div className="mt-4 border-t border-hairline pt-3">
         <p className="text-[11px] font-semibold text-muted">무효선·다음 확인</p>


### PR DESCRIPTION
## 변경\n- 위원회 트레이딩 문단과 현재 판단에 쉬운말 병기 적용\n- 점수 레이더 라벨·해석·축 근거에 쉬운말 병기 적용\n- 판단 기록과 신호 이력 뱃지에 쉬운말 병기 적용\n\n## 검증\n- 관련 테스트 8개 통과\n- fomo-web typecheck 통과\n- 프로덕션 Datadog 뎁스에서 확인한 정배열 잔재 후속 수정