### PR TITLE
fix(committee): US 밸류축 유실 관철 — candidateRecords 에 PSR 밴드 주입 (WO-LASTMILE ①)

### DIFF
--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -13,7 +13,8 @@ import {
   type CommitteeRunReport,
   type PublishedCommitteeSnapshot,
 } from "./expert-review-store";
-import { fetchStockBasics } from "./stock-basics";
+import { fetchStockBasics, fetchUsStockBasics } from "./stock-basics";
+import { usValuationBand } from "./us-valuation";
 import { kstDate } from "./fomo";
 import { readFeedContent, writeFeedContent } from "./feed-content-store";
 
@@ -702,11 +703,24 @@ async function candidateRecords(response: Daily30Response): Promise<CandidateRec
   }).slice(0, CANDIDATE_TARGET);
 
   return mapConcurrent(raw, 6, async (candidate): Promise<CandidateRecord> => {
+    // WO-LASTMILE ①: 위원회 재계산은 pool 점수를 덮어쓰므로, 여기서도 국/미 재무를 동일하게 주입해야
+    // 밸류축이 발행 스냅샷까지 흐른다. US 는 네이버가 없어 fetchUsStockBasics + 일봉 PSR 역산을 쓴다
+    // (fetchStockBasics 는 KR 전용 — US 에 쓰면 basics 결손 → 밸류축 전종목 유실).
+    const isUsStock = candidate.card.country === "US";
     const basics = candidate.card.market === "COIN"
       ? undefined
-      : await fetchStockBasics(candidate.card.canonical, candidate.card.naverCode, candidate.card.symbol).catch(() => undefined);
-    const financials = companyFinancialsFromBasics(basics);
+      : isUsStock
+        ? await fetchUsStockBasics(candidate.card.canonical, candidate.card.symbol ?? candidate.card.canonical, false).catch(() => undefined)
+        : await fetchStockBasics(candidate.card.canonical, candidate.card.naverCode, candidate.card.symbol).catch(() => undefined);
+    let financials = companyFinancialsFromBasics(basics);
     const latestPrice = candidate.front.candles?.at(-1)?.close;
+    if (isUsStock) {
+      const usCloses = (candidate.front.candles ?? []).map((c) => c.close);
+      if (usCloses.length > 0) {
+        const band = usValuationBand(basics ?? null, usCloses, latestPrice);
+        if (band) financials = { ...(financials ?? {}), ...band };
+      }
+    }
     const companyScore = computeCompanyScore({
       ...(financials ? { financials } : {}),
       signals: candidate.front.signals,


### PR DESCRIPTION
## 근본원인 (실측 확정)
덱 US 밸류축이 전량 결손(0/14)이던 진짜 원인을 committee-recovery 액션 로그로 확정:
- **pool 빌드 시점엔 US band=true** (basics=true·candles=183·marketCap 정상 — discovery-supply #939 주입 정상 동작)
- 그런데 위원회가 `candidateRecords`에서 점수를 **재계산해 덮어씀**, 이 재계산이:
  1. US 에도 KR 전용 `fetchStockBasics` 사용 → basics 결손
  2. `usValuationBand` **미호출**
  → 발행 스냅샷 US 밸류 **0/14 유실**
- 뎁스(stock-front)는 이 경로를 안 타서 정상(MDB PSR 10.03배 등 라이브)

## 수정
`candidateRecords`에서 US 는 `fetchUsStockBasics` + 일봉 PSR 역산(`usValuationBand`)을 동일 주입. **discovery-supply(#939)·stock-front(#937)·committee 3-경로 일치**.

## 검증
- 백엔드 타입체크 통과
- 머지 후 committee-recovery 재발행 → daily-30 US 밸류 확보율 재측정 예정(목표 ≥80%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)