### PR TITLE
fix(score): 미장 밸류축 복구 — PSR 밴드 실역산 (WO-VAL)

### DIFF
--- a/apps/web/__tests__/lib/us-valuation.test.ts
+++ b/apps/web/__tests__/lib/us-valuation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { StockBasics } from "@fomo/core";
+import { parseUsdCompact, usValuationBand } from "../../lib/us-valuation";
+
+// WO-VAL — 미장 밸류축 복구. 실일봉+실매출+시총으로 PSR 밴드 역산(가짜 금지).
+describe("parseUsdCompact", () => {
+  it("$25.9B·$416.2M·$1.2T 를 USD 숫자로", () => {
+    expect(parseUsdCompact("$25.9B")).toBe(25.9e9);
+    expect(parseUsdCompact("$416.2M")).toBe(416.2e6);
+    expect(parseUsdCompact("$1.2T")).toBe(1.2e12);
+    expect(parseUsdCompact("N/A")).toBeNull();
+    expect(parseUsdCompact(undefined)).toBeNull();
+  });
+});
+
+function basics(marketCap: string, revenueThousands: number): StockBasics {
+  return {
+    name: "테스트",
+    marketCap,
+    metrics: [],
+    financials: {
+      periods: [{ title: "2024", estimate: false }, { title: "2025", estimate: false }],
+      rows: [{ label: "벌어들인 돈(매출)", values: ["1억", "2억"], rawValues: [1000, revenueThousands] }],
+    },
+  };
+}
+
+describe("usValuationBand", () => {
+  it("일봉·매출·시총으로 PSR 현재값+밴드를 실역산한다", () => {
+    // 시총 $2.59B, 현재가 $100 → 발행주식수 2590만주. 매출 $1B(천달러 100만).
+    const closes = Array.from({ length: 60 }, (_, i) => 80 + (i % 40)); // 80~119 범위
+    const band = usValuationBand(basics("$2.59B", 1_000_000), closes, 100);
+    expect(band).toBeDefined();
+    expect(band!.currentPsr).toBeGreaterThan(0);
+    expect(band!.psrHistory!.length).toBeGreaterThanOrEqual(3);
+    // 현재 PSR = 시총/매출 = 2.59B / 1B = 2.59
+    expect(band!.currentPsr).toBeCloseTo(2.59, 1);
+    expect(band!.valuationHistoryLabel).toMatch(/최근/);
+  });
+
+  it("매출·시총·현재가·일봉 중 하나라도 없으면 undefined(억지 생성 금지)", () => {
+    const closes = [90, 100, 110];
+    expect(usValuationBand(basics("$2.59B", 1_000_000), closes, undefined)).toBeUndefined();
+    expect(usValuationBand(basics("", 1_000_000), closes, 100)).toBeUndefined();
+    expect(usValuationBand(null, closes, 100)).toBeUndefined();
+    expect(usValuationBand(basics("$2.59B", 1_000_000), [], 100)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -25,6 +25,7 @@ import {
   type MultiAxisHookSelection,
 } from "@fomo/core";
 import { fetchStockBasics, fetchStockBasicsLite, fetchUsStockBasics } from "./stock-basics";
+import { usValuationBand } from "./us-valuation";
 import { fetchNasdaqDailyCandles, fetchUsDailyCandles } from "./us-market-source";
 import type { DiscoveryMarketRow } from "./market-source-types";
 import { readUsMarketQuoteRows } from "./us-market-cache";
@@ -517,8 +518,14 @@ export async function assembleStockFront(
       currency: "USD",
     });
     const basics = await basicsPromise;
-    const financials = companyFinancialsFromBasics(basics);
     const latestPrice = daily.closes.at(-1);
+    // 미장 밸류축 복구(WO-VAL) — 무료 소스에 PER/PBR/밴드가 없어, 실일봉+실매출+시총으로 PSR 밴드 역산.
+    const usValuation = usValuationBand(basics, daily.closes, latestPrice);
+    const baseFinancials = companyFinancialsFromBasics(basics);
+    const financials =
+      usValuation && (baseFinancials || usValuation.currentPsr)
+        ? { ...(baseFinancials ?? {}), ...usValuation }
+        : baseFinancials;
     const companyScore = computeCompanyScore({
       ...(financials ? { financials } : {}),
       signals,

--- a/apps/web/lib/us-valuation.ts
+++ b/apps/web/lib/us-valuation.ts
@@ -1,0 +1,64 @@
+import type { CompanyFinancialScoreInput, StockBasics } from "@fomo/core";
+
+/**
+ * US 밸류에이션 밴드 역산 (WO-VAL) — 미장 밸류축 전종목 결손 복구.
+ *
+ * 미장은 무료 소스에 PER/PBR/PSR·과거 밴드가 없다(Yahoo quoteSummary=crumb 차단·확인됨,
+ * Nasdaq summary/financials=밸류 비율 미제공·실측 확인). 그래서 **가짜 밴드 대신 실데이터로 역산**:
+ *   PSR_t = (종가_t × 발행주식수) / 최근 매출,  발행주식수 = 시가총액 ÷ 현재가
+ * 이미 확보한 최근 1년 일봉(≈250거래일)로 PSR 분포(밴드)를 만들고, 현재 PSR 의 밴드 내 위치를 낸다.
+ * 전부 실측치(일봉·매출·시총) — 지어낸 값 0. 발행주식수는 1년간 대략 일정하다는 근사만 둔다("최근 1년 밴드" 라벨로 정직).
+ */
+
+/** "$25.9B"·"$416.2M"·"$1.2T" → USD 숫자. 실패 시 null. */
+export function parseUsdCompact(text: string | undefined): number | null {
+  if (!text) return null;
+  const m = text.replace(/,/g, "").match(/\$?\s*(-?\d+(?:\.\d+)?)\s*([TBM])?/i);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  const unit = (m[2] ?? "").toUpperCase();
+  const mult = unit === "T" ? 1e12 : unit === "B" ? 1e9 : unit === "M" ? 1e6 : 1;
+  return n * mult;
+}
+
+function latestRawValue(basics: StockBasics, labelIncludes: string): number | null {
+  const row = basics.financials?.rows.find((r) => r.label.includes(labelIncludes));
+  const raw = row?.rawValues ?? [];
+  for (let i = raw.length - 1; i >= 0; i -= 1) {
+    const v = raw[i];
+    if (typeof v === "number" && Number.isFinite(v) && v !== 0) return v;
+  }
+  return null;
+}
+
+/**
+ * 미장 종목의 PSR 현재값 + 최근 1년 밴드를 실역산해 CompanyFinancialScoreInput 조각으로 돌려준다.
+ * 매출/시총/현재가/일봉 중 하나라도 없으면 undefined(정직 — 억지 생성 금지).
+ */
+export function usValuationBand(
+  basics: StockBasics | null | undefined,
+  closes: readonly number[],
+  latestPrice: number | undefined
+): Partial<CompanyFinancialScoreInput> | undefined {
+  if (!basics) return undefined;
+  const marketCap = parseUsdCompact(basics.marketCap);
+  const revenue = latestRawValue(basics, "매출"); // Nasdaq financials 는 천달러 단위 → 비율은 단위 상쇄
+  const revenueUsd = revenue !== null ? revenue * 1000 : null;
+  const price = typeof latestPrice === "number" && latestPrice > 0 ? latestPrice : undefined;
+  if (!marketCap || !revenueUsd || revenueUsd <= 0 || !price) return undefined;
+
+  const shares = marketCap / price; // 발행주식수 근사(시총÷현재가)
+  const clean = closes.filter((c) => Number.isFinite(c) && c > 0);
+  if (clean.length < 3) return undefined;
+
+  const psrSeries = clean.map((c) => (c * shares) / revenueUsd).filter((v) => Number.isFinite(v) && v > 0);
+  if (psrSeries.length < 3) return undefined;
+  const currentPsr = (price * shares) / revenueUsd;
+  const months = Math.max(1, Math.round(clean.length / 21));
+  return {
+    currentPsr: Number(currentPsr.toFixed(2)),
+    psrHistory: psrSeries.map((v) => Number(v.toFixed(2))),
+    valuationHistoryLabel: months >= 11 ? "최근 1년" : `최근 ${months}개월`,
+  };
+}

--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -186,6 +186,25 @@ describe("company score", () => {
     expect(result.omittedAxes).toContain("valuation");
   });
 
+  // WO-VAL — 미장 밸류축: PER/PBR 미도달 시 PSR 밴드로 폴백(흑자기업도), 축을 죽이지 않는다.
+  it("PER/PBR 없고 흑자여도 PSR 밴드가 있으면 밸류축을 채운다", () => {
+    const psrHistory = Array.from({ length: 40 }, (_, i) => 2 + (i % 20) * 0.1); // 2.0~3.9
+    const result = computeCompanyScore({
+      financials: {
+        revenue: [100, 120, 150],
+        operatingIncome: [10, 15, 24], // 흑자 → 원래 PER/PBR 경로(둘 다 없음)
+        periods: ["2023", "2024", "2025"],
+        currentPsr: 2.1,
+        psrHistory,
+        valuationHistoryLabel: "최근 1년",
+      },
+    });
+    const valuation = result.axes.find((axis) => axis.key === "valuation");
+    expect(valuation, "PSR 폴백으로 밸류축이 살아야 함").toBeDefined();
+    expect(valuation!.evidence[0]).toContain("PSR");
+    expect(result.omittedAxes).not.toContain("valuation");
+  });
+
   // WO 번역 레이어 — 화면 노출 문자열(interpretation·조용함 축)에 엔진 내부어 누수 금지.
   it("종합 요약·조용함 축에 계산식·화제성·quietScore 은어가 새지 않는다", () => {
     const result = withCompanyQuietScore(computeCompanyScore(accumulation), {

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -104,16 +104,21 @@ function valuationAxis(financials: CompanyFinancialScoreInput | undefined): Comp
   if (!financials) return undefined;
   const operating = lastTwo(financials.operatingIncome)?.[1];
   const useSales = finite(operating) && operating <= 0;
+  const psrCandidate = { term: "PSR", value: financials.currentPsr, history: financials.psrHistory };
   const candidates = useSales
-    ? [{ term: "PSR", value: financials.currentPsr, history: financials.psrHistory }]
+    ? [psrCandidate]
     : [
         { term: "PER", value: financials.currentPer, history: financials.perHistory },
         { term: "PBR", value: financials.currentPbr, history: financials.pbrHistory },
       ];
-  const available = candidates.flatMap((candidate) => {
-    const position = historicalPosition(candidate.value, candidate.history);
-    return finite(candidate.value) && finite(position) ? [{ ...candidate, position }] : [];
-  });
+  const resolve = (list: readonly typeof psrCandidate[]) =>
+    list.flatMap((candidate) => {
+      const position = historicalPosition(candidate.value, candidate.history);
+      return finite(candidate.value) && finite(position) ? [{ ...candidate, position }] : [];
+    });
+  // PER/PBR 미도달(미장 등) 시 PSR 로 폴백 — PSR 도 실밸류 지표. 축 자체를 죽이지 않는다(WO-VAL).
+  let available = resolve(candidates);
+  if (available.length === 0 && !useSales) available = resolve([psrCandidate]);
   if (available.length === 0) return undefined;
   const score = Math.round(available.reduce((sum, item) => sum + (100 - item.position), 0) / available.length);
   const band = financials.valuationHistoryLabel ?? `최근 ${available[0]!.history?.length ?? 0}개년`;


### PR DESCRIPTION
## 원인 확정 (프로덕션 실측, 재진단 없음)
- **KR 밸류축은 이미 동작** (삼성전자 valuation 30 · "PER 20.93배 · 최근 3개년 밴드 하단 39%"). WO의 "30/30 전멸"은 stale — 현 결손은 **US 전용**.
- **US 전종목 MISSING** (MDB·DDOG·AXON 모두 `omitted: valuation`). 원인: `fetchUsStockBasics` 가 PER/PBR/PSR·밴드를 안 채움 + 무료 소스에 US 밸류 비율 부재(Yahoo=crumb 차단·repo 기록, Nasdaq summary/financials=비율 미제공·이번 실측 확인).

## 수정 (가짜 밴드 금지 — 실데이터 역산만)
- `us-valuation.ts`: `PSR_t = (종가_t × 발행주식수) / 최근매출`, 발행주식수 = 시총÷현재가. 이미 확보한 **1년 일봉으로 PSR 밴드** 생성 → 현재 PSR 위치. 전부 실측치, "최근 1년" 라벨(WO #2 짧으면 라벨).
- stock-front US 브랜치: 역산 밴드를 `financials` 주입.
- `valuationAxis`: PER/PBR 미도달 시 **PSR 폴백**(흑자기업도) — 축 미사망. 적자 PSR 분기(기존) 유지. 밴드 불가만 "정보 없음"(0점 아님).

## 검증
- 1250 테스트 통과(us-valuation 밴드·PSR 폴백 신규), typecheck(core·web) 0
- 머지 후 **미장 5종목 밸류 점수+근거 프로덕션 실측 첨부**

🤖 Generated with [Claude Code](https://claude.com/claude-code)