### PR TITLE
fix: 적자 KR 종목 PBR 밸류 축 복구

### DIFF
--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -257,6 +257,30 @@ describe("company score", () => {
     expect(result.omittedAxes).not.toContain("valuation");
   });
 
+  it("적자기업은 PSR을 우선하고 PSR이 없을 때만 실측 PBR 밴드를 사용한다", () => {
+    const pbrOnly = computeCompanyScore({
+      financials: {
+        currentPbr: 0.83,
+        pbrHistory: [0.56, 0.4, 0.6],
+        operatingIncome: [20, -82, -61],
+        valuationHistoryLabel: "최근 3개년",
+      },
+    });
+    expect(pbrOnly.axes.find((axis) => axis.key === "valuation")?.evidence[0]).toContain("PBR 0.83배");
+
+    const psrPreferred = computeCompanyScore({
+      financials: {
+        currentPbr: 0.83,
+        pbrHistory: [0.56, 0.4, 0.6],
+        currentPsr: 1.2,
+        psrHistory: [0.8, 1, 1.4],
+        operatingIncome: [20, -82, -61],
+      },
+    });
+    const evidence = psrPreferred.axes.find((axis) => axis.key === "valuation")?.evidence ?? [];
+    expect(evidence).toEqual([expect.stringContaining("PSR 1.20배")]);
+  });
+
   // WO 번역 레이어 — 화면 노출 문자열(interpretation·조용함 축)에 엔진 내부어 누수 금지.
   it("종합 요약·조용함 축에 계산식·화제성·quietScore 은어가 새지 않는다", () => {
     const result = withCompanyQuietScore(computeCompanyScore(accumulation), {

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -105,19 +105,24 @@ function valuationAxis(financials: CompanyFinancialScoreInput | undefined): Comp
   const operating = lastTwo(financials.operatingIncome)?.[1];
   const useSales = finite(operating) && operating <= 0;
   const psrCandidate = { term: "PSR", value: financials.currentPsr, history: financials.psrHistory };
+  const pbrCandidate = { term: "PBR", value: financials.currentPbr, history: financials.pbrHistory };
   const candidates = useSales
-    ? [psrCandidate]
+    ? [psrCandidate, pbrCandidate]
     : [
         { term: "PER", value: financials.currentPer, history: financials.perHistory },
-        { term: "PBR", value: financials.currentPbr, history: financials.pbrHistory },
+        pbrCandidate,
       ];
   const resolve = (list: readonly typeof psrCandidate[]) =>
     list.flatMap((candidate) => {
       const position = historicalPosition(candidate.value, candidate.history);
       return finite(candidate.value) && finite(position) ? [{ ...candidate, position }] : [];
     });
-  // PER/PBR 미도달(미장 등) 시 PSR 로 폴백 — PSR 도 실밸류 지표. 축 자체를 죽이지 않는다(WO-VAL).
+  // 적자기업은 PSR을 우선하되 PSR 밴드가 없는 경우 실측 PBR 밴드를 사용한다.
+  // 흑자기업의 PER/PBR 미도달(미장 등) 시에는 PSR로 폴백한다.
   let available = resolve(candidates);
+  if (useSales && available.some((item) => item.term === "PSR")) {
+    available = available.filter((item) => item.term === "PSR");
+  }
   if (available.length === 0 && !useSales) available = resolve([psrCandidate]);
   if (available.length === 0) return undefined;
   const score = Math.round(available.reduce((sum, item) => sum + (100 - item.position), 0) / available.length);


### PR DESCRIPTION
## 변경\n- 적자기업은 PSR 밴드를 우선 유지\n- PSR 밴드가 없고 실제 PBR 3개년 밴드가 있으면 PBR을 차선으로 사용\n- 밴드가 없는 종목은 계속 데이터 없음 처리\n\n## 검증\n- npm run typecheck\n- npm run test -- company-score daily-30 expert-review-committee