### PR TITLE
fix: hide insufficient sample metadata in UI

### DIFF
--- a/apps/fomo-web/__tests__/cardHookLayout.test.ts
+++ b/apps/fomo-web/__tests__/cardHookLayout.test.ts
@@ -15,10 +15,10 @@ describe("메인 카드 후킹 구조", () => {
     expect(card).toContain('easyMarketCopy(formatSignalResumeBadge(signalTrack.code, signalTrack.metric), "card")');
   });
 
-  it("점수는 점수대 사후 성과나 축적 상태와 함께만 노출한다", () => {
+  it("점수대 사후 성과는 충분한 실제 결과가 있을 때만 노출한다", () => {
     expect(card).toContain("이 점수대 역대 30일 승률");
-    expect(card).toContain("이 점수대 성과 축적 중");
-    expect(card).toContain("가용 분석축이 3개 미만이라 점수를 내지 않았어요");
+    expect(card).toContain("scoreTrack.n >= SIGNAL_RESUME_MIN_SAMPLE");
+    expect(card).toContain("if (score?.score == null) return null");
     expect(card).toContain("scoreTrack={scoreTrackFor(e)}");
   });
 });

--- a/apps/fomo-web/__tests__/insufficientSampleCopyGuard.test.ts
+++ b/apps/fomo-web/__tests__/insufficientSampleCopyGuard.test.ts
@@ -1,0 +1,25 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function tsxFiles(root: string): string[] {
+  return readdirSync(root).flatMap((name) => {
+    const path = join(root, name);
+    return statSync(path).isDirectory() ? tsxFiles(path) : path.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+describe("표본 부족 UI 문구 가드", () => {
+  it("컴포넌트와 앱 화면에 내부 표본 표기나 축적 상태를 노출하지 않는다", () => {
+    const roots = [
+      fileURLToPath(new URL("../components", import.meta.url)),
+      fileURLToPath(new URL("../app", import.meta.url)),
+    ];
+    for (const file of roots.flatMap(tsxFiles)) {
+      const source = readFileSync(file, "utf8");
+      expect(source, file).not.toContain("축적 중");
+      expect(source, file).not.toMatch(/(?:^|[\s·(])n=/m);
+    }
+  });
+});

--- a/apps/fomo-web/app/track-record/page.tsx
+++ b/apps/fomo-web/app/track-record/page.tsx
@@ -18,17 +18,17 @@ const SCORE_LABEL: Record<string, string> = {
   "0-59": "60점 미만",
 };
 
-function signed(value: number | null): string {
-  if (value === null) return "축적 중";
+function signed(value: number): string {
   return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
 }
 
 function MetricBlock({ label, metric, value }: { label: string; metric: TrackMetric; value: "winRate" | "median" | "n" }) {
+  if ((value === "winRate" && metric.winRate === null) || (value === "median" && metric.medianReturn === null)) return null;
   const display = value === "n"
     ? metric.n.toLocaleString("ko-KR")
     : value === "median"
-      ? signed(metric.medianReturn)
-      : metric.winRate === null ? "축적 중" : `${metric.winRate.toFixed(1)}%`;
+      ? signed(metric.medianReturn!)
+      : `${metric.winRate!.toFixed(1)}%`;
   const note = value === "winRate" ? "수익률 0% 초과" : value === "median" ? "전체 수익률 중앙값" : "상승·하락 모두 포함";
   return (
     <div className="min-w-0 border-l border-hairline pl-3 first:border-l-0 first:pl-0">
@@ -51,33 +51,30 @@ function Breakdown({
   order?: string[];
 }) {
   const rank = new Map((order ?? []).map((key, index) => [key, index]));
-  const rows = Object.entries(values).sort((a, b) => {
+  const rows = Object.entries(values).filter(([, metric]) => metric.n > 0 && metric.winRate !== null).sort((a, b) => {
     if (order) return (rank.get(a[0]) ?? 999) - (rank.get(b[0]) ?? 999);
     return b[1].n - a[1].n || a[0].localeCompare(b[0]);
   });
+  if (rows.length === 0) return null;
   return (
     <section className="border-t border-hairline py-5">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-sm font-semibold text-whiteout">{title}</h2>
         <span className="text-[10px] text-muted">상승·하락 전체</span>
       </div>
-      {rows.length === 0 ? (
-        <p className="py-4 text-sm text-muted">고정 기간이 지난 기록을 축적 중이에요.</p>
-      ) : (
-        <div className="divide-y divide-hairline">
+      <div className="divide-y divide-hairline">
           {rows.map(([key, metric]) => (
             <div key={key} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 py-3">
               <span className="min-w-0 truncate text-sm text-whiteout">{labels[key] ?? key}</span>
               <div className="min-w-16 text-right">
                 <p className="font-number text-sm font-bold" style={{ color: metric.winRate !== null && metric.winRate >= 50 ? NEON : "#A3A3A0" }}>
-                  {metric.winRate === null ? "축적 중" : `${metric.winRate.toFixed(1)}%`}
+                  {metric.winRate!.toFixed(1)}%
                 </p>
-                <p className="mt-0.5 text-[10px] text-muted">n={metric.n}</p>
+                <p className="mt-0.5 text-[10px] text-muted">{metric.n}건 기준</p>
               </div>
             </div>
           ))}
-        </div>
-      )}
+      </div>
     </section>
   );
 }
@@ -92,8 +89,7 @@ export default function TrackRecordPage() {
     void fetchTrackRecord().then(setRecord).catch(() => setFailed(true));
   }, []);
 
-  // 아직 도래한 outcome 이 특정 창(초기엔 7일)에만 쌓여 있을 수 있다. 유저가 탭을 직접 고르기 전엔
-  // 표본이 가장 많은 창을 기본 선택해, 첫 진입에서 "축적 중"(n=0) 대신 살아있는 성적표가 보이게 한다.
+  // 아직 도래한 outcome이 특정 창에만 있을 수 있어, 첫 진입은 기록이 가장 많은 창을 고른다.
   useEffect(() => {
     if (!record || userPicked) return;
     const best = record.windows.reduce<{ days: 7 | 30 | 90; n: number } | null>((acc, w) => {
@@ -144,7 +140,7 @@ export default function TrackRecordPage() {
         <p className="border-t border-hairline py-12 text-center text-sm text-muted">성과 원장을 불러오지 못했어요.</p>
       ) : !windowResult ? (
         <p className="border-t border-hairline py-12 text-center text-sm text-muted">성과 원장을 불러오는 중이에요.</p>
-      ) : (
+      ) : windowResult.overall.n > 0 ? (
         <>
           <section className="grid grid-cols-3 gap-4 border-y border-hairline py-5">
             <MetricBlock label={`${days}일 상승 비율`} metric={windowResult.overall} value="winRate" />
@@ -153,7 +149,7 @@ export default function TrackRecordPage() {
           </section>
           <Breakdown title="자산군별" values={windowResult.byAsset} labels={ASSET_LABEL} />
           <Breakdown
-            title="신호 유형별 · n<30 비공개"
+            title="신호 유형별"
             values={windowResult.bySignal}
             labels={SIGNAL_LABEL}
             order={[...SIGNAL_TYPE_CODES]}
@@ -165,7 +161,7 @@ export default function TrackRecordPage() {
             order={["80-100", "60-79", "0-59"]}
           />
         </>
-      )}
+      ) : null}
 
       <footer className="break-words border-t border-hairline pt-5 text-[11px] leading-5 text-muted [overflow-wrap:anywhere]">
         수익률은 선정 시점 가격 대비 목표일 당일 또는 다음 첫 거래일 종가입니다. 거래비용·세금·환율 효과는 포함하지 않습니다.

--- a/apps/fomo-web/components/CompanyScoreRadar.tsx
+++ b/apps/fomo-web/components/CompanyScoreRadar.tsx
@@ -45,22 +45,22 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
   if (!result) return null;
 
   return (
-    <DepthSection className="mt-4" ariaLabelledby="company-score-title">
+    <DepthSection className="mt-4" {...(result.score != null ? { ariaLabelledby: "company-score-title" } : {})}>
       <div className="flex items-start justify-between gap-4">
-        <div>
+        {result.score != null && <div>
           <p className="font-pixel text-[11px] text-muted">COMPANY SCORE</p>
           <div className="mt-1.5 flex items-baseline gap-2">
             <span
               id="company-score-title"
-              className={`font-number font-bold leading-none ${result.score == null ? "text-xl" : "text-4xl"}`}
+              className="font-number text-4xl font-bold leading-none"
               style={{ color: chartTokens.up }}
             >
-              {result.score ?? "분석 축적 중"}
+              {result.score}
             </span>
-            {result.score != null && <span className="text-sm font-semibold text-muted">/ 100</span>}
+            <span className="text-sm font-semibold text-muted">/ 100</span>
           </div>
-        </div>
-        <span className="max-w-[58%] text-right text-sm font-semibold leading-5 text-whiteout">{easyMarketCopy(result.label, "detail")}</span>
+        </div>}
+        {result.score != null && <span className="max-w-[58%] text-right text-sm font-semibold leading-5 text-whiteout">{easyMarketCopy(result.label, "detail")}</span>}
       </div>
 
       <div className="mt-4 flex justify-center">
@@ -93,10 +93,12 @@ export function CompanyScoreRadar({ result }: { result: CompanyScoreResult | nul
         </svg>
       </div>
 
-      <p className="text-sm leading-6 text-whiteout">{easyMarketCopy(result.interpretation, "detail")}</p>
-      <p className="mt-1 text-[10px] leading-4 text-muted">
-        데이터가 없는 축은 명시적으로 제외하고, 가용한 {result.availableAxisCount}개 축을 같은 비중으로 계산했어요.
-      </p>
+      {result.score != null && <>
+        <p className="text-sm leading-6 text-whiteout">{easyMarketCopy(result.interpretation, "detail")}</p>
+        <p className="mt-1 text-[10px] leading-4 text-muted">
+          데이터가 없는 축은 명시적으로 제외하고, 가용한 {result.availableAxisCount}개 축을 같은 비중으로 계산했어요.
+        </p>
+      </>}
 
       <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
         {ORDER.map((key) => {

--- a/apps/fomo-web/components/DesktopDashboard.tsx
+++ b/apps/fomo-web/components/DesktopDashboard.tsx
@@ -121,7 +121,9 @@ function CardListRow({
       {hook && (
         <p className="mt-1 truncate text-xs leading-5 text-muted">{hook}</p>
       )}
-      {companyScore?.label && <p className="mt-1 truncate text-[10px] leading-4 text-whiteout">{companyScore.label}</p>}
+      {typeof companyScore?.score === "number" && companyScore.label && (
+        <p className="mt-1 truncate text-[10px] leading-4 text-whiteout">{companyScore.label}</p>
+      )}
     </button>
   );
 }

--- a/apps/fomo-web/components/JudgmentReviewPanel.tsx
+++ b/apps/fomo-web/components/JudgmentReviewPanel.tsx
@@ -30,11 +30,17 @@ function actionLabel(action: ReviewAction): string {
 
 function reportText(review: JudgmentReviewResponse): string {
   const weekly = review.weekly;
-  if (!weekly) return "포모클럽 판단 복기 · 30일 결과를 축적 중이에요.";
+  if (!weekly) return "";
   const parts = [`포모클럽 주간 판단 복기 · 결과 ${weekly.count}건`];
   if (weekly.best) parts.push(`잘한 판단 ${weekly.best.canonical} ${signed(weekly.best.returnPct)}`);
   if (weekly.missed) parts.push(`아까운 판단 ${weekly.missed.canonical} ${signed(weekly.missed.returnPct)}`);
   return parts.join("\n");
+}
+
+function rateSummary(rate: JudgmentReviewResponse["userRate"]): string | null {
+  if (rate.n <= 0 || rate.winRate === null) return null;
+  const wins = Math.round((rate.n * rate.winRate) / 100);
+  return `${rate.n}번 중 ${wins}번`;
 }
 
 async function shareReview(review: JudgmentReviewResponse): Promise<void> {
@@ -98,14 +104,18 @@ function WeeklyCard({ review }: { review: JudgmentReviewResponse }) {
 }
 
 function HistoryReview({ review }: { review: JudgmentReviewResponse }) {
+  const userSummary = rateSummary(review.userRate);
+  const cardSummary = rateSummary(review.cardRate);
   const comparison = useMemo(() => {
     const user = review.userRate.winRate;
     const card = review.cardRate.winRate;
-    if (user === null || card === null) return "30일 결과가 쌓이면 두 판단을 같은 기준으로 비교해요.";
+    if (user === null || card === null) return null;
     if (user === card) return "현재 표본에서는 두 판단의 적중률이 같아요.";
     const gap = Math.abs(user - card).toFixed(1);
     return user > card ? `현재 표본에서 내 판단이 ${gap}%p 높아요.` : `현재 표본에서 카드 판단이 ${gap}%p 높아요.`;
   }, [review.cardRate.winRate, review.userRate.winRate]);
+
+  if (review.rows.length === 0) return null;
 
   return (
     <section className="mb-6">
@@ -114,21 +124,19 @@ function HistoryReview({ review }: { review: JudgmentReviewResponse }) {
         <span className="text-[10px] text-muted">확정 {review.rows.length} · 대기 {review.pendingCount}</span>
       </div>
 
-      <div className="rounded-lg border border-hairline bg-surface-raised p-4">
-        <div className="grid grid-cols-2 gap-3">
-          <div>
+      {(userSummary || cardSummary) && <div className="rounded-lg border border-hairline bg-surface-raised p-4">
+        <div className={`grid gap-3 ${userSummary && cardSummary ? "grid-cols-2" : "grid-cols-1"}`}>
+          {userSummary && <div>
             <p className="text-[10px] text-muted">내 판단 승률</p>
-            <p className="mt-1 text-2xl font-bold text-whiteout">{review.userRate.winRate === null ? "축적 중" : `${review.userRate.winRate}%`}</p>
-            <p className="text-[9px] text-muted">명시적 선택 n={review.userRate.n}</p>
-          </div>
-          <div>
+            <p className="mt-1 text-2xl font-bold text-whiteout">{userSummary}</p>
+          </div>}
+          {cardSummary && <div>
             <p className="text-[10px] text-muted">카드 판단 승률</p>
-            <p className="mt-1 text-2xl font-bold text-whiteout">{review.cardRate.winRate === null ? "축적 중" : `${review.cardRate.winRate}%`}</p>
-            <p className="text-[9px] text-muted">enter/avoid n={review.cardRate.n}</p>
-          </div>
+            <p className="mt-1 text-2xl font-bold text-whiteout">{cardSummary}</p>
+          </div>}
         </div>
-        <p className="mt-3 text-xs leading-5 text-muted">{comparison}</p>
-      </div>
+        {comparison && <p className="mt-3 text-xs leading-5 text-muted">{comparison}</p>}
+      </div>}
 
       <div className="mt-3 grid grid-cols-2 gap-2">
         {review.matrix.map((cell) => (
@@ -148,7 +156,7 @@ function HistoryReview({ review }: { review: JudgmentReviewResponse }) {
           <div className="mt-2 flex flex-wrap gap-2">
             {review.strongSignals.map((signal) => (
               <span key={signal.code} className="rounded-full border border-hairline-soft px-2.5 py-1 text-[10px] text-whiteout">
-                {signal.label} · {signal.winRate}% · n={signal.n}
+                {signal.label} · {rateSummary(signal)}
               </span>
             ))}
           </div>

--- a/apps/fomo-web/components/JudgmentTimeline.tsx
+++ b/apps/fomo-web/components/JudgmentTimeline.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   formatSignalResumeBadge,
   normalizeSignalTypeCodes,
+  SIGNAL_RESUME_MIN_SAMPLE,
   signalTypeLabel,
   type SignalTypeCode,
 } from "@fomo/core";
@@ -96,7 +97,7 @@ export function JudgmentTimeline({ canonical }: { canonical: string }) {
           const style = KIND_STYLE[entry.kind];
           const resumes = signalTypes(entry).flatMap((code) => {
             const metric = signalHistory30[code];
-            return metric ? [{ code, metric }] : [];
+            return metric && metric.n >= SIGNAL_RESUME_MIN_SAMPLE && metric.winRate !== null ? [{ code, metric }] : [];
           });
           return (
             <DepthLine key={`${entry.id}-${entry.date}`} className="grid grid-cols-[70px_1fr] gap-3">

--- a/apps/fomo-web/components/KeywordDepthPage.tsx
+++ b/apps/fomo-web/components/KeywordDepthPage.tsx
@@ -2027,7 +2027,7 @@ function structureMetrics(front: StockFrontResponse | null): StructureMetric[] {
   const resistance = levels.filter((level) => level.kind === "resistance" && level.value >= last).sort((a, b) => a.value - b.value)[0];
   const levelValue = [support ? `지지 ${formatChartPrice(support.value)}` : undefined, resistance ? `저항 ${formatChartPrice(resistance.value)}` : undefined]
     .filter(Boolean)
-    .join(" · ") || "레벨 축적 중";
+    .join(" · ");
   const latest = front?.ta?.latest;
   const momentumValue = finiteNumber(latest?.rsi14)
     ? latest.rsi14 >= 70
@@ -2037,27 +2037,28 @@ function structureMetrics(front: StockFrontResponse | null): StructureMetric[] {
       ? `변동폭 ${latest.atrPct.toFixed(1)}%`
       : finiteNumber(front?.signals?.volumeRatio) && front.signals.volumeRatio >= 0.1
         ? `거래량 ${front.signals.volumeRatio.toFixed(1)}배`
-        : "지표 축적 중";
+        : undefined;
 
-  return [
+  const metrics: StructureMetric[] = [
     {
       title: "추세 구조",
       value: structure,
       body: `현재 종가 ${formatChartPrice(last)}${finiteNumber(ma20) ? ` · MA20 ${formatChartPrice(ma20)}` : ""}${finiteNumber(ma60) ? ` · MA60 ${formatChartPrice(ma60)}` : ""}${finiteNumber(ma120) ? ` · MA120 ${formatChartPrice(ma120)}` : ""}`,
     },
-    {
+  ];
+  if (levelValue) metrics.push({
       title: "핵심 가격대",
       value: levelValue,
-      body: levelValue === "레벨 축적 중" ? "반복 확인된 최근 피벗이 아직 부족해요." : `최근 고점·저점 피벗에서 계산한 ${levelValue} 구간이에요.`,
-    },
-    {
+      body: `최근 고점·저점 피벗에서 계산한 ${levelValue} 구간이에요.`,
+    });
+  if (momentumValue) metrics.push({
       title: "모멘텀",
       value: momentumValue,
       body: finiteNumber(latest?.rsi14)
         ? `${latest.rsi14 >= 70 ? `단기 과열(RSI ${Math.round(latest.rsi14)})` : `RSI 14 기준 ${Math.round(latest.rsi14)}`}예요.${finiteNumber(latest?.atrPct) ? ` 최근 하루 변동폭은 ${latest.atrPct.toFixed(1)}%예요.` : ""}`
         : "현재 연결된 변동성·모멘텀 관측값을 보여줘요.",
-    },
-  ];
+    });
+  return metrics;
 }
 
 /**

--- a/apps/fomo-web/components/PerformanceProofPanel.tsx
+++ b/apps/fomo-web/components/PerformanceProofPanel.tsx
@@ -119,6 +119,7 @@ export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeen
     const tracked = trackedBands?.[key];
     return tracked ? { ...band, count: tracked.n, winRate: tracked.winRate } : band;
   });
+  const visibleScoreBands = scoreBands.filter((band) => band.count > 0 && band.winRate !== null);
 
   if (items.length === 0) return null;
 
@@ -129,7 +130,7 @@ export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeen
         <span className="text-[10px] font-medium text-muted">{returns.length}/{items.length}</span>
       </div>
 
-      <div className="rounded-2xl border border-hairline bg-surface-raised px-4 py-4">
+      {returns.length > 0 && <div className="rounded-2xl border border-hairline bg-surface-raised px-4 py-4">
         <div className="grid grid-cols-2 gap-3">
           <div>
             <span className="text-[10px] text-muted">상승 비율</span>
@@ -145,25 +146,23 @@ export function PerformanceProofPanel({ items }: { items: readonly DiscoverySeen
         <p className="mt-3 text-xs leading-5 text-muted">
           처음 본 시점 가격과 현재가가 모두 있는 종목 전체 기준입니다.
         </p>
-      </div>
+      </div>}
 
-      <div className="mt-3 border-y border-hairline py-3">
+      {visibleScoreBands.length > 0 && <div className="mt-3 border-y border-hairline py-3">
         <div className="flex items-center justify-between gap-3">
           <p className="text-xs font-semibold text-whiteout">점수대별 30일 후 승률</p>
           <span className="text-[10px] text-muted">전체 기록 기준</span>
         </div>
         <div className="mt-2 grid grid-cols-3 gap-2">
-          {scoreBands.map((band) => (
+          {visibleScoreBands.map((band) => (
             <div key={band.label}>
               <p className="text-[10px] text-muted">{band.label}</p>
-              <p className="mt-1 font-number text-base font-bold text-whiteout">
-                {band.winRate === null ? "축적 중" : `${band.winRate}%`}
-              </p>
-              <p className="text-[9px] text-muted">표본 {band.count}</p>
+              <p className="mt-1 font-number text-base font-bold text-whiteout">{band.winRate}%</p>
+              <p className="text-[9px] text-muted">{band.count}건 기준</p>
             </div>
           ))}
         </div>
-      </div>
+      </div>}
 
       <div className="mt-3 flex flex-col gap-2.5">
         {rows.slice(0, 10).map((row) => {

--- a/apps/fomo-web/components/StockSwipeDeck.tsx
+++ b/apps/fomo-web/components/StockSwipeDeck.tsx
@@ -6,6 +6,7 @@ import {
   inferStandardSignalTypes,
   isSignalTypeCode,
   normalizeSignalTypeCodes,
+  SIGNAL_RESUME_MIN_SAMPLE,
   signalTypeLabel,
 } from "@fomo/core";
 import type {
@@ -274,34 +275,31 @@ function CompanyScoreBlock({
   verdict?: CardVerdict | undefined;
   scoreTrack?: TrackMetric | undefined;
 }) {
+  if (score?.score == null) return null;
   const balance = verdictBalance(verdict);
-  const metric = scoreTrack ?? { n: 0, winRate: null, medianReturn: null };
-  const historyText =
-    score?.score == null
-      ? "가용 분석축이 3개 미만이라 점수를 내지 않았어요."
-      : metric.n >= 30 && metric.winRate !== null
-      ? `이 점수대 역대 30일 승률 ${Number.isInteger(metric.winRate) ? metric.winRate.toFixed(0) : metric.winRate.toFixed(1)}% · n=${metric.n}`
-      : `이 점수대 성과 축적 중 · n=${metric.n}`;
+  const historyText = scoreTrack && scoreTrack.n >= SIGNAL_RESUME_MIN_SAMPLE && scoreTrack.winRate !== null
+    ? `이 점수대 역대 30일 승률 ${Number.isInteger(scoreTrack.winRate) ? scoreTrack.winRate.toFixed(0) : scoreTrack.winRate.toFixed(1)}%`
+    : null;
   return (
     <div className="mt-2 shrink-0 border-y border-hairline py-2">
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2.5">
           <div className="flex shrink-0 items-baseline gap-1">
             <span
-              className={`font-number font-bold leading-none ${score?.score == null ? "text-sm" : "text-xl"}`}
+              className="font-number text-xl font-bold leading-none"
               style={{ color: NEON }}
             >
-              {score?.score ?? "분석 축적 중"}
+              {score.score}
             </span>
-            {score?.score != null && <span className="text-[10px] font-semibold text-muted">점</span>}
+            <span className="text-[10px] font-semibold text-muted">점</span>
           </div>
           <p className="min-w-0 truncate text-xs font-semibold text-whiteout">
-            {score?.score == null ? `가용 분석축 ${score?.availableAxisCount ?? 0}/6` : easyMarketCopy(score.label, "card")}
+            {easyMarketCopy(score.label, "card")}
           </p>
         </div>
         {balance && <span className="text-[10px] font-medium" style={{ color: balance.color }}>{balance.label}</span>}
       </div>
-      <p className="mt-1 text-[10px] leading-4 text-muted">{historyText}</p>
+      {historyText && <p className="mt-1 text-[10px] leading-4 text-muted">{historyText}</p>}
     </div>
   );
 }
@@ -432,7 +430,7 @@ function StockCardFace({
 
       {verdict && <FeedSignalStrip bull={feedBull} bear={feedBear} />}
 
-      {signalTrack && (
+      {signalTrack && signalTrack.metric.n >= SIGNAL_RESUME_MIN_SAMPLE && signalTrack.metric.winRate !== null && (
         <p className="mt-2 shrink-0 text-[11px] leading-4 text-muted">
           {easyMarketCopy(formatSignalResumeBadge(signalTrack.code, signalTrack.metric), "card")}
         </p>

--- a/packages/fomo-core/__tests__/company-score.test.ts
+++ b/packages/fomo-core/__tests__/company-score.test.ts
@@ -58,7 +58,8 @@ describe("company score", () => {
     const accumulating = computeCompanyScore({});
     expect(accumulating.status).toBe("accumulating");
     expect(accumulating.score).toBeNull();
-    expect(accumulating.label).toBe("분석 축적 중");
+    expect(accumulating.label).toBe("");
+    expect(accumulating.interpretation).toBe("");
     expect(accumulating.axisStates).toHaveLength(6);
     expect(accumulating.axisStates.filter((axis) => axis.status === "missing").every((axis) => axis.missingReason === "데이터 없음")).toBe(true);
     expect(accumulating.axes.map((axis) => axis.key)).toEqual(["chart"]);

--- a/packages/fomo-core/__tests__/signal-resume.test.ts
+++ b/packages/fomo-core/__tests__/signal-resume.test.ts
@@ -17,10 +17,16 @@ describe("signal resume taxonomy", () => {
     expect(new Set(SIGNAL_TYPE_CODES).size).toBe(SIGNAL_TYPE_CODES.length);
   });
 
-  it("n<30은 승률을 숨기고 표본수만 공개한다", () => {
+  it("표본 기준 미달이면 사용자용 문구를 만들지 않는다", () => {
     const text = formatSignalResumeBadge("insider_cluster", { n: SIGNAL_RESUME_MIN_SAMPLE - 1, winRate: 96.4, medianReturn: 12 });
-    expect(text).toBe("내부자 클러스터 매수 · 축적 중 (n=29)");
+    expect(text).toBe("");
     expect(text).not.toContain("96.4");
+  });
+
+  it("표본 기준을 충족해도 내부 표본 표기법을 사용자에게 노출하지 않는다", () => {
+    const text = formatSignalResumeBadge("insider_cluster", { n: SIGNAL_RESUME_MIN_SAMPLE, winRate: 63.3, medianReturn: 4.1 });
+    expect(text).toBe("내부자 클러스터 매수 · 역대 30일 승률 63.3%");
+    expect(text).not.toContain("n=");
   });
 
   it("실데이터 필드와 최근 와이코프 이벤트만 표준 코드로 판정한다", () => {

--- a/packages/fomo-core/src/keyword-cards/company-score.ts
+++ b/packages/fomo-core/src/keyword-cards/company-score.ts
@@ -388,12 +388,12 @@ function axisStates(axes: readonly CompanyScoreAxis[]): CompanyScoreAxisState[] 
 function resultFromAxes(axes: CompanyScoreAxis[], input: CompanyScoreInput, asOf?: string): CompanyScoreResult {
   const ready = axes.length >= 3;
   const score = ready ? Math.round(axes.reduce((sum, axis) => sum + axis.score, 0) / axes.length) : null;
-  const label = ready ? scoreLabel(axes, input) : "분석 축적 중";
+  const label = ready ? scoreLabel(axes, input) : "";
   return {
     score,
     status: ready ? "ready" : "accumulating",
     label,
-    interpretation: interpretation(axes, label),
+    interpretation: ready ? interpretation(axes, label) : "",
     axes,
     axisStates: axisStates(axes),
     availableAxisCount: axes.length,

--- a/packages/fomo-core/src/keyword-cards/signal-resume.ts
+++ b/packages/fomo-core/src/keyword-cards/signal-resume.ts
@@ -135,9 +135,9 @@ function compactPercent(value: number): string {
 export function formatSignalResumeBadge(code: SignalTypeCode, metric: SignalResumeMetric): string {
   const label = signalTypeLabel(code);
   if (metric.n < SIGNAL_RESUME_MIN_SAMPLE || metric.winRate === null) {
-    return `${label} · 축적 중 (n=${metric.n})`;
+    return "";
   }
-  return `${label} · 역대 30일 승률 ${compactPercent(metric.winRate)}% · n=${metric.n}`;
+  return `${label} · 역대 30일 승률 ${compactPercent(metric.winRate)}%`;
 }
 
 /** Good long-run evidence can move ranking slightly, never dominate today's signal. */


### PR DESCRIPTION
## Summary
- hide score and signal performance rows when sample thresholds are not met
- hide empty judgment review and track-record blocks, using plain-language counts only when data exists
- remove UI fallbacks containing internal sample metadata and add a global TSX copy guard

## Verification
- npm run test -- company-score signal-resume apps/fomo-web
- npm run typecheck
- npm run build:fomo-web