### PR TITLE
fix: daily-30 밸류 축 유실 복구

### DIFF
--- a/apps/web/__tests__/lib/expert-review-committee.test.ts
+++ b/apps/web/__tests__/lib/expert-review-committee.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
+import { computeCompanyScore } from "@fomo/core";
 import {
   applyAnalystFactGate,
   completeEditorSelectedIds,
   enforceEditorAssetFloors,
+  mergeCommitteeCompanyScore,
   parseEditorOutput,
   runExpertReviewCommittee,
   runExpertReviewCommitteeStage,
@@ -110,6 +112,31 @@ function fakePool(count = 40): Daily30Response {
 }
 
 describe("expert committee orchestration", () => {
+  it("후보 풀의 실측 밸류축을 위원회 라이트 재계산이 지우지 않는다", () => {
+    const source = computeCompanyScore({
+      financials: {
+        currentPsr: 2.5,
+        psrHistory: [1.9, 2.2, 2.8, 3.1],
+        valuationHistoryLabel: "최근 1년",
+      },
+    });
+    const recalculated = computeCompanyScore({
+      signals: { changePct: 2.1, volumeRatio: 1.4 },
+    });
+
+    const merged = mergeCommitteeCompanyScore(
+      source,
+      recalculated,
+      { quietScore: 72, signalScore: 80, hypePenalty: 8 },
+      "2026-07-22"
+    );
+
+    expect(merged.axes.find((axis) => axis.key === "valuation")).toMatchObject({
+      evidence: [expect.stringContaining("PSR 2.50배")],
+    });
+    expect(merged.axes.some((axis) => axis.key === "quiet")).toBe(true);
+  });
+
   it("편집장 핵심 선정 ID가 있으면 누락된 부가 필드를 결정론 기본값으로 보완한다", () => {
     expect(parseEditorOutput(JSON.stringify({ selected_ids: ["a", "b"] }))).toEqual({
       selectedIds: ["a", "b"],

--- a/apps/web/__tests__/lib/us-valuation.test.ts
+++ b/apps/web/__tests__/lib/us-valuation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { StockBasics } from "@fomo/core";
-import { parseUsdCompact, usValuationBand } from "../../lib/us-valuation";
+import { parseUsdCompact, usValuationBand, usValuationBandWithDiagnostics } from "../../lib/us-valuation";
 
 // WO-VAL — 미장 밸류축 복구. 실일봉+실매출+시총으로 PSR 밴드 역산(가짜 금지).
 describe("parseUsdCompact", () => {
@@ -44,5 +44,14 @@ describe("usValuationBand", () => {
     expect(usValuationBand(basics("", 1_000_000), closes, 100)).toBeUndefined();
     expect(usValuationBand(null, closes, 100)).toBeUndefined();
     expect(usValuationBand(basics("$2.59B", 1_000_000), [], 100)).toBeUndefined();
+  });
+
+  it("밴드 계산 실패 원인을 입력별로 구조화해 남긴다", () => {
+    const noRevenue: StockBasics = { name: "테스트", marketCap: "$2.59B", metrics: [] };
+    expect(usValuationBandWithDiagnostics(null, [90, 100, 110], 100).diagnostic.reason).toBe("basics-missing");
+    expect(usValuationBandWithDiagnostics(basics("", 1_000_000), [90, 100, 110], 100).diagnostic.reason).toBe("market-cap-missing");
+    expect(usValuationBandWithDiagnostics(noRevenue, [90, 100, 110], 100).diagnostic.reason).toBe("revenue-missing");
+    expect(usValuationBandWithDiagnostics(basics("$2.59B", 1_000_000), [90, 100, 110], undefined).diagnostic.reason).toBe("latest-price-missing");
+    expect(usValuationBandWithDiagnostics(basics("$2.59B", 1_000_000), [100], 100).diagnostic.reason).toBe("closes-insufficient");
   });
 });

--- a/apps/web/lib/expert-review-committee.ts
+++ b/apps/web/lib/expert-review-committee.ts
@@ -1,5 +1,12 @@
 import { callAI, isAiConfigured } from "@fomo/shared";
-import { companyFinancialsFromBasics, computeCompanyScore, type StockBasics } from "@fomo/core";
+import {
+  companyFinancialsFromBasics,
+  computeCompanyScore,
+  withCompanyQuietScore,
+  type CompanyQuietScoreInput,
+  type CompanyScoreResult,
+  type StockBasics,
+} from "@fomo/core";
 import { buildDaily30CandidatePoolResponse, type Daily30Response } from "./daily-30";
 import { writeDaily30Ledger } from "./judgment-ledger";
 import type { DiscoveryDeckCardPayload, DiscoveryFrontSeed, DiscoveryStockPayload } from "./discovery-supply";
@@ -14,7 +21,7 @@ import {
   type PublishedCommitteeSnapshot,
 } from "./expert-review-store";
 import { fetchStockBasics, fetchUsStockBasics } from "./stock-basics";
-import { usValuationBand } from "./us-valuation";
+import { usValuationBandWithDiagnostics, type UsValuationDiagnostic } from "./us-valuation";
 import { kstDate } from "./fomo";
 import { readFeedContent, writeFeedContent } from "./feed-content-store";
 
@@ -145,6 +152,25 @@ function isStockCard(card: DiscoveryDeckCardPayload): card is { kind: "stock" } 
 
 function finite(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+const FINANCIAL_AXIS_KEYS = new Set(["valuation", "growth", "profitability"]);
+
+/** 위원회가 재무를 다시 읽지 못한 날에도 후보 풀에서 이미 계산된 실측 재무축을 지우지 않는다. */
+export function mergeCommitteeCompanyScore(
+  source: CompanyScoreResult | undefined,
+  recalculated: CompanyScoreResult,
+  quiet: CompanyQuietScoreInput,
+  asOf?: string
+): CompanyScoreResult {
+  const recalculatedKeys = new Set(recalculated.axes.map((axis) => axis.key));
+  const preservedFinancialAxes = (source?.axes ?? []).filter(
+    (axis) => FINANCIAL_AXIS_KEYS.has(axis.key) && !recalculatedKeys.has(axis.key)
+  );
+  const merged = preservedFinancialAxes.length > 0
+    ? { ...recalculated, axes: [...preservedFinancialAxes, ...recalculated.axes] }
+    : recalculated;
+  return withCompanyQuietScore(merged, quiet, asOf);
 }
 
 function summarizeCandles(front: DiscoveryFrontSeed) {
@@ -713,15 +739,18 @@ async function candidateRecords(response: Daily30Response): Promise<CandidateRec
         ? await fetchUsStockBasics(candidate.card.canonical, candidate.card.symbol ?? candidate.card.canonical, false).catch(() => undefined)
         : await fetchStockBasics(candidate.card.canonical, candidate.card.naverCode, candidate.card.symbol).catch(() => undefined);
     let financials = companyFinancialsFromBasics(basics);
-    const latestPrice = candidate.front.candles?.at(-1)?.close;
-    if (isUsStock) {
-      const usCloses = (candidate.front.candles ?? []).map((c) => c.close);
-      if (usCloses.length > 0) {
-        const band = usValuationBand(basics ?? null, usCloses, latestPrice);
-        if (band) financials = { ...(financials ?? {}), ...band };
-      }
+    const sourceHasValuation = candidate.front.score?.axes.some((axis) => axis.key === "valuation") ?? false;
+    const candleCloses = (candidate.front.candles ?? []).map((c) => c.close).filter((close) => finite(close) && close > 0);
+    const fallbackCloses = (candidate.front.sparkline ?? []).filter((close) => finite(close) && close > 0);
+    const usCloses = candleCloses.length > 0 ? candleCloses : fallbackCloses;
+    const latestPrice = candleCloses.at(-1) ?? fallbackCloses.at(-1);
+    let valuationDiagnostic: UsValuationDiagnostic | undefined;
+    if (isUsStock && !sourceHasValuation) {
+      const valuation = usValuationBandWithDiagnostics(basics ?? null, usCloses, latestPrice);
+      valuationDiagnostic = valuation.diagnostic;
+      if (valuation.band) financials = { ...(financials ?? {}), ...valuation.band };
     }
-    const companyScore = computeCompanyScore({
+    const recalculatedScore = computeCompanyScore({
       ...(financials ? { financials } : {}),
       signals: candidate.front.signals,
       ...(candidate.front.verdict ? { verdict: candidate.front.verdict } : {}),
@@ -732,13 +761,28 @@ async function candidateRecords(response: Daily30Response): Promise<CandidateRec
         candidate.card.reason,
       ].filter(Boolean).join(" ")),
       ...(finite(latestPrice) ? { currentPrice: latestPrice } : {}),
-      quiet: {
+      asOf: candidate.front.signals.asOf ?? response.asOf,
+    });
+    const companyScore = mergeCommitteeCompanyScore(
+      candidate.front.score,
+      recalculatedScore,
+      {
         quietScore: candidate.quietScore,
         signalScore: candidate.signalScore,
         hypePenalty: candidate.hypePenalty,
       },
-      asOf: candidate.front.signals.asOf ?? response.asOf,
-    });
+      candidate.front.signals.asOf ?? response.asOf
+    );
+    if (candidate.card.market !== "COIN" && !companyScore.axes.some((axis) => axis.key === "valuation")) {
+      console.warn("[expert-committee] valuation unavailable", {
+        canonical: candidate.card.canonical,
+        country: candidate.card.country,
+        symbol: candidate.card.symbol,
+        naverCode: candidate.card.naverCode,
+        sourceHasValuation,
+        diagnostic: valuationDiagnostic ?? { reason: basics ? "kr-valuation-unavailable" : "basics-missing" },
+      });
+    }
     const front: DiscoveryFrontSeed = { ...candidate.front, score: companyScore };
     const scoreAxes = companyScore.axes;
     return {

--- a/apps/web/lib/stock-front.ts
+++ b/apps/web/lib/stock-front.ts
@@ -557,7 +557,7 @@ export async function assembleStockFront(
   const lite = options.lite === true;
 
   const [basics, history, daily] = await Promise.all([
-    (lite ? fetchStockBasicsLite(stock) : fetchStockBasics(stock)).catch(() => null),
+    (lite ? fetchStockBasicsLite(stock, 3500, code) : fetchStockBasics(stock, code, options.symbol)).catch(() => null),
     readSupplyDemandHistory(code).catch(() => []),
     fetchStockDaily(code, lite ? 110 : 420),
   ]);

--- a/apps/web/lib/us-valuation.ts
+++ b/apps/web/lib/us-valuation.ts
@@ -1,5 +1,27 @@
 import type { CompanyFinancialScoreInput, StockBasics } from "@fomo/core";
 
+export type UsValuationFailureReason =
+  | "basics-missing"
+  | "market-cap-missing"
+  | "revenue-missing"
+  | "latest-price-missing"
+  | "closes-insufficient"
+  | "psr-series-insufficient";
+
+export interface UsValuationDiagnostic {
+  reason?: UsValuationFailureReason;
+  closeCount: number;
+  hasBasics: boolean;
+  hasMarketCap: boolean;
+  hasRevenue: boolean;
+  hasLatestPrice: boolean;
+}
+
+export interface UsValuationBandResult {
+  band?: Partial<CompanyFinancialScoreInput>;
+  diagnostic: UsValuationDiagnostic;
+}
+
 /**
  * US 밸류에이션 밴드 역산 (WO-VAL) — 미장 밸류축 전종목 결손 복구.
  *
@@ -36,29 +58,55 @@ function latestRawValue(basics: StockBasics, labelIncludes: string): number | nu
  * 미장 종목의 PSR 현재값 + 최근 1년 밴드를 실역산해 CompanyFinancialScoreInput 조각으로 돌려준다.
  * 매출/시총/현재가/일봉 중 하나라도 없으면 undefined(정직 — 억지 생성 금지).
  */
+export function usValuationBandWithDiagnostics(
+  basics: StockBasics | null | undefined,
+  closes: readonly number[],
+  latestPrice: number | undefined
+): UsValuationBandResult {
+  const clean = closes.filter((c) => Number.isFinite(c) && c > 0);
+  const price = typeof latestPrice === "number" && latestPrice > 0 ? latestPrice : undefined;
+  const diagnosticBase = {
+    closeCount: clean.length,
+    hasBasics: Boolean(basics),
+    hasMarketCap: false,
+    hasRevenue: false,
+    hasLatestPrice: Boolean(price),
+  };
+  if (!basics) {
+    return { diagnostic: { ...diagnosticBase, reason: "basics-missing" } };
+  }
+  const marketCap = parseUsdCompact(basics.marketCap);
+  const revenue = latestRawValue(basics, "매출"); // Nasdaq financials 는 천달러 단위 → 비율은 단위 상쇄
+  const revenueUsd = revenue !== null ? revenue * 1000 : null;
+  const diagnostic = {
+    ...diagnosticBase,
+    hasMarketCap: Boolean(marketCap),
+    hasRevenue: Boolean(revenueUsd && revenueUsd > 0),
+  };
+  if (!marketCap) return { diagnostic: { ...diagnostic, reason: "market-cap-missing" } };
+  if (!revenueUsd || revenueUsd <= 0) return { diagnostic: { ...diagnostic, reason: "revenue-missing" } };
+  if (!price) return { diagnostic: { ...diagnostic, reason: "latest-price-missing" } };
+  if (clean.length < 3) return { diagnostic: { ...diagnostic, reason: "closes-insufficient" } };
+
+  const shares = marketCap / price; // 발행주식수 근사(시총÷현재가)
+  const psrSeries = clean.map((c) => (c * shares) / revenueUsd).filter((v) => Number.isFinite(v) && v > 0);
+  if (psrSeries.length < 3) return { diagnostic: { ...diagnostic, reason: "psr-series-insufficient" } };
+  const currentPsr = (price * shares) / revenueUsd;
+  const months = Math.max(1, Math.round(clean.length / 21));
+  return {
+    band: {
+      currentPsr: Number(currentPsr.toFixed(2)),
+      psrHistory: psrSeries.map((v) => Number(v.toFixed(2))),
+      valuationHistoryLabel: months >= 11 ? "최근 1년" : `최근 ${months}개월`,
+    },
+    diagnostic,
+  };
+}
+
 export function usValuationBand(
   basics: StockBasics | null | undefined,
   closes: readonly number[],
   latestPrice: number | undefined
 ): Partial<CompanyFinancialScoreInput> | undefined {
-  if (!basics) return undefined;
-  const marketCap = parseUsdCompact(basics.marketCap);
-  const revenue = latestRawValue(basics, "매출"); // Nasdaq financials 는 천달러 단위 → 비율은 단위 상쇄
-  const revenueUsd = revenue !== null ? revenue * 1000 : null;
-  const price = typeof latestPrice === "number" && latestPrice > 0 ? latestPrice : undefined;
-  if (!marketCap || !revenueUsd || revenueUsd <= 0 || !price) return undefined;
-
-  const shares = marketCap / price; // 발행주식수 근사(시총÷현재가)
-  const clean = closes.filter((c) => Number.isFinite(c) && c > 0);
-  if (clean.length < 3) return undefined;
-
-  const psrSeries = clean.map((c) => (c * shares) / revenueUsd).filter((v) => Number.isFinite(v) && v > 0);
-  if (psrSeries.length < 3) return undefined;
-  const currentPsr = (price * shares) / revenueUsd;
-  const months = Math.max(1, Math.round(clean.length / 21));
-  return {
-    currentPsr: Number(currentPsr.toFixed(2)),
-    psrHistory: psrSeries.map((v) => Number(v.toFixed(2))),
-    valuationHistoryLabel: months >= 11 ? "최근 1년" : `최근 ${months}개월`,
-  };
+  return usValuationBandWithDiagnostics(basics, closes, latestPrice).band;
 }


### PR DESCRIPTION
## 변경\n- 위원회 라이트 재계산에서 후보 풀의 실측 재무 축을 보존\n- 캔들 미포함 daily-30 후보는 sparkline으로 US PSR 밴드 재계산\n- KR 동적 종목 naverCode를 stock basics 조회에 전달\n- US 밸류 실패 원인 구조화 계측 추가\n\n## 검증\n- npm run typecheck\n- npm run test -- us-valuation expert-review-committee company-score\n- npm run test -- stock-front daily-30 discovery-supply daily-30-schema\n- npm run build:web