### PR TITLE
fix(web): 모바일 뎁스 탭 스크롤 영역 밖 고정

### DIFF
--- a/apps/fomo-web/__tests__/depthLayout.test.ts
+++ b/apps/fomo-web/__tests__/depthLayout.test.ts
@@ -8,14 +8,16 @@ const chartCard = readFileSync(new URL("../components/cards/ChartCardBody.tsx", 
 const tokens = readFileSync(new URL("../lib/chartTokens.ts", import.meta.url), "utf8");
 
 describe("종목 뎁스 정보 구조", () => {
-  it("판단을 기본으로 열고 네 개의 탭을 레이아웃별로 고정한다", () => {
+  it("판단을 기본으로 열고 네 개의 탭을 모바일·데스크톱 모두 본문 밖에 고정한다", () => {
     expect(component).toContain('useState<DepthTab>("judgment")');
-    expect(component).toContain("sticky top-0 z-30");
-    expect(component).toContain('inline = false');
-    expect(component).toContain('"z-30 shrink-0 border-b border-hairline bg-black px-6 py-2"');
-    expect(component).toContain("{inline && detailsReady && (");
-    expect(component).toContain('<DepthTabBar tab={depthTab} onChange={setDepthTab} inline />');
-    expect(component).toContain("{!inline && <DepthTabBar tab={depthTab} onChange={setDepthTab} />}");
+    expect(component).not.toContain("sticky top-0 z-30");
+    expect(component).toContain('className="z-30 shrink-0 border-b border-hairline bg-black px-6 py-2"');
+    expect(component).toContain("{detailsReady && (");
+    expect(component).toContain('<DepthTabBar tab={depthTab} onChange={setDepthTab} />');
+    expect(component).toContain('className="scrollbar-none min-h-0 flex-1 overflow-y-auto px-6 py-6"');
+    expect(component.indexOf("{detailsReady && (")).toBeLessThan(
+      component.indexOf('className="scrollbar-none min-h-0 flex-1 overflow-y-auto px-6 py-6"'),
+    );
     for (const label of ["판단", "차트·구간", "기업·재무", "신호 이력"]) {
       expect(component).toContain(`label: "${label}"`);
     }

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -1387,16 +1387,8 @@ function CommunityWordingBlock({ insight }: { insight: CondensedInsight | null }
 
 type DepthTab = "judgment" | "chart" | "company" | "history";
 
-/** 상세 정보 위계를 고정하는 4축 탭. 인라인에서는 스크롤 본문 밖의 고정 행으로 쓴다. */
-function DepthTabBar({
-  tab,
-  onChange,
-  inline = false,
-}: {
-  tab: DepthTab;
-  onChange: (tab: DepthTab) => void;
-  inline?: boolean;
-}) {
+/** 상세 정보 위계를 고정하는 4축 탭. 모든 화면에서 스크롤 본문 밖의 고정 행으로 쓴다. */
+function DepthTabBar({ tab, onChange }: { tab: DepthTab; onChange: (tab: DepthTab) => void }) {
   const tabs: Array<{ key: DepthTab; label: string }> = [
     { key: "judgment", label: "판단" },
     { key: "chart", label: "차트·구간" },
@@ -1405,9 +1397,7 @@ function DepthTabBar({
   ];
   return (
     <div
-      className={inline
-        ? "z-30 shrink-0 border-b border-hairline bg-black px-6 py-2"
-        : "sticky top-0 z-30 -mx-6 mt-4 border-y border-hairline bg-black/95 px-6 py-2 backdrop-blur"}
+      className="z-30 shrink-0 border-b border-hairline bg-black px-6 py-2"
       role="tablist"
       aria-label="종목 상세"
     >
@@ -2747,11 +2737,11 @@ export function StockInsightView({
           </button>
         </div>
 
-        {inline && detailsReady && (
-          <DepthTabBar tab={depthTab} onChange={setDepthTab} inline />
+        {detailsReady && (
+          <DepthTabBar tab={depthTab} onChange={setDepthTab} />
         )}
 
-        <div className="scrollbar-none flex-1 overflow-y-auto px-6 py-6">
+        <div className="scrollbar-none min-h-0 flex-1 overflow-y-auto px-6 py-6">
           {/* 전부 로드 전엔 아무것도 노출하지 않는다(2026-07-18 User Zero: "정보가 나왔다가 바뀌어 어색") —
               가격 헤더 선노출·seed→fresh 교체 없이 메인홈과 동일한 로딩 하나만. */}
           {!detailsReady ? (
@@ -2760,7 +2750,6 @@ export function StockInsightView({
           <>
           {/* 가격 먼저 — 일반 주식 상세 화면의 첫 독해 지점. */}
           <StockPriceHeader basics={basics} front={front} />
-          {!inline && <DepthTabBar tab={depthTab} onChange={setDepthTab} />}
           <div
             id={`depth-panel-${depthTab}`}
             role="tabpanel"


### PR DESCRIPTION
## 문제\n모바일 종목 상세에서 탭이 스크롤 본문 안의 sticky 요소라 레이더가 탭 뒤로 지나가며 잘렸습니다.\n\n## 변경\n- 모바일·데스크톱 모두 헤더 → 고정 탭 → 독립 스크롤 본문 구조로 통일\n- 모바일 전용 sticky/negative margin 분기 제거\n- 본문 flex 자식에 min-h-0 추가\n- 레이아웃 회귀 테스트 강화\n\n## 검증\n- npm run test -- depthLayout desktopDashboard card-axis\n- npm --workspace @fomo/web run build\n- npm --workspace @fomo/web run typecheck\n- 390x844 모바일 실측: 탭 top 67/bottom 124 고정, 본문 scrollTop 0→250, 겹침 없음