### PR TITLE
fix: diversify company score explanations

### DIFF
--- a/apps/web/__tests__/lib/daily-30-schema.test.ts
+++ b/apps/web/__tests__/lib/daily-30-schema.test.ts
@@ -30,7 +30,10 @@ function front(): DiscoveryFrontSeed {
 
 describe("daily-30 unified card schema", () => {
   it("KR/US/coin cards expose the exact same required field set", () => {
-    const score = withCompanyQuietScore(computeCompanyScore({}), { quietScore: 40 });
+    const score = withCompanyQuietScore(
+      computeCompanyScore({ signals: { volumeRatio: 2, changePct: 2.5 } }),
+      { quietScore: 40 }
+    );
     const cards = (["kr-stock", "us-stock", "coin"] as const).map((asset) =>
       buildUnifiedCardSnapshot(stock(asset), asset, front(), score)
     );
@@ -42,7 +45,7 @@ describe("daily-30 unified card schema", () => {
     expect(cards.every((card) => card.score.status === "ready" && card.sparkline.length > 0)).toBe(true);
   });
 
-  it("upgrades legacy snapshots with flow, chart, and quiet as guaranteed minimum axes", () => {
+  it("keeps legacy flow missing when the snapshot has no measured flow evidence", () => {
     const legacy = {
       asOf: "2026-07-20",
       country: "all",
@@ -76,7 +79,7 @@ describe("daily-30 unified card schema", () => {
     } as unknown as Daily30Response;
     const normalized = normalizeDaily30Response(legacy).fronts["us-stock"]!;
     expect(normalized.score?.axisStates.filter((axis) => ["flow", "chart", "quiet"].includes(axis.key)).map((axis) => axis.status)).toEqual([
-      "available", "available", "available",
+      "missing", "available", "available",
     ]);
     expect(normalized).not.toHaveProperty("fomo");
     expect(normalized).not.toHaveProperty("companyScore");

--- a/apps/web/__tests__/lib/judgment-ledger.test.ts
+++ b/apps/web/__tests__/lib/judgment-ledger.test.ts
@@ -163,7 +163,10 @@ describe("Judgment Ledger", () => {
           priceText: "$123.45",
           axisSignals: [],
           verdict: { stance: "watch", stanceText: "구간 확인", evidence: [], confidence: "medium" },
-          score: computeCompanyScore({ quiet: { quietScore: 80 } }),
+          score: computeCompanyScore({
+            signals: { volumeRatio: 2, changePct: 3.1 },
+            quiet: { quietScore: 80 },
+          }),
         },
       },
       meta: { cards: [{ id: "stock:US:ACME:ACME", assetClass: "us-stock", quietScore: 75, signalScore: 90, hypePenalty: 15 }], assetCounts: {}, targetCount: 1 },

--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -61,12 +61,12 @@ describe("company score", () => {
     expect(accumulating.label).toBe("분석 축적 중");
     expect(accumulating.axisStates).toHaveLength(6);
     expect(accumulating.axisStates.filter((axis) => axis.status === "missing").every((axis) => axis.missingReason === "데이터 없음")).toBe(true);
-    expect(accumulating.axes.map((axis) => axis.key)).toEqual(["flow", "chart"]);
+    expect(accumulating.axes.map((axis) => axis.key)).toEqual(["chart"]);
 
     const ready = withCompanyQuietScore(accumulating, { quietScore: 40 });
-    expect(ready.status).toBe("ready");
-    expect(ready.availableAxisCount).toBe(3);
-    expect(ready.score).not.toBeNull();
+    expect(ready.status).toBe("accumulating");
+    expect(ready.availableAxisCount).toBe(2);
+    expect(ready.score).toBeNull();
   });
 
   it("uses six evidence-backed axes and derives the combined label", () => {
@@ -182,8 +182,60 @@ describe("company score", () => {
     };
     const input = companyFinancialsFromBasics(basics)!;
     const result = computeCompanyScore({ financials: input });
-    expect(result.axes.map((axis) => axis.key)).toEqual(["growth", "profitability", "flow", "chart"]);
+    expect(result.axes.map((axis) => axis.key)).toEqual(["growth", "profitability", "chart"]);
     expect(result.omittedAxes).toContain("valuation");
+  });
+
+  it("treats absent flow evidence as missing and uses verified volume anomalies when present", () => {
+    const missing = computeCompanyScore({ financials: accumulation.financials, quiet: { quietScore: 40 } });
+    expect(missing.omittedAxes).toContain("flow");
+    expect(missing.axisStates.find((axis) => axis.key === "flow")).toMatchObject({
+      status: "missing",
+      score: null,
+      missingReason: "데이터 없음",
+    });
+
+    const measured = computeCompanyScore({
+      signals: { volumeRatio: 2.2, changePct: 4.1 },
+      quiet: { quietScore: 40 },
+    });
+    expect(measured.axes.find((axis) => axis.key === "flow")).toMatchObject({ score: 62 });
+    expect(measured.axes.find((axis) => axis.key === "flow")?.evidence[0]).toContain("거래량 평소 2.2배");
+  });
+
+  it("keeps 30 deterministic score explanations diverse without inventing missing flow", () => {
+    const profiles = Array.from({ length: 30 }, (_, index): CompanyScoreInput => {
+      const phase = (["accumulation", "markup", "distribution", "markdown"] as const)[index % 4]!;
+      const revenueGrowth = 8 + index * 1.7;
+      const margin = 4 + (index % 11) * 1.8;
+      const revenue = [100, 112 + (index % 5), 112 * (1 + revenueGrowth / 100)];
+      const operatingIncome = [7, 8 + (index % 4), revenue[2]! * (margin / 100)];
+      return {
+        financials: {
+          revenue,
+          operatingIncome,
+          periods: ["2024", "2025", "2026"],
+          ...(index % 3 === 0
+            ? { currentPsr: 1.4 + index * 0.04, psrHistory: [1.1, 1.5, 1.9, 2.3, 2.8] }
+            : {}),
+        },
+        signals:
+          index % 4 === 0
+            ? { volumeRatio: 1.55 + index * 0.03, changePct: index % 8 === 0 ? 3.2 : -2.4 }
+            : index % 5 === 0
+              ? { foreignNetStreak: 1 + (index % 7) }
+              : {},
+        verdict: { stance: "watch", stanceText: "관찰", phase, evidence: [], confidence: "medium" },
+        currentPrice: 100 + index,
+        quiet: { quietScore: 18 + index * 1.9, signalScore: 30 + index, hypePenalty: index % 9 },
+      };
+    });
+    const explanations = profiles.map((profile) => computeCompanyScore(profile).interpretation);
+    const counts = explanations.reduce((map, sentence) => map.set(sentence, (map.get(sentence) ?? 0) + 1), new Map<string, number>());
+
+    expect(new Set(explanations).size).toBeGreaterThanOrEqual(20);
+    expect(Math.max(...counts.values())).toBeLessThanOrEqual(3);
+    expect(explanations.every((sentence) => /\d+점/u.test(sentence))).toBe(true);
   });
 
   // WO-VAL — 미장 밸류축: PER/PBR 미도달 시 PSR 밴드로 폴백(흑자기업도), 축을 죽이지 않는다.

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -353,7 +353,7 @@ function interpretation(axes: readonly CompanyScoreAxis[], label: string): strin
     return `성장 ${top.score}점이 가장 빠르게 앞서고 ${runnerUp.label}도 ${runnerUp.score}점으로 받쳐줘요. ${bottom.label} ${bottom.score}점과의 격차는 ${gap}점이에요.`;
   }
   if (top.key === "flow") {
-    return `실제 돈의 움직임을 반영한 수급이 ${top.score}점으로 선두예요. 다음 강점은 ${runnerUp.label} ${runnerUp.score}점이고, ${bottom.label}과는 ${gap}점 차이예요.`;
+    return `검증된 수급이 ${top.score}점으로 선두예요. 다음 강점은 ${runnerUp.label} ${runnerUp.score}점이고, ${bottom.label}과는 ${gap}점 차이예요.`;
   }
   if (top.key === "chart") {
     return `차트 타이밍이 ${top.score}점으로 가장 낫고 ${runnerUp.label}은 ${runnerUp.score}점이에요. 가장 약한 ${bottom.label} ${bottom.score}점까지 격차는 ${gap}점이에요.`;

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -43,7 +43,7 @@ export interface CompanyQuietScoreInput {
 
 export interface CompanyScoreInput {
   financials?: CompanyFinancialScoreInput;
-  signals?: Pick<CardFrontSignals, "foreignNetStreak" | "institutionNetStreak">;
+  signals?: Pick<CardFrontSignals, "foreignNetStreak" | "institutionNetStreak" | "volumeRatio" | "changePct">;
   insiderPurchaseConfirmed?: boolean;
   whaleStrength?: number;
   quietMoney?: QuietMoneyTimeline;
@@ -179,9 +179,11 @@ function profitabilityAxis(financials: CompanyFinancialScoreInput | undefined): 
   };
 }
 
-function flowAxis(input: CompanyScoreInput): CompanyScoreAxis {
+function flowAxis(input: CompanyScoreInput): CompanyScoreAxis | undefined {
   const foreign = input.signals?.foreignNetStreak;
   const institution = input.signals?.institutionNetStreak;
+  const volumeRatio = input.signals?.volumeRatio;
+  const changePct = input.signals?.changePct;
   const whale = input.whaleStrength;
   const quietMoney = input.quietMoney;
   let score = 50;
@@ -198,6 +200,16 @@ function flowAxis(input: CompanyScoreInput): CompanyScoreAxis {
     score += 24;
     evidence.push("내부자 공개시장 매수 공시 확인");
   }
+  if (finite(volumeRatio) && volumeRatio >= 1.5) {
+    const direction = finite(changePct) && Math.abs(changePct) >= 0.3 ? Math.sign(changePct) : 0;
+    const adjustment = Math.min(18, Math.round((volumeRatio - 1) * 10));
+    score += adjustment * direction;
+    evidence.push(
+      `거래량 평소 ${volumeRatio.toFixed(1)}배${
+        direction > 0 ? " · 가격 동반 상승" : direction < 0 ? " · 가격 동반 하락" : " · 방향 확인 중"
+      }`
+    );
+  }
   if (finite(whale)) {
     score += clamp(whale, -1, 1) * 25;
     evidence.push(`고래 신호 강도 ${whale.toFixed(2)}`);
@@ -206,7 +218,7 @@ function flowAxis(input: CompanyScoreInput): CompanyScoreAxis {
     score += quietMoney.cluster.strength * 4;
     evidence.push(`${quietMoney.cluster.headline} · 강도 ${quietMoney.cluster.strength}/5`);
   }
-  if (evidence.length === 0) evidence.push("확인된 연속 수급·내부자·고래 유입 신호 없음");
+  if (evidence.length === 0) return undefined;
   return { key: "flow", label: AXIS_LABEL.flow, score: Math.round(clamp(score)), evidence };
 }
 
@@ -308,14 +320,48 @@ function axisMeaning(axis: CompanyScoreAxis): string {
   }
 }
 
+function rankAxes(axes: readonly CompanyScoreAxis[]): CompanyScoreAxis[] {
+  return [...axes].sort((a, b) => b.score - a.score || ALL_AXES.indexOf(a.key) - ALL_AXES.indexOf(b.key));
+}
+
 function interpretation(axes: readonly CompanyScoreAxis[], label: string): string {
   if (axes.length < 3) return "검증 가능한 분석 축이 3개 미만이라 종합 점수를 보류했어요.";
-  const sorted = [...axes].sort((a, b) => b.score - a.score);
+  const sorted = rankAxes(axes);
   const top = sorted[0]!;
+  const runnerUp = sorted[1]!;
   const bottom = sorted.at(-1)!;
   if (top.key === bottom.key) return `${label}. ${axisMeaning(top)}.`;
-  // "가장 강한 축=의미 / 가장 약한 축=의미" — 숫자 점수는 육각형·리스트에 이미 있으니 문장은 뜻만.
-  return `${label}. 지금 가장 돋보이는 건 '${axisMeaning(top)}', 반대로 '${axisMeaning(bottom)}'은 약한 편이에요.`;
+  const gap = top.score - bottom.score;
+  const leadGap = top.score - runnerUp.score;
+  const valuationMissing = !axisOf(axes, "valuation");
+  const growth = axisOf(axes, "growth");
+
+  if (valuationMissing && (growth?.score ?? 0) >= 70) {
+    const operating = axisOf(axes, "profitability") ?? runnerUp;
+    return `성장 ${growth!.score}점이 앞서지만 비싼지 싼지는 아직 데이터가 부족해요. ${operating.label}은 ${operating.score}점이고, ${bottom.label} ${bottom.score}점까지 격차는 ${gap}점이에요.`;
+  }
+  if (gap <= 10) {
+    return `${top.label} ${top.score}점부터 ${bottom.label} ${bottom.score}점까지 격차가 ${gap}점뿐이에요. 한 축이 튀기보다 가용 ${axes.length}개 축이 고른 편이에요.`;
+  }
+  if (leadGap <= 5) {
+    return `${top.label} ${top.score}점과 ${runnerUp.label} ${runnerUp.score}점이 함께 앞서요. ${bottom.label} ${bottom.score}점까지 격차는 ${gap}점이라 약한 축도 같이 봐야 해요.`;
+  }
+  if (gap >= 35) {
+    return `${top.label}은 ${top.score}점으로 뚜렷하고 ${runnerUp.label} ${runnerUp.score}점이 뒤를 이어요. ${bottom.label} ${bottom.score}점까지 격차 ${gap}점이 큰 비대칭 구조예요.`;
+  }
+  if (top.key === "growth") {
+    return `성장 ${top.score}점이 가장 빠르게 앞서고 ${runnerUp.label}도 ${runnerUp.score}점으로 받쳐줘요. ${bottom.label} ${bottom.score}점과의 격차는 ${gap}점이에요.`;
+  }
+  if (top.key === "flow") {
+    return `실제 돈의 움직임을 반영한 수급이 ${top.score}점으로 선두예요. 다음 강점은 ${runnerUp.label} ${runnerUp.score}점이고, ${bottom.label}과는 ${gap}점 차이예요.`;
+  }
+  if (top.key === "chart") {
+    return `차트 타이밍이 ${top.score}점으로 가장 낫고 ${runnerUp.label}은 ${runnerUp.score}점이에요. 가장 약한 ${bottom.label} ${bottom.score}점까지 격차는 ${gap}점이에요.`;
+  }
+  if (top.key === "quiet") {
+    return `조용함 ${top.score}점이라 화제보다 신호가 앞서 있어요. ${runnerUp.label} ${runnerUp.score}점이 뒤를 잇고, ${bottom.label}과의 격차는 ${gap}점이에요.`;
+  }
+  return `${top.label} ${top.score}점이 가장 강하고 ${runnerUp.label} ${runnerUp.score}점이 다음이에요. ${bottom.label} ${bottom.score}점까지 ${gap}점 벌어져 있어요.`;
 }
 
 function axisStates(axes: readonly CompanyScoreAxis[]): CompanyScoreAxisState[] {


### PR DESCRIPTION
## Summary
- replace the single company-score explanation template with deterministic profile-aware structures
- omit flow when no verified flow evidence exists; use insider, streak, whale, cluster, or abnormal volume signals only
- enforce 30-profile explanation diversity and update legacy schema fixtures

## Verification
- npm test (1252 passed)
- npm run typecheck
- npm run build:web
- npm run build:fomo-web
- production snapshot replay: 30/30 unique explanations, max repeat 1